### PR TITLE
Fix broken tasks in composite build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,22 +94,22 @@ task build {
 
 task checkstyle {
   dependsOn findTasks(':checkstyle',
-    ['servicetalk-bom-internal', 'servicetalk-examples', 'servicetalk-gradle-plugin-internal'])
+    ['servicetalk-bom', 'servicetalk-bom-internal', 'servicetalk-examples', 'servicetalk-gradle-plugin-internal'])
 }
 
 task pmd {
   dependsOn findTasks(':pmd',
-    ['servicetalk-bom-internal', 'servicetalk-examples', 'servicetalk-gradle-plugin-internal'])
+    ['servicetalk-bom', 'servicetalk-bom-internal', 'servicetalk-examples', 'servicetalk-gradle-plugin-internal'])
 }
 
 task spotbugs {
   dependsOn findTasks(':spotbugs',
-    ['servicetalk-bom-internal', 'servicetalk-examples', 'servicetalk-gradle-plugin-internal'])
+    ['servicetalk-bom', 'servicetalk-bom-internal', 'servicetalk-examples', 'servicetalk-gradle-plugin-internal'])
 }
 
 task quality {
   dependsOn findTasks(':quality',
-    ['servicetalk-bom-internal', 'servicetalk-examples', 'servicetalk-gradle-plugin-internal'])
+    ['servicetalk-bom', 'servicetalk-bom-internal', 'servicetalk-examples', 'servicetalk-gradle-plugin-internal'])
 }
 
 task bintrayUpload {
@@ -119,7 +119,7 @@ task bintrayUpload {
 // Override behavior for existing tasks:
 
 task publish(overwrite: true) {
-  dependsOn findTasks(':publish', ['servicetalk-benchmarks'])
+  dependsOn findTasks(':publish', ['servicetalk-benchmarks', 'servicetalk-examples'])
 }
 
 task publishToMavenLocal(overwrite: true) {


### PR DESCRIPTION
Motivations:

Quality tasks are broken for composite build, because we merged
`servicetalk-bom` into composite, but didn't exclude it from quality
tasks.
`servicetalk-examples` should not be a part of composite's `publish`
task even if its `publish` implementation is noop.

Modifications:

- Add `servicetalk-bom` as an excluded build for quality tasks;
- Add `servicetalk-examples` as an excluded build for `publish` task;

Result:

Correct tasks configuration for composite build.