### PR TITLE
ConnectableOutputStream.close() should not busy spin when not subscribed

### DIFF
--- a/servicetalk-concurrent-api-internal/src/main/java/io/servicetalk/concurrent/api/internal/ConnectableOutputStream.java
+++ b/servicetalk-concurrent-api-internal/src/main/java/io/servicetalk/concurrent/api/internal/ConnectableOutputStream.java
@@ -257,8 +257,8 @@ public final class ConnectableOutputStream extends OutputStream {
         flush();
         for (;;) {
             final Object currentState = state;
-            if (currentState == TERMINAL_SENT || currentState == CLOSED || currentState == CANCEL_AFTER_EMIT ||
-                    currentState instanceof Throwable) {
+            if (currentState == TERMINAL_SENT || currentState == CLOSED || currentState == CLOSE_ON_SUB ||
+                    currentState == CANCEL_AFTER_EMIT || currentState instanceof Throwable) {
                 // Subscriber already terminated or terminating
                 return;
             }

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectableOutputStreamTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectableOutputStreamTest.java
@@ -99,6 +99,14 @@ public class ConnectableOutputStreamTest {
     }
 
     @Test
+    public void closeShouldBeIdempotentWhenNotSubscribed() throws IOException {
+        cos.connect();
+        cos.write(1);
+        cos.close();
+        cos.close(); // should be idempotent
+    }
+
+    @Test
     public void multipleConnectWithInvalidRequestnShouldFailConnect() throws Exception {
         @SuppressWarnings("unchecked")
         CountDownLatch onSubscribe = new CountDownLatch(1);


### PR DESCRIPTION
__Motivation__

Currently close() hangs in a busy spin after a prior close()
until the connected Publisher is subscribed.

__Modifications__

Early exit the loop when the state is CLOSE_ON_SUB

__Result__

Subsequent close() calls won't hang