### PR TITLE
Add copy constructor for HttpServiceContext

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServiceContext.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServiceContext.java
@@ -33,12 +33,20 @@ public abstract class HttpServiceContext implements ConnectionContext {
      * @param streamingFactory The {@link StreamingHttpResponseFactory} used for API conversions.
      * @param blockingFactory The {@link BlockingStreamingHttpResponseFactory} used for API conversions.
      */
-    protected HttpServiceContext(HttpResponseFactory factory,
-                                 StreamingHttpResponseFactory streamingFactory,
+    protected HttpServiceContext(HttpResponseFactory factory, StreamingHttpResponseFactory streamingFactory,
                                  BlockingStreamingHttpResponseFactory blockingFactory) {
         this.factory = requireNonNull(factory);
         this.streamingFactory = requireNonNull(streamingFactory);
         this.blockingFactory = requireNonNull(blockingFactory);
+    }
+
+    /**
+     * Copy constructor.
+     *
+     * @param other {@link HttpServiceContext} to copy from.
+     */
+    protected HttpServiceContext(HttpServiceContext other) {
+        this(other.factory, other.streamingFactory, other.blockingFactory);
     }
 
     final HttpResponseFactory getResponseFactory() {


### PR DESCRIPTION
__Motivation__

To aid in decoration of context, we should provide a way for users to extend this class.
The current protected constructor requires entities that are not visible to the user.

__Modification__

Added a copy constructor

__Result__

Users can implement this class for decoration.