### PR TITLE
Add missing methods on request/response factories

### DIFF
--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/BlockingGatewayService.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/BlockingGatewayService.java
@@ -35,8 +35,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.servicetalk.http.api.HttpResponseStatuses.BAD_REQUEST;
-
 /**
  * This service provides an API that fetches recommendations serially using blocking APIs. Returned response is a single
  * JSON array containing all {@link FullRecommendation}s.
@@ -75,7 +73,7 @@ final class BlockingGatewayService extends BlockingHttpService {
                                final HttpResponseFactory responseFactory) throws Exception {
         final String userId = request.parseQuery().get(USER_ID_QP_NAME);
         if (userId == null) {
-            return responseFactory.newResponse(BAD_REQUEST);
+            return responseFactory.badRequest();
         }
 
         List<Recommendation> recommendations =

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/GatewayService.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/GatewayService.java
@@ -36,7 +36,6 @@ import java.util.List;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.success;
 import static io.servicetalk.examples.http.service.composition.AsyncUtil.zip;
-import static io.servicetalk.http.api.HttpResponseStatuses.BAD_REQUEST;
 
 /**
  * This service provides an API that fetches recommendations in parallel but provides an aggregated JSON array as a
@@ -71,7 +70,7 @@ final class GatewayService extends HttpService {
                                        final HttpResponseFactory factory) {
         final String userId = request.parseQuery().get(USER_ID_QP_NAME);
         if (userId == null) {
-            return success(factory.newResponse(BAD_REQUEST));
+            return success(factory.badRequest());
         }
 
         return recommendationsClient.request(recommendationsClient.get("/recommendations/aggregated?userId=" + userId))

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/StreamingGatewayService.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/StreamingGatewayService.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 
 import static io.servicetalk.concurrent.api.Single.success;
 import static io.servicetalk.examples.http.service.composition.AsyncUtil.zip;
-import static io.servicetalk.http.api.HttpResponseStatuses.BAD_REQUEST;
 
 /**
  * This service provides an API that fetches recommendations in parallel and responds with a stream of
@@ -69,7 +68,7 @@ final class StreamingGatewayService extends StreamingHttpService {
                                                 final StreamingHttpResponseFactory factory) {
         final String userId = request.parseQuery().get(USER_ID_QP_NAME);
         if (userId == null) {
-            return success(factory.newResponse(BAD_REQUEST));
+            return success(factory.badRequest());
         }
 
         return recommendationsClient.request(recommendationsClient.get("/recommendations/stream?userId=" + userId))

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/backends/MetadataBackend.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/backends/MetadataBackend.java
@@ -28,7 +28,6 @@ import io.servicetalk.http.router.predicate.HttpPredicateRouterBuilder;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static io.servicetalk.concurrent.api.Single.success;
-import static io.servicetalk.http.api.HttpResponseStatuses.BAD_REQUEST;
 import static java.util.concurrent.ThreadLocalRandom.current;
 
 /**
@@ -48,7 +47,7 @@ final class MetadataBackend extends HttpService {
                                                  HttpResponseFactory responseFactory) {
         final String entityId = request.parseQuery().get(ENTITY_ID_QP_NAME);
         if (entityId == null) {
-            return success(responseFactory.newResponse(BAD_REQUEST));
+            return success(responseFactory.badRequest());
         }
 
         // Create random names and author for the metadata

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/backends/RatingBackend.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/backends/RatingBackend.java
@@ -28,7 +28,6 @@ import io.servicetalk.http.router.predicate.HttpPredicateRouterBuilder;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static io.servicetalk.concurrent.api.Single.success;
-import static io.servicetalk.http.api.HttpResponseStatuses.BAD_REQUEST;
 
 /**
  * A service that returns {@link Rating}s for an entity.
@@ -47,7 +46,7 @@ final class RatingBackend extends HttpService {
                                                  HttpResponseFactory responseFactory) {
         final String entityId = request.parseQuery().get(ENTITY_ID_QP_NAME);
         if (entityId == null) {
-            return success(responseFactory.newResponse(BAD_REQUEST));
+            return success(responseFactory.badRequest());
         }
 
         // Create a random rating

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/backends/RecommendationBackend.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/backends/RecommendationBackend.java
@@ -38,7 +38,6 @@ import javax.annotation.Nonnull;
 
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.success;
-import static io.servicetalk.http.api.HttpResponseStatuses.BAD_REQUEST;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.valueOf;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -82,7 +81,7 @@ final class RecommendationBackend {
                                                     StreamingHttpResponseFactory factory) {
             final String userId = request.parseQuery().get(USER_ID_QP_NAME);
             if (userId == null) {
-                return success(factory.newResponse(BAD_REQUEST));
+                return success(factory.badRequest());
             }
 
             // Create a new random recommendation every 1 SECOND.
@@ -114,7 +113,7 @@ final class RecommendationBackend {
                                                      HttpRequest request, HttpResponseFactory responseFactory) {
             final String userId = request.parseQuery().get(USER_ID_QP_NAME);
             if (userId == null) {
-                return success(responseFactory.newResponse(BAD_REQUEST));
+                return success(responseFactory.badRequest());
             }
             int expectedEntitiesCount = 10;
             final String expectedEntitiesCountStr = request.parseQuery().get(EXPECTED_ENTITY_COUNT_QP_NAME);

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/backends/UserBackend.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/backends/UserBackend.java
@@ -28,7 +28,6 @@ import io.servicetalk.http.router.predicate.HttpPredicateRouterBuilder;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static io.servicetalk.concurrent.api.Single.success;
-import static io.servicetalk.http.api.HttpResponseStatuses.BAD_REQUEST;
 import static java.util.concurrent.ThreadLocalRandom.current;
 
 /**
@@ -48,7 +47,7 @@ final class UserBackend extends HttpService {
                                                  HttpResponseFactory responseFactory) {
         final String userId = request.parseQuery().get(USER_ID_QP_NAME);
         if (userId == null) {
-            return success(responseFactory.newResponse(BAD_REQUEST));
+            return success(responseFactory.badRequest());
         }
 
         // Create a random rating

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequestFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequestFactory.java
@@ -15,8 +15,14 @@
  */
 package io.servicetalk.http.api;
 
+import static io.servicetalk.http.api.HttpRequestMethods.CONNECT;
+import static io.servicetalk.http.api.HttpRequestMethods.DELETE;
 import static io.servicetalk.http.api.HttpRequestMethods.GET;
+import static io.servicetalk.http.api.HttpRequestMethods.HEAD;
+import static io.servicetalk.http.api.HttpRequestMethods.OPTIONS;
+import static io.servicetalk.http.api.HttpRequestMethods.PATCH;
 import static io.servicetalk.http.api.HttpRequestMethods.POST;
+import static io.servicetalk.http.api.HttpRequestMethods.TRACE;
 
 /**
  * A factory for creating {@link BlockingStreamingHttpRequest}s.
@@ -46,5 +52,59 @@ public interface BlockingStreamingHttpRequestFactory {
      */
     default BlockingStreamingHttpRequest post(String requestTarget) {
         return newRequest(POST, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#OPTIONS} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#OPTIONS} request.
+     */
+    default BlockingStreamingHttpRequest options(String requestTarget) {
+        return newRequest(OPTIONS, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#HEAD} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#HEAD} request.
+     */
+    default BlockingStreamingHttpRequest head(String requestTarget) {
+        return newRequest(HEAD, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#TRACE} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#TRACE} request.
+     */
+    default BlockingStreamingHttpRequest trace(String requestTarget) {
+        return newRequest(TRACE, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#DELETE} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#DELETE} request.
+     */
+    default BlockingStreamingHttpRequest delete(String requestTarget) {
+        return newRequest(DELETE, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#PATCH} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#PATCH} request.
+     */
+    default BlockingStreamingHttpRequest patch(String requestTarget) {
+        return newRequest(PATCH, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#CONNECT} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#CONNECT} request.
+     */
+    default BlockingStreamingHttpRequest connect(String requestTarget) {
+        return newRequest(CONNECT, requestTarget);
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponseFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponseFactory.java
@@ -15,8 +15,62 @@
  */
 package io.servicetalk.http.api;
 
+import static io.servicetalk.http.api.HttpResponseStatuses.ACCEPTED;
+import static io.servicetalk.http.api.HttpResponseStatuses.BAD_GATEWAY;
+import static io.servicetalk.http.api.HttpResponseStatuses.BAD_REQUEST;
+import static io.servicetalk.http.api.HttpResponseStatuses.CONFLICT;
+import static io.servicetalk.http.api.HttpResponseStatuses.CONTINUE;
+import static io.servicetalk.http.api.HttpResponseStatuses.CREATED;
+import static io.servicetalk.http.api.HttpResponseStatuses.EXPECTATION_FAILED;
+import static io.servicetalk.http.api.HttpResponseStatuses.FAILED_DEPENDENCY;
+import static io.servicetalk.http.api.HttpResponseStatuses.FORBIDDEN;
+import static io.servicetalk.http.api.HttpResponseStatuses.FOUND;
+import static io.servicetalk.http.api.HttpResponseStatuses.GATEWAY_TIMEOUT;
+import static io.servicetalk.http.api.HttpResponseStatuses.GONE;
+import static io.servicetalk.http.api.HttpResponseStatuses.HTTP_VERSION_NOT_SUPPORTED;
+import static io.servicetalk.http.api.HttpResponseStatuses.INSUFFICIENT_STORAGE;
 import static io.servicetalk.http.api.HttpResponseStatuses.INTERNAL_SERVER_ERROR;
+import static io.servicetalk.http.api.HttpResponseStatuses.LENGTH_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatuses.LOCKED;
+import static io.servicetalk.http.api.HttpResponseStatuses.METHOD_NOT_ALLOWED;
+import static io.servicetalk.http.api.HttpResponseStatuses.MISDIRECTED_REQUEST;
+import static io.servicetalk.http.api.HttpResponseStatuses.MOVED_PERMANENTLY;
+import static io.servicetalk.http.api.HttpResponseStatuses.MULTIPLE_CHOICES;
+import static io.servicetalk.http.api.HttpResponseStatuses.MULTI_STATUS;
+import static io.servicetalk.http.api.HttpResponseStatuses.NETWORK_AUTHENTICATION_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatuses.NON_AUTHORITATIVE_INFORMATION;
+import static io.servicetalk.http.api.HttpResponseStatuses.NOT_ACCEPTABLE;
+import static io.servicetalk.http.api.HttpResponseStatuses.NOT_EXTENDED;
+import static io.servicetalk.http.api.HttpResponseStatuses.NOT_FOUND;
+import static io.servicetalk.http.api.HttpResponseStatuses.NOT_IMPLEMENTED;
+import static io.servicetalk.http.api.HttpResponseStatuses.NOT_MODIFIED;
+import static io.servicetalk.http.api.HttpResponseStatuses.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatuses.OK;
+import static io.servicetalk.http.api.HttpResponseStatuses.PARTIAL_CONTENT;
+import static io.servicetalk.http.api.HttpResponseStatuses.PAYMENT_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatuses.PERMANENT_REDIRECT;
+import static io.servicetalk.http.api.HttpResponseStatuses.PRECONDITION_FAILED;
+import static io.servicetalk.http.api.HttpResponseStatuses.PRECONDITION_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatuses.PROCESSING;
+import static io.servicetalk.http.api.HttpResponseStatuses.PROXY_AUTHENTICATION_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatuses.REQUESTED_RANGE_NOT_SATISFIABLE;
+import static io.servicetalk.http.api.HttpResponseStatuses.REQUEST_ENTITY_TOO_LARGE;
+import static io.servicetalk.http.api.HttpResponseStatuses.REQUEST_HEADER_FIELDS_TOO_LARGE;
+import static io.servicetalk.http.api.HttpResponseStatuses.REQUEST_TIMEOUT;
+import static io.servicetalk.http.api.HttpResponseStatuses.REQUEST_URI_TOO_LONG;
+import static io.servicetalk.http.api.HttpResponseStatuses.RESET_CONTENT;
+import static io.servicetalk.http.api.HttpResponseStatuses.SEE_OTHER;
+import static io.servicetalk.http.api.HttpResponseStatuses.SERVICE_UNAVAILABLE;
+import static io.servicetalk.http.api.HttpResponseStatuses.SWITCHING_PROTOCOLS;
+import static io.servicetalk.http.api.HttpResponseStatuses.TEMPORARY_REDIRECT;
+import static io.servicetalk.http.api.HttpResponseStatuses.TOO_MANY_REQUESTS;
+import static io.servicetalk.http.api.HttpResponseStatuses.UNAUTHORIZED;
+import static io.servicetalk.http.api.HttpResponseStatuses.UNORDERED_COLLECTION;
+import static io.servicetalk.http.api.HttpResponseStatuses.UNPROCESSABLE_ENTITY;
+import static io.servicetalk.http.api.HttpResponseStatuses.UNSUPPORTED_MEDIA_TYPE;
+import static io.servicetalk.http.api.HttpResponseStatuses.UPGRADE_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatuses.USE_PROXY;
+import static io.servicetalk.http.api.HttpResponseStatuses.VARIANT_ALSO_NEGOTIATES;
 
 /**
  * A factory for creating {@link BlockingStreamingHttpResponse}s.
@@ -30,6 +84,30 @@ public interface BlockingStreamingHttpResponseFactory {
     BlockingStreamingHttpResponse newResponse(HttpResponseStatus status);
 
     /**
+     * Create a new {@link HttpResponseStatuses#CONTINUE} response.
+     * @return a new {@link HttpResponseStatuses#CONTINUE} response.
+     */
+    default BlockingStreamingHttpResponse continueResponse() {
+        return newResponse(CONTINUE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#SWITCHING_PROTOCOLS} response.
+     * @return a new {@link HttpResponseStatuses#SWITCHING_PROTOCOLS} response.
+     */
+    default BlockingStreamingHttpResponse switchingProtocols() {
+        return newResponse(SWITCHING_PROTOCOLS);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PROCESSING} response.
+     * @return a new {@link HttpResponseStatuses#PROCESSING} response.
+     */
+    default BlockingStreamingHttpResponse processing() {
+        return newResponse(PROCESSING);
+    }
+
+    /**
      * Create a new {@link HttpResponseStatuses#OK} response.
      * @return a new {@link HttpResponseStatuses#OK} response.
      */
@@ -38,10 +116,418 @@ public interface BlockingStreamingHttpResponseFactory {
     }
 
     /**
+     * Create a new {@link HttpResponseStatuses#CREATED} response.
+     * @return a new {@link HttpResponseStatuses#CREATED} response.
+     */
+    default BlockingStreamingHttpResponse created() {
+        return newResponse(CREATED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#ACCEPTED} response.
+     * @return a new {@link HttpResponseStatuses#ACCEPTED} response.
+     */
+    default BlockingStreamingHttpResponse accepted() {
+        return newResponse(ACCEPTED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NON_AUTHORITATIVE_INFORMATION} response.
+     * @return a new {@link HttpResponseStatuses#NON_AUTHORITATIVE_INFORMATION} response.
+     */
+    default BlockingStreamingHttpResponse nonAuthoritativeInformation() {
+        return newResponse(NON_AUTHORITATIVE_INFORMATION);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NO_CONTENT} response.
+     * @return a new {@link HttpResponseStatuses#NO_CONTENT} response.
+     */
+    default BlockingStreamingHttpResponse noContent() {
+        return newResponse(NO_CONTENT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#RESET_CONTENT} response.
+     * @return a new {@link HttpResponseStatuses#RESET_CONTENT} response.
+     */
+    default BlockingStreamingHttpResponse resetContent() {
+        return newResponse(RESET_CONTENT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PARTIAL_CONTENT} response.
+     * @return a new {@link HttpResponseStatuses#PARTIAL_CONTENT} response.
+     */
+    default BlockingStreamingHttpResponse partialContent() {
+        return newResponse(PARTIAL_CONTENT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#MULTI_STATUS} response.
+     * @return a new {@link HttpResponseStatuses#MULTI_STATUS} response.
+     */
+    default BlockingStreamingHttpResponse multiStatus() {
+        return newResponse(MULTI_STATUS);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#MULTIPLE_CHOICES} response.
+     * @return a new {@link HttpResponseStatuses#MULTIPLE_CHOICES} response.
+     */
+    default BlockingStreamingHttpResponse multipleChoices() {
+        return newResponse(MULTIPLE_CHOICES);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#MOVED_PERMANENTLY} response.
+     * @return a new {@link HttpResponseStatuses#MOVED_PERMANENTLY} response.
+     */
+    default BlockingStreamingHttpResponse movedPermanently() {
+        return newResponse(MOVED_PERMANENTLY);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#FOUND} response.
+     * @return a new {@link HttpResponseStatuses#FOUND} response.
+     */
+    default BlockingStreamingHttpResponse found() {
+        return newResponse(FOUND);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#SEE_OTHER} response.
+     * @return a new {@link HttpResponseStatuses#SEE_OTHER} response.
+     */
+    default BlockingStreamingHttpResponse seeOther() {
+        return newResponse(SEE_OTHER);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NOT_MODIFIED} response.
+     * @return a new {@link HttpResponseStatuses#NOT_MODIFIED} response.
+     */
+    default BlockingStreamingHttpResponse notModified() {
+        return newResponse(NOT_MODIFIED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#USE_PROXY} response.
+     * @return a new {@link HttpResponseStatuses#USE_PROXY} response.
+     */
+    default BlockingStreamingHttpResponse useProxy() {
+        return newResponse(USE_PROXY);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#TEMPORARY_REDIRECT} response.
+     * @return a new {@link HttpResponseStatuses#TEMPORARY_REDIRECT} response.
+     */
+    default BlockingStreamingHttpResponse temporaryRedirect() {
+        return newResponse(TEMPORARY_REDIRECT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PERMANENT_REDIRECT} response.
+     * @return a new {@link HttpResponseStatuses#PERMANENT_REDIRECT} response.
+     */
+    default BlockingStreamingHttpResponse permanentRedirect() {
+        return newResponse(PERMANENT_REDIRECT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#BAD_REQUEST} response.
+     * @return a new {@link HttpResponseStatuses#BAD_REQUEST} response.
+     */
+    default BlockingStreamingHttpResponse badRequest() {
+        return newResponse(BAD_REQUEST);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#UNAUTHORIZED} response.
+     * @return a new {@link HttpResponseStatuses#UNAUTHORIZED} response.
+     */
+    default BlockingStreamingHttpResponse unauthorized() {
+        return newResponse(UNAUTHORIZED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PAYMENT_REQUIRED} response.
+     * @return a new {@link HttpResponseStatuses#PAYMENT_REQUIRED} response.
+     */
+    default BlockingStreamingHttpResponse paymentRequired() {
+        return newResponse(PAYMENT_REQUIRED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#FORBIDDEN} response.
+     * @return a new {@link HttpResponseStatuses#FORBIDDEN} response.
+     */
+    default BlockingStreamingHttpResponse forbidden() {
+        return newResponse(FORBIDDEN);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NOT_FOUND} response.
+     * @return a new {@link HttpResponseStatuses#NOT_FOUND} response.
+     */
+    default BlockingStreamingHttpResponse notFound() {
+        return newResponse(NOT_FOUND);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#METHOD_NOT_ALLOWED} response.
+     * @return a new {@link HttpResponseStatuses#METHOD_NOT_ALLOWED} response.
+     */
+    default BlockingStreamingHttpResponse methodNotAllowed() {
+        return newResponse(METHOD_NOT_ALLOWED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NOT_ACCEPTABLE} response.
+     * @return a new {@link HttpResponseStatuses#NOT_ACCEPTABLE} response.
+     */
+    default BlockingStreamingHttpResponse notAcceptable() {
+        return newResponse(NOT_ACCEPTABLE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PROXY_AUTHENTICATION_REQUIRED} response.
+     * @return a new {@link HttpResponseStatuses#PROXY_AUTHENTICATION_REQUIRED} response.
+     */
+    default BlockingStreamingHttpResponse proxyAuthenticationRequired() {
+        return newResponse(PROXY_AUTHENTICATION_REQUIRED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#REQUEST_TIMEOUT} response.
+     * @return a new {@link HttpResponseStatuses#REQUEST_TIMEOUT} response.
+     */
+    default BlockingStreamingHttpResponse requestTimeout() {
+        return newResponse(REQUEST_TIMEOUT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#CONFLICT} response.
+     * @return a new {@link HttpResponseStatuses#CONFLICT} response.
+     */
+    default BlockingStreamingHttpResponse conflict() {
+        return newResponse(CONFLICT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#GONE} response.
+     * @return a new {@link HttpResponseStatuses#GONE} response.
+     */
+    default BlockingStreamingHttpResponse gone() {
+        return newResponse(GONE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#LENGTH_REQUIRED} response.
+     * @return a new {@link HttpResponseStatuses#LENGTH_REQUIRED} response.
+     */
+    default BlockingStreamingHttpResponse lengthRequired() {
+        return newResponse(LENGTH_REQUIRED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PRECONDITION_FAILED} response.
+     * @return a new {@link HttpResponseStatuses#PRECONDITION_FAILED} response.
+     */
+    default BlockingStreamingHttpResponse preconditionFailed() {
+        return newResponse(PRECONDITION_FAILED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#REQUEST_ENTITY_TOO_LARGE} response.
+     * @return a new {@link HttpResponseStatuses#REQUEST_ENTITY_TOO_LARGE} response.
+     */
+    default BlockingStreamingHttpResponse requestEntityTooLarge() {
+        return newResponse(REQUEST_ENTITY_TOO_LARGE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#REQUEST_URI_TOO_LONG} response.
+     * @return a new {@link HttpResponseStatuses#REQUEST_URI_TOO_LONG} response.
+     */
+    default BlockingStreamingHttpResponse requestUriTooLong() {
+        return newResponse(REQUEST_URI_TOO_LONG);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#UNSUPPORTED_MEDIA_TYPE} response.
+     * @return a new {@link HttpResponseStatuses#UNSUPPORTED_MEDIA_TYPE} response.
+     */
+    default BlockingStreamingHttpResponse unsupportedMediaType() {
+        return newResponse(UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#REQUESTED_RANGE_NOT_SATISFIABLE} response.
+     * @return a new {@link HttpResponseStatuses#REQUESTED_RANGE_NOT_SATISFIABLE} response.
+     */
+    default BlockingStreamingHttpResponse requestedRangeNotSatisfiable() {
+        return newResponse(REQUESTED_RANGE_NOT_SATISFIABLE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#EXPECTATION_FAILED} response.
+     * @return a new {@link HttpResponseStatuses#EXPECTATION_FAILED} response.
+     */
+    default BlockingStreamingHttpResponse expectationFailed() {
+        return newResponse(EXPECTATION_FAILED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#MISDIRECTED_REQUEST} response.
+     * @return a new {@link HttpResponseStatuses#MISDIRECTED_REQUEST} response.
+     */
+    default BlockingStreamingHttpResponse misdirectedRequest() {
+        return newResponse(MISDIRECTED_REQUEST);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#UNPROCESSABLE_ENTITY} response.
+     * @return a new {@link HttpResponseStatuses#UNPROCESSABLE_ENTITY} response.
+     */
+    default BlockingStreamingHttpResponse unprocessableEntity() {
+        return newResponse(UNPROCESSABLE_ENTITY);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#LOCKED} response.
+     * @return a new {@link HttpResponseStatuses#LOCKED} response.
+     */
+    default BlockingStreamingHttpResponse locked() {
+        return newResponse(LOCKED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#FAILED_DEPENDENCY} response.
+     * @return a new {@link HttpResponseStatuses#FAILED_DEPENDENCY} response.
+     */
+    default BlockingStreamingHttpResponse failedDependency() {
+        return newResponse(FAILED_DEPENDENCY);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#UNORDERED_COLLECTION} response.
+     * @return a new {@link HttpResponseStatuses#UNORDERED_COLLECTION} response.
+     */
+    default BlockingStreamingHttpResponse unorderedCollection() {
+        return newResponse(UNORDERED_COLLECTION);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#UPGRADE_REQUIRED} response.
+     * @return a new {@link HttpResponseStatuses#UPGRADE_REQUIRED} response.
+     */
+    default BlockingStreamingHttpResponse upgradeRequired() {
+        return newResponse(UPGRADE_REQUIRED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PRECONDITION_REQUIRED} response.
+     * @return a new {@link HttpResponseStatuses#PRECONDITION_REQUIRED} response.
+     */
+    default BlockingStreamingHttpResponse preconditionRequired() {
+        return newResponse(PRECONDITION_REQUIRED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#TOO_MANY_REQUESTS} response.
+     * @return a new {@link HttpResponseStatuses#TOO_MANY_REQUESTS} response.
+     */
+    default BlockingStreamingHttpResponse tooManyRequests() {
+        return newResponse(TOO_MANY_REQUESTS);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#REQUEST_HEADER_FIELDS_TOO_LARGE} response.
+     * @return a new {@link HttpResponseStatuses#REQUEST_HEADER_FIELDS_TOO_LARGE} response.
+     */
+    default BlockingStreamingHttpResponse requestHeaderFieldsTooLarge() {
+        return newResponse(REQUEST_HEADER_FIELDS_TOO_LARGE);
+    }
+
+    /**
      * Create a new {@link HttpResponseStatuses#INTERNAL_SERVER_ERROR} response.
      * @return a new {@link HttpResponseStatuses#INTERNAL_SERVER_ERROR} response.
      */
-    default BlockingStreamingHttpResponse serverError() {
+    default BlockingStreamingHttpResponse internalServerError() {
         return newResponse(INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NOT_IMPLEMENTED} response.
+     * @return a new {@link HttpResponseStatuses#NOT_IMPLEMENTED} response.
+     */
+    default BlockingStreamingHttpResponse notImplemented() {
+        return newResponse(NOT_IMPLEMENTED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#BAD_GATEWAY} response.
+     * @return a new {@link HttpResponseStatuses#BAD_GATEWAY} response.
+     */
+    default BlockingStreamingHttpResponse badGateway() {
+        return newResponse(BAD_GATEWAY);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#SERVICE_UNAVAILABLE} response.
+     * @return a new {@link HttpResponseStatuses#SERVICE_UNAVAILABLE} response.
+     */
+    default BlockingStreamingHttpResponse serviceUnavailable() {
+        return newResponse(SERVICE_UNAVAILABLE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#GATEWAY_TIMEOUT} response.
+     * @return a new {@link HttpResponseStatuses#GATEWAY_TIMEOUT} response.
+     */
+    default BlockingStreamingHttpResponse gatewayTimeout() {
+        return newResponse(GATEWAY_TIMEOUT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#HTTP_VERSION_NOT_SUPPORTED} response.
+     * @return a new {@link HttpResponseStatuses#HTTP_VERSION_NOT_SUPPORTED} response.
+     */
+    default BlockingStreamingHttpResponse httpVersionNotSupported() {
+        return newResponse(HTTP_VERSION_NOT_SUPPORTED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#VARIANT_ALSO_NEGOTIATES} response.
+     * @return a new {@link HttpResponseStatuses#VARIANT_ALSO_NEGOTIATES} response.
+     */
+    default BlockingStreamingHttpResponse variantAlsoNegotiates() {
+        return newResponse(VARIANT_ALSO_NEGOTIATES);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#INSUFFICIENT_STORAGE} response.
+     * @return a new {@link HttpResponseStatuses#INSUFFICIENT_STORAGE} response.
+     */
+    default BlockingStreamingHttpResponse insufficientStorage() {
+        return newResponse(INSUFFICIENT_STORAGE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NOT_EXTENDED} response.
+     * @return a new {@link HttpResponseStatuses#NOT_EXTENDED} response.
+     */
+    default BlockingStreamingHttpResponse notExtended() {
+        return newResponse(NOT_EXTENDED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NETWORK_AUTHENTICATION_REQUIRED} response.
+     * @return a new {@link HttpResponseStatuses#NETWORK_AUTHENTICATION_REQUIRED} response.
+     */
+    default BlockingStreamingHttpResponse networkAuthenticationRequired() {
+        return newResponse(NETWORK_AUTHENTICATION_REQUIRED);
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestFactory.java
@@ -15,8 +15,15 @@
  */
 package io.servicetalk.http.api;
 
+import static io.servicetalk.http.api.HttpRequestMethods.CONNECT;
+import static io.servicetalk.http.api.HttpRequestMethods.DELETE;
 import static io.servicetalk.http.api.HttpRequestMethods.GET;
+import static io.servicetalk.http.api.HttpRequestMethods.HEAD;
+import static io.servicetalk.http.api.HttpRequestMethods.OPTIONS;
+import static io.servicetalk.http.api.HttpRequestMethods.PATCH;
 import static io.servicetalk.http.api.HttpRequestMethods.POST;
+import static io.servicetalk.http.api.HttpRequestMethods.PUT;
+import static io.servicetalk.http.api.HttpRequestMethods.TRACE;
 
 /**
  * A factory for creating {@link HttpRequest}s.
@@ -46,5 +53,68 @@ public interface HttpRequestFactory {
      */
     default HttpRequest post(String requestTarget) {
         return newRequest(POST, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#PUT} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#PUT} request.
+     */
+    default HttpRequest put(String requestTarget) {
+        return newRequest(PUT, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#OPTIONS} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#OPTIONS} request.
+     */
+    default HttpRequest options(String requestTarget) {
+        return newRequest(OPTIONS, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#HEAD} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#HEAD} request.
+     */
+    default HttpRequest head(String requestTarget) {
+        return newRequest(HEAD, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#TRACE} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#TRACE} request.
+     */
+    default HttpRequest trace(String requestTarget) {
+        return newRequest(TRACE, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#DELETE} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#DELETE} request.
+     */
+    default HttpRequest delete(String requestTarget) {
+        return newRequest(DELETE, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#PATCH} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#PATCH} request.
+     */
+    default HttpRequest patch(String requestTarget) {
+        return newRequest(PATCH, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#CONNECT} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#CONNECT} request.
+     */
+    default HttpRequest connect(String requestTarget) {
+        return newRequest(CONNECT, requestTarget);
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponseFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponseFactory.java
@@ -15,8 +15,62 @@
  */
 package io.servicetalk.http.api;
 
+import static io.servicetalk.http.api.HttpResponseStatuses.ACCEPTED;
+import static io.servicetalk.http.api.HttpResponseStatuses.BAD_GATEWAY;
+import static io.servicetalk.http.api.HttpResponseStatuses.BAD_REQUEST;
+import static io.servicetalk.http.api.HttpResponseStatuses.CONFLICT;
+import static io.servicetalk.http.api.HttpResponseStatuses.CONTINUE;
+import static io.servicetalk.http.api.HttpResponseStatuses.CREATED;
+import static io.servicetalk.http.api.HttpResponseStatuses.EXPECTATION_FAILED;
+import static io.servicetalk.http.api.HttpResponseStatuses.FAILED_DEPENDENCY;
+import static io.servicetalk.http.api.HttpResponseStatuses.FORBIDDEN;
+import static io.servicetalk.http.api.HttpResponseStatuses.FOUND;
+import static io.servicetalk.http.api.HttpResponseStatuses.GATEWAY_TIMEOUT;
+import static io.servicetalk.http.api.HttpResponseStatuses.GONE;
+import static io.servicetalk.http.api.HttpResponseStatuses.HTTP_VERSION_NOT_SUPPORTED;
+import static io.servicetalk.http.api.HttpResponseStatuses.INSUFFICIENT_STORAGE;
 import static io.servicetalk.http.api.HttpResponseStatuses.INTERNAL_SERVER_ERROR;
+import static io.servicetalk.http.api.HttpResponseStatuses.LENGTH_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatuses.LOCKED;
+import static io.servicetalk.http.api.HttpResponseStatuses.METHOD_NOT_ALLOWED;
+import static io.servicetalk.http.api.HttpResponseStatuses.MISDIRECTED_REQUEST;
+import static io.servicetalk.http.api.HttpResponseStatuses.MOVED_PERMANENTLY;
+import static io.servicetalk.http.api.HttpResponseStatuses.MULTIPLE_CHOICES;
+import static io.servicetalk.http.api.HttpResponseStatuses.MULTI_STATUS;
+import static io.servicetalk.http.api.HttpResponseStatuses.NETWORK_AUTHENTICATION_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatuses.NON_AUTHORITATIVE_INFORMATION;
+import static io.servicetalk.http.api.HttpResponseStatuses.NOT_ACCEPTABLE;
+import static io.servicetalk.http.api.HttpResponseStatuses.NOT_EXTENDED;
+import static io.servicetalk.http.api.HttpResponseStatuses.NOT_FOUND;
+import static io.servicetalk.http.api.HttpResponseStatuses.NOT_IMPLEMENTED;
+import static io.servicetalk.http.api.HttpResponseStatuses.NOT_MODIFIED;
+import static io.servicetalk.http.api.HttpResponseStatuses.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatuses.OK;
+import static io.servicetalk.http.api.HttpResponseStatuses.PARTIAL_CONTENT;
+import static io.servicetalk.http.api.HttpResponseStatuses.PAYMENT_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatuses.PERMANENT_REDIRECT;
+import static io.servicetalk.http.api.HttpResponseStatuses.PRECONDITION_FAILED;
+import static io.servicetalk.http.api.HttpResponseStatuses.PRECONDITION_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatuses.PROCESSING;
+import static io.servicetalk.http.api.HttpResponseStatuses.PROXY_AUTHENTICATION_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatuses.REQUESTED_RANGE_NOT_SATISFIABLE;
+import static io.servicetalk.http.api.HttpResponseStatuses.REQUEST_ENTITY_TOO_LARGE;
+import static io.servicetalk.http.api.HttpResponseStatuses.REQUEST_HEADER_FIELDS_TOO_LARGE;
+import static io.servicetalk.http.api.HttpResponseStatuses.REQUEST_TIMEOUT;
+import static io.servicetalk.http.api.HttpResponseStatuses.REQUEST_URI_TOO_LONG;
+import static io.servicetalk.http.api.HttpResponseStatuses.RESET_CONTENT;
+import static io.servicetalk.http.api.HttpResponseStatuses.SEE_OTHER;
+import static io.servicetalk.http.api.HttpResponseStatuses.SERVICE_UNAVAILABLE;
+import static io.servicetalk.http.api.HttpResponseStatuses.SWITCHING_PROTOCOLS;
+import static io.servicetalk.http.api.HttpResponseStatuses.TEMPORARY_REDIRECT;
+import static io.servicetalk.http.api.HttpResponseStatuses.TOO_MANY_REQUESTS;
+import static io.servicetalk.http.api.HttpResponseStatuses.UNAUTHORIZED;
+import static io.servicetalk.http.api.HttpResponseStatuses.UNORDERED_COLLECTION;
+import static io.servicetalk.http.api.HttpResponseStatuses.UNPROCESSABLE_ENTITY;
+import static io.servicetalk.http.api.HttpResponseStatuses.UNSUPPORTED_MEDIA_TYPE;
+import static io.servicetalk.http.api.HttpResponseStatuses.UPGRADE_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatuses.USE_PROXY;
+import static io.servicetalk.http.api.HttpResponseStatuses.VARIANT_ALSO_NEGOTIATES;
 
 /**
  * A factory for creating {@link HttpResponse}s.
@@ -30,6 +84,30 @@ public interface HttpResponseFactory {
     HttpResponse newResponse(HttpResponseStatus status);
 
     /**
+     * Create a new {@link HttpResponseStatuses#CONTINUE} response.
+     * @return a new {@link HttpResponseStatuses#CONTINUE} response.
+     */
+    default HttpResponse continueResponse() {
+        return newResponse(CONTINUE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#SWITCHING_PROTOCOLS} response.
+     * @return a new {@link HttpResponseStatuses#SWITCHING_PROTOCOLS} response.
+     */
+    default HttpResponse switchingProtocols() {
+        return newResponse(SWITCHING_PROTOCOLS);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PROCESSING} response.
+     * @return a new {@link HttpResponseStatuses#PROCESSING} response.
+     */
+    default HttpResponse processing() {
+        return newResponse(PROCESSING);
+    }
+
+    /**
      * Create a new {@link HttpResponseStatuses#OK} response.
      * @return a new {@link HttpResponseStatuses#OK} response.
      */
@@ -38,10 +116,418 @@ public interface HttpResponseFactory {
     }
 
     /**
+     * Create a new {@link HttpResponseStatuses#CREATED} response.
+     * @return a new {@link HttpResponseStatuses#CREATED} response.
+     */
+    default HttpResponse created() {
+        return newResponse(CREATED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#ACCEPTED} response.
+     * @return a new {@link HttpResponseStatuses#ACCEPTED} response.
+     */
+    default HttpResponse accepted() {
+        return newResponse(ACCEPTED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NON_AUTHORITATIVE_INFORMATION} response.
+     * @return a new {@link HttpResponseStatuses#NON_AUTHORITATIVE_INFORMATION} response.
+     */
+    default HttpResponse nonAuthoritativeInformation() {
+        return newResponse(NON_AUTHORITATIVE_INFORMATION);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NO_CONTENT} response.
+     * @return a new {@link HttpResponseStatuses#NO_CONTENT} response.
+     */
+    default HttpResponse noContent() {
+        return newResponse(NO_CONTENT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#RESET_CONTENT} response.
+     * @return a new {@link HttpResponseStatuses#RESET_CONTENT} response.
+     */
+    default HttpResponse resetContent() {
+        return newResponse(RESET_CONTENT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PARTIAL_CONTENT} response.
+     * @return a new {@link HttpResponseStatuses#PARTIAL_CONTENT} response.
+     */
+    default HttpResponse partialContent() {
+        return newResponse(PARTIAL_CONTENT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#MULTI_STATUS} response.
+     * @return a new {@link HttpResponseStatuses#MULTI_STATUS} response.
+     */
+    default HttpResponse multiStatus() {
+        return newResponse(MULTI_STATUS);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#MULTIPLE_CHOICES} response.
+     * @return a new {@link HttpResponseStatuses#MULTIPLE_CHOICES} response.
+     */
+    default HttpResponse multipleChoices() {
+        return newResponse(MULTIPLE_CHOICES);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#MOVED_PERMANENTLY} response.
+     * @return a new {@link HttpResponseStatuses#MOVED_PERMANENTLY} response.
+     */
+    default HttpResponse movedPermanently() {
+        return newResponse(MOVED_PERMANENTLY);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#FOUND} response.
+     * @return a new {@link HttpResponseStatuses#FOUND} response.
+     */
+    default HttpResponse found() {
+        return newResponse(FOUND);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#SEE_OTHER} response.
+     * @return a new {@link HttpResponseStatuses#SEE_OTHER} response.
+     */
+    default HttpResponse seeOther() {
+        return newResponse(SEE_OTHER);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NOT_MODIFIED} response.
+     * @return a new {@link HttpResponseStatuses#NOT_MODIFIED} response.
+     */
+    default HttpResponse notModified() {
+        return newResponse(NOT_MODIFIED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#USE_PROXY} response.
+     * @return a new {@link HttpResponseStatuses#USE_PROXY} response.
+     */
+    default HttpResponse useProxy() {
+        return newResponse(USE_PROXY);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#TEMPORARY_REDIRECT} response.
+     * @return a new {@link HttpResponseStatuses#TEMPORARY_REDIRECT} response.
+     */
+    default HttpResponse temporaryRedirect() {
+        return newResponse(TEMPORARY_REDIRECT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PERMANENT_REDIRECT} response.
+     * @return a new {@link HttpResponseStatuses#PERMANENT_REDIRECT} response.
+     */
+    default HttpResponse permanentRedirect() {
+        return newResponse(PERMANENT_REDIRECT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#BAD_REQUEST} response.
+     * @return a new {@link HttpResponseStatuses#BAD_REQUEST} response.
+     */
+    default HttpResponse badRequest() {
+        return newResponse(BAD_REQUEST);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#UNAUTHORIZED} response.
+     * @return a new {@link HttpResponseStatuses#UNAUTHORIZED} response.
+     */
+    default HttpResponse unauthorized() {
+        return newResponse(UNAUTHORIZED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PAYMENT_REQUIRED} response.
+     * @return a new {@link HttpResponseStatuses#PAYMENT_REQUIRED} response.
+     */
+    default HttpResponse paymentRequired() {
+        return newResponse(PAYMENT_REQUIRED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#FORBIDDEN} response.
+     * @return a new {@link HttpResponseStatuses#FORBIDDEN} response.
+     */
+    default HttpResponse forbidden() {
+        return newResponse(FORBIDDEN);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NOT_FOUND} response.
+     * @return a new {@link HttpResponseStatuses#NOT_FOUND} response.
+     */
+    default HttpResponse notFound() {
+        return newResponse(NOT_FOUND);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#METHOD_NOT_ALLOWED} response.
+     * @return a new {@link HttpResponseStatuses#METHOD_NOT_ALLOWED} response.
+     */
+    default HttpResponse methodNotAllowed() {
+        return newResponse(METHOD_NOT_ALLOWED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NOT_ACCEPTABLE} response.
+     * @return a new {@link HttpResponseStatuses#NOT_ACCEPTABLE} response.
+     */
+    default HttpResponse notAcceptable() {
+        return newResponse(NOT_ACCEPTABLE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PROXY_AUTHENTICATION_REQUIRED} response.
+     * @return a new {@link HttpResponseStatuses#PROXY_AUTHENTICATION_REQUIRED} response.
+     */
+    default HttpResponse proxyAuthenticationRequired() {
+        return newResponse(PROXY_AUTHENTICATION_REQUIRED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#REQUEST_TIMEOUT} response.
+     * @return a new {@link HttpResponseStatuses#REQUEST_TIMEOUT} response.
+     */
+    default HttpResponse requestTimeout() {
+        return newResponse(REQUEST_TIMEOUT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#CONFLICT} response.
+     * @return a new {@link HttpResponseStatuses#CONFLICT} response.
+     */
+    default HttpResponse conflict() {
+        return newResponse(CONFLICT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#GONE} response.
+     * @return a new {@link HttpResponseStatuses#GONE} response.
+     */
+    default HttpResponse gone() {
+        return newResponse(GONE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#LENGTH_REQUIRED} response.
+     * @return a new {@link HttpResponseStatuses#LENGTH_REQUIRED} response.
+     */
+    default HttpResponse lengthRequired() {
+        return newResponse(LENGTH_REQUIRED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PRECONDITION_FAILED} response.
+     * @return a new {@link HttpResponseStatuses#PRECONDITION_FAILED} response.
+     */
+    default HttpResponse preconditionFailed() {
+        return newResponse(PRECONDITION_FAILED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#REQUEST_ENTITY_TOO_LARGE} response.
+     * @return a new {@link HttpResponseStatuses#REQUEST_ENTITY_TOO_LARGE} response.
+     */
+    default HttpResponse requestEntityTooLarge() {
+        return newResponse(REQUEST_ENTITY_TOO_LARGE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#REQUEST_URI_TOO_LONG} response.
+     * @return a new {@link HttpResponseStatuses#REQUEST_URI_TOO_LONG} response.
+     */
+    default HttpResponse requestUriTooLong() {
+        return newResponse(REQUEST_URI_TOO_LONG);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#UNSUPPORTED_MEDIA_TYPE} response.
+     * @return a new {@link HttpResponseStatuses#UNSUPPORTED_MEDIA_TYPE} response.
+     */
+    default HttpResponse unsupportedMediaType() {
+        return newResponse(UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#REQUESTED_RANGE_NOT_SATISFIABLE} response.
+     * @return a new {@link HttpResponseStatuses#REQUESTED_RANGE_NOT_SATISFIABLE} response.
+     */
+    default HttpResponse requestedRangeNotSatisfiable() {
+        return newResponse(REQUESTED_RANGE_NOT_SATISFIABLE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#EXPECTATION_FAILED} response.
+     * @return a new {@link HttpResponseStatuses#EXPECTATION_FAILED} response.
+     */
+    default HttpResponse expectationFailed() {
+        return newResponse(EXPECTATION_FAILED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#MISDIRECTED_REQUEST} response.
+     * @return a new {@link HttpResponseStatuses#MISDIRECTED_REQUEST} response.
+     */
+    default HttpResponse misdirectedRequest() {
+        return newResponse(MISDIRECTED_REQUEST);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#UNPROCESSABLE_ENTITY} response.
+     * @return a new {@link HttpResponseStatuses#UNPROCESSABLE_ENTITY} response.
+     */
+    default HttpResponse unprocessableEntity() {
+        return newResponse(UNPROCESSABLE_ENTITY);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#LOCKED} response.
+     * @return a new {@link HttpResponseStatuses#LOCKED} response.
+     */
+    default HttpResponse locked() {
+        return newResponse(LOCKED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#FAILED_DEPENDENCY} response.
+     * @return a new {@link HttpResponseStatuses#FAILED_DEPENDENCY} response.
+     */
+    default HttpResponse failedDependency() {
+        return newResponse(FAILED_DEPENDENCY);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#UNORDERED_COLLECTION} response.
+     * @return a new {@link HttpResponseStatuses#UNORDERED_COLLECTION} response.
+     */
+    default HttpResponse unorderedCollection() {
+        return newResponse(UNORDERED_COLLECTION);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#UPGRADE_REQUIRED} response.
+     * @return a new {@link HttpResponseStatuses#UPGRADE_REQUIRED} response.
+     */
+    default HttpResponse upgradeRequired() {
+        return newResponse(UPGRADE_REQUIRED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PRECONDITION_REQUIRED} response.
+     * @return a new {@link HttpResponseStatuses#PRECONDITION_REQUIRED} response.
+     */
+    default HttpResponse preconditionRequired() {
+        return newResponse(PRECONDITION_REQUIRED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#TOO_MANY_REQUESTS} response.
+     * @return a new {@link HttpResponseStatuses#TOO_MANY_REQUESTS} response.
+     */
+    default HttpResponse tooManyRequests() {
+        return newResponse(TOO_MANY_REQUESTS);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#REQUEST_HEADER_FIELDS_TOO_LARGE} response.
+     * @return a new {@link HttpResponseStatuses#REQUEST_HEADER_FIELDS_TOO_LARGE} response.
+     */
+    default HttpResponse requestHeaderFieldsTooLarge() {
+        return newResponse(REQUEST_HEADER_FIELDS_TOO_LARGE);
+    }
+
+    /**
      * Create a new {@link HttpResponseStatuses#INTERNAL_SERVER_ERROR} response.
      * @return a new {@link HttpResponseStatuses#INTERNAL_SERVER_ERROR} response.
      */
-    default HttpResponse serverError() {
+    default HttpResponse internalServerError() {
         return newResponse(INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NOT_IMPLEMENTED} response.
+     * @return a new {@link HttpResponseStatuses#NOT_IMPLEMENTED} response.
+     */
+    default HttpResponse notImplemented() {
+        return newResponse(NOT_IMPLEMENTED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#BAD_GATEWAY} response.
+     * @return a new {@link HttpResponseStatuses#BAD_GATEWAY} response.
+     */
+    default HttpResponse badGateway() {
+        return newResponse(BAD_GATEWAY);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#SERVICE_UNAVAILABLE} response.
+     * @return a new {@link HttpResponseStatuses#SERVICE_UNAVAILABLE} response.
+     */
+    default HttpResponse serviceUnavailable() {
+        return newResponse(SERVICE_UNAVAILABLE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#GATEWAY_TIMEOUT} response.
+     * @return a new {@link HttpResponseStatuses#GATEWAY_TIMEOUT} response.
+     */
+    default HttpResponse gatewayTimeout() {
+        return newResponse(GATEWAY_TIMEOUT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#HTTP_VERSION_NOT_SUPPORTED} response.
+     * @return a new {@link HttpResponseStatuses#HTTP_VERSION_NOT_SUPPORTED} response.
+     */
+    default HttpResponse httpVersionNotSupported() {
+        return newResponse(HTTP_VERSION_NOT_SUPPORTED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#VARIANT_ALSO_NEGOTIATES} response.
+     * @return a new {@link HttpResponseStatuses#VARIANT_ALSO_NEGOTIATES} response.
+     */
+    default HttpResponse variantAlsoNegotiates() {
+        return newResponse(VARIANT_ALSO_NEGOTIATES);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#INSUFFICIENT_STORAGE} response.
+     * @return a new {@link HttpResponseStatuses#INSUFFICIENT_STORAGE} response.
+     */
+    default HttpResponse insufficientStorage() {
+        return newResponse(INSUFFICIENT_STORAGE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NOT_EXTENDED} response.
+     * @return a new {@link HttpResponseStatuses#NOT_EXTENDED} response.
+     */
+    default HttpResponse notExtended() {
+        return newResponse(NOT_EXTENDED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NETWORK_AUTHENTICATION_REQUIRED} response.
+     * @return a new {@link HttpResponseStatuses#NETWORK_AUTHENTICATION_REQUIRED} response.
+     */
+    default HttpResponse networkAuthenticationRequired() {
+        return newResponse(NETWORK_AUTHENTICATION_REQUIRED);
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequestFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequestFactory.java
@@ -15,8 +15,14 @@
  */
 package io.servicetalk.http.api;
 
+import static io.servicetalk.http.api.HttpRequestMethods.CONNECT;
+import static io.servicetalk.http.api.HttpRequestMethods.DELETE;
 import static io.servicetalk.http.api.HttpRequestMethods.GET;
+import static io.servicetalk.http.api.HttpRequestMethods.HEAD;
+import static io.servicetalk.http.api.HttpRequestMethods.OPTIONS;
+import static io.servicetalk.http.api.HttpRequestMethods.PATCH;
 import static io.servicetalk.http.api.HttpRequestMethods.POST;
+import static io.servicetalk.http.api.HttpRequestMethods.TRACE;
 
 /**
  * A factory for creating {@link StreamingHttpRequest}s.
@@ -29,13 +35,6 @@ public interface StreamingHttpRequestFactory {
      * @return a new {@link HttpRequestFactory}.
      */
     StreamingHttpRequest newRequest(HttpRequestMethod method, String requestTarget);
-
-    // TODO(scott): if the new source is provided at creation, then we don't have to pay the costs of set(Publisher<>)
-    // to manage flow control of both streams.
-    // default StreamingHttpRequest newRequest(HttpRequestMethod method, String requestTarget) {
-    //     return newRequest(method, requestTarget, empty());
-    // }
-    // StreamingHttpRequest newRequest(HttpRequestMethod method, String requestTarget, Publisher<Buffer> payloadBody);
 
     /**
      * Create a new {@link HttpRequestMethods#GET} request.
@@ -53,5 +52,59 @@ public interface StreamingHttpRequestFactory {
      */
     default StreamingHttpRequest post(String requestTarget) {
         return newRequest(POST, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#OPTIONS} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#OPTIONS} request.
+     */
+    default StreamingHttpRequest options(String requestTarget) {
+        return newRequest(OPTIONS, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#HEAD} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#HEAD} request.
+     */
+    default StreamingHttpRequest head(String requestTarget) {
+        return newRequest(HEAD, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#TRACE} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#TRACE} request.
+     */
+    default StreamingHttpRequest trace(String requestTarget) {
+        return newRequest(TRACE, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#DELETE} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#DELETE} request.
+     */
+    default StreamingHttpRequest delete(String requestTarget) {
+        return newRequest(DELETE, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#PATCH} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#PATCH} request.
+     */
+    default StreamingHttpRequest patch(String requestTarget) {
+        return newRequest(PATCH, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethods#CONNECT} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethods#CONNECT} request.
+     */
+    default StreamingHttpRequest connect(String requestTarget) {
+        return newRequest(CONNECT, requestTarget);
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpResponseFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpResponseFactory.java
@@ -15,8 +15,62 @@
  */
 package io.servicetalk.http.api;
 
+import static io.servicetalk.http.api.HttpResponseStatuses.ACCEPTED;
+import static io.servicetalk.http.api.HttpResponseStatuses.BAD_GATEWAY;
+import static io.servicetalk.http.api.HttpResponseStatuses.BAD_REQUEST;
+import static io.servicetalk.http.api.HttpResponseStatuses.CONFLICT;
+import static io.servicetalk.http.api.HttpResponseStatuses.CONTINUE;
+import static io.servicetalk.http.api.HttpResponseStatuses.CREATED;
+import static io.servicetalk.http.api.HttpResponseStatuses.EXPECTATION_FAILED;
+import static io.servicetalk.http.api.HttpResponseStatuses.FAILED_DEPENDENCY;
+import static io.servicetalk.http.api.HttpResponseStatuses.FORBIDDEN;
+import static io.servicetalk.http.api.HttpResponseStatuses.FOUND;
+import static io.servicetalk.http.api.HttpResponseStatuses.GATEWAY_TIMEOUT;
+import static io.servicetalk.http.api.HttpResponseStatuses.GONE;
+import static io.servicetalk.http.api.HttpResponseStatuses.HTTP_VERSION_NOT_SUPPORTED;
+import static io.servicetalk.http.api.HttpResponseStatuses.INSUFFICIENT_STORAGE;
 import static io.servicetalk.http.api.HttpResponseStatuses.INTERNAL_SERVER_ERROR;
+import static io.servicetalk.http.api.HttpResponseStatuses.LENGTH_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatuses.LOCKED;
+import static io.servicetalk.http.api.HttpResponseStatuses.METHOD_NOT_ALLOWED;
+import static io.servicetalk.http.api.HttpResponseStatuses.MISDIRECTED_REQUEST;
+import static io.servicetalk.http.api.HttpResponseStatuses.MOVED_PERMANENTLY;
+import static io.servicetalk.http.api.HttpResponseStatuses.MULTIPLE_CHOICES;
+import static io.servicetalk.http.api.HttpResponseStatuses.MULTI_STATUS;
+import static io.servicetalk.http.api.HttpResponseStatuses.NETWORK_AUTHENTICATION_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatuses.NON_AUTHORITATIVE_INFORMATION;
+import static io.servicetalk.http.api.HttpResponseStatuses.NOT_ACCEPTABLE;
+import static io.servicetalk.http.api.HttpResponseStatuses.NOT_EXTENDED;
+import static io.servicetalk.http.api.HttpResponseStatuses.NOT_FOUND;
+import static io.servicetalk.http.api.HttpResponseStatuses.NOT_IMPLEMENTED;
+import static io.servicetalk.http.api.HttpResponseStatuses.NOT_MODIFIED;
+import static io.servicetalk.http.api.HttpResponseStatuses.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatuses.OK;
+import static io.servicetalk.http.api.HttpResponseStatuses.PARTIAL_CONTENT;
+import static io.servicetalk.http.api.HttpResponseStatuses.PAYMENT_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatuses.PERMANENT_REDIRECT;
+import static io.servicetalk.http.api.HttpResponseStatuses.PRECONDITION_FAILED;
+import static io.servicetalk.http.api.HttpResponseStatuses.PRECONDITION_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatuses.PROCESSING;
+import static io.servicetalk.http.api.HttpResponseStatuses.PROXY_AUTHENTICATION_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatuses.REQUESTED_RANGE_NOT_SATISFIABLE;
+import static io.servicetalk.http.api.HttpResponseStatuses.REQUEST_ENTITY_TOO_LARGE;
+import static io.servicetalk.http.api.HttpResponseStatuses.REQUEST_HEADER_FIELDS_TOO_LARGE;
+import static io.servicetalk.http.api.HttpResponseStatuses.REQUEST_TIMEOUT;
+import static io.servicetalk.http.api.HttpResponseStatuses.REQUEST_URI_TOO_LONG;
+import static io.servicetalk.http.api.HttpResponseStatuses.RESET_CONTENT;
+import static io.servicetalk.http.api.HttpResponseStatuses.SEE_OTHER;
+import static io.servicetalk.http.api.HttpResponseStatuses.SERVICE_UNAVAILABLE;
+import static io.servicetalk.http.api.HttpResponseStatuses.SWITCHING_PROTOCOLS;
+import static io.servicetalk.http.api.HttpResponseStatuses.TEMPORARY_REDIRECT;
+import static io.servicetalk.http.api.HttpResponseStatuses.TOO_MANY_REQUESTS;
+import static io.servicetalk.http.api.HttpResponseStatuses.UNAUTHORIZED;
+import static io.servicetalk.http.api.HttpResponseStatuses.UNORDERED_COLLECTION;
+import static io.servicetalk.http.api.HttpResponseStatuses.UNPROCESSABLE_ENTITY;
+import static io.servicetalk.http.api.HttpResponseStatuses.UNSUPPORTED_MEDIA_TYPE;
+import static io.servicetalk.http.api.HttpResponseStatuses.UPGRADE_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatuses.USE_PROXY;
+import static io.servicetalk.http.api.HttpResponseStatuses.VARIANT_ALSO_NEGOTIATES;
 
 /**
  * A factory for creating {@link StreamingHttpResponse}s.
@@ -30,6 +84,30 @@ public interface StreamingHttpResponseFactory {
     StreamingHttpResponse newResponse(HttpResponseStatus status);
 
     /**
+     * Create a new {@link HttpResponseStatuses#CONTINUE} response.
+     * @return a new {@link HttpResponseStatuses#CONTINUE} response.
+     */
+    default StreamingHttpResponse continueResponse() {
+        return newResponse(CONTINUE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#SWITCHING_PROTOCOLS} response.
+     * @return a new {@link HttpResponseStatuses#SWITCHING_PROTOCOLS} response.
+     */
+    default StreamingHttpResponse switchingProtocols() {
+        return newResponse(SWITCHING_PROTOCOLS);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PROCESSING} response.
+     * @return a new {@link HttpResponseStatuses#PROCESSING} response.
+     */
+    default StreamingHttpResponse processing() {
+        return newResponse(PROCESSING);
+    }
+
+    /**
      * Create a new {@link HttpResponseStatuses#OK} response.
      * @return a new {@link HttpResponseStatuses#OK} response.
      */
@@ -38,10 +116,418 @@ public interface StreamingHttpResponseFactory {
     }
 
     /**
+     * Create a new {@link HttpResponseStatuses#CREATED} response.
+     * @return a new {@link HttpResponseStatuses#CREATED} response.
+     */
+    default StreamingHttpResponse created() {
+        return newResponse(CREATED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#ACCEPTED} response.
+     * @return a new {@link HttpResponseStatuses#ACCEPTED} response.
+     */
+    default StreamingHttpResponse accepted() {
+        return newResponse(ACCEPTED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NON_AUTHORITATIVE_INFORMATION} response.
+     * @return a new {@link HttpResponseStatuses#NON_AUTHORITATIVE_INFORMATION} response.
+     */
+    default StreamingHttpResponse nonAuthoritativeInformation() {
+        return newResponse(NON_AUTHORITATIVE_INFORMATION);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NO_CONTENT} response.
+     * @return a new {@link HttpResponseStatuses#NO_CONTENT} response.
+     */
+    default StreamingHttpResponse noContent() {
+        return newResponse(NO_CONTENT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#RESET_CONTENT} response.
+     * @return a new {@link HttpResponseStatuses#RESET_CONTENT} response.
+     */
+    default StreamingHttpResponse resetContent() {
+        return newResponse(RESET_CONTENT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PARTIAL_CONTENT} response.
+     * @return a new {@link HttpResponseStatuses#PARTIAL_CONTENT} response.
+     */
+    default StreamingHttpResponse partialContent() {
+        return newResponse(PARTIAL_CONTENT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#MULTI_STATUS} response.
+     * @return a new {@link HttpResponseStatuses#MULTI_STATUS} response.
+     */
+    default StreamingHttpResponse multiStatus() {
+        return newResponse(MULTI_STATUS);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#MULTIPLE_CHOICES} response.
+     * @return a new {@link HttpResponseStatuses#MULTIPLE_CHOICES} response.
+     */
+    default StreamingHttpResponse multipleChoices() {
+        return newResponse(MULTIPLE_CHOICES);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#MOVED_PERMANENTLY} response.
+     * @return a new {@link HttpResponseStatuses#MOVED_PERMANENTLY} response.
+     */
+    default StreamingHttpResponse movedPermanently() {
+        return newResponse(MOVED_PERMANENTLY);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#FOUND} response.
+     * @return a new {@link HttpResponseStatuses#FOUND} response.
+     */
+    default StreamingHttpResponse found() {
+        return newResponse(FOUND);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#SEE_OTHER} response.
+     * @return a new {@link HttpResponseStatuses#SEE_OTHER} response.
+     */
+    default StreamingHttpResponse seeOther() {
+        return newResponse(SEE_OTHER);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NOT_MODIFIED} response.
+     * @return a new {@link HttpResponseStatuses#NOT_MODIFIED} response.
+     */
+    default StreamingHttpResponse notModified() {
+        return newResponse(NOT_MODIFIED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#USE_PROXY} response.
+     * @return a new {@link HttpResponseStatuses#USE_PROXY} response.
+     */
+    default StreamingHttpResponse useProxy() {
+        return newResponse(USE_PROXY);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#TEMPORARY_REDIRECT} response.
+     * @return a new {@link HttpResponseStatuses#TEMPORARY_REDIRECT} response.
+     */
+    default StreamingHttpResponse temporaryRedirect() {
+        return newResponse(TEMPORARY_REDIRECT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PERMANENT_REDIRECT} response.
+     * @return a new {@link HttpResponseStatuses#PERMANENT_REDIRECT} response.
+     */
+    default StreamingHttpResponse permanentRedirect() {
+        return newResponse(PERMANENT_REDIRECT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#BAD_REQUEST} response.
+     * @return a new {@link HttpResponseStatuses#BAD_REQUEST} response.
+     */
+    default StreamingHttpResponse badRequest() {
+        return newResponse(BAD_REQUEST);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#UNAUTHORIZED} response.
+     * @return a new {@link HttpResponseStatuses#UNAUTHORIZED} response.
+     */
+    default StreamingHttpResponse unauthorized() {
+        return newResponse(UNAUTHORIZED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PAYMENT_REQUIRED} response.
+     * @return a new {@link HttpResponseStatuses#PAYMENT_REQUIRED} response.
+     */
+    default StreamingHttpResponse paymentRequired() {
+        return newResponse(PAYMENT_REQUIRED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#FORBIDDEN} response.
+     * @return a new {@link HttpResponseStatuses#FORBIDDEN} response.
+     */
+    default StreamingHttpResponse forbidden() {
+        return newResponse(FORBIDDEN);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NOT_FOUND} response.
+     * @return a new {@link HttpResponseStatuses#NOT_FOUND} response.
+     */
+    default StreamingHttpResponse notFound() {
+        return newResponse(NOT_FOUND);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#METHOD_NOT_ALLOWED} response.
+     * @return a new {@link HttpResponseStatuses#METHOD_NOT_ALLOWED} response.
+     */
+    default StreamingHttpResponse methodNotAllowed() {
+        return newResponse(METHOD_NOT_ALLOWED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NOT_ACCEPTABLE} response.
+     * @return a new {@link HttpResponseStatuses#NOT_ACCEPTABLE} response.
+     */
+    default StreamingHttpResponse notAcceptable() {
+        return newResponse(NOT_ACCEPTABLE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PROXY_AUTHENTICATION_REQUIRED} response.
+     * @return a new {@link HttpResponseStatuses#PROXY_AUTHENTICATION_REQUIRED} response.
+     */
+    default StreamingHttpResponse proxyAuthenticationRequired() {
+        return newResponse(PROXY_AUTHENTICATION_REQUIRED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#REQUEST_TIMEOUT} response.
+     * @return a new {@link HttpResponseStatuses#REQUEST_TIMEOUT} response.
+     */
+    default StreamingHttpResponse requestTimeout() {
+        return newResponse(REQUEST_TIMEOUT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#CONFLICT} response.
+     * @return a new {@link HttpResponseStatuses#CONFLICT} response.
+     */
+    default StreamingHttpResponse conflict() {
+        return newResponse(CONFLICT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#GONE} response.
+     * @return a new {@link HttpResponseStatuses#GONE} response.
+     */
+    default StreamingHttpResponse gone() {
+        return newResponse(GONE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#LENGTH_REQUIRED} response.
+     * @return a new {@link HttpResponseStatuses#LENGTH_REQUIRED} response.
+     */
+    default StreamingHttpResponse lengthRequired() {
+        return newResponse(LENGTH_REQUIRED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PRECONDITION_FAILED} response.
+     * @return a new {@link HttpResponseStatuses#PRECONDITION_FAILED} response.
+     */
+    default StreamingHttpResponse preconditionFailed() {
+        return newResponse(PRECONDITION_FAILED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#REQUEST_ENTITY_TOO_LARGE} response.
+     * @return a new {@link HttpResponseStatuses#REQUEST_ENTITY_TOO_LARGE} response.
+     */
+    default StreamingHttpResponse requestEntityTooLarge() {
+        return newResponse(REQUEST_ENTITY_TOO_LARGE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#REQUEST_URI_TOO_LONG} response.
+     * @return a new {@link HttpResponseStatuses#REQUEST_URI_TOO_LONG} response.
+     */
+    default StreamingHttpResponse requestUriTooLong() {
+        return newResponse(REQUEST_URI_TOO_LONG);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#UNSUPPORTED_MEDIA_TYPE} response.
+     * @return a new {@link HttpResponseStatuses#UNSUPPORTED_MEDIA_TYPE} response.
+     */
+    default StreamingHttpResponse unsupportedMediaType() {
+        return newResponse(UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#REQUESTED_RANGE_NOT_SATISFIABLE} response.
+     * @return a new {@link HttpResponseStatuses#REQUESTED_RANGE_NOT_SATISFIABLE} response.
+     */
+    default StreamingHttpResponse requestedRangeNotSatisfiable() {
+        return newResponse(REQUESTED_RANGE_NOT_SATISFIABLE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#EXPECTATION_FAILED} response.
+     * @return a new {@link HttpResponseStatuses#EXPECTATION_FAILED} response.
+     */
+    default StreamingHttpResponse expectationFailed() {
+        return newResponse(EXPECTATION_FAILED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#MISDIRECTED_REQUEST} response.
+     * @return a new {@link HttpResponseStatuses#MISDIRECTED_REQUEST} response.
+     */
+    default StreamingHttpResponse misdirectedRequest() {
+        return newResponse(MISDIRECTED_REQUEST);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#UNPROCESSABLE_ENTITY} response.
+     * @return a new {@link HttpResponseStatuses#UNPROCESSABLE_ENTITY} response.
+     */
+    default StreamingHttpResponse unprocessableEntity() {
+        return newResponse(UNPROCESSABLE_ENTITY);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#LOCKED} response.
+     * @return a new {@link HttpResponseStatuses#LOCKED} response.
+     */
+    default StreamingHttpResponse locked() {
+        return newResponse(LOCKED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#FAILED_DEPENDENCY} response.
+     * @return a new {@link HttpResponseStatuses#FAILED_DEPENDENCY} response.
+     */
+    default StreamingHttpResponse failedDependency() {
+        return newResponse(FAILED_DEPENDENCY);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#UNORDERED_COLLECTION} response.
+     * @return a new {@link HttpResponseStatuses#UNORDERED_COLLECTION} response.
+     */
+    default StreamingHttpResponse unorderedCollection() {
+        return newResponse(UNORDERED_COLLECTION);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#UPGRADE_REQUIRED} response.
+     * @return a new {@link HttpResponseStatuses#UPGRADE_REQUIRED} response.
+     */
+    default StreamingHttpResponse upgradeRequired() {
+        return newResponse(UPGRADE_REQUIRED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#PRECONDITION_REQUIRED} response.
+     * @return a new {@link HttpResponseStatuses#PRECONDITION_REQUIRED} response.
+     */
+    default StreamingHttpResponse preconditionRequired() {
+        return newResponse(PRECONDITION_REQUIRED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#TOO_MANY_REQUESTS} response.
+     * @return a new {@link HttpResponseStatuses#TOO_MANY_REQUESTS} response.
+     */
+    default StreamingHttpResponse tooManyRequests() {
+        return newResponse(TOO_MANY_REQUESTS);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#REQUEST_HEADER_FIELDS_TOO_LARGE} response.
+     * @return a new {@link HttpResponseStatuses#REQUEST_HEADER_FIELDS_TOO_LARGE} response.
+     */
+    default StreamingHttpResponse requestHeaderFieldsTooLarge() {
+        return newResponse(REQUEST_HEADER_FIELDS_TOO_LARGE);
+    }
+
+    /**
      * Create a new {@link HttpResponseStatuses#INTERNAL_SERVER_ERROR} response.
      * @return a new {@link HttpResponseStatuses#INTERNAL_SERVER_ERROR} response.
      */
-    default StreamingHttpResponse serverError() {
+    default StreamingHttpResponse internalServerError() {
         return newResponse(INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NOT_IMPLEMENTED} response.
+     * @return a new {@link HttpResponseStatuses#NOT_IMPLEMENTED} response.
+     */
+    default StreamingHttpResponse notImplemented() {
+        return newResponse(NOT_IMPLEMENTED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#BAD_GATEWAY} response.
+     * @return a new {@link HttpResponseStatuses#BAD_GATEWAY} response.
+     */
+    default StreamingHttpResponse badGateway() {
+        return newResponse(BAD_GATEWAY);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#SERVICE_UNAVAILABLE} response.
+     * @return a new {@link HttpResponseStatuses#SERVICE_UNAVAILABLE} response.
+     */
+    default StreamingHttpResponse serviceUnavailable() {
+        return newResponse(SERVICE_UNAVAILABLE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#GATEWAY_TIMEOUT} response.
+     * @return a new {@link HttpResponseStatuses#GATEWAY_TIMEOUT} response.
+     */
+    default StreamingHttpResponse gatewayTimeout() {
+        return newResponse(GATEWAY_TIMEOUT);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#HTTP_VERSION_NOT_SUPPORTED} response.
+     * @return a new {@link HttpResponseStatuses#HTTP_VERSION_NOT_SUPPORTED} response.
+     */
+    default StreamingHttpResponse httpVersionNotSupported() {
+        return newResponse(HTTP_VERSION_NOT_SUPPORTED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#VARIANT_ALSO_NEGOTIATES} response.
+     * @return a new {@link HttpResponseStatuses#VARIANT_ALSO_NEGOTIATES} response.
+     */
+    default StreamingHttpResponse variantAlsoNegotiates() {
+        return newResponse(VARIANT_ALSO_NEGOTIATES);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#INSUFFICIENT_STORAGE} response.
+     * @return a new {@link HttpResponseStatuses#INSUFFICIENT_STORAGE} response.
+     */
+    default StreamingHttpResponse insufficientStorage() {
+        return newResponse(INSUFFICIENT_STORAGE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NOT_EXTENDED} response.
+     * @return a new {@link HttpResponseStatuses#NOT_EXTENDED} response.
+     */
+    default StreamingHttpResponse notExtended() {
+        return newResponse(NOT_EXTENDED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatuses#NETWORK_AUTHENTICATION_REQUIRED} response.
+     * @return a new {@link HttpResponseStatuses#NETWORK_AUTHENTICATION_REQUIRED} response.
+     */
+    default StreamingHttpResponse networkAuthenticationRequired() {
+        return newResponse(NETWORK_AUTHENTICATION_REQUIRED);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServerConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServerConnection.java
@@ -168,7 +168,7 @@ final class NettyHttpServerConnection extends NettyConnection<Object, Object> {
     private Single<StreamingHttpResponse> newErrorResponse(final Throwable cause,
                                                            final StreamingHttpRequest request) {
         LOGGER.error("internal server error service={} connection={}", service, context, cause);
-        StreamingHttpResponse resp = context.getStreamingFactory().serverError().version(request.version());
+        StreamingHttpResponse resp = context.getStreamingFactory().internalServerError().version(request.version());
         resp.headers().set(CONTENT_LENGTH, ZERO);
         return success(resp);
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServiceAsyncContextTest.java
@@ -198,7 +198,7 @@ public class HttpServiceAsyncContextTest {
                 request.payloadBody().ignoreElements().subscribe();
 
                 if (!AsyncContext.isEmpty()) {
-                    return success(factory.serverError());
+                    return success(factory.internalServerError());
                 }
                 CharSequence requestId = request.headers().getAndRemove(REQUEST_ID_HEADER);
                 if (requestId != null) {


### PR DESCRIPTION
__Motivation__

We added only few methods for standard HTTP methods and response codes in the factories.
We should add the remaining methods for completion.

__Modification__

Added all remaining methods to the factories.

__Result__

Complete coverage of standard methods.