### PR TITLE
Remove `CloseableIterable` and `Iterable` variants of `setPayload()`

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BufferHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BufferHttpResponse.java
@@ -17,15 +17,11 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.buffer.api.BufferAllocator;
-import io.servicetalk.buffer.api.CompositeBuffer;
-import io.servicetalk.concurrent.CloseableIterable;
-import io.servicetalk.concurrent.CloseableIterator;
 
 import static io.servicetalk.buffer.api.EmptyBuffer.EMPTY_BUFFER;
 import static io.servicetalk.concurrent.api.Publisher.just;
 import static io.servicetalk.concurrent.api.Single.success;
 import static io.servicetalk.concurrent.internal.Iterables.singletonBlockingIterable;
-import static java.lang.Integer.MAX_VALUE;
 import static java.util.Objects.requireNonNull;
 
 final class BufferHttpResponse extends DefaultHttpResponseMetaData implements HttpResponse {
@@ -92,37 +88,6 @@ final class BufferHttpResponse extends DefaultHttpResponseMetaData implements Ht
     @Override
     public <T> HttpResponse setPayloadBody(final T pojo, final HttpSerializer<T> serializer) {
         return new BufferHttpResponse(this, allocator, trailers, serializer.serialize(getHeaders(), pojo, allocator));
-    }
-
-    @Override
-    public <T> HttpResponse setPayloadBody(final Iterable<T> pojos, final HttpSerializer<T> serializer) {
-        Iterable<Buffer> buffers = serializer.serialize(getHeaders(), pojos, allocator);
-        CompositeBuffer payloadBody = allocator.newCompositeBuffer(MAX_VALUE);
-        for (Buffer buffer : buffers) {
-            payloadBody.addBuffer(buffer);
-        }
-        return new BufferHttpResponse(this, allocator, trailers, payloadBody);
-    }
-
-    @Override
-    public <T> HttpResponse setPayloadBody(final CloseableIterable<T> pojos, final HttpSerializer<T> serializer) {
-        CloseableIterable<Buffer> buffers = serializer.serialize(getHeaders(), pojos, allocator);
-        CloseableIterator<Buffer> bufferItr = buffers.iterator();
-        final CompositeBuffer payloadBody;
-        try {
-            payloadBody = allocator.newCompositeBuffer(MAX_VALUE);
-            while (bufferItr.hasNext()) {
-                payloadBody.addBuffer(bufferItr.next());
-            }
-        } catch (Throwable cause) {
-            try {
-                bufferItr.close();
-            } catch (Exception e) {
-                cause.addSuppressed(e);
-            }
-            throw cause;
-        }
-        return new BufferHttpResponse(this, allocator, trailers, payloadBody);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequest.java
@@ -16,7 +16,6 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.Buffer;
-import io.servicetalk.concurrent.CloseableIterable;
 
 /**
  * An HTTP request. The payload is represented as a single {@link Object}.
@@ -59,30 +58,6 @@ public interface HttpRequest extends HttpRequestMetaData {
      * @return A {@link HttpRequest} with the new serialized payload body.
      */
     <T> HttpRequest setPayloadBody(T pojo, HttpSerializer<T> serializer);
-
-    /**
-     * Set the underlying payload to be the results of serialization of {@code pojo}.
-     * <p>
-     * Note this method will consume the {@link Iterable} in a blocking fashion! If the results are not already
-     * available in memory this method will block.
-     * @param pojos An {@link Iterable} which provides the objects to serialize.
-     * @param serializer The {@link HttpSerializer} which converts {@code pojo} into bytes.
-     * @param <T> The type of object to serialize.
-     * @return A {@link HttpRequest} with the new serialized payload body.
-     */
-    <T> HttpRequest setPayloadBody(Iterable<T> pojos, HttpSerializer<T> serializer);
-
-    /**
-     * Set the underlying payload to be the results of serialization of {@code pojo}.
-     * <p>
-     * Note this method will consume the {@link CloseableIterable} in a blocking fashion! If the results are not already
-     * available in memory this method will block.
-     * @param pojos An {@link CloseableIterable} which provides the objects to serialize.
-     * @param serializer The {@link HttpSerializer} which converts {@code pojo} into bytes.
-     * @param <T> The type of object to serialize.
-     * @return A {@link HttpRequest} with the new serialized payload body.
-     */
-    <T> HttpRequest setPayloadBody(CloseableIterable<T> pojos, HttpSerializer<T> serializer);
 
     /**
      * Translate this {@link HttpRequest} to a {@link StreamingHttpRequest}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponse.java
@@ -16,7 +16,6 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.Buffer;
-import io.servicetalk.concurrent.CloseableIterable;
 
 /**
  * An HTTP response. The payload is represented as a single {@link Object}.
@@ -59,30 +58,6 @@ public interface HttpResponse extends HttpResponseMetaData {
      * @return {@code this}.
      */
     <T> HttpResponse setPayloadBody(T pojo, HttpSerializer<T> serializer);
-
-    /**
-     * Set the underlying payload to be the results of serialization of {@code pojo}.
-     * <p>
-     * Note this method will consume the {@link Iterable} in a blocking fashion! If the results are not already
-     * available in memory this method will block.
-     * @param pojos An {@link Iterable} which provides the objects to serialize.
-     * @param serializer The {@link HttpSerializer} which converts {@code pojo} into bytes.
-     * @param <T> The type of object to serialize.
-     * @return A {@link HttpResponse} with the new serialized payload body.
-     */
-    <T> HttpResponse setPayloadBody(Iterable<T> pojos, HttpSerializer<T> serializer);
-
-    /**
-     * Set the underlying payload to be the results of serialization of {@code pojo}.
-     * <p>
-     * Note this method will consume the {@link CloseableIterable} in a blocking fashion! If the results are not already
-     * available in memory this method will block.
-     * @param pojos An {@link CloseableIterable} which provides the objects to serialize.
-     * @param serializer The {@link HttpSerializer} which converts {@code pojo} into bytes.
-     * @param <T> The type of object to serialize.
-     * @return A {@link HttpResponse} with the new serialized payload body.
-     */
-    <T> HttpResponse setPayloadBody(CloseableIterable<T> pojos, HttpSerializer<T> serializer);
 
     /**
      * Translate this {@link HttpResponse} to a {@link StreamingHttpResponse}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpSerializer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpSerializer.java
@@ -17,8 +17,6 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.buffer.api.BufferAllocator;
-import io.servicetalk.concurrent.BlockingIterable;
-import io.servicetalk.concurrent.CloseableIterable;
 import io.servicetalk.concurrent.api.Publisher;
 
 /**
@@ -46,28 +44,6 @@ public interface HttpSerializer<T> {
      * @return The result of the serialization operation.
      */
     Iterable<Buffer> serialize(HttpHeaders headers, Iterable<T> value, BufferAllocator allocator);
-
-    /**
-     * Serialize an {@link Iterable} of type {@link T} into an {@link Iterable} of type
-     * {@link Buffer}. If necessary the {@link HttpHeaders} should be updated to indicate the
-     * <a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.5">content-type</a>.
-     * @param headers The {@link HttpHeaders} associated with the serialization operation.
-     * @param value The objects to serialize.
-     * @param allocator The {@link BufferAllocator} used to create the resulting {@link Buffer}s.
-     * @return The result of the serialization operation.
-     */
-    CloseableIterable<Buffer> serialize(HttpHeaders headers, CloseableIterable<T> value, BufferAllocator allocator);
-
-    /**
-     * Serialize an {@link BlockingIterable} of type {@link T} into an {@link BlockingIterable} of type
-     * {@link Buffer}. If necessary the {@link HttpHeaders} should be updated to indicate the
-     * <a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.5">content-type</a>.
-     * @param headers The {@link HttpHeaders} associated with the serialization operation.
-     * @param value The objects to serialize.
-     * @param allocator The {@link BufferAllocator} used to create the resulting {@link Buffer}s.
-     * @return The result of the serialization operation.
-     */
-    BlockingIterable<Buffer> serialize(HttpHeaders headers, BlockingIterable<T> value, BufferAllocator allocator);
 
     /**
      * Serialize a {@link Publisher} of type {@link T} into a {@link Publisher} of type {@link Buffer}. If necessary the


### PR DESCRIPTION
For aggregated request/response we would not support setting a stream for payload as that would be done using the streaming client/server variant.