### PR TITLE
DefaultDnsServiceDiscoverer test cleanup

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscoverer.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscoverer.java
@@ -32,6 +32,7 @@ import io.netty.resolver.ResolvedAddressTypes;
 import io.netty.resolver.dns.DnsNameResolver;
 import io.netty.resolver.dns.DnsNameResolverBuilder;
 import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
@@ -365,7 +366,7 @@ final class DefaultDnsServiceDiscoverer implements ServiceDiscoverer<String, Ine
                     if (addressFuture.isDone()) {
                         handleResolveDone(addressFuture);
                     } else {
-                        addressFuture.addListener(future -> handleResolveDone((Future<List<InetAddress>>) future));
+                        addressFuture.addListener((FutureListener<List<InetAddress>>) this::handleResolveDone);
                     }
                 }
 

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererTest.java
@@ -101,7 +101,6 @@ public class DefaultDnsServiceDiscovererTest {
 
     @Test
     public void testRetry() throws Exception {
-        assumeThat("Ignored flaky test", parseBoolean(System.getenv("CI")), is(FALSE));
         AtomicInteger retryStrategyCalledCount = new AtomicInteger();
         ServiceDiscoverer<String, InetAddress> retryingDiscoverer = buildServiceDiscoverer((retryCount, cause) -> {
             retryStrategyCalledCount.incrementAndGet();
@@ -122,7 +121,6 @@ public class DefaultDnsServiceDiscovererTest {
 
     @Test
     public void unknownHostDiscover() throws InterruptedException {
-        assumeThat("Ignored flaky test", parseBoolean(System.getenv("CI")), is(FALSE));
         CountDownLatch latch = new CountDownLatch(1);
         AtomicReference<Throwable> throwableRef = new AtomicReference<>();
         Publisher<Event<InetAddress>> publisher = discoverer.discover("unknown.com");

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/TestDnsServer.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/TestDnsServer.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.dns.discovery.netty;
 
-import io.netty.util.NetUtil;
 import io.netty.util.internal.PlatformDependent;
 import org.apache.directory.server.dns.DnsServer;
 import org.apache.directory.server.dns.io.encoder.DnsMessageEncoder;
@@ -49,6 +48,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import static java.net.InetAddress.getLoopbackAddress;
+
 class TestDnsServer extends DnsServer {
     private static final Map<String, byte[]> BYTES = new HashMap<>();
     private static final String[] IPV6_ADDRESSES = initializeIPs();
@@ -79,8 +80,8 @@ class TestDnsServer extends DnsServer {
 
     @Override
     public void start() throws IOException {
-        InetSocketAddress address = new InetSocketAddress(NetUtil.LOCALHOST4, 9999);
-        UdpTransport transport = new UdpTransport(address.getHostName(), address.getPort());
+        InetSocketAddress address = new InetSocketAddress(getLoopbackAddress(), 0);
+        UdpTransport transport = new UdpTransport(address.getHostString(), address.getPort());
         setTransports(transport);
 
         DatagramAcceptor acceptor = transport.getAcceptor();


### PR DESCRIPTION
Motivation:
DefaultDnsServiceDiscoverer tests were disabled due to failure on build servers which revealed a Netty issue. The issue has been fixed in Netty and the unit tests can now be re-enabled. There was also some miscellaneous cleanup done as part of the debugging.

Modifications:
- Enable tests that were ignored due to a Netty issue

Result:
DefaultDnsServiceDiscoverer tests are no longer ignored, related code is cleaned up.