### PR TITLE
Improving close of Http client and server

### DIFF
--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FutureUtils.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FutureUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.internal;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static io.servicetalk.concurrent.internal.PlatformDependent.throwException;
+
+/**
+ * A set of utilities for interacting with {@link Future}.
+ */
+public final class FutureUtils {
+
+    private FutureUtils() {
+        // No instances.
+    }
+
+    /**
+     * Await the completion of the passed {@link Future}.
+     *
+     * @param future {@link Future} to await termination.
+     */
+    public static void awaitTermination(Future<Void> future) {
+        try {
+            future.get();
+        } catch (InterruptedException e) {
+            throwException(e);
+        } catch (ExecutionException e) {
+            throwException(e.getCause());
+        }
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequester.java
@@ -19,9 +19,7 @@ import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ExecutionContext;
 
-import java.util.concurrent.ExecutionException;
-
-import static io.servicetalk.concurrent.internal.PlatformDependent.throwException;
+import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -102,13 +100,7 @@ public abstract class HttpRequester implements HttpRequestFactory, ListenableAsy
 
     @Override
     public final void close() {
-        try {
-            closeAsyncGracefully().toFuture().get();
-        } catch (InterruptedException e) {
-            throwException(e);
-        } catch (ExecutionException e) {
-            throwException(e.getCause());
-        }
+        awaitTermination(closeAsyncGracefully().toFuture());
     }
 
     StreamingHttpRequester asStreamingRequesterInternal() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequester.java
@@ -19,9 +19,7 @@ import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ExecutionContext;
 
-import java.util.concurrent.ExecutionException;
-
-import static io.servicetalk.concurrent.internal.PlatformDependent.throwException;
+import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -109,13 +107,7 @@ public abstract class StreamingHttpRequester implements
 
     @Override
     public final void close() {
-        try {
-            closeAsyncGracefully().toFuture().get();
-        } catch (InterruptedException e) {
-            throwException(e);
-        } catch (ExecutionException e) {
-            throwException(e.getCause());
-        }
+        awaitTermination(closeAsyncGracefully().toFuture());
     }
 
     HttpRequester asRequesterInternal() {

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -349,7 +349,8 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends ListenableA
         @Override
         public Completable closeAsync() {
             return connections == null ? completed() :
-                    completed().mergeDelayError(connections.stream().map(AsyncCloseable::closeAsync)::iterator);
+                    completed().mergeDelayError(connections.stream()
+                            .map(AsyncCloseable::closeAsync)::iterator);
         }
 
         @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServerContext.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServerContext.java
@@ -18,9 +18,8 @@ package io.servicetalk.transport.api;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 
 import java.net.SocketAddress;
-import java.util.concurrent.ExecutionException;
 
-import static io.servicetalk.concurrent.internal.PlatformDependent.throwException;
+import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 
 /**
  * Context for servers.
@@ -40,23 +39,11 @@ public interface ServerContext extends ListenableAsyncCloseable, AutoCloseable {
      * This method will return when {@link #onClose()} terminates either successfully or unsuccessfully.
      */
     default void awaitShutdown() {
-        try {
-            onClose().toFuture().get();
-        } catch (InterruptedException e) {
-            throwException(e);
-        } catch (ExecutionException e) {
-            throwException(e.getCause()); // unwrap ExecutionException
-        }
+        awaitTermination(onClose().toFuture());
     }
 
     @Override
     default void close() {
-        try {
-            closeAsyncGracefully().toFuture().get();
-        } catch (InterruptedException e) {
-            throwException(e);
-        } catch (ExecutionException e) {
-            throwException(e.getCause());
-        }
+        awaitTermination(closeAsyncGracefully().toFuture());
     }
 }


### PR DESCRIPTION
__Motivation__

`AsyncCloseable#closeAsync()` is good for composing closes or when asynchronous execution is required.
For regular lifecycle methods a simple blocking close is sufficient and convenient sometime.

__Modification__

- `HttpRequester` and `ServerContext` now also implements `AutoCloseable` which simply blocks on `closeAsyncGracefully()`.
- Also added `awaitShutdown()` on `ServerContext` as a short-cut to `onClose().toFuture().get()`

__Result__

Simplify closing and awaiting server shutdown.