### PR TITLE
Examples update

### DIFF
--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/async/HelloWorldClient.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/async/HelloWorldClient.java
@@ -18,11 +18,25 @@ package io.servicetalk.examples.http.helloworld.async;
 import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.netty.HttpClients;
 
+import java.util.concurrent.CountDownLatch;
+
+import static io.servicetalk.http.api.HttpSerializationProviders.deserializeText;
+
 public final class HelloWorldClient {
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         try (HttpClient client = HttpClients.forSingleAddress("localhost", 8080).build()) {
-            client.request(client.get("http://localhost:8080/sayHello"))
-                    .subscribe(System.out::println);
+            // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
+            // before the response has been processed. This isn't typical usage for a streaming API but is useful for
+            // demonstration purposes.
+            CountDownLatch responseProcessedLatch = new CountDownLatch(1);
+            client.request(client.get("sayHello"))
+                    .doFinally(responseProcessedLatch::countDown)
+                    .subscribe(resp -> {
+                        System.out.println(resp.toString((name, value) -> value));
+                        System.out.println(resp.getPayloadBody(deserializeText()));
+                    });
+
+            responseProcessedLatch.await();
         }
     }
 }

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/async/HelloWorldUrlClient.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/async/HelloWorldUrlClient.java
@@ -18,11 +18,25 @@ package io.servicetalk.examples.http.helloworld.async;
 import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.netty.HttpClients;
 
+import java.util.concurrent.CountDownLatch;
+
+import static io.servicetalk.http.api.HttpSerializationProviders.deserializeText;
+
 public final class HelloWorldUrlClient {
-    public static void main(String[] args) {
-        try (HttpClient client = HttpClients.forMultiAddressUrl().build()) {
+    public static void main(String[] args) throws Exception {
+        try (HttpClient client = HttpClients.forSingleAddress("localhost", 8080).build()) {
+            // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
+            // before the response has been processed. This isn't typical usage for a streaming API but is useful for
+            // demonstration purposes.
+            CountDownLatch responseProcessedLatch = new CountDownLatch(1);
             client.request(client.get("http://localhost:8080/sayHello"))
-                    .subscribe(System.out::println);
+                    .doFinally(responseProcessedLatch::countDown)
+                    .subscribe(resp -> {
+                        System.out.println(resp.toString((name, value) -> value));
+                        System.out.println(resp.getPayloadBody(deserializeText()));
+                    });
+
+            responseProcessedLatch.await();
         }
     }
 }

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/async/streaming/HelloWorldStreamingClient.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/async/streaming/HelloWorldStreamingClient.java
@@ -16,17 +16,28 @@
 package io.servicetalk.examples.http.helloworld.async.streaming;
 
 import io.servicetalk.http.api.StreamingHttpClient;
-import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.netty.HttpClients;
+
+import java.util.concurrent.CountDownLatch;
+
+import static io.servicetalk.http.api.HttpSerializationProviders.deserializeText;
 
 public final class HelloWorldStreamingClient {
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         try (StreamingHttpClient client = HttpClients.forSingleAddress("localhost", 8080).buildStreaming()) {
+            // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
+            // before the response has been processed. This isn't typical usage for a streaming API but is useful for
+            // demonstration purposes.
+            CountDownLatch responseProcessedLatch = new CountDownLatch(1);
+
             client.request(client.get("/sayHello"))
-                    .doBeforeSuccess(System.out::println)
-                    .flatMapPublisher(StreamingHttpResponse::getPayloadBody)
+                    .doBeforeSuccess(response -> System.out.println(response.toString((name, value) -> value)))
+                    .flatMapPublisher(resp -> resp.getPayloadBody(deserializeText()))
+                    .doFinally(responseProcessedLatch::countDown)
                     .forEach(System.out::println);
+
+            responseProcessedLatch.await();
         }
     }
 }

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/async/streaming/HelloWorldStreamingServer.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/async/streaming/HelloWorldStreamingServer.java
@@ -26,7 +26,7 @@ public final class HelloWorldStreamingServer {
         new DefaultHttpServerStarter()
                 .startStreaming(8080, (ctx, request, responseFactory) ->
                         success(responseFactory.ok()
-                                .setPayloadBody(from("Hello\n", " World\n", " From\n", " ServiceTalk\n"),
+                                .setPayloadBody(from("Hello\n", "World\n", "From\n", "ServiceTalk\n"),
                                         serializeText())))
                 .toFuture().get()
                 .awaitShutdown();

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/blocking/BlockingHelloWorldClient.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/blocking/BlockingHelloWorldClient.java
@@ -19,11 +19,14 @@ import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.HttpResponse;
 import io.servicetalk.http.netty.HttpClients;
 
+import static io.servicetalk.http.api.HttpSerializationProviders.deserializeText;
+
 public final class BlockingHelloWorldClient {
     public static void main(String[] args) throws Exception {
         try (BlockingHttpClient client = HttpClients.forSingleAddress("localhost", 8080).buildBlocking()) {
             HttpResponse response = client.request(client.get("/sayHello"));
-            System.out.println(response);
+            System.out.println(response.toString((name, value) -> value));
+            System.out.println(response.getPayloadBody(deserializeText()));
         }
     }
 }

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/blocking/BlockingHelloWorldUrlClient.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/blocking/BlockingHelloWorldUrlClient.java
@@ -19,11 +19,14 @@ import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.HttpResponse;
 import io.servicetalk.http.netty.HttpClients;
 
+import static io.servicetalk.http.api.HttpSerializationProviders.deserializeText;
+
 public final class BlockingHelloWorldUrlClient {
     public static void main(String[] args) throws Exception {
         try (BlockingHttpClient client = HttpClients.forMultiAddressUrl().buildBlocking()) {
             HttpResponse response = client.request(client.get("http://localhost:8080/sayHello"));
-            System.out.println(response);
+            System.out.println(response.toString((name, value) -> value));
+            System.out.println(response.getPayloadBody(deserializeText()));
         }
     }
 }

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/blocking/streaming/BlockingHelloWorldStreamingClient.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/blocking/streaming/BlockingHelloWorldStreamingClient.java
@@ -15,11 +15,12 @@
  */
 package io.servicetalk.examples.http.helloworld.blocking.streaming;
 
-import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.BlockingIterator;
 import io.servicetalk.http.api.BlockingStreamingHttpClient;
 import io.servicetalk.http.api.BlockingStreamingHttpResponse;
 import io.servicetalk.http.netty.HttpClients;
+
+import static io.servicetalk.http.api.HttpSerializationProviders.deserializeText;
 
 public final class BlockingHelloWorldStreamingClient {
 
@@ -27,8 +28,8 @@ public final class BlockingHelloWorldStreamingClient {
         try (BlockingStreamingHttpClient client = HttpClients.forSingleAddress("localhost", 8080)
                 .buildBlockingStreaming()) {
             BlockingStreamingHttpResponse response = client.request(client.get("/sayHello"));
-            System.out.println(response);
-            try (BlockingIterator<Buffer> payload = response.getPayloadBody().iterator()) {
+            System.out.println(response.toString((name, value) -> value));
+            try (BlockingIterator<String> payload = response.getPayloadBody(deserializeText()).iterator()) {
                 while (payload.hasNext()) {
                     System.out.println(payload.next());
                 }

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/blocking/streaming/BlockingHelloWorldStreamingServer.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/blocking/streaming/BlockingHelloWorldStreamingServer.java
@@ -25,7 +25,7 @@ public final class BlockingHelloWorldStreamingServer {
         new DefaultHttpServerStarter()
                 .startBlockingStreaming(8080, (ctx, request, responseFactory) ->
                         responseFactory.ok()
-                                .setPayloadBody(asList("Hello\n", " World\n", " From\n", " ServiceTalk\n"),
+                                .setPayloadBody(asList("Hello\n", "World\n", "From\n", "ServiceTalk\n"),
                                         serializeText()))
                 .awaitShutdown();
     }

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/blocking/streaming/BlockingHelloWorldStreamingUrlClient.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/blocking/streaming/BlockingHelloWorldStreamingUrlClient.java
@@ -15,19 +15,20 @@
  */
 package io.servicetalk.examples.http.helloworld.blocking.streaming;
 
-import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.BlockingIterator;
 import io.servicetalk.http.api.BlockingStreamingHttpClient;
 import io.servicetalk.http.api.BlockingStreamingHttpResponse;
 import io.servicetalk.http.netty.HttpClients;
+
+import static io.servicetalk.http.api.HttpSerializationProviders.deserializeText;
 
 public final class BlockingHelloWorldStreamingUrlClient {
 
     public static void main(String[] args) throws Exception {
         try (BlockingStreamingHttpClient client = HttpClients.forMultiAddressUrl().buildBlockingStreaming()) {
             BlockingStreamingHttpResponse response = client.request(client.get("http://localhost:8080/sayHello"));
-            System.out.println(response);
-            try (BlockingIterator<Buffer> payload = response.getPayloadBody().iterator()) {
+            System.out.println(response.toString((name, value) -> value));
+            try (BlockingIterator<String> payload = response.getPayloadBody(deserializeText()).iterator()) {
                 while (payload.hasNext()) {
                     System.out.println(payload.next());
                 }

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/serialization/async/PojoClient.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/serialization/async/PojoClient.java
@@ -22,19 +22,28 @@ import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.api.HttpSerializationProvider;
 import io.servicetalk.http.netty.HttpClients;
 
+import java.util.concurrent.CountDownLatch;
+
 import static io.servicetalk.http.api.HttpSerializationProviders.serializeJson;
 
 public final class PojoClient {
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         HttpSerializationProvider serializer = serializeJson(new JacksonSerializationProvider());
         try (HttpClient client = HttpClients.forSingleAddress("localhost", 8080).build()) {
+            // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
+            // before the response has been processed. This isn't typical usage for a streaming API but is useful for
+            // demonstration purposes.
+            CountDownLatch responseProcessedLatch = new CountDownLatch(1);
+
             client.request(client.get("pojo")
                     .setPayloadBody(new PojoRequest("1"), serializer.serializerFor(PojoRequest.class)))
+                    .doFinally(responseProcessedLatch::countDown)
                     .subscribe(resp -> {
-                        // TODO: We probably need a toString() overload in aggregated req/resp to print payload too.
                         System.out.println(resp.toString((name, value) -> value));
                         System.out.println(resp.getPayloadBody(serializer.deserializerFor(MyPojo.class)));
                     });
+
+            responseProcessedLatch.await();
         }
     }
 }

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/serialization/async/streaming/PojoStreamingClient.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/serialization/async/streaming/PojoStreamingClient.java
@@ -22,20 +22,30 @@ import io.servicetalk.http.api.HttpSerializationProvider;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.netty.HttpClients;
 
+import java.util.concurrent.CountDownLatch;
+
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.http.api.HttpSerializationProviders.serializeJson;
 
 public class PojoStreamingClient {
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         HttpSerializationProvider serializer = serializeJson(new JacksonSerializationProvider());
         try (StreamingHttpClient client = HttpClients.forSingleAddress("localhost", 8080).buildStreaming()) {
+            // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
+            // before the response has been processed. This isn't typical usage for a streaming API but is useful for
+            // demonstration purposes.
+            CountDownLatch responseProcessedLatch = new CountDownLatch(1);
+
             client.request(client.get("pojo")
                     .setPayloadBody(from("1", "2", "3").map(PojoRequest::new),
                             serializer.serializerFor(PojoRequest.class)))
-                    .doBeforeSuccess(System.out::println)
+                    .doBeforeSuccess(response -> System.out.println(response.toString((name, value) -> value)))
                     .flatMapPublisher(resp -> resp.getPayloadBody(serializer.deserializerFor(MyPojo.class)))
+                    .doFinally(responseProcessedLatch::countDown)
                     .forEach(System.out::println);
+
+            responseProcessedLatch.await();
         }
     }
 }

--- a/servicetalk-examples/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/src/main/resources/log4j2.xml
@@ -28,6 +28,8 @@
     -->
     <Logger name="servicetalk-tests-client-wire-logger" level="TRACE"/>
     <Logger name="servicetalk-tests-server-wire-logger" level="TRACE"/>
+    <Logger name="io.servicetalk.http.netty.NettyHttpServer" level="DEBUG"/> <!-- Prints server start and shutdown -->
+    <Logger name="io.servicetalk.concurrent.api" level="DEBUG"/> <!-- Prints default subscriber errors-->
     <!-- Use `-Dservicetalk.logger.level=DEBUG` to change the root logger level via command line  -->
     <Root level="${sys:servicetalk.logger.level:-INFO}">
       <AppenderRef ref="Console"/>

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpRequest.java
@@ -136,11 +136,10 @@ class DefaultStreamingHttpRequest<P> extends DefaultHttpRequestMetaData implemen
     @Override
     public final <T> StreamingHttpRequest setPayloadBody(final Publisher<T> payloadBody,
                                                          final HttpSerializer<T> serializer) {
-        final SingleProcessor<HttpHeaders> outTrailersSingle = new SingleProcessor<>();
         return new BufferStreamingHttpRequest(this, allocator, serializer.serialize(getHeaders(),
                     payloadBody.liftSynchronous(new SerializeBridgeFlowControlAndDiscardOperator<>(getPayloadBody())),
                     allocator),
-                outTrailersSingle);
+                trailersSingle);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpResponse.java
@@ -109,11 +109,10 @@ class DefaultStreamingHttpResponse<P> extends DefaultHttpResponseMetaData implem
     @Override
     public final <T> StreamingHttpResponse setPayloadBody(final Publisher<T> payloadBody,
                                                           final HttpSerializer<T> serializer) {
-        final SingleProcessor<HttpHeaders> outTrailersSingle = new SingleProcessor<>();
         return new BufferStreamingHttpResponse(this, allocator, serializer.serialize(getHeaders(),
                     payloadBody.liftSynchronous(new SerializeBridgeFlowControlAndDiscardOperator<>(getPayloadBody())),
                     allocator),
-                outTrailersSingle);
+                trailersSingle);
     }
 
     @Override


### PR DESCRIPTION
__Motivation__

Examples do not run currently.

__Modification__

Following changes are done:

- Client graceful closure has some rough edges, so we can not use try-with-resources for async clients yet. Reverted to use a latch as before.
- Fix issues related to `setPayloadBody()` for async streaming request/response.
- Use `getPayloadBody(HttpDeserializer)` for printing the content.
- Use `HttpMetaData#toString(BiFunction)` to correctly print metadata.

__Result__

Examples are working (but for service composition).