### PR TITLE
Fix Jersery premature cancel

### DIFF
--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/resources/ExecutionStrategyResources.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/resources/ExecutionStrategyResources.java
@@ -312,7 +312,7 @@ public final class ExecutionStrategyResources {
 
             return content
                     .doOnNext(__ -> requireFromSameExecutorAs(resourceMethodThread))
-                    .ignoreElements().andThen(bufferSingle.flatMapPublisher(Publisher::just))
+                    .ignoreElements().andThen(bufferSingle.toPublisher())
                     .doOnRequest(__ -> requireFromSameExecutorAs(resourceMethodThread));
         }
 


### PR DESCRIPTION
Motivation:
The first() operator will take the first element and then cancel. In the event the stream has more items this will cause the Splice operator to reset and become un-synchronized which leads to processing trailers as meta data and closes the connection.

Modifications:
- Instead of first() use ignoreElements() to wait until all elements are drained from the stream

Result:
Jersey tests now pass.