### PR TITLE
Fix how SpotBugs choose format of the report when running in CI

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -234,8 +234,8 @@ class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
       // This task defaults to XML reporting for CI, but humans like HTML
       tasks.withType(com.github.spotbugs.SpotBugsTask) {
         reports {
-          xml.enabled = System.getenv("CI")
-          html.enabled = true
+          xml.enabled = "true" == System.getenv("CI")
+          html.enabled = "true" != System.getenv("CI")
         }
       }
 


### PR DESCRIPTION
motivation: spot bugs only produces html reports now, we need xml for CI dashboards

changes: use env variable instead of system property, simplify logic