### PR TITLE
Remove get/set from client APIs

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClient.java
@@ -30,7 +30,7 @@ public abstract class BlockingHttpClient extends BlockingHttpRequester {
      * Create a new instance.
      *
      * @param reqRespFactory The {@link HttpRequestResponseFactory} used to
-     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
      */
     protected BlockingHttpClient(final HttpRequestResponseFactory reqRespFactory) {
         super(reqRespFactory);
@@ -54,7 +54,7 @@ public abstract class BlockingHttpClient extends BlockingHttpRequester {
      * cannot be any pipelined requests pending or any pipeline requests issued during the upgrade process. That means
      * the {@link BlockingHttpConnection} associated with the {@link UpgradableHttpResponse} will be
      * reserved for exclusive use. The code responsible for determining the result of the upgrade attempt is responsible
-     * for calling {@link UpgradableHttpResponse#getHttpConnection(boolean)}.
+     * for calling {@link UpgradableHttpResponse#httpConnection(boolean)}.
      *
      * @param request the request which initiates the upgrade.
      * @return An {@link UpgradableHttpResponse} for the upgrade attempt and also contains the
@@ -109,7 +109,7 @@ public abstract class BlockingHttpClient extends BlockingHttpRequester {
          * Create a new instance.
          *
          * @param reqRespFactory The {@link HttpRequestResponseFactory} used to
-         * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+         * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
          */
         protected ReservedBlockingHttpConnection(final HttpRequestResponseFactory reqRespFactory) {
             super(reqRespFactory);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClientGroup.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClientGroup.java
@@ -32,7 +32,7 @@ public abstract class BlockingHttpClientGroup<UnresolvedAddress> implements Http
     /**
      * Create a new instance.
      * @param reqRespFactory The {@link HttpRequestResponseFactory} used to
-     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
      */
     protected BlockingHttpClientGroup(final HttpRequestResponseFactory reqRespFactory) {
         this.reqRespFactory = requireNonNull(reqRespFactory);
@@ -91,7 +91,7 @@ public abstract class BlockingHttpClientGroup<UnresolvedAddress> implements Http
      * Get a {@link HttpResponseFactory}.
      * @return a {@link HttpResponseFactory}.
      */
-    public final HttpResponseFactory getHttpResponseFactory() {
+    public final HttpResponseFactory httpResponseFactory() {
         return reqRespFactory;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClientToHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClientToHttpClient.java
@@ -54,8 +54,8 @@ final class BlockingHttpClientToHttpClient extends HttpClient {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return client.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return client.executionContext();
     }
 
     @Override
@@ -91,13 +91,13 @@ final class BlockingHttpClientToHttpClient extends HttpClient {
         }
 
         @Override
-        public ConnectionContext getConnectionContext() {
-            return connection.getConnectionContext();
+        public ConnectionContext connectionContext() {
+            return connection.connectionContext();
         }
 
         @Override
-        public <T> Publisher<T> getSettingStream(final StreamingHttpConnection.SettingKey<T> settingKey) {
-            return from(connection.getSettingIterable(settingKey));
+        public <T> Publisher<T> settingStream(final StreamingHttpConnection.SettingKey<T> settingKey) {
+            return from(connection.settingIterable(settingKey));
         }
 
         @Override
@@ -106,8 +106,8 @@ final class BlockingHttpClientToHttpClient extends HttpClient {
         }
 
         @Override
-        public ExecutionContext getExecutionContext() {
-            return connection.getExecutionContext();
+        public ExecutionContext executionContext() {
+            return connection.executionContext();
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClientToStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClientToStreamingHttpClient.java
@@ -55,8 +55,8 @@ final class BlockingHttpClientToStreamingHttpClient extends StreamingHttpClient 
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return client.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return client.executionContext();
     }
 
     @Override
@@ -92,13 +92,13 @@ final class BlockingHttpClientToStreamingHttpClient extends StreamingHttpClient 
         }
 
         @Override
-        public ConnectionContext getConnectionContext() {
-            return connection.getConnectionContext();
+        public ConnectionContext connectionContext() {
+            return connection.connectionContext();
         }
 
         @Override
-        public <T> Publisher<T> getSettingStream(final SettingKey<T> settingKey) {
-            return from(connection.getSettingIterable(settingKey));
+        public <T> Publisher<T> settingStream(final SettingKey<T> settingKey) {
+            return from(connection.settingIterable(settingKey));
         }
 
         @Override
@@ -107,8 +107,8 @@ final class BlockingHttpClientToStreamingHttpClient extends StreamingHttpClient 
         }
 
         @Override
-        public ExecutionContext getExecutionContext() {
-            return connection.getExecutionContext();
+        public ExecutionContext executionContext() {
+            return connection.executionContext();
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpConnection.java
@@ -29,7 +29,7 @@ public abstract class BlockingHttpConnection extends BlockingHttpRequester {
      * Create a new instance.
      *
      * @param reqRespFactory The {@link HttpRequestResponseFactory} used to
-     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
      */
     protected BlockingHttpConnection(final HttpRequestResponseFactory reqRespFactory) {
         super(reqRespFactory);
@@ -40,7 +40,7 @@ public abstract class BlockingHttpConnection extends BlockingHttpRequester {
      *
      * @return the {@link ConnectionContext}.
      */
-    public abstract ConnectionContext getConnectionContext();
+    public abstract ConnectionContext connectionContext();
 
     /**
      * Returns a {@link BlockingIterable} that gives the current value of the setting as well as subsequent changes to
@@ -50,7 +50,7 @@ public abstract class BlockingHttpConnection extends BlockingHttpRequester {
      * @param <T> Type of the setting value.
      * @return {@link BlockingIterable} for the setting values.
      */
-    public abstract <T> BlockingIterable<T> getSettingIterable(SettingKey<T> settingKey);
+    public abstract <T> BlockingIterable<T> settingIterable(SettingKey<T> settingKey);
 
     /**
      * Convert this {@link BlockingHttpConnection} to the {@link StreamingHttpConnection} API.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpConnectionToHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpConnectionToHttpConnection.java
@@ -36,13 +36,13 @@ final class BlockingHttpConnectionToHttpConnection extends HttpConnection {
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
-        return connection.getConnectionContext();
+    public ConnectionContext connectionContext() {
+        return connection.connectionContext();
     }
 
     @Override
-    public <T> Publisher<T> getSettingStream(final SettingKey<T> settingKey) {
-        return from(connection.getSettingIterable(settingKey));
+    public <T> Publisher<T> settingStream(final SettingKey<T> settingKey) {
+        return from(connection.settingIterable(settingKey));
     }
 
     @Override
@@ -51,8 +51,8 @@ final class BlockingHttpConnectionToHttpConnection extends HttpConnection {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return connection.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return connection.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpConnectionToStreamingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpConnectionToStreamingHttpConnection.java
@@ -35,13 +35,13 @@ final class BlockingHttpConnectionToStreamingHttpConnection extends StreamingHtt
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
-        return connection.getConnectionContext();
+    public ConnectionContext connectionContext() {
+        return connection.connectionContext();
     }
 
     @Override
-    public <T> Publisher<T> getSettingStream(final SettingKey<T> settingKey) {
-        return from(connection.getSettingIterable(settingKey));
+    public <T> Publisher<T> settingStream(final SettingKey<T> settingKey) {
+        return from(connection.settingIterable(settingKey));
     }
 
     @Override
@@ -50,8 +50,8 @@ final class BlockingHttpConnectionToStreamingHttpConnection extends StreamingHtt
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return connection.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return connection.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpRequester.java
@@ -28,7 +28,7 @@ public abstract class BlockingHttpRequester implements HttpRequestFactory, AutoC
     /**
      * Create a new instance.
      * @param reqRespFactory The {@link HttpRequestResponseFactory} used to
-     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
      */
     protected BlockingHttpRequester(final HttpRequestResponseFactory reqRespFactory) {
         this.reqRespFactory = requireNonNull(reqRespFactory);
@@ -51,7 +51,7 @@ public abstract class BlockingHttpRequester implements HttpRequestFactory, AutoC
      *
      * @return the {@link ExecutionContext} used during construction of this object.
      */
-    public abstract ExecutionContext getExecutionContext();
+    public abstract ExecutionContext executionContext();
 
     @Override
     public final HttpRequest newRequest(HttpRequestMethod method, String requestTarget) {
@@ -62,7 +62,7 @@ public abstract class BlockingHttpRequester implements HttpRequestFactory, AutoC
      * Get a {@link HttpResponseFactory}.
      * @return a {@link HttpResponseFactory}.
      */
-    public final HttpResponseFactory getHttpResponseFactory() {
+    public final HttpResponseFactory httpResponseFactory() {
         return reqRespFactory;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpRequesterToHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpRequesterToHttpRequester.java
@@ -37,8 +37,8 @@ final class BlockingHttpRequesterToHttpRequester extends HttpRequester {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return requester.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return requester.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpRequesterToStreamingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpRequesterToStreamingHttpRequester.java
@@ -37,8 +37,8 @@ final class BlockingHttpRequesterToStreamingHttpRequester extends StreamingHttpR
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return requester.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return requester.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClient.java
@@ -39,7 +39,7 @@ public abstract class BlockingStreamingHttpClient extends BlockingStreamingHttpR
      * Create a new instance.
      *
      * @param reqRespFactory The {@link BlockingStreamingHttpRequestResponseFactory} used to
-     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
      */
     protected BlockingStreamingHttpClient(final BlockingStreamingHttpRequestResponseFactory reqRespFactory) {
         super(reqRespFactory);
@@ -64,7 +64,7 @@ public abstract class BlockingStreamingHttpClient extends BlockingStreamingHttpR
      * cannot be any pipelined requests pending or any pipeline requests issued during the upgrade process. That means
      * the {@link BlockingStreamingHttpConnection} associated with the {@link UpgradableBlockingStreamingHttpResponse}
      * will be reserved for exclusive use. The code responsible for determining the result of the upgrade attempt is
-     * responsible for calling {@link UpgradableBlockingStreamingHttpResponse#getHttpConnection(boolean)}.
+     * responsible for calling {@link UpgradableBlockingStreamingHttpResponse#httpConnection(boolean)}.
      *
      * @param request the request which initiates the upgrade.
      * @return An object that provides the {@link StreamingHttpResponse} for the upgrade attempt and also contains the
@@ -125,7 +125,7 @@ public abstract class BlockingStreamingHttpClient extends BlockingStreamingHttpR
          * Create a new instance.
          *
          * @param reqRespFactory The {@link BlockingStreamingHttpRequestResponseFactory} used to
-         * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+         * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
          */
         protected ReservedBlockingStreamingHttpConnection(
                 final BlockingStreamingHttpRequestResponseFactory reqRespFactory) {
@@ -219,7 +219,7 @@ public abstract class BlockingStreamingHttpClient extends BlockingStreamingHttpR
          * {@link BlockingStreamingHttpConnection} used for the upgrade attempt, and controls the lifetime of the
          * {@link BlockingStreamingHttpConnection} relative to this {@link BlockingStreamingHttpClient}.
          */
-        ReservedBlockingStreamingHttpConnection getHttpConnection(boolean releaseReturnsToClient);
+        ReservedBlockingStreamingHttpConnection httpConnection(boolean releaseReturnsToClient);
 
         @Override
         UpgradableBlockingStreamingHttpResponse payloadBody(Iterable<Buffer> payloadBody);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClientGroup.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClientGroup.java
@@ -33,7 +33,7 @@ public abstract class BlockingStreamingHttpClientGroup<UnresolvedAddress> implem
     /**
      * Create a new instance.
      * @param reqRespFactory The {@link BlockingStreamingHttpRequestResponseFactory} used to
-     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
      */
     protected BlockingStreamingHttpClientGroup(final BlockingStreamingHttpRequestResponseFactory reqRespFactory) {
         this.reqRespFactory = requireNonNull(reqRespFactory);
@@ -93,7 +93,7 @@ public abstract class BlockingStreamingHttpClientGroup<UnresolvedAddress> implem
      * Get a {@link BlockingStreamingHttpResponseFactory}.
      * @return a {@link BlockingStreamingHttpResponseFactory}.
      */
-    public final BlockingStreamingHttpResponseFactory getHttpResponseFactory() {
+    public final BlockingStreamingHttpResponseFactory httpResponseFactory() {
         return reqRespFactory;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClientToStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClientToStreamingHttpClient.java
@@ -73,7 +73,7 @@ final class BlockingStreamingHttpClientToStreamingHttpClient extends StreamingHt
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
+    public ExecutionContext executionContext() {
         return blockingClient.getExecutionContext();
     }
 
@@ -111,13 +111,13 @@ final class BlockingStreamingHttpClientToStreamingHttpClient extends StreamingHt
         }
 
         @Override
-        public ConnectionContext getConnectionContext() {
-            return blockingReservedConnection.getConnectionContext();
+        public ConnectionContext connectionContext() {
+            return blockingReservedConnection.connectionContext();
         }
 
         @Override
-        public <T> Publisher<T> getSettingStream(final SettingKey<T> settingKey) {
-            return from(blockingReservedConnection.getSettingIterable(settingKey));
+        public <T> Publisher<T> settingStream(final SettingKey<T> settingKey) {
+            return from(blockingReservedConnection.settingIterable(settingKey));
         }
 
         @Override
@@ -126,7 +126,7 @@ final class BlockingStreamingHttpClientToStreamingHttpClient extends StreamingHt
         }
 
         @Override
-        public ExecutionContext getExecutionContext() {
+        public ExecutionContext executionContext() {
             return blockingReservedConnection.getExecutionContext();
         }
 
@@ -168,9 +168,9 @@ final class BlockingStreamingHttpClientToStreamingHttpClient extends StreamingHt
         }
 
         @Override
-        public ReservedStreamingHttpConnection getHttpConnection(final boolean releaseReturnsToClient) {
+        public ReservedStreamingHttpConnection httpConnection(final boolean releaseReturnsToClient) {
             return new BlockingToReservedStreamingHttpConnection(
-                    upgradeResponse.getHttpConnection(releaseReturnsToClient));
+                    upgradeResponse.httpConnection(releaseReturnsToClient));
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpConnection.java
@@ -27,7 +27,7 @@ public abstract class BlockingStreamingHttpConnection extends BlockingStreamingH
      * Create a new instance.
      *
      * @param reqRespFactory The {@link BlockingStreamingHttpRequestResponseFactory} used to
-     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
      */
     protected BlockingStreamingHttpConnection(final BlockingStreamingHttpRequestResponseFactory reqRespFactory) {
         super(reqRespFactory);
@@ -38,7 +38,7 @@ public abstract class BlockingStreamingHttpConnection extends BlockingStreamingH
      *
      * @return the {@link ConnectionContext}.
      */
-    public abstract ConnectionContext getConnectionContext();
+    public abstract ConnectionContext connectionContext();
 
     /**
      * Returns a {@link BlockingIterable} that gives the current value of the setting as well as subsequent changes to
@@ -48,7 +48,7 @@ public abstract class BlockingStreamingHttpConnection extends BlockingStreamingH
      * @param <T> Type of the setting value.
      * @return {@link BlockingIterable} for the setting values.
      */
-    public abstract <T> BlockingIterable<T> getSettingIterable(SettingKey<T> settingKey);
+    public abstract <T> BlockingIterable<T> settingIterable(SettingKey<T> settingKey);
 
     /**
      * Convert this {@link BlockingStreamingHttpConnection} to the {@link StreamingHttpConnection} API.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpConnectionToStreamingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpConnectionToStreamingHttpConnection.java
@@ -36,13 +36,13 @@ final class BlockingStreamingHttpConnectionToStreamingHttpConnection extends Str
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
-        return blockingConnection.getConnectionContext();
+    public ConnectionContext connectionContext() {
+        return blockingConnection.connectionContext();
     }
 
     @Override
-    public <T> Publisher<T> getSettingStream(final SettingKey<T> settingKey) {
-        return from(blockingConnection.getSettingIterable(settingKey));
+    public <T> Publisher<T> settingStream(final SettingKey<T> settingKey) {
+        return from(blockingConnection.settingIterable(settingKey));
     }
 
     @Override
@@ -51,7 +51,7 @@ final class BlockingStreamingHttpConnectionToStreamingHttpConnection extends Str
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
+    public ExecutionContext executionContext() {
         return blockingConnection.getExecutionContext();
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequester.java
@@ -28,7 +28,7 @@ public abstract class BlockingStreamingHttpRequester implements BlockingStreamin
     /**
      * Create a new instance.
      * @param reqRespFactory The {@link BlockingStreamingHttpRequestResponseFactory} used to
-     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
      */
     protected BlockingStreamingHttpRequester(final BlockingStreamingHttpRequestResponseFactory reqRespFactory) {
         this.reqRespFactory = requireNonNull(reqRespFactory);
@@ -62,7 +62,7 @@ public abstract class BlockingStreamingHttpRequester implements BlockingStreamin
      * Get a {@link BlockingStreamingHttpResponseFactory}.
      * @return a {@link BlockingStreamingHttpResponseFactory}.
      */
-    public final BlockingStreamingHttpResponseFactory getHttpResponseFactory() {
+    public final BlockingStreamingHttpResponseFactory httpResponseFactory() {
         return reqRespFactory;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequesterToStreamingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequesterToStreamingHttpRequester.java
@@ -38,7 +38,7 @@ final class BlockingStreamingHttpRequesterToStreamingHttpRequester extends Strea
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
+    public ExecutionContext executionContext() {
         return requester.getExecutionContext();
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpClientGroup.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpClientGroup.java
@@ -71,7 +71,7 @@ final class DefaultStreamingHttpClientGroup<UnresolvedAddress> extends Streaming
         }
 
         @Override
-        public ExecutionContext getExecutionContext() {
+        public ExecutionContext executionContext() {
             throw new UnsupportedOperationException(PLACEHOLDER_EXCEPTION_MSG);
         }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClient.java
@@ -35,7 +35,7 @@ public abstract class HttpClient extends HttpRequester {
      * Create a new instance.
      *
      * @param reqRespFactory The {@link HttpRequestResponseFactory} used to
-     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
      */
     protected HttpClient(final HttpRequestResponseFactory reqRespFactory) {
         super(reqRespFactory);
@@ -56,7 +56,7 @@ public abstract class HttpClient extends HttpRequester {
      * cannot be any pipelined requests pending or any pipeline requests issued during the upgrade process. That means
      * the {@link HttpConnection} associated with the {@link UpgradableHttpResponse} will be
      * reserved for exclusive use. The code responsible for determining the result of the upgrade attempt is responsible
-     * for calling {@link UpgradableHttpResponse#getHttpConnection(boolean)}.
+     * for calling {@link UpgradableHttpResponse#httpConnection(boolean)}.
      *
      * @param request the request which initiates the upgrade.
      * @return An object that provides the {@link UpgradableHttpResponse} for the upgrade attempt and also
@@ -109,7 +109,7 @@ public abstract class HttpClient extends HttpRequester {
          * Create a new instance.
          *
          * @param reqRespFactory The {@link HttpRequestResponseFactory} used to
-         * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+         * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
          */
         protected ReservedHttpConnection(final HttpRequestResponseFactory reqRespFactory) {
             super(reqRespFactory);
@@ -195,7 +195,7 @@ public abstract class HttpClient extends HttpRequester {
          * for the upgrade attempt, and controls the lifetime of the {@link HttpConnection} relative to this
          * {@link HttpClient}.
          */
-        ReservedHttpConnection getHttpConnection(boolean releaseReturnsToClient);
+        ReservedHttpConnection httpConnection(boolean releaseReturnsToClient);
 
         @Override
         UpgradableHttpResponse payloadBody(Buffer payloadBody);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientAdapter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientAdapter.java
@@ -39,7 +39,7 @@ public abstract class HttpClientAdapter extends HttpClient {
      * Get the {@link HttpClient} that this class delegates to.
      * @return the {@link HttpClient} that this class delegates to.
      */
-    protected final HttpClient getDelegate() {
+    protected final HttpClient delegate() {
         return delegate;
     }
 
@@ -59,8 +59,8 @@ public abstract class HttpClientAdapter extends HttpClient {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return delegate.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return delegate.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
@@ -25,7 +25,7 @@ public interface HttpClientBuilder {
     /**
      * Build a new {@link StreamingHttpClient}.
      *
-     * @param executionContext {@link ExecutionContext} used for {@link StreamingHttpClient#getExecutionContext()} and to buildStreaming
+     * @param executionContext {@link ExecutionContext} used for {@link StreamingHttpClient#executionContext()} and to buildStreaming
      * new {@link StreamingHttpConnection}s.
      * @return A new {@link StreamingHttpClient}
      */
@@ -42,7 +42,7 @@ public interface HttpClientBuilder {
     /**
      * Build a new {@link HttpClient}.
      *
-     * @param executionContext {@link ExecutionContext} used for {@link HttpClient#getExecutionContext()} and
+     * @param executionContext {@link ExecutionContext} used for {@link HttpClient#executionContext()} and
      * to buildStreaming new {@link StreamingHttpConnection}s.
      * @return A new {@link HttpClient}
      */

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientGroup.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientGroup.java
@@ -38,7 +38,7 @@ public abstract class HttpClientGroup<UnresolvedAddress> implements HttpRequestF
     /**
      * Create a new instance.
      * @param reqRespFactory The {@link HttpRequestResponseFactory} used to
-     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
      */
     protected HttpClientGroup(final HttpRequestResponseFactory reqRespFactory) {
         this.reqRespFactory = requireNonNull(reqRespFactory);
@@ -91,7 +91,7 @@ public abstract class HttpClientGroup<UnresolvedAddress> implements HttpRequestF
      * Get a {@link HttpResponseFactory}.
      * @return a {@link HttpResponseFactory}.
      */
-    public final HttpResponseFactory getHttpResponseFactory() {
+    public final HttpResponseFactory httpResponseFactory() {
         return reqRespFactory;
     }
 
@@ -106,7 +106,7 @@ public abstract class HttpClientGroup<UnresolvedAddress> implements HttpRequestF
      * @param requestToGroupKeyFunc A {@link Function} which returns the {@link GroupKey} given a
      * {@link HttpRequest}.
      * @param executionContext the {@link ExecutionContext} to use for
-     * {@link HttpRequester#getExecutionContext()}.
+     * {@link HttpRequester#executionContext()}.
      * @return A {@link HttpRequester}, which is backed by this {@link HttpClientGroup}.
      */
     public final HttpRequester asRequester(final Function<HttpRequest,

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientGroupAdapter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientGroupAdapter.java
@@ -42,7 +42,7 @@ public abstract class HttpClientGroupAdapter<UnresolvedAddress> extends HttpClie
      * Get the {@link HttpClientGroup} that this class delegates to.
      * @return the {@link HttpClientGroup} that this class delegates to.
      */
-    protected final HttpClientGroup<UnresolvedAddress> getDelegate() {
+    protected final HttpClientGroup<UnresolvedAddress> delegate() {
         return delegate;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientGroupToHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientGroupToHttpRequester.java
@@ -59,7 +59,7 @@ final class HttpClientGroupToHttpRequester<UnresolvedAddress> extends HttpReques
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
+    public ExecutionContext executionContext() {
         return executionContext;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientGroups.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientGroups.java
@@ -33,7 +33,7 @@ public final class HttpClientGroups {
      * to buildStreaming inner {@link StreamingHttpClient}s.
      * @param reqRespFactory The {@link StreamingHttpRequestFactory} used by the returned
      * {@link StreamingHttpClientGroup#newRequest(HttpRequestMethod, String)} and
-     * {@link StreamingHttpClientGroup#getHttpResponseFactory()}.
+     * {@link StreamingHttpClientGroup#httpResponseFactory()}.
      * @param clientFactory A factory to create a {@link StreamingHttpClient} for the passed {@link GroupKey}.
      * @param <UnresolvedAddress> The address type used to create new {@link StreamingHttpClient}s.
      * @return A new {@link StreamingHttpClientGroup}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientToBlockingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientToBlockingHttpClient.java
@@ -51,8 +51,8 @@ final class HttpClientToBlockingHttpClient extends BlockingHttpClient {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return client.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return client.executionContext();
     }
 
     @Override
@@ -83,13 +83,13 @@ final class HttpClientToBlockingHttpClient extends BlockingHttpClient {
         }
 
         @Override
-        public ConnectionContext getConnectionContext() {
-            return connection.getConnectionContext();
+        public ConnectionContext connectionContext() {
+            return connection.connectionContext();
         }
 
         @Override
-        public <T> BlockingIterable<T> getSettingIterable(final StreamingHttpConnection.SettingKey<T> settingKey) {
-            return connection.getSettingStream(settingKey).toIterable();
+        public <T> BlockingIterable<T> settingIterable(final StreamingHttpConnection.SettingKey<T> settingKey) {
+            return connection.settingStream(settingKey).toIterable();
         }
 
         @Override
@@ -98,8 +98,8 @@ final class HttpClientToBlockingHttpClient extends BlockingHttpClient {
         }
 
         @Override
-        public ExecutionContext getExecutionContext() {
-            return connection.getExecutionContext();
+        public ExecutionContext executionContext() {
+            return connection.executionContext();
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientToStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientToStreamingHttpClient.java
@@ -61,7 +61,7 @@ final class HttpClientToStreamingHttpClient extends StreamingHttpClient {
     @Override
     public Single<? extends UpgradableStreamingHttpResponse> upgradeConnection(final StreamingHttpRequest request) {
         return request.toRequest().flatMap(client::upgradeConnection).map(resp ->
-                        newUpgradeResponse(resp, getExecutionContext().bufferAllocator()));
+                        newUpgradeResponse(resp, executionContext().bufferAllocator()));
     }
 
     @Override
@@ -70,8 +70,8 @@ final class HttpClientToStreamingHttpClient extends StreamingHttpClient {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return client.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return client.executionContext();
     }
 
     @Override
@@ -109,13 +109,13 @@ final class HttpClientToStreamingHttpClient extends StreamingHttpClient {
         }
 
         @Override
-        public ConnectionContext getConnectionContext() {
-            return reservedConnection.getConnectionContext();
+        public ConnectionContext connectionContext() {
+            return reservedConnection.connectionContext();
         }
 
         @Override
-        public <T> Publisher<T> getSettingStream(final SettingKey<T> settingKey) {
-            return reservedConnection.getSettingStream(settingKey);
+        public <T> Publisher<T> settingStream(final SettingKey<T> settingKey) {
+            return reservedConnection.settingStream(settingKey);
         }
 
         @Override
@@ -124,8 +124,8 @@ final class HttpClientToStreamingHttpClient extends StreamingHttpClient {
         }
 
         @Override
-        public ExecutionContext getExecutionContext() {
-            return reservedConnection.getExecutionContext();
+        public ExecutionContext executionContext() {
+            return reservedConnection.executionContext();
         }
 
         @Override
@@ -173,9 +173,9 @@ final class HttpClientToStreamingHttpClient extends StreamingHttpClient {
         }
 
         @Override
-        public ReservedStreamingHttpConnection getHttpConnection(final boolean releaseReturnsToClient) {
+        public ReservedStreamingHttpConnection httpConnection(final boolean releaseReturnsToClient) {
             return new ReservedHttpConnectionToReservedStreamingHttpConnection(
-                    upgradableResponse.getHttpConnection(releaseReturnsToClient));
+                    upgradableResponse.httpConnection(releaseReturnsToClient));
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnection.java
@@ -29,7 +29,7 @@ public abstract class HttpConnection extends HttpRequester {
      * Create a new instance.
      *
      * @param reqRespFactory The {@link HttpRequestResponseFactory} used to
-     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
      */
     protected HttpConnection(final HttpRequestResponseFactory reqRespFactory) {
         super(reqRespFactory);
@@ -40,7 +40,7 @@ public abstract class HttpConnection extends HttpRequester {
      *
      * @return the {@link ConnectionContext}.
      */
-    public abstract ConnectionContext getConnectionContext();
+    public abstract ConnectionContext connectionContext();
 
     /**
      * Returns a {@link Publisher} that gives the current value of the setting as well as subsequent changes to
@@ -50,7 +50,7 @@ public abstract class HttpConnection extends HttpRequester {
      * @param <T> Type of the setting value.
      * @return {@link Publisher} for the setting values.
      */
-    public abstract <T> Publisher<T> getSettingStream(SettingKey<T> settingKey);
+    public abstract <T> Publisher<T> settingStream(SettingKey<T> settingKey);
 
     /**
      * Convert this {@link HttpConnection} to the {@link StreamingHttpConnection} API.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnectionAdapter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnectionAdapter.java
@@ -42,18 +42,18 @@ public abstract class HttpConnectionAdapter extends HttpConnection {
      * Get the {@link HttpConnection} that this class delegates to.
      * @return the {@link HttpConnection} that this class delegates to.
      */
-    protected final HttpConnection getDelegate() {
+    protected final HttpConnection delegate() {
         return delegate;
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
-        return delegate.getConnectionContext();
+    public ConnectionContext connectionContext() {
+        return delegate.connectionContext();
     }
 
     @Override
-    public <T> Publisher<T> getSettingStream(final SettingKey<T> settingKey) {
-        return delegate.getSettingStream(settingKey);
+    public <T> Publisher<T> settingStream(final SettingKey<T> settingKey) {
+        return delegate.settingStream(settingKey);
     }
 
     @Override
@@ -62,8 +62,8 @@ public abstract class HttpConnectionAdapter extends HttpConnection {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return delegate.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return delegate.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnectionToBlockingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnectionToBlockingHttpConnection.java
@@ -33,13 +33,13 @@ final class HttpConnectionToBlockingHttpConnection extends BlockingHttpConnectio
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
-        return connection.getConnectionContext();
+    public ConnectionContext connectionContext() {
+        return connection.connectionContext();
     }
 
     @Override
-    public <T> BlockingIterable<T> getSettingIterable(final SettingKey<T> settingKey) {
-        return connection.getSettingStream(settingKey).toIterable();
+    public <T> BlockingIterable<T> settingIterable(final SettingKey<T> settingKey) {
+        return connection.settingStream(settingKey).toIterable();
     }
 
     @Override
@@ -48,8 +48,8 @@ final class HttpConnectionToBlockingHttpConnection extends BlockingHttpConnectio
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return connection.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return connection.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnectionToStreamingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnectionToStreamingHttpConnection.java
@@ -32,13 +32,13 @@ final class HttpConnectionToStreamingHttpConnection extends StreamingHttpConnect
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
-        return connection.getConnectionContext();
+    public ConnectionContext connectionContext() {
+        return connection.connectionContext();
     }
 
     @Override
-    public <T> Publisher<T> getSettingStream(final SettingKey<T> settingKey) {
-        return connection.getSettingStream(settingKey);
+    public <T> Publisher<T> settingStream(final SettingKey<T> settingKey) {
+        return connection.settingStream(settingKey);
     }
 
     @Override
@@ -47,8 +47,8 @@ final class HttpConnectionToStreamingHttpConnection extends StreamingHttpConnect
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return connection.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return connection.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequester.java
@@ -31,7 +31,7 @@ public abstract class HttpRequester implements HttpRequestFactory, ListenableAsy
     /**
      * Create a new instance.
      * @param reqRespFactory The {@link HttpRequestResponseFactory} used to
-     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
      */
     protected HttpRequester(final HttpRequestResponseFactory reqRespFactory) {
         this.reqRespFactory = requireNonNull(reqRespFactory);
@@ -53,7 +53,7 @@ public abstract class HttpRequester implements HttpRequestFactory, ListenableAsy
      *
      * @return the {@link ExecutionContext} used during construction of this object.
      */
-    public abstract ExecutionContext getExecutionContext();
+    public abstract ExecutionContext executionContext();
 
     @Override
     public final HttpRequest newRequest(HttpRequestMethod method, String requestTarget) {
@@ -64,7 +64,7 @@ public abstract class HttpRequester implements HttpRequestFactory, ListenableAsy
      * Get a {@link HttpResponseFactory}.
      * @return a {@link HttpResponseFactory}.
      */
-    public final HttpResponseFactory getHttpResponseFactory() {
+    public final HttpResponseFactory httpResponseFactory() {
         return reqRespFactory;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequesterAdapter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequesterAdapter.java
@@ -39,7 +39,7 @@ public abstract class HttpRequesterAdapter extends HttpRequester {
      * Get the {@link HttpRequester} that this class delegates to.
      * @return the {@link HttpRequester} that this class delegates to.
      */
-    protected final HttpRequester getDelegate() {
+    protected final HttpRequester delegate() {
         return delegate;
     }
 
@@ -49,8 +49,8 @@ public abstract class HttpRequesterAdapter extends HttpRequester {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return delegate.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return delegate.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequesterToBlockingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequesterToBlockingHttpRequester.java
@@ -35,8 +35,8 @@ final class HttpRequesterToBlockingHttpRequester extends BlockingHttpRequester {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return requester.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return requester.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequesterToStreamingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequesterToStreamingHttpRequester.java
@@ -35,8 +35,8 @@ final class HttpRequesterToStreamingHttpRequester extends StreamingHttpRequester
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return requester.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return requester.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/LoadBalancerReadyStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/LoadBalancerReadyStreamingHttpClient.java
@@ -74,8 +74,8 @@ public final class LoadBalancerReadyStreamingHttpClient extends StreamingHttpCli
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return next.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return next.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ReservedFromStreamingHttpConnectionAdapter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ReservedFromStreamingHttpConnectionAdapter.java
@@ -42,18 +42,18 @@ public abstract class ReservedFromStreamingHttpConnectionAdapter extends Reserve
      * Get the {@link ReservedStreamingHttpConnection} that this class delegates to.
      * @return the {@link ReservedStreamingHttpConnection} that this class delegates to.
      */
-    protected final StreamingHttpConnection getDelegate() {
+    protected final StreamingHttpConnection delegate() {
         return delegate;
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
-        return delegate.getConnectionContext();
+    public ConnectionContext connectionContext() {
+        return delegate.connectionContext();
     }
 
     @Override
-    public <T> Publisher<T> getSettingStream(final SettingKey<T> settingKey) {
-        return delegate.getSettingStream(settingKey);
+    public <T> Publisher<T> settingStream(final SettingKey<T> settingKey) {
+        return delegate.settingStream(settingKey);
     }
 
     @Override
@@ -62,8 +62,8 @@ public abstract class ReservedFromStreamingHttpConnectionAdapter extends Reserve
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return delegate.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return delegate.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClient.java
@@ -43,7 +43,7 @@ public abstract class StreamingHttpClient extends StreamingHttpRequester {
      * Create a new instance.
      *
      * @param reqRespFactory The {@link StreamingHttpRequestResponseFactory} used to
-     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
      */
     protected StreamingHttpClient(final StreamingHttpRequestResponseFactory reqRespFactory) {
         super(reqRespFactory);
@@ -64,7 +64,7 @@ public abstract class StreamingHttpClient extends StreamingHttpRequester {
      * cannot be any pipelined requests pending or any pipeline requests issued during the upgrade process. That means
      * the {@link StreamingHttpConnection} associated with the {@link UpgradableStreamingHttpResponse} will be reserved
      * for exclusive use. The code responsible for determining the result of the upgrade attempt is responsible for
-     * calling {@link UpgradableStreamingHttpResponse#getHttpConnection(boolean)}.
+     * calling {@link UpgradableStreamingHttpResponse#httpConnection(boolean)}.
      * @param request the request which initiates the upgrade.
      * @return An object that provides the {@link StreamingHttpResponse} for the upgrade attempt and also contains the
      * {@link StreamingHttpConnection} used for the upgrade.
@@ -125,7 +125,7 @@ public abstract class StreamingHttpClient extends StreamingHttpRequester {
          * Create a new instance.
          *
          * @param reqRespFactory The {@link StreamingHttpRequestResponseFactory} used to
-         * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+         * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
          */
         protected ReservedStreamingHttpConnection(final StreamingHttpRequestResponseFactory reqRespFactory) {
             super(reqRespFactory);
@@ -222,7 +222,7 @@ public abstract class StreamingHttpClient extends StreamingHttpRequester {
          * the upgrade attempt, and controls the lifetime of the {@link StreamingHttpConnection} relative to this
          * {@link StreamingHttpClient}.
          */
-        ReservedStreamingHttpConnection getHttpConnection(boolean releaseReturnsToClient);
+        ReservedStreamingHttpConnection httpConnection(boolean releaseReturnsToClient);
 
         @Override
         UpgradableStreamingHttpResponse payloadBody(Publisher<Buffer> payloadBody);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientAdapter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientAdapter.java
@@ -39,7 +39,7 @@ public abstract class StreamingHttpClientAdapter extends StreamingHttpClient {
      * Get the {@link StreamingHttpClient} that this class delegates to.
      * @return the {@link StreamingHttpClient} that this class delegates to.
      */
-    protected final StreamingHttpClient getDelegate() {
+    protected final StreamingHttpClient delegate() {
         return delegate;
     }
 
@@ -59,8 +59,8 @@ public abstract class StreamingHttpClientAdapter extends StreamingHttpClient {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return delegate.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return delegate.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientGroup.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientGroup.java
@@ -39,7 +39,7 @@ public abstract class StreamingHttpClientGroup<UnresolvedAddress> implements
     /**
      * Create a new instance.
      * @param reqRespFactory The {@link StreamingHttpRequestResponseFactory} used to
-     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
      */
     protected StreamingHttpClientGroup(final StreamingHttpRequestResponseFactory reqRespFactory) {
         this.reqRespFactory = requireNonNull(reqRespFactory);
@@ -93,7 +93,7 @@ public abstract class StreamingHttpClientGroup<UnresolvedAddress> implements
      * Get a {@link StreamingHttpResponseFactory}.
      * @return a {@link StreamingHttpResponseFactory}.
      */
-    public final StreamingHttpResponseFactory getHttpResponseFactory() {
+    public final StreamingHttpResponseFactory httpResponseFactory() {
         return reqRespFactory;
     }
 
@@ -108,7 +108,7 @@ public abstract class StreamingHttpClientGroup<UnresolvedAddress> implements
      * @param requestToGroupKeyFunc A {@link Function} which returns the {@link GroupKey} given a
      * {@link StreamingHttpRequest}.
      * @param executionContext the {@link ExecutionContext} to use for
-     * {@link StreamingHttpClient#getExecutionContext()}.
+     * {@link StreamingHttpClient#executionContext()}.
      * @return A {@link StreamingHttpClient}, which is backed by this {@link StreamingHttpClientGroup}.
      */
     public final StreamingHttpClient asClient(final Function<StreamingHttpRequest,

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientGroupAdapter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientGroupAdapter.java
@@ -43,7 +43,7 @@ public abstract class StreamingHttpClientGroupAdapter<UnresolvedAddress> extends
      * Get the {@link StreamingHttpClientGroup} that this class delegates to.
      * @return the {@link StreamingHttpClientGroup} that this class delegates to.
      */
-    protected final StreamingHttpClientGroup<UnresolvedAddress> getDelegate() {
+    protected final StreamingHttpClientGroup<UnresolvedAddress> delegate() {
         return delegate;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientGroupToStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientGroupToStreamingHttpClient.java
@@ -96,7 +96,7 @@ final class StreamingHttpClientGroupToStreamingHttpClient<UnresolvedAddress> ext
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
+    public ExecutionContext executionContext() {
         return executionContext;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingHttpClient.java
@@ -52,8 +52,8 @@ final class StreamingHttpClientToBlockingHttpClient extends BlockingHttpClient {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return client.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return client.executionContext();
     }
 
     @Override
@@ -84,13 +84,13 @@ final class StreamingHttpClientToBlockingHttpClient extends BlockingHttpClient {
         }
 
         @Override
-        public ConnectionContext getConnectionContext() {
-            return connection.getConnectionContext();
+        public ConnectionContext connectionContext() {
+            return connection.connectionContext();
         }
 
         @Override
-        public <T> BlockingIterable<T> getSettingIterable(final SettingKey<T> settingKey) {
-            return connection.getSettingStream(settingKey).toIterable();
+        public <T> BlockingIterable<T> settingIterable(final SettingKey<T> settingKey) {
+            return connection.settingStream(settingKey).toIterable();
         }
 
         @Override
@@ -99,8 +99,8 @@ final class StreamingHttpClientToBlockingHttpClient extends BlockingHttpClient {
         }
 
         @Override
-        public ExecutionContext getExecutionContext() {
-            return connection.getExecutionContext();
+        public ExecutionContext executionContext() {
+            return connection.executionContext();
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingStreamingHttpClient.java
@@ -61,7 +61,7 @@ final class StreamingHttpClientToBlockingStreamingHttpClient extends BlockingStr
 
     @Override
     public ExecutionContext getExecutionContext() {
-        return client.getExecutionContext();
+        return client.executionContext();
     }
 
     @Override
@@ -112,13 +112,13 @@ final class StreamingHttpClientToBlockingStreamingHttpClient extends BlockingStr
         }
 
         @Override
-        public ConnectionContext getConnectionContext() {
-            return connection.getConnectionContext();
+        public ConnectionContext connectionContext() {
+            return connection.connectionContext();
         }
 
         @Override
-        public <T> BlockingIterable<T> getSettingIterable(final StreamingHttpConnection.SettingKey<T> settingKey) {
-            return connection.getSettingStream(settingKey).toIterable();
+        public <T> BlockingIterable<T> settingIterable(final StreamingHttpConnection.SettingKey<T> settingKey) {
+            return connection.settingStream(settingKey).toIterable();
         }
 
         @Override
@@ -128,7 +128,7 @@ final class StreamingHttpClientToBlockingStreamingHttpClient extends BlockingStr
 
         @Override
         public ExecutionContext getExecutionContext() {
-            return connection.getExecutionContext();
+            return connection.executionContext();
         }
 
         @Override
@@ -164,9 +164,9 @@ final class StreamingHttpClientToBlockingStreamingHttpClient extends BlockingStr
         }
 
         @Override
-        public ReservedBlockingStreamingHttpConnection getHttpConnection(final boolean releaseReturnsToClient) {
+        public ReservedBlockingStreamingHttpConnection httpConnection(final boolean releaseReturnsToClient) {
             return new ReservedStreamingHttpConnectionToBlockingStreaming(
-                    upgradeResponse.getHttpConnection(releaseReturnsToClient));
+                    upgradeResponse.httpConnection(releaseReturnsToClient));
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToHttpClient.java
@@ -65,8 +65,8 @@ final class StreamingHttpClientToHttpClient extends HttpClient {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return client.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return client.executionContext();
     }
 
     @Override
@@ -104,13 +104,13 @@ final class StreamingHttpClientToHttpClient extends HttpClient {
         }
 
         @Override
-        public ConnectionContext getConnectionContext() {
-            return reservedConnection.getConnectionContext();
+        public ConnectionContext connectionContext() {
+            return reservedConnection.connectionContext();
         }
 
         @Override
-        public <T> Publisher<T> getSettingStream(final StreamingHttpConnection.SettingKey<T> settingKey) {
-            return reservedConnection.getSettingStream(settingKey);
+        public <T> Publisher<T> settingStream(final StreamingHttpConnection.SettingKey<T> settingKey) {
+            return reservedConnection.settingStream(settingKey);
         }
 
         @Override
@@ -120,8 +120,8 @@ final class StreamingHttpClientToHttpClient extends HttpClient {
         }
 
         @Override
-        public ExecutionContext getExecutionContext() {
-            return reservedConnection.getExecutionContext();
+        public ExecutionContext executionContext() {
+            return reservedConnection.executionContext();
         }
 
         @Override
@@ -162,9 +162,9 @@ final class StreamingHttpClientToHttpClient extends HttpClient {
         }
 
         @Override
-        public ReservedHttpConnection getHttpConnection(final boolean releaseReturnsToClient) {
+        public ReservedHttpConnection httpConnection(final boolean releaseReturnsToClient) {
             return new ReservedStreamingHttpConnectionToReservedHttpConnection(
-                    upgradableResponse.getHttpConnection(releaseReturnsToClient));
+                    upgradableResponse.httpConnection(releaseReturnsToClient));
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnection.java
@@ -31,7 +31,7 @@ public abstract class StreamingHttpConnection extends StreamingHttpRequester {
      * Create a new instance.
      *
      * @param reqRespFactory The {@link StreamingHttpRequestResponseFactory} used to
-     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
      */
     protected StreamingHttpConnection(final StreamingHttpRequestResponseFactory reqRespFactory) {
         super(reqRespFactory);
@@ -41,7 +41,7 @@ public abstract class StreamingHttpConnection extends StreamingHttpRequester {
      * Get the {@link ConnectionContext}.
      * @return the {@link ConnectionContext}.
      */
-    public abstract ConnectionContext getConnectionContext();
+    public abstract ConnectionContext connectionContext();
 
     /**
      * Returns a {@link Publisher} that gives the current value of the setting as well as subsequent changes to the
@@ -51,7 +51,7 @@ public abstract class StreamingHttpConnection extends StreamingHttpRequester {
      * @param <T> Type of the setting value.
      * @return {@link Publisher} for the setting values.
      */
-    public abstract <T> Publisher<T> getSettingStream(SettingKey<T> settingKey);
+    public abstract <T> Publisher<T> settingStream(SettingKey<T> settingKey);
 
     /**
      * Convert this {@link StreamingHttpConnection} to the {@link HttpConnection} API.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionAdapter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionAdapter.java
@@ -41,18 +41,18 @@ public abstract class StreamingHttpConnectionAdapter extends StreamingHttpConnec
      * Get the {@link StreamingHttpConnection} that this class delegates to.
      * @return the {@link StreamingHttpConnection} that this class delegates to.
      */
-    protected final StreamingHttpConnection getDelegate() {
+    protected final StreamingHttpConnection delegate() {
         return delegate;
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
-        return delegate.getConnectionContext();
+    public ConnectionContext connectionContext() {
+        return delegate.connectionContext();
     }
 
     @Override
-    public <T> Publisher<T> getSettingStream(final SettingKey<T> settingKey) {
-        return delegate.getSettingStream(settingKey);
+    public <T> Publisher<T> settingStream(final SettingKey<T> settingKey) {
+        return delegate.settingStream(settingKey);
     }
 
     @Override
@@ -61,8 +61,8 @@ public abstract class StreamingHttpConnectionAdapter extends StreamingHttpConnec
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return delegate.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return delegate.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToBlockingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToBlockingHttpConnection.java
@@ -32,13 +32,13 @@ final class StreamingHttpConnectionToBlockingHttpConnection extends BlockingHttp
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
-        return connection.getConnectionContext();
+    public ConnectionContext connectionContext() {
+        return connection.connectionContext();
     }
 
     @Override
-    public <T> BlockingIterable<T> getSettingIterable(final StreamingHttpConnection.SettingKey<T> settingKey) {
-        return connection.getSettingStream(settingKey).toIterable();
+    public <T> BlockingIterable<T> settingIterable(final StreamingHttpConnection.SettingKey<T> settingKey) {
+        return connection.settingStream(settingKey).toIterable();
     }
 
     @Override
@@ -47,8 +47,8 @@ final class StreamingHttpConnectionToBlockingHttpConnection extends BlockingHttp
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return connection.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return connection.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToBlockingStreamingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToBlockingStreamingHttpConnection.java
@@ -34,13 +34,13 @@ final class StreamingHttpConnectionToBlockingStreamingHttpConnection extends Blo
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
-        return connection.getConnectionContext();
+    public ConnectionContext connectionContext() {
+        return connection.connectionContext();
     }
 
     @Override
-    public <T> BlockingIterable<T> getSettingIterable(final SettingKey<T> settingKey) {
-        return connection.getSettingStream(settingKey).toIterable();
+    public <T> BlockingIterable<T> settingIterable(final SettingKey<T> settingKey) {
+        return connection.settingStream(settingKey).toIterable();
     }
 
     @Override
@@ -50,7 +50,7 @@ final class StreamingHttpConnectionToBlockingStreamingHttpConnection extends Blo
 
     @Override
     public ExecutionContext getExecutionContext() {
-        return connection.getExecutionContext();
+        return connection.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToHttpConnection.java
@@ -32,13 +32,13 @@ final class StreamingHttpConnectionToHttpConnection extends HttpConnection {
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
-        return connection.getConnectionContext();
+    public ConnectionContext connectionContext() {
+        return connection.connectionContext();
     }
 
     @Override
-    public <T> Publisher<T> getSettingStream(final StreamingHttpConnection.SettingKey<T> settingKey) {
-        return connection.getSettingStream(settingKey);
+    public <T> Publisher<T> settingStream(final StreamingHttpConnection.SettingKey<T> settingKey) {
+        return connection.settingStream(settingKey);
     }
 
     @Override
@@ -47,8 +47,8 @@ final class StreamingHttpConnectionToHttpConnection extends HttpConnection {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return connection.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return connection.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequester.java
@@ -33,7 +33,7 @@ public abstract class StreamingHttpRequester implements
     /**
      * Create a new instance.
      * @param reqRespFactory The {@link StreamingHttpRequestResponseFactory} used to
-     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+     * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
      */
     protected StreamingHttpRequester(final StreamingHttpRequestResponseFactory reqRespFactory) {
         this.reqRespFactory = requireNonNull(reqRespFactory);
@@ -53,7 +53,7 @@ public abstract class StreamingHttpRequester implements
      * unless that was how this object was built.
      * @return the {@link ExecutionContext} used during construction of this object.
      */
-    public abstract ExecutionContext getExecutionContext();
+    public abstract ExecutionContext executionContext();
 
     @Override
     public final StreamingHttpRequest newRequest(HttpRequestMethod method, String requestTarget) {
@@ -64,7 +64,7 @@ public abstract class StreamingHttpRequester implements
      * Get a {@link StreamingHttpResponseFactory}.
      * @return a {@link StreamingHttpResponseFactory}.
      */
-    public final StreamingHttpResponseFactory getHttpResponseFactory() {
+    public final StreamingHttpResponseFactory httpResponseFactory() {
         return reqRespFactory;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequesterAdapter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequesterAdapter.java
@@ -39,7 +39,7 @@ public abstract class StreamingHttpRequesterAdapter extends StreamingHttpRequest
      * Get the {@link StreamingHttpRequester} that this class delegates to.
      * @return the {@link StreamingHttpRequester} that this class delegates to.
      */
-    protected final StreamingHttpRequester getDelegate() {
+    protected final StreamingHttpRequester delegate() {
         return delegate;
     }
 
@@ -49,8 +49,8 @@ public abstract class StreamingHttpRequesterAdapter extends StreamingHttpRequest
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return delegate.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return delegate.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequesterToBlockingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequesterToBlockingHttpRequester.java
@@ -35,8 +35,8 @@ final class StreamingHttpRequesterToBlockingHttpRequester extends BlockingHttpRe
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return requester.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return requester.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequesterToBlockingStreamingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequesterToBlockingStreamingHttpRequester.java
@@ -37,7 +37,7 @@ final class StreamingHttpRequesterToBlockingStreamingHttpRequester extends Block
 
     @Override
     public ExecutionContext getExecutionContext() {
-        return requester.getExecutionContext();
+        return requester.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequesterToHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequesterToHttpRequester.java
@@ -35,8 +35,8 @@ final class StreamingHttpRequesterToHttpRequester extends HttpRequester {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return requester.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return requester.executionContext();
     }
 
     @Override

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpClientGroupTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpClientGroupTest.java
@@ -266,7 +266,7 @@ public class BlockingStreamingHttpClientGroupTest {
          * Create a new instance.
          *
          * @param reqRespFactory The {@link StreamingHttpRequestResponseFactory} used to
-         * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+         * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
          */
         protected TestStreamingHttpClientGroup(final StreamingHttpRequestResponseFactory reqRespFactory) {
             super(reqRespFactory);
@@ -303,7 +303,7 @@ public class BlockingStreamingHttpClientGroupTest {
          * Create a new instance.
          *
          * @param reqRespFactory The {@link BlockingStreamingHttpRequestResponseFactory} used to
-         * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #getHttpResponseFactory()}.
+         * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
          */
         protected TestBlockingStreamingHttpClientGroup(final BlockingStreamingHttpRequestResponseFactory reqRespFactory) {
             super(reqRespFactory);

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpClientTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpClientTest.java
@@ -90,7 +90,7 @@ public class BlockingStreamingHttpClientTest extends AbstractBlockingStreamingHt
         }
 
         @Override
-        public ExecutionContext getExecutionContext() {
+        public ExecutionContext executionContext() {
             return executionContext;
         }
 

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpConnectionTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpConnectionTest.java
@@ -73,12 +73,12 @@ public class BlockingStreamingHttpConnectionTest extends AbstractBlockingStreami
         }
 
         @Override
-        public final ConnectionContext getConnectionContext() {
+        public final ConnectionContext connectionContext() {
             return connectionContext;
         }
 
         @Override
-        public final <T> Publisher<T> getSettingStream(final SettingKey<T> settingKey) {
+        public final <T> Publisher<T> settingStream(final SettingKey<T> settingKey) {
             return Publisher.error(new IllegalStateException("unsupported"));
         }
 
@@ -101,7 +101,7 @@ public class BlockingStreamingHttpConnectionTest extends AbstractBlockingStreami
         }
 
         @Override
-        public ExecutionContext getExecutionContext() {
+        public ExecutionContext executionContext() {
             return executionContext;
         }
 
@@ -126,7 +126,7 @@ public class BlockingStreamingHttpConnectionTest extends AbstractBlockingStreami
         }
 
         @Override
-        public ConnectionContext getConnectionContext() {
+        public ConnectionContext connectionContext() {
             return connectionContext;
         }
 
@@ -136,7 +136,7 @@ public class BlockingStreamingHttpConnectionTest extends AbstractBlockingStreami
         }
 
         @Override
-        public <T> BlockingIterable<T> getSettingIterable(final StreamingHttpConnection.SettingKey<T> settingKey) {
+        public <T> BlockingIterable<T> settingIterable(final StreamingHttpConnection.SettingKey<T> settingKey) {
             throw new UnsupportedOperationException();
         }
 

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultStreamingHttpClientGroupTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultStreamingHttpClientGroupTest.java
@@ -263,7 +263,7 @@ public class DefaultStreamingHttpClientGroupTest {
         final StreamingHttpRequester requester = clientGroup.asClient(r ->
                 new DefaultGroupKey<>("address", executionContext), executionContext);
         assertNotNull(requester);
-        assertEquals(executionContext, requester.getExecutionContext());
+        assertEquals(executionContext, requester.executionContext());
     }
 
     @Test

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpClient.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpClient.java
@@ -46,7 +46,7 @@ public class TestStreamingHttpClient extends StreamingHttpClient {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
+    public ExecutionContext executionContext() {
         return executionContext;
     }
 

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpConnection.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpConnection.java
@@ -51,17 +51,17 @@ public class TestStreamingHttpConnection extends StreamingHttpConnection {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
+    public ExecutionContext executionContext() {
         return executionContext;
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
+    public ConnectionContext connectionContext() {
         return connectionContext;
     }
 
     @Override
-    public <T> Publisher<T> getSettingStream(final SettingKey<T> settingKey) {
+    public <T> Publisher<T> settingStream(final SettingKey<T> settingKey) {
         return Publisher.error(new UnsupportedOperationException());
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -50,13 +50,13 @@ abstract class AbstractStreamingHttpConnection<CC extends ConnectionContext> ext
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
+    public ConnectionContext connectionContext() {
         return connection;
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public final <T> Publisher<T> getSettingStream(final SettingKey<T> settingKey) {
+    public final <T> Publisher<T> settingStream(final SettingKey<T> settingKey) {
         if (settingKey == SettingKey.MAX_CONCURRENCY) {
             return (Publisher<T>) maxConcurrencySetting;
         }
@@ -76,7 +76,7 @@ abstract class AbstractStreamingHttpConnection<CC extends ConnectionContext> ext
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
+    public ExecutionContext executionContext() {
         return executionContext;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -274,8 +274,8 @@ final class DefaultMultiAddressUrlHttpClientBuilder
         }
 
         @Override
-        public ExecutionContext getExecutionContext() {
-            return httpClient.getExecutionContext();
+        public ExecutionContext executionContext() {
+            return httpClient.executionContext();
         }
 
         @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultStreamingHttpClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultStreamingHttpClient.java
@@ -71,7 +71,7 @@ final class DefaultStreamingHttpClient extends StreamingHttpClient {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
+    public ExecutionContext executionContext() {
         return executionContext;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpConnection.java
@@ -58,6 +58,6 @@ final class LoadBalancedStreamingHttpConnection extends ReservedFromStreamingHtt
 
     @Override
     public String toString() {
-        return LoadBalancedStreamingHttpConnection.class.getSimpleName() + "(" + getDelegate() + ")";
+        return LoadBalancedStreamingHttpConnection.class.getSimpleName() + "(" + delegate() + ")";
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NonPipelinedLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NonPipelinedLBHttpConnectionFactory.java
@@ -46,7 +46,7 @@ final class NonPipelinedLBHttpConnectionFactory<ResolvedAddress>
                                                               final ConnectionFilterFunction connectionFilterFunction) {
         return buildForNonPipelined(executionContext, resolvedAddress, config, connectionFilterFunction, reqRespFactory)
                 .map(filteredConnection -> new LoadBalancedStreamingHttpConnection(filteredConnection,
-                        newSingleController(filteredConnection.getSettingStream(MAX_CONCURRENCY),
+                        newSingleController(filteredConnection.settingStream(MAX_CONCURRENCY),
                                 filteredConnection.onClose())));
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
@@ -45,7 +45,7 @@ final class PipelinedLBHttpConnectionFactory<ResolvedAddress> extends AbstractLB
                                                               final ConnectionFilterFunction connectionFilterFunction) {
         return buildForPipelined(executionContext, resolvedAddress, config, connectionFilterFunction, reqRespFactory)
                 .map(filteredConnection -> new LoadBalancedStreamingHttpConnection(filteredConnection,
-                        newController(filteredConnection.getSettingStream(MAX_CONCURRENCY),
+                        newController(filteredConnection.settingStream(MAX_CONCURRENCY),
                                    filteredConnection.onClose(),
                                    config.getMaxPipelinedRequests())));
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingHttpConnectionConcurrentRequestsFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingHttpConnectionConcurrentRequestsFilter.java
@@ -35,8 +35,8 @@ final class StreamingHttpConnectionConcurrentRequestsFilter extends StreamingHtt
                                                     int defaultMaxPipelinedRequests) {
         super(next);
         limiter = defaultMaxPipelinedRequests == 1 ?
-                newSingleController(next.getSettingStream(MAX_CONCURRENCY), next.onClose()) :
-                newController(next.getSettingStream(MAX_CONCURRENCY), next.onClose(), defaultMaxPipelinedRequests);
+                newSingleController(next.settingStream(MAX_CONCURRENCY), next.onClose()) :
+                newController(next.settingStream(MAX_CONCURRENCY), next.onClose(), defaultMaxPipelinedRequests);
     }
 
     @Override
@@ -45,7 +45,7 @@ final class StreamingHttpConnectionConcurrentRequestsFilter extends StreamingHtt
             @Override
             protected void handleSubscribe(final Subscriber<? super StreamingHttpResponse> subscriber) {
                 if (limiter.tryRequest()) {
-                    getDelegate().request(request).liftSynchronous(new ConcurrencyControlSingleOperator(limiter))
+                    delegate().request(request).liftSynchronous(new ConcurrencyControlSingleOperator(limiter))
                             .subscribe(subscriber);
                 } else {
                     subscriber.onSubscribe(IGNORE_CANCEL);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpConnectionTest.java
@@ -108,7 +108,7 @@ public final class AbstractHttpConnectionTest {
 
     @Test
     public void shouldEmitMaxConcurrencyInSettingStream() throws ExecutionException, InterruptedException {
-        Integer max = awaitIndefinitely(http.getSettingStream(MAX_CONCURRENCY).first());
+        Integer max = awaitIndefinitely(http.settingStream(MAX_CONCURRENCY).first());
         assertThat(max, equalTo(101));
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultHttpConnectionBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultHttpConnectionBuilderTest.java
@@ -65,18 +65,18 @@ public class DefaultHttpConnectionBuilderTest extends AbstractEchoServerBasedHtt
         @Override
         public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
             // fanout - simulates followup request on response
-            return getDelegate().request(request).flatMap(resp ->
-                    resp.payloadBody().ignoreElements().andThen(getDelegate().request(request)));
+            return delegate().request(request).flatMap(resp ->
+                    resp.payloadBody().ignoreElements().andThen(delegate().request(request)));
         }
 
         @Override
         @SuppressWarnings("unchecked")
-        public <T> Publisher<T> getSettingStream(final SettingKey<T> settingKey) {
+        public <T> Publisher<T> settingStream(final SettingKey<T> settingKey) {
             if (settingKey == MAX_CONCURRENCY) {
                 // Compensate for the extra request
-                return (Publisher<T>) getDelegate().getSettingStream(MAX_CONCURRENCY).map(i -> i - 1);
+                return (Publisher<T>) delegate().settingStream(MAX_CONCURRENCY).map(i -> i - 1);
             }
-            return getDelegate().getSettingStream(settingKey);
+            return delegate().settingStream(settingKey);
         }
     }
 
@@ -90,7 +90,7 @@ public class DefaultHttpConnectionBuilderTest extends AbstractEchoServerBasedHtt
 
         DummyFanoutFilter connection = awaitIndefinitelyNonNull(connectionSingle);
 
-        Integer maxConcurrent = awaitIndefinitely(connection.getSettingStream(MAX_CONCURRENCY).first());
+        Integer maxConcurrent = awaitIndefinitely(connection.settingStream(MAX_CONCURRENCY).first());
         assertThat(maxConcurrent, equalTo(9));
 
         makeRequestValidateResponseAndClose(connection);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionConcurrentRequestsFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionConcurrentRequestsFilterTest.java
@@ -76,8 +76,8 @@ public class HttpConnectionConcurrentRequestsFilterTest {
                 connectionContext) {
             private final AtomicInteger reqCount = new AtomicInteger(0);
             @Override
-            public <T> Publisher<T> getSettingStream(final SettingKey<T> settingKey) {
-                return settingKey == MAX_CONCURRENCY ? (Publisher<T>) just(2) : super.getSettingStream(settingKey);
+            public <T> Publisher<T> settingStream(final SettingKey<T> settingKey) {
+                return settingKey == MAX_CONCURRENCY ? (Publisher<T>) just(2) : super.settingStream(settingKey);
             }
 
             @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionEmptyPayloadTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionEmptyPayloadTest.java
@@ -102,7 +102,7 @@ public class HttpConnectionEmptyPayloadTest {
             assertNotNull(contentLength);
             assertEquals(expectedContentLength, parseInt(contentLength.toString()));
             Buffer buffer = awaitIndefinitelyNonNull(response.payloadBody().reduce(
-                    () -> connection.getConnectionContext().executionContext().bufferAllocator().newBuffer(),
+                    () -> connection.connectionContext().executionContext().bufferAllocator().newBuffer(),
                     Buffer::writeBytes));
             byte[] actualBytes = new byte[buffer.getReadableBytes()];
             buffer.readBytes(actualBytes);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
@@ -106,7 +106,7 @@ public class HttpOffloadingTest {
         client = forSingleAddress(HostAndPort.of(LOOPBACK_ADDRESS.getHostName(), socketAddress.getPort()))
                 .buildStreaming(CLIENT_CTX);
         httpConnection = awaitIndefinitelyNonNull(client.reserveConnection(client.get("/")));
-        connectionContext = httpConnection.getConnectionContext();
+        connectionContext = httpConnection.connectionContext();
     }
 
     @After
@@ -117,7 +117,7 @@ public class HttpOffloadingTest {
     @Test
     public void requestResponseIsOffloaded() throws Exception {
         final Publisher<Buffer> reqPayload =
-                just(httpConnection.getConnectionContext().executionContext().bufferAllocator()
+                just(httpConnection.connectionContext().executionContext().bufferAllocator()
                         .fromAscii("Hello"))
                         .doBeforeRequest(n -> {
                             if (inEventLoopOrTestThread().test(currentThread())) {
@@ -232,7 +232,7 @@ public class HttpOffloadingTest {
     @Test
     public void clientSettingsStreamIsOffloaded() throws Exception {
         subscribeTo(inEventLoop(), errors,
-                httpConnection.getSettingStream(MAX_CONCURRENCY).doAfterFinally(terminated::countDown),
+                httpConnection.settingStream(MAX_CONCURRENCY).doAfterFinally(terminated::countDown),
                 "Client settings stream: ");
         awaitIndefinitely(httpConnection.closeAsyncGracefully());
         terminated.await();

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RedirectingStreamingHttpClientGroup.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RedirectingStreamingHttpClientGroup.java
@@ -95,7 +95,7 @@ public final class RedirectingStreamingHttpClientGroup<UnresolvedAddress> extend
     @Override
     public Single<StreamingHttpResponse> request(final GroupKey<UnresolvedAddress> key,
                                                  final StreamingHttpRequest request) {
-        final Single<StreamingHttpResponse> response = getDelegate().request(key, request);
+        final Single<StreamingHttpResponse> response = delegate().request(key, request);
         if (maxRedirects <= 0) {
             return response;
         }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/StreamingHttpConnectionHostHeaderFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/StreamingHttpConnectionHostHeaderFilter.java
@@ -90,6 +90,6 @@ public final class StreamingHttpConnectionHostHeaderFilter extends StreamingHttp
         if (request.version() == HTTP_1_1 && !request.headers().contains(HOST)) {
             request.headers().set(HOST, fallbackHost);
         }
-        return getDelegate().request(request);
+        return delegate().request(request);
     }
 }

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/OpenTracingStreamingHttpConnectionFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/OpenTracingStreamingHttpConnectionFilter.java
@@ -93,7 +93,7 @@ public class OpenTracingStreamingHttpConnectionFilter extends StreamingHttpConne
 
                 Scope childScope = spanBuilder.startActive(true);
                 tracer.inject(childScope.span().context(), formatter, request.headers());
-                getDelegate().request(request).map(resp -> resp.transformRawPayloadBody(pub ->
+                delegate().request(request).map(resp -> resp.transformRawPayloadBody(pub ->
                         pub.doOnError(cause -> tagErrorAndClose(childScope))
                            .doOnCancel(() -> tagErrorAndClose(childScope))
                            .doOnComplete(() -> {

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultBufferRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultBufferRedisCommander.java
@@ -61,7 +61,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> append(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.APPEND, allocator);
@@ -75,7 +75,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<String> auth(final Buffer password) {
         requireNonNull(password);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.AUTH, allocator);
@@ -87,7 +87,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> bgrewriteaof() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BGREWRITEAOF, allocator);
@@ -98,7 +98,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> bgsave() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BGSAVE, allocator);
@@ -110,7 +110,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> bitcount(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITCOUNT, allocator);
@@ -124,7 +124,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> bitcount(@RedisProtocolSupport.Key final Buffer key, @Nullable final Long start,
                                  @Nullable final Long end) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (start != null) {
@@ -151,7 +151,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                        final Collection<RedisProtocolSupport.BitfieldOperation> operations) {
         requireNonNull(key);
         requireNonNull(operations);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         final CompositeBuffer cbOps = allocator.newCompositeBuffer();
         final int len = 2 + operations.stream().mapToInt(op -> op.writeTo(cbOps, allocator)).sum();
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITFIELD, allocator);
@@ -168,7 +168,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(operation);
         requireNonNull(destkey);
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITOP, allocator);
@@ -188,7 +188,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(destkey);
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITOP, allocator);
@@ -210,7 +210,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITOP, allocator);
@@ -230,7 +230,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(operation);
         requireNonNull(destkey);
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -246,7 +246,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> bitpos(@RedisProtocolSupport.Key final Buffer key, final long bit) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITPOS, allocator);
@@ -261,7 +261,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> bitpos(@RedisProtocolSupport.Key final Buffer key, final long bit, @Nullable final Long start,
                                @Nullable final Long end) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (start != null) {
@@ -287,7 +287,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> blpop(@RedisProtocolSupport.Key final Collection<Buffer> keys, final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -302,7 +302,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> brpop(@RedisProtocolSupport.Key final Collection<Buffer> keys, final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -319,7 +319,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                      @RedisProtocolSupport.Key final Buffer destination, final long timeout) {
         requireNonNull(source);
         requireNonNull(destination);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BRPOPLPUSH, allocator);
@@ -334,7 +334,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> bzpopmax(@RedisProtocolSupport.Key final Collection<Buffer> keys, final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -349,7 +349,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> bzpopmin(@RedisProtocolSupport.Key final Collection<Buffer> keys, final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -364,7 +364,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> clientKill(@Nullable final Long id, @Nullable final RedisProtocolSupport.ClientKillType type,
                                    @Nullable final Buffer addrIpPort, @Nullable final Buffer skipmeYesNo) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (id != null) {
@@ -403,7 +403,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<Buffer> clientList() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -415,7 +415,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<Buffer> clientGetname() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -427,7 +427,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> clientPause(final long timeout) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -441,7 +441,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<String> clientReply(final RedisProtocolSupport.ClientReplyReplyMode replyMode) {
         requireNonNull(replyMode);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -455,7 +455,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<String> clientSetname(final Buffer connectionName) {
         requireNonNull(connectionName);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -468,7 +468,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> clusterAddslots(final long slot) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -481,7 +481,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> clusterAddslots(final long slot1, final long slot2) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -495,7 +495,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> clusterAddslots(final long slot1, final long slot2, final long slot3) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -511,7 +511,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<String> clusterAddslots(final Collection<Long> slots) {
         requireNonNull(slots);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += slots.size();
@@ -526,7 +526,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> clusterCountFailureReports(final Buffer nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -539,7 +539,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<Long> clusterCountkeysinslot(final long slot) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -552,7 +552,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> clusterDelslots(final long slot) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -565,7 +565,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> clusterDelslots(final long slot1, final long slot2) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -579,7 +579,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> clusterDelslots(final long slot1, final long slot2, final long slot3) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -595,7 +595,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<String> clusterDelslots(final Collection<Long> slots) {
         requireNonNull(slots);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += slots.size();
@@ -609,7 +609,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> clusterFailover() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -621,7 +621,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> clusterFailover(@Nullable final RedisProtocolSupport.ClusterFailoverOptions options) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (options != null) {
@@ -640,7 +640,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<String> clusterForget(final Buffer nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -653,7 +653,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public <T> Single<List<T>> clusterGetkeysinslot(final long slot, final long count) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -667,7 +667,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<Buffer> clusterInfo() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -680,7 +680,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> clusterKeyslot(final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -694,7 +694,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<String> clusterMeet(final Buffer ip, final long port) {
         requireNonNull(ip);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -708,7 +708,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<Buffer> clusterNodes() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -721,7 +721,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<String> clusterReplicate(final Buffer nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -734,7 +734,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> clusterReset() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -746,7 +746,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> clusterReset(@Nullable final RedisProtocolSupport.ClusterResetResetType resetType) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (resetType != null) {
@@ -764,7 +764,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> clusterSaveconfig() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -776,7 +776,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> clusterSetConfigEpoch(final long configEpoch) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -791,7 +791,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<String> clusterSetslot(final long slot,
                                          final RedisProtocolSupport.ClusterSetslotSubcommand subcommand) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -808,7 +808,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                          final RedisProtocolSupport.ClusterSetslotSubcommand subcommand,
                                          @Nullable final Buffer nodeId) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (nodeId != null) {
@@ -829,7 +829,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Buffer> clusterSlaves(final Buffer nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -842,7 +842,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public <T> Single<List<T>> clusterSlots() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -854,7 +854,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public <T> Single<List<T>> command() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND, allocator);
@@ -865,7 +865,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<Long> commandCount() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -877,7 +877,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public <T> Single<List<T>> commandGetkeys() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -890,7 +890,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> commandInfo(final Buffer commandName) {
         requireNonNull(commandName);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -905,7 +905,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public <T> Single<List<T>> commandInfo(final Buffer commandName1, final Buffer commandName2) {
         requireNonNull(commandName1);
         requireNonNull(commandName2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -923,7 +923,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(commandName1);
         requireNonNull(commandName2);
         requireNonNull(commandName3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -939,7 +939,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> commandInfo(final Collection<Buffer> commandNames) {
         requireNonNull(commandNames);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += commandNames.size();
@@ -954,7 +954,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> configGet(final Buffer parameter) {
         requireNonNull(parameter);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -967,7 +967,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> configRewrite() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -981,7 +981,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<String> configSet(final Buffer parameter, final Buffer value) {
         requireNonNull(parameter);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -995,7 +995,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> configResetstat() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1007,7 +1007,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<Long> dbsize() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DBSIZE, allocator);
@@ -1019,7 +1019,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<String> debugObject(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEBUG,
@@ -1032,7 +1032,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> debugSegfault() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEBUG,
@@ -1045,7 +1045,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> decr(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DECR, allocator);
@@ -1058,7 +1058,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> decrby(@RedisProtocolSupport.Key final Buffer key, final long decrement) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DECRBY, allocator);
@@ -1072,7 +1072,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> del(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEL, allocator);
@@ -1086,7 +1086,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> del(@RedisProtocolSupport.Key final Buffer key1, @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEL, allocator);
@@ -1103,7 +1103,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEL, allocator);
@@ -1118,7 +1118,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> del(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -1132,7 +1132,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Buffer> dump(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DUMP, allocator);
@@ -1145,7 +1145,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Buffer> echo(final Buffer message) {
         requireNonNull(message);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ECHO, allocator);
@@ -1161,7 +1161,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(script);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1183,7 +1183,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(script);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1205,7 +1205,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(script);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1227,7 +1227,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(sha1);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1249,7 +1249,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(sha1);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1271,7 +1271,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(sha1);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1289,7 +1289,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> exists(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXISTS, allocator);
@@ -1304,7 +1304,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXISTS, allocator);
@@ -1321,7 +1321,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXISTS, allocator);
@@ -1336,7 +1336,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> exists(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -1350,7 +1350,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> expire(@RedisProtocolSupport.Key final Buffer key, final long seconds) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXPIRE, allocator);
@@ -1364,7 +1364,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> expireat(@RedisProtocolSupport.Key final Buffer key, final long timestamp) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXPIREAT, allocator);
@@ -1377,7 +1377,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> flushall() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.FLUSHALL, allocator);
@@ -1388,7 +1388,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> flushall(@Nullable final RedisProtocolSupport.FlushallAsync async) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (async != null) {
@@ -1405,7 +1405,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> flushdb() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.FLUSHDB, allocator);
@@ -1416,7 +1416,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> flushdb(@Nullable final RedisProtocolSupport.FlushdbAsync async) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (async != null) {
@@ -1436,7 +1436,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                final double latitude, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOADD, allocator);
@@ -1456,7 +1456,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 8;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOADD, allocator);
@@ -1481,7 +1481,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 11;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOADD, allocator);
@@ -1505,7 +1505,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                final Collection<RedisProtocolSupport.BufferLongitudeLatitudeMember> longitudeLatitudeMembers) {
         requireNonNull(key);
         requireNonNull(longitudeLatitudeMembers);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += RedisProtocolSupport.BufferLongitudeLatitudeMember.SIZE * longitudeLatitudeMembers.size();
@@ -1523,7 +1523,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEODIST, allocator);
@@ -1542,7 +1542,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (unit != null) {
@@ -1565,7 +1565,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public <T> Single<List<T>> geohash(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOHASH, allocator);
@@ -1582,7 +1582,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOHASH, allocator);
@@ -1601,7 +1601,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOHASH, allocator);
@@ -1618,7 +1618,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public <T> Single<List<T>> geohash(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -1634,7 +1634,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public <T> Single<List<T>> geopos(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOPOS, allocator);
@@ -1651,7 +1651,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOPOS, allocator);
@@ -1670,7 +1670,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOPOS, allocator);
@@ -1687,7 +1687,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public <T> Single<List<T>> geopos(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -1705,7 +1705,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                          final RedisProtocolSupport.GeoradiusUnit unit) {
         requireNonNull(key);
         requireNonNull(unit);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEORADIUS, allocator);
@@ -1732,7 +1732,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                          @Nullable @RedisProtocolSupport.Key final Buffer storedistKey) {
         requireNonNull(key);
         requireNonNull(unit);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         if (withcoord != null) {
@@ -1798,7 +1798,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(member);
         requireNonNull(unit);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEORADIUSBYMEMBER,
@@ -1826,7 +1826,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(member);
         requireNonNull(unit);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         if (withcoord != null) {
@@ -1888,7 +1888,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Buffer> get(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GET, allocator);
@@ -1901,7 +1901,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> getbit(@RedisProtocolSupport.Key final Buffer key, final long offset) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GETBIT, allocator);
@@ -1915,7 +1915,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Buffer> getrange(@RedisProtocolSupport.Key final Buffer key, final long start, final long end) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GETRANGE, allocator);
@@ -1931,7 +1931,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Buffer> getset(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GETSET, allocator);
@@ -1946,7 +1946,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> hdel(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HDEL, allocator);
@@ -1962,7 +1962,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HDEL, allocator);
@@ -1981,7 +1981,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(field1);
         requireNonNull(field2);
         requireNonNull(field3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HDEL, allocator);
@@ -1998,7 +1998,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> hdel(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
         requireNonNull(key);
         requireNonNull(fields);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += fields.size();
@@ -2014,7 +2014,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> hexists(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HEXISTS, allocator);
@@ -2029,7 +2029,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Buffer> hget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HGET, allocator);
@@ -2043,7 +2043,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> hgetall(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HGETALL, allocator);
@@ -2057,7 +2057,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> hincrby(@RedisProtocolSupport.Key final Buffer key, final Buffer field, final long increment) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HINCRBY, allocator);
@@ -2074,7 +2074,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                        final double increment) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HINCRBYFLOAT, allocator);
@@ -2090,7 +2090,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> hkeys(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HKEYS, allocator);
@@ -2103,7 +2103,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> hlen(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HLEN, allocator);
@@ -2117,7 +2117,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMGET, allocator);
@@ -2134,7 +2134,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMGET, allocator);
@@ -2153,7 +2153,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(field1);
         requireNonNull(field2);
         requireNonNull(field3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMGET, allocator);
@@ -2170,7 +2170,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
         requireNonNull(key);
         requireNonNull(fields);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += fields.size();
@@ -2187,7 +2187,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMSET, allocator);
@@ -2207,7 +2207,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(value1);
         requireNonNull(field2);
         requireNonNull(value2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMSET, allocator);
@@ -2231,7 +2231,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(value2);
         requireNonNull(field3);
         requireNonNull(value3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 8;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMSET, allocator);
@@ -2252,7 +2252,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                 final Collection<RedisProtocolSupport.BufferFieldValue> fieldValues) {
         requireNonNull(key);
         requireNonNull(fieldValues);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += RedisProtocolSupport.BufferFieldValue.SIZE * fieldValues.size();
@@ -2267,7 +2267,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> hscan(@RedisProtocolSupport.Key final Buffer key, final long cursor) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSCAN, allocator);
@@ -2282,7 +2282,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public <T> Single<List<T>> hscan(@RedisProtocolSupport.Key final Buffer key, final long cursor,
                                      @Nullable final Buffer matchPattern, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (matchPattern != null) {
@@ -2312,7 +2312,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSET, allocator);
@@ -2329,7 +2329,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSETNX, allocator);
@@ -2345,7 +2345,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> hstrlen(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSTRLEN, allocator);
@@ -2359,7 +2359,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> hvals(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HVALS, allocator);
@@ -2372,7 +2372,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> incr(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INCR, allocator);
@@ -2385,7 +2385,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> incrby(@RedisProtocolSupport.Key final Buffer key, final long increment) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INCRBY, allocator);
@@ -2399,7 +2399,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Double> incrbyfloat(@RedisProtocolSupport.Key final Buffer key, final double increment) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INCRBYFLOAT, allocator);
@@ -2413,7 +2413,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<Buffer> info() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INFO, allocator);
@@ -2424,7 +2424,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<Buffer> info(@Nullable final Buffer section) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (section != null) {
@@ -2442,7 +2442,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> keys(final Buffer pattern) {
         requireNonNull(pattern);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.KEYS, allocator);
@@ -2454,7 +2454,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<Long> lastsave() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LASTSAVE, allocator);
@@ -2466,7 +2466,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Buffer> lindex(@RedisProtocolSupport.Key final Buffer key, final long index) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LINDEX, allocator);
@@ -2484,7 +2484,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(where);
         requireNonNull(pivot);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LINSERT, allocator);
@@ -2500,7 +2500,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> llen(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LLEN, allocator);
@@ -2513,7 +2513,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Buffer> lpop(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPOP, allocator);
@@ -2527,7 +2527,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> lpush(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSH, allocator);
@@ -2543,7 +2543,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(value1);
         requireNonNull(value2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSH, allocator);
@@ -2562,7 +2562,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(value1);
         requireNonNull(value2);
         requireNonNull(value3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSH, allocator);
@@ -2579,7 +2579,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> lpush(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> values) {
         requireNonNull(key);
         requireNonNull(values);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += values.size();
@@ -2595,7 +2595,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> lpushx(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSHX, allocator);
@@ -2609,7 +2609,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> lrange(@RedisProtocolSupport.Key final Buffer key, final long start, final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LRANGE, allocator);
@@ -2625,7 +2625,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> lrem(@RedisProtocolSupport.Key final Buffer key, final long count, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LREM, allocator);
@@ -2641,7 +2641,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<String> lset(@RedisProtocolSupport.Key final Buffer key, final long index, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LSET, allocator);
@@ -2656,7 +2656,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<String> ltrim(@RedisProtocolSupport.Key final Buffer key, final long start, final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LTRIM, allocator);
@@ -2670,7 +2670,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<Buffer> memoryDoctor() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2682,7 +2682,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public <T> Single<List<T>> memoryHelp() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2694,7 +2694,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<Buffer> memoryMallocStats() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2706,7 +2706,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> memoryPurge() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2718,7 +2718,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public <T> Single<List<T>> memoryStats() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2731,7 +2731,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> memoryUsage(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2745,7 +2745,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> memoryUsage(@RedisProtocolSupport.Key final Buffer key, @Nullable final Long samplesCount) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (samplesCount != null) {
@@ -2766,7 +2766,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
@@ -2781,7 +2781,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                     @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
@@ -2799,7 +2799,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
@@ -2814,7 +2814,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -2827,7 +2827,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Publisher<String> monitor() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MONITOR, allocator);
@@ -2839,7 +2839,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> move(@RedisProtocolSupport.Key final Buffer key, final long db) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MOVE, allocator);
@@ -2854,7 +2854,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<String> mset(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSET, allocator);
@@ -2872,7 +2872,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(value1);
         requireNonNull(key2);
         requireNonNull(value2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSET, allocator);
@@ -2895,7 +2895,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(value2);
         requireNonNull(key3);
         requireNonNull(value3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSET, allocator);
@@ -2913,7 +2913,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<String> mset(final Collection<RedisProtocolSupport.BufferKeyValue> keyValues) {
         requireNonNull(keyValues);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += RedisProtocolSupport.BufferKeyValue.SIZE * keyValues.size();
@@ -2928,7 +2928,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> msetnx(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSETNX, allocator);
@@ -2946,7 +2946,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(value1);
         requireNonNull(key2);
         requireNonNull(value2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSETNX, allocator);
@@ -2969,7 +2969,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(value2);
         requireNonNull(key3);
         requireNonNull(value3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSETNX, allocator);
@@ -2987,7 +2987,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> msetnx(final Collection<RedisProtocolSupport.BufferKeyValue> keyValues) {
         requireNonNull(keyValues);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += RedisProtocolSupport.BufferKeyValue.SIZE * keyValues.size();
@@ -3000,7 +3000,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<TransactedBufferRedisCommander> multi() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MULTI, allocator);
@@ -3011,7 +3011,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Buffer> objectEncoding(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3025,7 +3025,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> objectFreq(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3038,7 +3038,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<List<String>> objectHelp() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3051,7 +3051,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> objectIdletime(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3065,7 +3065,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> objectRefcount(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3079,7 +3079,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> persist(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PERSIST, allocator);
@@ -3092,7 +3092,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> pexpire(@RedisProtocolSupport.Key final Buffer key, final long milliseconds) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PEXPIRE, allocator);
@@ -3106,7 +3106,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> pexpireat(@RedisProtocolSupport.Key final Buffer key, final long millisecondsTimestamp) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PEXPIREAT, allocator);
@@ -3121,7 +3121,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> pfadd(@RedisProtocolSupport.Key final Buffer key, final Buffer element) {
         requireNonNull(key);
         requireNonNull(element);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFADD, allocator);
@@ -3138,7 +3138,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(element1);
         requireNonNull(element2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFADD, allocator);
@@ -3157,7 +3157,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(element1);
         requireNonNull(element2);
         requireNonNull(element3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFADD, allocator);
@@ -3174,7 +3174,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> pfadd(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> elements) {
         requireNonNull(key);
         requireNonNull(elements);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += elements.size();
@@ -3189,7 +3189,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> pfcount(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFCOUNT, allocator);
@@ -3204,7 +3204,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                 @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFCOUNT, allocator);
@@ -3222,7 +3222,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFCOUNT, allocator);
@@ -3237,7 +3237,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> pfcount(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -3253,7 +3253,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                   @RedisProtocolSupport.Key final Buffer sourcekey) {
         requireNonNull(destkey);
         requireNonNull(sourcekey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFMERGE, allocator);
@@ -3271,7 +3271,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(destkey);
         requireNonNull(sourcekey1);
         requireNonNull(sourcekey2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFMERGE, allocator);
@@ -3292,7 +3292,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(sourcekey1);
         requireNonNull(sourcekey2);
         requireNonNull(sourcekey3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFMERGE, allocator);
@@ -3310,7 +3310,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                   @RedisProtocolSupport.Key final Collection<Buffer> sourcekeys) {
         requireNonNull(destkey);
         requireNonNull(sourcekeys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += sourcekeys.size();
@@ -3324,7 +3324,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> ping() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PING, allocator);
@@ -3336,7 +3336,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Buffer> ping(final Buffer message) {
         requireNonNull(message);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PING, allocator);
@@ -3351,7 +3351,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                  final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PSETEX, allocator);
@@ -3366,7 +3366,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<PubSubBufferRedisConnection> psubscribe(final Buffer pattern) {
         requireNonNull(pattern);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PSUBSCRIBE, allocator);
@@ -3379,7 +3379,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> pttl(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PTTL, allocator);
@@ -3393,7 +3393,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> publish(final Buffer channel, final Buffer message) {
         requireNonNull(channel);
         requireNonNull(message);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBLISH, allocator);
@@ -3406,7 +3406,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<List<String>> pubsubChannels() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBSUB,
@@ -3418,7 +3418,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<List<String>> pubsubChannels(@Nullable final Buffer pattern) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (pattern != null) {
@@ -3436,7 +3436,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<List<String>> pubsubChannels(@Nullable final Buffer pattern1, @Nullable final Buffer pattern2) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (pattern1 != null) {
@@ -3461,7 +3461,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<List<String>> pubsubChannels(@Nullable final Buffer pattern1, @Nullable final Buffer pattern2,
                                                @Nullable final Buffer pattern3) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (pattern1 != null) {
@@ -3492,7 +3492,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<List<String>> pubsubChannels(final Collection<Buffer> patterns) {
         requireNonNull(patterns);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += patterns.size();
@@ -3506,7 +3506,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public <T> Single<List<T>> pubsubNumsub() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBSUB,
@@ -3518,7 +3518,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public <T> Single<List<T>> pubsubNumsub(@Nullable final Buffer channel) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (channel != null) {
@@ -3536,7 +3536,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public <T> Single<List<T>> pubsubNumsub(@Nullable final Buffer channel1, @Nullable final Buffer channel2) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (channel1 != null) {
@@ -3561,7 +3561,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> pubsubNumsub(@Nullable final Buffer channel1, @Nullable final Buffer channel2,
                                             @Nullable final Buffer channel3) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (channel1 != null) {
@@ -3592,7 +3592,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> pubsubNumsub(final Collection<Buffer> channels) {
         requireNonNull(channels);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += channels.size();
@@ -3606,7 +3606,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<Long> pubsubNumpat() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBSUB,
@@ -3618,7 +3618,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<Buffer> randomkey() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RANDOMKEY, allocator);
@@ -3629,7 +3629,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> readonly() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.READONLY, allocator);
@@ -3640,7 +3640,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> readwrite() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.READWRITE, allocator);
@@ -3654,7 +3654,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                  @RedisProtocolSupport.Key final Buffer newkey) {
         requireNonNull(key);
         requireNonNull(newkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RENAME, allocator);
@@ -3670,7 +3670,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                  @RedisProtocolSupport.Key final Buffer newkey) {
         requireNonNull(key);
         requireNonNull(newkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RENAMENX, allocator);
@@ -3686,7 +3686,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                   final Buffer serializedValue) {
         requireNonNull(key);
         requireNonNull(serializedValue);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RESTORE, allocator);
@@ -3704,7 +3704,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                   @Nullable final RedisProtocolSupport.RestoreReplace replace) {
         requireNonNull(key);
         requireNonNull(serializedValue);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (replace != null) {
@@ -3724,7 +3724,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public <T> Single<List<T>> role() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ROLE, allocator);
@@ -3736,7 +3736,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Buffer> rpop(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPOP, allocator);
@@ -3751,7 +3751,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                     @RedisProtocolSupport.Key final Buffer destination) {
         requireNonNull(source);
         requireNonNull(destination);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPOPLPUSH, allocator);
@@ -3766,7 +3766,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> rpush(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSH, allocator);
@@ -3782,7 +3782,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(value1);
         requireNonNull(value2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSH, allocator);
@@ -3801,7 +3801,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(value1);
         requireNonNull(value2);
         requireNonNull(value3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSH, allocator);
@@ -3818,7 +3818,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> rpush(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> values) {
         requireNonNull(key);
         requireNonNull(values);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += values.size();
@@ -3834,7 +3834,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> rpushx(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSHX, allocator);
@@ -3849,7 +3849,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> sadd(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SADD, allocator);
@@ -3865,7 +3865,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SADD, allocator);
@@ -3884,7 +3884,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SADD, allocator);
@@ -3901,7 +3901,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> sadd(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -3915,7 +3915,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> save() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SAVE, allocator);
@@ -3926,7 +3926,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public <T> Single<List<T>> scan(final long cursor) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCAN, allocator);
@@ -3939,7 +3939,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> scan(final long cursor, @Nullable final Buffer matchPattern,
                                     @Nullable final Long count) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (matchPattern != null) {
@@ -3966,7 +3966,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> scard(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCARD, allocator);
@@ -3979,7 +3979,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<String> scriptDebug(final RedisProtocolSupport.ScriptDebugMode mode) {
         requireNonNull(mode);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -3993,7 +3993,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> scriptExists(final Buffer sha1) {
         requireNonNull(sha1);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4008,7 +4008,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public <T> Single<List<T>> scriptExists(final Buffer sha11, final Buffer sha12) {
         requireNonNull(sha11);
         requireNonNull(sha12);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4025,7 +4025,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(sha11);
         requireNonNull(sha12);
         requireNonNull(sha13);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4041,7 +4041,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> scriptExists(final Collection<Buffer> sha1s) {
         requireNonNull(sha1s);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += sha1s.size();
@@ -4055,7 +4055,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> scriptFlush() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4067,7 +4067,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> scriptKill() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4080,7 +4080,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Buffer> scriptLoad(final Buffer script) {
         requireNonNull(script);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4094,7 +4094,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> sdiff(@RedisProtocolSupport.Key final Buffer firstkey) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SDIFF, allocator);
@@ -4108,7 +4108,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public <T> Single<List<T>> sdiff(@RedisProtocolSupport.Key final Buffer firstkey,
                                      @Nullable @RedisProtocolSupport.Key final Buffer otherkey) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (otherkey != null) {
@@ -4129,7 +4129,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                      @Nullable @RedisProtocolSupport.Key final Buffer otherkey1,
                                      @Nullable @RedisProtocolSupport.Key final Buffer otherkey2) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (otherkey1 != null) {
@@ -4157,7 +4157,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                      @Nullable @RedisProtocolSupport.Key final Buffer otherkey2,
                                      @Nullable @RedisProtocolSupport.Key final Buffer otherkey3) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (otherkey1 != null) {
@@ -4190,7 +4190,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                      @RedisProtocolSupport.Key final Collection<Buffer> otherkeys) {
         requireNonNull(firstkey);
         requireNonNull(otherkeys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += otherkeys.size();
@@ -4207,7 +4207,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                    @RedisProtocolSupport.Key final Buffer firstkey) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SDIFFSTORE, allocator);
@@ -4224,7 +4224,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                    @Nullable @RedisProtocolSupport.Key final Buffer otherkey) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (otherkey != null) {
@@ -4248,7 +4248,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                    @Nullable @RedisProtocolSupport.Key final Buffer otherkey2) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (otherkey1 != null) {
@@ -4279,7 +4279,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                    @Nullable @RedisProtocolSupport.Key final Buffer otherkey3) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (otherkey1 != null) {
@@ -4315,7 +4315,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(destination);
         requireNonNull(firstkey);
         requireNonNull(otherkeys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += otherkeys.size();
@@ -4330,7 +4330,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> select(final long index) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SELECT, allocator);
@@ -4344,7 +4344,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<String> set(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SET, allocator);
@@ -4361,7 +4361,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                               @Nullable final RedisProtocolSupport.SetCondition condition) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (expireDuration != null) {
@@ -4388,7 +4388,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> setbit(@RedisProtocolSupport.Key final Buffer key, final long offset, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETBIT, allocator);
@@ -4404,7 +4404,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<String> setex(@RedisProtocolSupport.Key final Buffer key, final long seconds, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETEX, allocator);
@@ -4420,7 +4420,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> setnx(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETNX, allocator);
@@ -4435,7 +4435,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> setrange(@RedisProtocolSupport.Key final Buffer key, final long offset, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETRANGE, allocator);
@@ -4449,7 +4449,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> shutdown() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SHUTDOWN, allocator);
@@ -4460,7 +4460,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> shutdown(@Nullable final RedisProtocolSupport.ShutdownSaveMode saveMode) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (saveMode != null) {
@@ -4478,7 +4478,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> sinter(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTER, allocator);
@@ -4493,7 +4493,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                       @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTER, allocator);
@@ -4511,7 +4511,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTER, allocator);
@@ -4526,7 +4526,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> sinter(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -4542,7 +4542,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                     @RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(destination);
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTERSTORE, allocator);
@@ -4560,7 +4560,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(destination);
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTERSTORE, allocator);
@@ -4581,7 +4581,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTERSTORE, allocator);
@@ -4599,7 +4599,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                     @RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -4615,7 +4615,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> sismember(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SISMEMBER, allocator);
@@ -4630,7 +4630,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<String> slaveof(final Buffer host, final Buffer port) {
         requireNonNull(host);
         requireNonNull(port);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SLAVEOF, allocator);
@@ -4644,7 +4644,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> slowlog(final Buffer subcommand) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SLOWLOG, allocator);
@@ -4657,7 +4657,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> slowlog(final Buffer subcommand, @Nullable final Buffer argument) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (argument != null) {
@@ -4676,7 +4676,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> smembers(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SMEMBERS, allocator);
@@ -4692,7 +4692,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(source);
         requireNonNull(destination);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SMOVE, allocator);
@@ -4707,7 +4707,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> sort(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SORT, allocator);
@@ -4725,7 +4725,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                     @Nullable final RedisProtocolSupport.SortSorting sorting) {
         requireNonNull(key);
         requireNonNull(getPatterns);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (byPattern != null) {
@@ -4767,7 +4767,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                              @RedisProtocolSupport.Key final Buffer storeDestination) {
         requireNonNull(key);
         requireNonNull(storeDestination);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SORT, allocator);
@@ -4788,7 +4788,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(storeDestination);
         requireNonNull(getPatterns);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (byPattern != null) {
@@ -4830,7 +4830,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Buffer> spop(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SPOP, allocator);
@@ -4843,7 +4843,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Buffer> spop(@RedisProtocolSupport.Key final Buffer key, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -4862,7 +4862,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Buffer> srandmember(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SRANDMEMBER, allocator);
@@ -4875,7 +4875,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<List<String>> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SRANDMEMBER, allocator);
@@ -4890,7 +4890,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> srem(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SREM, allocator);
@@ -4906,7 +4906,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SREM, allocator);
@@ -4925,7 +4925,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SREM, allocator);
@@ -4942,7 +4942,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> srem(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -4957,7 +4957,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> sscan(@RedisProtocolSupport.Key final Buffer key, final long cursor) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SSCAN, allocator);
@@ -4972,7 +4972,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public <T> Single<List<T>> sscan(@RedisProtocolSupport.Key final Buffer key, final long cursor,
                                      @Nullable final Buffer matchPattern, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (matchPattern != null) {
@@ -5000,7 +5000,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> strlen(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.STRLEN, allocator);
@@ -5013,7 +5013,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<PubSubBufferRedisConnection> subscribe(final Buffer channel) {
         requireNonNull(channel);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUBSCRIBE, allocator);
@@ -5026,7 +5026,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> sunion(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNION, allocator);
@@ -5041,7 +5041,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                       @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNION, allocator);
@@ -5059,7 +5059,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNION, allocator);
@@ -5074,7 +5074,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> sunion(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -5090,7 +5090,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                     @RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(destination);
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNIONSTORE, allocator);
@@ -5108,7 +5108,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(destination);
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNIONSTORE, allocator);
@@ -5129,7 +5129,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNIONSTORE, allocator);
@@ -5147,7 +5147,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                     @RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -5161,7 +5161,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> swapdb(final long index, final long index1) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SWAPDB, allocator);
@@ -5174,7 +5174,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public <T> Single<List<T>> time() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TIME, allocator);
@@ -5186,7 +5186,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> touch(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TOUCH, allocator);
@@ -5201,7 +5201,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                               @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TOUCH, allocator);
@@ -5218,7 +5218,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TOUCH, allocator);
@@ -5233,7 +5233,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> touch(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -5247,7 +5247,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> ttl(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TTL, allocator);
@@ -5260,7 +5260,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<String> type(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TYPE, allocator);
@@ -5273,7 +5273,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> unlink(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNLINK, allocator);
@@ -5288,7 +5288,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNLINK, allocator);
@@ -5305,7 +5305,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNLINK, allocator);
@@ -5320,7 +5320,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> unlink(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -5333,7 +5333,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<String> unwatch() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNWATCH, allocator);
@@ -5344,7 +5344,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
 
     @Override
     public Single<Long> wait(final long numslaves, final long timeout) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WAIT, allocator);
@@ -5358,7 +5358,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<String> watch(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WATCH, allocator);
@@ -5373,7 +5373,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                 @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WATCH, allocator);
@@ -5391,7 +5391,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WATCH, allocator);
@@ -5406,7 +5406,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<String> watch(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -5424,7 +5424,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(id);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XADD, allocator);
@@ -5446,7 +5446,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(value1);
         requireNonNull(field2);
         requireNonNull(value2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XADD, allocator);
@@ -5473,7 +5473,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(value2);
         requireNonNull(field3);
         requireNonNull(value3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 9;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XADD, allocator);
@@ -5496,7 +5496,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(id);
         requireNonNull(fieldValues);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += RedisProtocolSupport.BufferFieldValue.SIZE * fieldValues.size();
@@ -5512,7 +5512,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> xlen(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XLEN, allocator);
@@ -5526,7 +5526,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public <T> Single<List<T>> xpending(@RedisProtocolSupport.Key final Buffer key, final Buffer group) {
         requireNonNull(key);
         requireNonNull(group);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XPENDING, allocator);
@@ -5543,7 +5543,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                         @Nullable final Long count, @Nullable final Buffer consumer) {
         requireNonNull(key);
         requireNonNull(group);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (start != null) {
@@ -5584,7 +5584,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(start);
         requireNonNull(end);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XRANGE, allocator);
@@ -5602,7 +5602,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(start);
         requireNonNull(end);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (count != null) {
@@ -5626,7 +5626,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                      final Collection<Buffer> ids) {
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -5646,7 +5646,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                      final Collection<Buffer> ids) {
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -5681,7 +5681,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(groupConsumer);
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2 + RedisProtocolSupport.BufferGroupConsumer.SIZE;
         len += keys.size();
@@ -5704,7 +5704,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(groupConsumer);
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2 + RedisProtocolSupport.BufferGroupConsumer.SIZE;
         if (count != null) {
@@ -5739,7 +5739,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(end);
         requireNonNull(start);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XREVRANGE, allocator);
@@ -5757,7 +5757,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(end);
         requireNonNull(start);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (count != null) {
@@ -5781,7 +5781,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                              final Collection<RedisProtocolSupport.BufferScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += RedisProtocolSupport.BufferScoreMember.SIZE * scoreMembers.size();
@@ -5800,7 +5800,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                              final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (condition != null) {
@@ -5832,7 +5832,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         if (condition != null) {
@@ -5868,7 +5868,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 8;
         if (condition != null) {
@@ -5903,7 +5903,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                              final Collection<RedisProtocolSupport.BufferScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (condition != null) {
@@ -5932,7 +5932,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                    final Collection<RedisProtocolSupport.BufferScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += RedisProtocolSupport.BufferScoreMember.SIZE * scoreMembers.size();
@@ -5953,7 +5953,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                    final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         if (condition != null) {
@@ -5987,7 +5987,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         if (condition != null) {
@@ -6025,7 +6025,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 9;
         if (condition != null) {
@@ -6062,7 +6062,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                    final Collection<RedisProtocolSupport.BufferScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (condition != null) {
@@ -6091,7 +6091,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> zcard(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZCARD, allocator);
@@ -6104,7 +6104,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> zcount(@RedisProtocolSupport.Key final Buffer key, final double min, final double max) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZCOUNT, allocator);
@@ -6121,7 +6121,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                   final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZINCRBY, allocator);
@@ -6139,7 +6139,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                     @RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -6160,7 +6160,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(destination);
         requireNonNull(keys);
         requireNonNull(weightses);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -6186,7 +6186,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZLEXCOUNT, allocator);
@@ -6201,7 +6201,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> zpopmax(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZPOPMAX, allocator);
@@ -6214,7 +6214,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> zpopmax(@RedisProtocolSupport.Key final Buffer key, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -6233,7 +6233,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> zpopmin(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZPOPMIN, allocator);
@@ -6246,7 +6246,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> zpopmin(@RedisProtocolSupport.Key final Buffer key, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -6265,7 +6265,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> zrange(@RedisProtocolSupport.Key final Buffer key, final long start, final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANGE, allocator);
@@ -6281,7 +6281,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public <T> Single<List<T>> zrange(@RedisProtocolSupport.Key final Buffer key, final long start, final long stop,
                                       @Nullable final RedisProtocolSupport.ZrangeWithscores withscores) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -6305,7 +6305,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANGEBYLEX, allocator);
@@ -6324,7 +6324,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (offsetCount != null) {
@@ -6346,7 +6346,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public <T> Single<List<T>> zrangebyscore(@RedisProtocolSupport.Key final Buffer key, final double min,
                                              final double max) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANGEBYSCORE,
@@ -6365,7 +6365,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                              @Nullable final RedisProtocolSupport.ZrangebyscoreWithscores withscores,
                                              @Nullable final RedisProtocolSupport.OffsetCount offsetCount) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -6394,7 +6394,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> zrank(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANK, allocator);
@@ -6409,7 +6409,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> zrem(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREM, allocator);
@@ -6425,7 +6425,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREM, allocator);
@@ -6444,7 +6444,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREM, allocator);
@@ -6461,7 +6461,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> zrem(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -6478,7 +6478,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREMRANGEBYLEX,
@@ -6494,7 +6494,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public Single<Long> zremrangebyrank(@RedisProtocolSupport.Key final Buffer key, final long start, final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREMRANGEBYRANK,
@@ -6511,7 +6511,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> zremrangebyscore(@RedisProtocolSupport.Key final Buffer key, final double min,
                                          final double max) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREMRANGEBYSCORE,
@@ -6528,7 +6528,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public <T> Single<List<T>> zrevrange(@RedisProtocolSupport.Key final Buffer key, final long start,
                                          final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANGE, allocator);
@@ -6544,7 +6544,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public <T> Single<List<T>> zrevrange(@RedisProtocolSupport.Key final Buffer key, final long start, final long stop,
                                          @Nullable final RedisProtocolSupport.ZrevrangeWithscores withscores) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -6568,7 +6568,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(max);
         requireNonNull(min);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANGEBYLEX,
@@ -6588,7 +6588,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(key);
         requireNonNull(max);
         requireNonNull(min);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (offsetCount != null) {
@@ -6611,7 +6611,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public <T> Single<List<T>> zrevrangebyscore(@RedisProtocolSupport.Key final Buffer key, final double max,
                                                 final double min) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANGEBYSCORE,
@@ -6630,7 +6630,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                                 @Nullable final RedisProtocolSupport.ZrevrangebyscoreWithscores withscores,
                                                 @Nullable final RedisProtocolSupport.OffsetCount offsetCount) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -6659,7 +6659,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Long> zrevrank(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANK, allocator);
@@ -6673,7 +6673,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     @Override
     public <T> Single<List<T>> zscan(@RedisProtocolSupport.Key final Buffer key, final long cursor) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZSCAN, allocator);
@@ -6688,7 +6688,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public <T> Single<List<T>> zscan(@RedisProtocolSupport.Key final Buffer key, final long cursor,
                                      @Nullable final Buffer matchPattern, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (matchPattern != null) {
@@ -6717,7 +6717,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     public Single<Double> zscore(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZSCORE, allocator);
@@ -6734,7 +6734,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
                                     @RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -6755,7 +6755,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         requireNonNull(destination);
         requireNonNull(keys);
         requireNonNull(weightses);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultPartitionedBufferRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultPartitionedBufferRedisCommander.java
@@ -67,7 +67,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> append(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.APPEND, allocator);
@@ -85,7 +85,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<String> auth(final Buffer password) {
         requireNonNull(password);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.AUTH, allocator);
@@ -100,7 +100,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> bgrewriteaof() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BGREWRITEAOF, allocator);
@@ -114,7 +114,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> bgsave() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BGSAVE, allocator);
@@ -129,7 +129,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> bitcount(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITCOUNT, allocator);
@@ -147,7 +147,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> bitcount(@RedisProtocolSupport.Key final Buffer key, @Nullable final Long start,
                                  @Nullable final Long end) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (start != null) {
@@ -178,7 +178,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                        final Collection<RedisProtocolSupport.BitfieldOperation> operations) {
         requireNonNull(key);
         requireNonNull(operations);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         final CompositeBuffer cbOps = allocator.newCompositeBuffer();
         final int len = 2 + operations.stream().mapToInt(op -> op.writeTo(cbOps, allocator)).sum();
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITFIELD, allocator);
@@ -199,7 +199,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(operation);
         requireNonNull(destkey);
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITOP, allocator);
@@ -224,7 +224,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(destkey);
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITOP, allocator);
@@ -252,7 +252,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITOP, allocator);
@@ -279,7 +279,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(operation);
         requireNonNull(destkey);
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -300,7 +300,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> bitpos(@RedisProtocolSupport.Key final Buffer key, final long bit) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITPOS, allocator);
@@ -319,7 +319,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> bitpos(@RedisProtocolSupport.Key final Buffer key, final long bit, @Nullable final Long start,
                                @Nullable final Long end) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (start != null) {
@@ -349,7 +349,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> blpop(@RedisProtocolSupport.Key final Collection<Buffer> keys, final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -368,7 +368,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> brpop(@RedisProtocolSupport.Key final Collection<Buffer> keys, final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -389,7 +389,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                      @RedisProtocolSupport.Key final Buffer destination, final long timeout) {
         requireNonNull(source);
         requireNonNull(destination);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BRPOPLPUSH, allocator);
@@ -409,7 +409,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> bzpopmax(@RedisProtocolSupport.Key final Collection<Buffer> keys, final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -428,7 +428,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> bzpopmin(@RedisProtocolSupport.Key final Collection<Buffer> keys, final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -447,7 +447,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> clientKill(@Nullable final Long id, @Nullable final RedisProtocolSupport.ClientKillType type,
                                    @Nullable final Buffer addrIpPort, @Nullable final Buffer skipmeYesNo) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (id != null) {
@@ -489,7 +489,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<Buffer> clientList() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -504,7 +504,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<Buffer> clientGetname() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -519,7 +519,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> clientPause(final long timeout) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -536,7 +536,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<String> clientReply(final RedisProtocolSupport.ClientReplyReplyMode replyMode) {
         requireNonNull(replyMode);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -553,7 +553,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<String> clientSetname(final Buffer connectionName) {
         requireNonNull(connectionName);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -569,7 +569,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> clusterAddslots(final long slot) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -585,7 +585,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> clusterAddslots(final long slot1, final long slot2) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -602,7 +602,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> clusterAddslots(final long slot1, final long slot2, final long slot3) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -621,7 +621,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<String> clusterAddslots(final Collection<Long> slots) {
         requireNonNull(slots);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += slots.size();
@@ -639,7 +639,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> clusterCountFailureReports(final Buffer nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -655,7 +655,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<Long> clusterCountkeysinslot(final long slot) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -671,7 +671,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> clusterDelslots(final long slot) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -687,7 +687,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> clusterDelslots(final long slot1, final long slot2) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -704,7 +704,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> clusterDelslots(final long slot1, final long slot2, final long slot3) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -723,7 +723,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<String> clusterDelslots(final Collection<Long> slots) {
         requireNonNull(slots);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += slots.size();
@@ -740,7 +740,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> clusterFailover() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -755,7 +755,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> clusterFailover(@Nullable final RedisProtocolSupport.ClusterFailoverOptions options) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (options != null) {
@@ -777,7 +777,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<String> clusterForget(final Buffer nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -793,7 +793,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public <T> Single<List<T>> clusterGetkeysinslot(final long slot, final long count) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -810,7 +810,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<Buffer> clusterInfo() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -826,7 +826,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> clusterKeyslot(final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -843,7 +843,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<String> clusterMeet(final Buffer ip, final long port) {
         requireNonNull(ip);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -860,7 +860,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<Buffer> clusterNodes() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -876,7 +876,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<String> clusterReplicate(final Buffer nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -892,7 +892,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> clusterReset() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -907,7 +907,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> clusterReset(@Nullable final RedisProtocolSupport.ClusterResetResetType resetType) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (resetType != null) {
@@ -928,7 +928,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> clusterSaveconfig() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -943,7 +943,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> clusterSetConfigEpoch(final long configEpoch) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -961,7 +961,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<String> clusterSetslot(final long slot,
                                          final RedisProtocolSupport.ClusterSetslotSubcommand subcommand) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -981,7 +981,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                          final RedisProtocolSupport.ClusterSetslotSubcommand subcommand,
                                          @Nullable final Buffer nodeId) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (nodeId != null) {
@@ -1005,7 +1005,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Buffer> clusterSlaves(final Buffer nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -1021,7 +1021,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public <T> Single<List<T>> clusterSlots() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -1036,7 +1036,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public <T> Single<List<T>> command() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND, allocator);
@@ -1050,7 +1050,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<Long> commandCount() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -1065,7 +1065,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public <T> Single<List<T>> commandGetkeys() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -1081,7 +1081,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> commandInfo(final Buffer commandName) {
         requireNonNull(commandName);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -1099,7 +1099,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public <T> Single<List<T>> commandInfo(final Buffer commandName1, final Buffer commandName2) {
         requireNonNull(commandName1);
         requireNonNull(commandName2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -1120,7 +1120,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(commandName1);
         requireNonNull(commandName2);
         requireNonNull(commandName3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -1139,7 +1139,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> commandInfo(final Collection<Buffer> commandNames) {
         requireNonNull(commandNames);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += commandNames.size();
@@ -1157,7 +1157,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> configGet(final Buffer parameter) {
         requireNonNull(parameter);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1173,7 +1173,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> configRewrite() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1190,7 +1190,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<String> configSet(final Buffer parameter, final Buffer value) {
         requireNonNull(parameter);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1207,7 +1207,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> configResetstat() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1222,7 +1222,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<Long> dbsize() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DBSIZE, allocator);
@@ -1237,7 +1237,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<String> debugObject(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEBUG,
@@ -1254,7 +1254,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> debugSegfault() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEBUG,
@@ -1270,7 +1270,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> decr(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DECR, allocator);
@@ -1287,7 +1287,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> decrby(@RedisProtocolSupport.Key final Buffer key, final long decrement) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DECRBY, allocator);
@@ -1305,7 +1305,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> del(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEL, allocator);
@@ -1323,7 +1323,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> del(@RedisProtocolSupport.Key final Buffer key1, @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEL, allocator);
@@ -1345,7 +1345,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEL, allocator);
@@ -1366,7 +1366,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> del(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -1384,7 +1384,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Buffer> dump(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DUMP, allocator);
@@ -1401,7 +1401,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Buffer> echo(final Buffer message) {
         requireNonNull(message);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ECHO, allocator);
@@ -1420,7 +1420,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(script);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1446,7 +1446,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(script);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1472,7 +1472,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(script);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1498,7 +1498,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(sha1);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1524,7 +1524,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(sha1);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1550,7 +1550,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(sha1);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1572,7 +1572,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> exists(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXISTS, allocator);
@@ -1591,7 +1591,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXISTS, allocator);
@@ -1613,7 +1613,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXISTS, allocator);
@@ -1634,7 +1634,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> exists(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -1652,7 +1652,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> expire(@RedisProtocolSupport.Key final Buffer key, final long seconds) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXPIRE, allocator);
@@ -1670,7 +1670,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> expireat(@RedisProtocolSupport.Key final Buffer key, final long timestamp) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXPIREAT, allocator);
@@ -1687,7 +1687,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> flushall() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.FLUSHALL, allocator);
@@ -1701,7 +1701,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> flushall(@Nullable final RedisProtocolSupport.FlushallAsync async) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (async != null) {
@@ -1721,7 +1721,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> flushdb() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.FLUSHDB, allocator);
@@ -1735,7 +1735,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> flushdb(@Nullable final RedisProtocolSupport.FlushdbAsync async) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (async != null) {
@@ -1758,7 +1758,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                final double latitude, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOADD, allocator);
@@ -1782,7 +1782,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 8;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOADD, allocator);
@@ -1811,7 +1811,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 11;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOADD, allocator);
@@ -1839,7 +1839,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                final Collection<RedisProtocolSupport.BufferLongitudeLatitudeMember> longitudeLatitudeMembers) {
         requireNonNull(key);
         requireNonNull(longitudeLatitudeMembers);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += RedisProtocolSupport.BufferLongitudeLatitudeMember.SIZE * longitudeLatitudeMembers.size();
@@ -1861,7 +1861,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEODIST, allocator);
@@ -1884,7 +1884,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (unit != null) {
@@ -1911,7 +1911,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public <T> Single<List<T>> geohash(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOHASH, allocator);
@@ -1932,7 +1932,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOHASH, allocator);
@@ -1955,7 +1955,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOHASH, allocator);
@@ -1976,7 +1976,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public <T> Single<List<T>> geohash(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -1996,7 +1996,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public <T> Single<List<T>> geopos(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOPOS, allocator);
@@ -2017,7 +2017,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOPOS, allocator);
@@ -2040,7 +2040,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOPOS, allocator);
@@ -2061,7 +2061,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public <T> Single<List<T>> geopos(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -2083,7 +2083,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                          final RedisProtocolSupport.GeoradiusUnit unit) {
         requireNonNull(key);
         requireNonNull(unit);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEORADIUS, allocator);
@@ -2114,7 +2114,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                          @Nullable @RedisProtocolSupport.Key final Buffer storedistKey) {
         requireNonNull(key);
         requireNonNull(unit);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         if (withcoord != null) {
@@ -2190,7 +2190,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(member);
         requireNonNull(unit);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEORADIUSBYMEMBER,
@@ -2222,7 +2222,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(member);
         requireNonNull(unit);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         if (withcoord != null) {
@@ -2294,7 +2294,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Buffer> get(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GET, allocator);
@@ -2311,7 +2311,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> getbit(@RedisProtocolSupport.Key final Buffer key, final long offset) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GETBIT, allocator);
@@ -2329,7 +2329,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Buffer> getrange(@RedisProtocolSupport.Key final Buffer key, final long start, final long end) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GETRANGE, allocator);
@@ -2349,7 +2349,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Buffer> getset(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GETSET, allocator);
@@ -2368,7 +2368,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> hdel(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HDEL, allocator);
@@ -2388,7 +2388,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HDEL, allocator);
@@ -2411,7 +2411,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(field1);
         requireNonNull(field2);
         requireNonNull(field3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HDEL, allocator);
@@ -2432,7 +2432,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> hdel(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
         requireNonNull(key);
         requireNonNull(fields);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += fields.size();
@@ -2452,7 +2452,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> hexists(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HEXISTS, allocator);
@@ -2471,7 +2471,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Buffer> hget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HGET, allocator);
@@ -2489,7 +2489,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> hgetall(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HGETALL, allocator);
@@ -2507,7 +2507,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> hincrby(@RedisProtocolSupport.Key final Buffer key, final Buffer field, final long increment) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HINCRBY, allocator);
@@ -2528,7 +2528,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                        final double increment) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HINCRBYFLOAT, allocator);
@@ -2548,7 +2548,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> hkeys(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HKEYS, allocator);
@@ -2565,7 +2565,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> hlen(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HLEN, allocator);
@@ -2583,7 +2583,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMGET, allocator);
@@ -2604,7 +2604,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMGET, allocator);
@@ -2627,7 +2627,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(field1);
         requireNonNull(field2);
         requireNonNull(field3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMGET, allocator);
@@ -2648,7 +2648,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
         requireNonNull(key);
         requireNonNull(fields);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += fields.size();
@@ -2669,7 +2669,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMSET, allocator);
@@ -2693,7 +2693,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(value1);
         requireNonNull(field2);
         requireNonNull(value2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMSET, allocator);
@@ -2721,7 +2721,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(value2);
         requireNonNull(field3);
         requireNonNull(value3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 8;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMSET, allocator);
@@ -2746,7 +2746,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                 final Collection<RedisProtocolSupport.BufferFieldValue> fieldValues) {
         requireNonNull(key);
         requireNonNull(fieldValues);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += RedisProtocolSupport.BufferFieldValue.SIZE * fieldValues.size();
@@ -2765,7 +2765,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> hscan(@RedisProtocolSupport.Key final Buffer key, final long cursor) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSCAN, allocator);
@@ -2784,7 +2784,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public <T> Single<List<T>> hscan(@RedisProtocolSupport.Key final Buffer key, final long cursor,
                                      @Nullable final Buffer matchPattern, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (matchPattern != null) {
@@ -2818,7 +2818,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSET, allocator);
@@ -2839,7 +2839,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSETNX, allocator);
@@ -2859,7 +2859,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> hstrlen(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSTRLEN, allocator);
@@ -2877,7 +2877,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> hvals(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HVALS, allocator);
@@ -2894,7 +2894,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> incr(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INCR, allocator);
@@ -2911,7 +2911,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> incrby(@RedisProtocolSupport.Key final Buffer key, final long increment) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INCRBY, allocator);
@@ -2929,7 +2929,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Double> incrbyfloat(@RedisProtocolSupport.Key final Buffer key, final double increment) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INCRBYFLOAT, allocator);
@@ -2947,7 +2947,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<Buffer> info() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INFO, allocator);
@@ -2961,7 +2961,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<Buffer> info(@Nullable final Buffer section) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (section != null) {
@@ -2982,7 +2982,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> keys(final Buffer pattern) {
         requireNonNull(pattern);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.KEYS, allocator);
@@ -2997,7 +2997,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<Long> lastsave() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LASTSAVE, allocator);
@@ -3012,7 +3012,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Buffer> lindex(@RedisProtocolSupport.Key final Buffer key, final long index) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LINDEX, allocator);
@@ -3034,7 +3034,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(where);
         requireNonNull(pivot);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LINSERT, allocator);
@@ -3054,7 +3054,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> llen(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LLEN, allocator);
@@ -3071,7 +3071,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Buffer> lpop(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPOP, allocator);
@@ -3089,7 +3089,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> lpush(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSH, allocator);
@@ -3109,7 +3109,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(value1);
         requireNonNull(value2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSH, allocator);
@@ -3132,7 +3132,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(value1);
         requireNonNull(value2);
         requireNonNull(value3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSH, allocator);
@@ -3153,7 +3153,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> lpush(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> values) {
         requireNonNull(key);
         requireNonNull(values);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += values.size();
@@ -3173,7 +3173,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> lpushx(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSHX, allocator);
@@ -3191,7 +3191,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> lrange(@RedisProtocolSupport.Key final Buffer key, final long start, final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LRANGE, allocator);
@@ -3211,7 +3211,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> lrem(@RedisProtocolSupport.Key final Buffer key, final long count, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LREM, allocator);
@@ -3231,7 +3231,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<String> lset(@RedisProtocolSupport.Key final Buffer key, final long index, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LSET, allocator);
@@ -3250,7 +3250,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<String> ltrim(@RedisProtocolSupport.Key final Buffer key, final long start, final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LTRIM, allocator);
@@ -3268,7 +3268,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<Buffer> memoryDoctor() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -3283,7 +3283,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public <T> Single<List<T>> memoryHelp() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -3298,7 +3298,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<Buffer> memoryMallocStats() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -3313,7 +3313,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> memoryPurge() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -3328,7 +3328,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public <T> Single<List<T>> memoryStats() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -3344,7 +3344,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> memoryUsage(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -3362,7 +3362,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> memoryUsage(@RedisProtocolSupport.Key final Buffer key, @Nullable final Long samplesCount) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (samplesCount != null) {
@@ -3387,7 +3387,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
@@ -3406,7 +3406,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                     @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
@@ -3429,7 +3429,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
@@ -3450,7 +3450,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -3467,7 +3467,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Publisher<String> monitor() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MONITOR, allocator);
@@ -3481,7 +3481,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> move(@RedisProtocolSupport.Key final Buffer key, final long db) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MOVE, allocator);
@@ -3500,7 +3500,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<String> mset(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSET, allocator);
@@ -3522,7 +3522,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(value1);
         requireNonNull(key2);
         requireNonNull(value2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSET, allocator);
@@ -3550,7 +3550,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(value2);
         requireNonNull(key3);
         requireNonNull(value3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSET, allocator);
@@ -3574,7 +3574,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<String> mset(final Collection<RedisProtocolSupport.BufferKeyValue> keyValues) {
         requireNonNull(keyValues);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += RedisProtocolSupport.BufferKeyValue.SIZE * keyValues.size();
@@ -3592,7 +3592,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> msetnx(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSETNX, allocator);
@@ -3614,7 +3614,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(value1);
         requireNonNull(key2);
         requireNonNull(value2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSETNX, allocator);
@@ -3642,7 +3642,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(value2);
         requireNonNull(key3);
         requireNonNull(value3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSETNX, allocator);
@@ -3666,7 +3666,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> msetnx(final Collection<RedisProtocolSupport.BufferKeyValue> keyValues) {
         requireNonNull(keyValues);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += RedisProtocolSupport.BufferKeyValue.SIZE * keyValues.size();
@@ -3682,7 +3682,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<TransactedBufferRedisCommander> multi() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MULTI, allocator);
@@ -3696,7 +3696,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Buffer> objectEncoding(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3714,7 +3714,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> objectFreq(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3731,7 +3731,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<List<String>> objectHelp() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3747,7 +3747,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> objectIdletime(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3765,7 +3765,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> objectRefcount(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3783,7 +3783,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> persist(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PERSIST, allocator);
@@ -3800,7 +3800,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> pexpire(@RedisProtocolSupport.Key final Buffer key, final long milliseconds) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PEXPIRE, allocator);
@@ -3818,7 +3818,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> pexpireat(@RedisProtocolSupport.Key final Buffer key, final long millisecondsTimestamp) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PEXPIREAT, allocator);
@@ -3837,7 +3837,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> pfadd(@RedisProtocolSupport.Key final Buffer key, final Buffer element) {
         requireNonNull(key);
         requireNonNull(element);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFADD, allocator);
@@ -3858,7 +3858,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(element1);
         requireNonNull(element2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFADD, allocator);
@@ -3881,7 +3881,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(element1);
         requireNonNull(element2);
         requireNonNull(element3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFADD, allocator);
@@ -3902,7 +3902,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> pfadd(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> elements) {
         requireNonNull(key);
         requireNonNull(elements);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += elements.size();
@@ -3921,7 +3921,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> pfcount(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFCOUNT, allocator);
@@ -3940,7 +3940,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                 @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFCOUNT, allocator);
@@ -3963,7 +3963,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFCOUNT, allocator);
@@ -3984,7 +3984,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> pfcount(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -4004,7 +4004,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                   @RedisProtocolSupport.Key final Buffer sourcekey) {
         requireNonNull(destkey);
         requireNonNull(sourcekey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFMERGE, allocator);
@@ -4027,7 +4027,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(destkey);
         requireNonNull(sourcekey1);
         requireNonNull(sourcekey2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFMERGE, allocator);
@@ -4054,7 +4054,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(sourcekey1);
         requireNonNull(sourcekey2);
         requireNonNull(sourcekey3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFMERGE, allocator);
@@ -4079,7 +4079,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                   @RedisProtocolSupport.Key final Collection<Buffer> sourcekeys) {
         requireNonNull(destkey);
         requireNonNull(sourcekeys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += sourcekeys.size();
@@ -4098,7 +4098,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> ping() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PING, allocator);
@@ -4113,7 +4113,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Buffer> ping(final Buffer message) {
         requireNonNull(message);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PING, allocator);
@@ -4131,7 +4131,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                  final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PSETEX, allocator);
@@ -4150,7 +4150,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<PubSubBufferRedisConnection> psubscribe(final Buffer pattern) {
         requireNonNull(pattern);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PSUBSCRIBE, allocator);
@@ -4166,7 +4166,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> pttl(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PTTL, allocator);
@@ -4184,7 +4184,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> publish(final Buffer channel, final Buffer message) {
         requireNonNull(channel);
         requireNonNull(message);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBLISH, allocator);
@@ -4200,7 +4200,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<List<String>> pubsubChannels() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBSUB,
@@ -4215,7 +4215,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<List<String>> pubsubChannels(@Nullable final Buffer pattern) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (pattern != null) {
@@ -4236,7 +4236,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<List<String>> pubsubChannels(@Nullable final Buffer pattern1, @Nullable final Buffer pattern2) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (pattern1 != null) {
@@ -4264,7 +4264,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<List<String>> pubsubChannels(@Nullable final Buffer pattern1, @Nullable final Buffer pattern2,
                                                @Nullable final Buffer pattern3) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (pattern1 != null) {
@@ -4298,7 +4298,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<List<String>> pubsubChannels(final Collection<Buffer> patterns) {
         requireNonNull(patterns);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += patterns.size();
@@ -4315,7 +4315,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public <T> Single<List<T>> pubsubNumsub() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBSUB,
@@ -4330,7 +4330,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public <T> Single<List<T>> pubsubNumsub(@Nullable final Buffer channel) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (channel != null) {
@@ -4351,7 +4351,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public <T> Single<List<T>> pubsubNumsub(@Nullable final Buffer channel1, @Nullable final Buffer channel2) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (channel1 != null) {
@@ -4379,7 +4379,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> pubsubNumsub(@Nullable final Buffer channel1, @Nullable final Buffer channel2,
                                             @Nullable final Buffer channel3) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (channel1 != null) {
@@ -4413,7 +4413,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> pubsubNumsub(final Collection<Buffer> channels) {
         requireNonNull(channels);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += channels.size();
@@ -4430,7 +4430,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<Long> pubsubNumpat() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBSUB,
@@ -4445,7 +4445,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<Buffer> randomkey() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RANDOMKEY, allocator);
@@ -4459,7 +4459,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> readonly() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.READONLY, allocator);
@@ -4473,7 +4473,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> readwrite() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.READWRITE, allocator);
@@ -4490,7 +4490,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                  @RedisProtocolSupport.Key final Buffer newkey) {
         requireNonNull(key);
         requireNonNull(newkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RENAME, allocator);
@@ -4511,7 +4511,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                  @RedisProtocolSupport.Key final Buffer newkey) {
         requireNonNull(key);
         requireNonNull(newkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RENAMENX, allocator);
@@ -4532,7 +4532,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                   final Buffer serializedValue) {
         requireNonNull(key);
         requireNonNull(serializedValue);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RESTORE, allocator);
@@ -4554,7 +4554,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                   @Nullable final RedisProtocolSupport.RestoreReplace replace) {
         requireNonNull(key);
         requireNonNull(serializedValue);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (replace != null) {
@@ -4578,7 +4578,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public <T> Single<List<T>> role() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ROLE, allocator);
@@ -4593,7 +4593,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Buffer> rpop(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPOP, allocator);
@@ -4612,7 +4612,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                     @RedisProtocolSupport.Key final Buffer destination) {
         requireNonNull(source);
         requireNonNull(destination);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPOPLPUSH, allocator);
@@ -4632,7 +4632,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> rpush(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSH, allocator);
@@ -4652,7 +4652,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(value1);
         requireNonNull(value2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSH, allocator);
@@ -4675,7 +4675,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(value1);
         requireNonNull(value2);
         requireNonNull(value3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSH, allocator);
@@ -4696,7 +4696,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> rpush(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> values) {
         requireNonNull(key);
         requireNonNull(values);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += values.size();
@@ -4716,7 +4716,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> rpushx(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSHX, allocator);
@@ -4735,7 +4735,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> sadd(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SADD, allocator);
@@ -4755,7 +4755,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SADD, allocator);
@@ -4778,7 +4778,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SADD, allocator);
@@ -4799,7 +4799,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> sadd(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -4817,7 +4817,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> save() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SAVE, allocator);
@@ -4831,7 +4831,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public <T> Single<List<T>> scan(final long cursor) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCAN, allocator);
@@ -4847,7 +4847,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> scan(final long cursor, @Nullable final Buffer matchPattern,
                                     @Nullable final Long count) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (matchPattern != null) {
@@ -4877,7 +4877,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> scard(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCARD, allocator);
@@ -4894,7 +4894,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<String> scriptDebug(final RedisProtocolSupport.ScriptDebugMode mode) {
         requireNonNull(mode);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4911,7 +4911,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> scriptExists(final Buffer sha1) {
         requireNonNull(sha1);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4929,7 +4929,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public <T> Single<List<T>> scriptExists(final Buffer sha11, final Buffer sha12) {
         requireNonNull(sha11);
         requireNonNull(sha12);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4949,7 +4949,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(sha11);
         requireNonNull(sha12);
         requireNonNull(sha13);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4968,7 +4968,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> scriptExists(final Collection<Buffer> sha1s) {
         requireNonNull(sha1s);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += sha1s.size();
@@ -4985,7 +4985,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> scriptFlush() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -5000,7 +5000,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> scriptKill() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -5016,7 +5016,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Buffer> scriptLoad(final Buffer script) {
         requireNonNull(script);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -5033,7 +5033,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> sdiff(@RedisProtocolSupport.Key final Buffer firstkey) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SDIFF, allocator);
@@ -5051,7 +5051,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public <T> Single<List<T>> sdiff(@RedisProtocolSupport.Key final Buffer firstkey,
                                      @Nullable @RedisProtocolSupport.Key final Buffer otherkey) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (otherkey != null) {
@@ -5079,7 +5079,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                      @Nullable @RedisProtocolSupport.Key final Buffer otherkey1,
                                      @Nullable @RedisProtocolSupport.Key final Buffer otherkey2) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (otherkey1 != null) {
@@ -5117,7 +5117,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                      @Nullable @RedisProtocolSupport.Key final Buffer otherkey2,
                                      @Nullable @RedisProtocolSupport.Key final Buffer otherkey3) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (otherkey1 != null) {
@@ -5163,7 +5163,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                      @RedisProtocolSupport.Key final Collection<Buffer> otherkeys) {
         requireNonNull(firstkey);
         requireNonNull(otherkeys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += otherkeys.size();
@@ -5185,7 +5185,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                    @RedisProtocolSupport.Key final Buffer firstkey) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SDIFFSTORE, allocator);
@@ -5207,7 +5207,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                    @Nullable @RedisProtocolSupport.Key final Buffer otherkey) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (otherkey != null) {
@@ -5239,7 +5239,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                    @Nullable @RedisProtocolSupport.Key final Buffer otherkey2) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (otherkey1 != null) {
@@ -5281,7 +5281,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                    @Nullable @RedisProtocolSupport.Key final Buffer otherkey3) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (otherkey1 != null) {
@@ -5331,7 +5331,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(destination);
         requireNonNull(firstkey);
         requireNonNull(otherkeys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += otherkeys.size();
@@ -5352,7 +5352,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> select(final long index) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SELECT, allocator);
@@ -5369,7 +5369,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<String> set(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SET, allocator);
@@ -5390,7 +5390,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                               @Nullable final RedisProtocolSupport.SetCondition condition) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (expireDuration != null) {
@@ -5421,7 +5421,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> setbit(@RedisProtocolSupport.Key final Buffer key, final long offset, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETBIT, allocator);
@@ -5441,7 +5441,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<String> setex(@RedisProtocolSupport.Key final Buffer key, final long seconds, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETEX, allocator);
@@ -5461,7 +5461,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> setnx(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETNX, allocator);
@@ -5480,7 +5480,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> setrange(@RedisProtocolSupport.Key final Buffer key, final long offset, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETRANGE, allocator);
@@ -5498,7 +5498,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> shutdown() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SHUTDOWN, allocator);
@@ -5512,7 +5512,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> shutdown(@Nullable final RedisProtocolSupport.ShutdownSaveMode saveMode) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (saveMode != null) {
@@ -5533,7 +5533,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> sinter(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTER, allocator);
@@ -5552,7 +5552,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                       @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTER, allocator);
@@ -5575,7 +5575,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTER, allocator);
@@ -5596,7 +5596,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> sinter(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -5616,7 +5616,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                     @RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(destination);
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTERSTORE, allocator);
@@ -5639,7 +5639,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(destination);
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTERSTORE, allocator);
@@ -5666,7 +5666,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTERSTORE, allocator);
@@ -5691,7 +5691,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                     @RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -5712,7 +5712,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> sismember(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SISMEMBER, allocator);
@@ -5731,7 +5731,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<String> slaveof(final Buffer host, final Buffer port) {
         requireNonNull(host);
         requireNonNull(port);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SLAVEOF, allocator);
@@ -5748,7 +5748,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> slowlog(final Buffer subcommand) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SLOWLOG, allocator);
@@ -5764,7 +5764,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> slowlog(final Buffer subcommand, @Nullable final Buffer argument) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (argument != null) {
@@ -5786,7 +5786,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> smembers(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SMEMBERS, allocator);
@@ -5806,7 +5806,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(source);
         requireNonNull(destination);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SMOVE, allocator);
@@ -5826,7 +5826,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> sort(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SORT, allocator);
@@ -5848,7 +5848,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                     @Nullable final RedisProtocolSupport.SortSorting sorting) {
         requireNonNull(key);
         requireNonNull(getPatterns);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (byPattern != null) {
@@ -5894,7 +5894,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                              @RedisProtocolSupport.Key final Buffer storeDestination) {
         requireNonNull(key);
         requireNonNull(storeDestination);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SORT, allocator);
@@ -5920,7 +5920,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(storeDestination);
         requireNonNull(getPatterns);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (byPattern != null) {
@@ -5967,7 +5967,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Buffer> spop(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SPOP, allocator);
@@ -5984,7 +5984,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Buffer> spop(@RedisProtocolSupport.Key final Buffer key, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -6007,7 +6007,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Buffer> srandmember(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SRANDMEMBER, allocator);
@@ -6024,7 +6024,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<List<String>> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SRANDMEMBER, allocator);
@@ -6043,7 +6043,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> srem(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SREM, allocator);
@@ -6063,7 +6063,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SREM, allocator);
@@ -6086,7 +6086,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SREM, allocator);
@@ -6107,7 +6107,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> srem(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -6126,7 +6126,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> sscan(@RedisProtocolSupport.Key final Buffer key, final long cursor) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SSCAN, allocator);
@@ -6145,7 +6145,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public <T> Single<List<T>> sscan(@RedisProtocolSupport.Key final Buffer key, final long cursor,
                                      @Nullable final Buffer matchPattern, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (matchPattern != null) {
@@ -6177,7 +6177,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> strlen(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.STRLEN, allocator);
@@ -6194,7 +6194,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<PubSubBufferRedisConnection> subscribe(final Buffer channel) {
         requireNonNull(channel);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUBSCRIBE, allocator);
@@ -6210,7 +6210,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> sunion(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNION, allocator);
@@ -6229,7 +6229,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                       @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNION, allocator);
@@ -6252,7 +6252,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNION, allocator);
@@ -6273,7 +6273,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> sunion(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -6293,7 +6293,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                     @RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(destination);
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNIONSTORE, allocator);
@@ -6316,7 +6316,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(destination);
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNIONSTORE, allocator);
@@ -6343,7 +6343,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNIONSTORE, allocator);
@@ -6368,7 +6368,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                     @RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -6387,7 +6387,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> swapdb(final long index, final long index1) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SWAPDB, allocator);
@@ -6403,7 +6403,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public <T> Single<List<T>> time() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TIME, allocator);
@@ -6418,7 +6418,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> touch(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TOUCH, allocator);
@@ -6437,7 +6437,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                               @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TOUCH, allocator);
@@ -6459,7 +6459,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TOUCH, allocator);
@@ -6480,7 +6480,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> touch(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -6498,7 +6498,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> ttl(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TTL, allocator);
@@ -6515,7 +6515,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<String> type(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TYPE, allocator);
@@ -6532,7 +6532,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> unlink(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNLINK, allocator);
@@ -6551,7 +6551,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNLINK, allocator);
@@ -6573,7 +6573,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNLINK, allocator);
@@ -6594,7 +6594,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> unlink(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -6611,7 +6611,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<String> unwatch() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNWATCH, allocator);
@@ -6625,7 +6625,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
 
     @Override
     public Single<Long> wait(final long numslaves, final long timeout) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WAIT, allocator);
@@ -6642,7 +6642,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<String> watch(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WATCH, allocator);
@@ -6661,7 +6661,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                 @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WATCH, allocator);
@@ -6684,7 +6684,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WATCH, allocator);
@@ -6705,7 +6705,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<String> watch(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -6727,7 +6727,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(id);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XADD, allocator);
@@ -6753,7 +6753,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(value1);
         requireNonNull(field2);
         requireNonNull(value2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XADD, allocator);
@@ -6784,7 +6784,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(value2);
         requireNonNull(field3);
         requireNonNull(value3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 9;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XADD, allocator);
@@ -6811,7 +6811,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(id);
         requireNonNull(fieldValues);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += RedisProtocolSupport.BufferFieldValue.SIZE * fieldValues.size();
@@ -6831,7 +6831,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> xlen(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XLEN, allocator);
@@ -6849,7 +6849,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public <T> Single<List<T>> xpending(@RedisProtocolSupport.Key final Buffer key, final Buffer group) {
         requireNonNull(key);
         requireNonNull(group);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XPENDING, allocator);
@@ -6870,7 +6870,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                         @Nullable final Long count, @Nullable final Buffer consumer) {
         requireNonNull(key);
         requireNonNull(group);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (start != null) {
@@ -6915,7 +6915,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(start);
         requireNonNull(end);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XRANGE, allocator);
@@ -6937,7 +6937,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(start);
         requireNonNull(end);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (count != null) {
@@ -6965,7 +6965,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                      final Collection<Buffer> ids) {
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -6989,7 +6989,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                      final Collection<Buffer> ids) {
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -7028,7 +7028,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(groupConsumer);
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2 + RedisProtocolSupport.BufferGroupConsumer.SIZE;
         len += keys.size();
@@ -7055,7 +7055,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(groupConsumer);
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2 + RedisProtocolSupport.BufferGroupConsumer.SIZE;
         if (count != null) {
@@ -7094,7 +7094,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(end);
         requireNonNull(start);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XREVRANGE, allocator);
@@ -7116,7 +7116,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(end);
         requireNonNull(start);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (count != null) {
@@ -7144,7 +7144,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                              final Collection<RedisProtocolSupport.BufferScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += RedisProtocolSupport.BufferScoreMember.SIZE * scoreMembers.size();
@@ -7167,7 +7167,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                              final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (condition != null) {
@@ -7203,7 +7203,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         if (condition != null) {
@@ -7243,7 +7243,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 8;
         if (condition != null) {
@@ -7282,7 +7282,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                              final Collection<RedisProtocolSupport.BufferScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (condition != null) {
@@ -7315,7 +7315,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                    final Collection<RedisProtocolSupport.BufferScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += RedisProtocolSupport.BufferScoreMember.SIZE * scoreMembers.size();
@@ -7340,7 +7340,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                    final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         if (condition != null) {
@@ -7378,7 +7378,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         if (condition != null) {
@@ -7420,7 +7420,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 9;
         if (condition != null) {
@@ -7461,7 +7461,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                    final Collection<RedisProtocolSupport.BufferScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (condition != null) {
@@ -7494,7 +7494,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> zcard(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZCARD, allocator);
@@ -7511,7 +7511,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> zcount(@RedisProtocolSupport.Key final Buffer key, final double min, final double max) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZCOUNT, allocator);
@@ -7532,7 +7532,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                   final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZINCRBY, allocator);
@@ -7554,7 +7554,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                     @RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -7580,7 +7580,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(destination);
         requireNonNull(keys);
         requireNonNull(weightses);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -7611,7 +7611,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZLEXCOUNT, allocator);
@@ -7630,7 +7630,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> zpopmax(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZPOPMAX, allocator);
@@ -7647,7 +7647,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> zpopmax(@RedisProtocolSupport.Key final Buffer key, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -7670,7 +7670,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> zpopmin(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZPOPMIN, allocator);
@@ -7687,7 +7687,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> zpopmin(@RedisProtocolSupport.Key final Buffer key, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -7710,7 +7710,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> zrange(@RedisProtocolSupport.Key final Buffer key, final long start, final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANGE, allocator);
@@ -7730,7 +7730,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public <T> Single<List<T>> zrange(@RedisProtocolSupport.Key final Buffer key, final long start, final long stop,
                                       @Nullable final RedisProtocolSupport.ZrangeWithscores withscores) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -7758,7 +7758,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANGEBYLEX, allocator);
@@ -7781,7 +7781,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (offsetCount != null) {
@@ -7807,7 +7807,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public <T> Single<List<T>> zrangebyscore(@RedisProtocolSupport.Key final Buffer key, final double min,
                                              final double max) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANGEBYSCORE,
@@ -7830,7 +7830,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                              @Nullable final RedisProtocolSupport.ZrangebyscoreWithscores withscores,
                                              @Nullable final RedisProtocolSupport.OffsetCount offsetCount) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -7863,7 +7863,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> zrank(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANK, allocator);
@@ -7882,7 +7882,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> zrem(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREM, allocator);
@@ -7902,7 +7902,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREM, allocator);
@@ -7925,7 +7925,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREM, allocator);
@@ -7946,7 +7946,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> zrem(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -7967,7 +7967,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREMRANGEBYLEX,
@@ -7987,7 +7987,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public Single<Long> zremrangebyrank(@RedisProtocolSupport.Key final Buffer key, final long start, final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREMRANGEBYRANK,
@@ -8008,7 +8008,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> zremrangebyscore(@RedisProtocolSupport.Key final Buffer key, final double min,
                                          final double max) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREMRANGEBYSCORE,
@@ -8029,7 +8029,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public <T> Single<List<T>> zrevrange(@RedisProtocolSupport.Key final Buffer key, final long start,
                                          final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANGE, allocator);
@@ -8049,7 +8049,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public <T> Single<List<T>> zrevrange(@RedisProtocolSupport.Key final Buffer key, final long start, final long stop,
                                          @Nullable final RedisProtocolSupport.ZrevrangeWithscores withscores) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -8077,7 +8077,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(max);
         requireNonNull(min);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANGEBYLEX,
@@ -8101,7 +8101,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(key);
         requireNonNull(max);
         requireNonNull(min);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (offsetCount != null) {
@@ -8128,7 +8128,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public <T> Single<List<T>> zrevrangebyscore(@RedisProtocolSupport.Key final Buffer key, final double max,
                                                 final double min) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANGEBYSCORE,
@@ -8151,7 +8151,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                                 @Nullable final RedisProtocolSupport.ZrevrangebyscoreWithscores withscores,
                                                 @Nullable final RedisProtocolSupport.OffsetCount offsetCount) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -8184,7 +8184,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Long> zrevrank(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANK, allocator);
@@ -8202,7 +8202,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     @Override
     public <T> Single<List<T>> zscan(@RedisProtocolSupport.Key final Buffer key, final long cursor) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZSCAN, allocator);
@@ -8221,7 +8221,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public <T> Single<List<T>> zscan(@RedisProtocolSupport.Key final Buffer key, final long cursor,
                                      @Nullable final Buffer matchPattern, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (matchPattern != null) {
@@ -8254,7 +8254,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     public Single<Double> zscore(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZSCORE, allocator);
@@ -8275,7 +8275,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                                     @RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -8301,7 +8301,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         requireNonNull(destination);
         requireNonNull(keys);
         requireNonNull(weightses);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultPartitionedRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultPartitionedRedisCommander.java
@@ -67,7 +67,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> append(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.APPEND, allocator);
@@ -85,7 +85,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> auth(final CharSequence password) {
         requireNonNull(password);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.AUTH, allocator);
@@ -100,7 +100,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> bgrewriteaof() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BGREWRITEAOF, allocator);
@@ -114,7 +114,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> bgsave() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BGSAVE, allocator);
@@ -129,7 +129,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> bitcount(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITCOUNT, allocator);
@@ -147,7 +147,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> bitcount(@RedisProtocolSupport.Key final CharSequence key, @Nullable final Long start,
                                  @Nullable final Long end) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (start != null) {
@@ -178,7 +178,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                        final Collection<RedisProtocolSupport.BitfieldOperation> operations) {
         requireNonNull(key);
         requireNonNull(operations);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         final CompositeBuffer cbOps = allocator.newCompositeBuffer();
         final int len = 2 + operations.stream().mapToInt(op -> op.writeTo(cbOps, allocator)).sum();
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITFIELD, allocator);
@@ -199,7 +199,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(operation);
         requireNonNull(destkey);
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITOP, allocator);
@@ -224,7 +224,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(destkey);
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITOP, allocator);
@@ -253,7 +253,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITOP, allocator);
@@ -280,7 +280,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(operation);
         requireNonNull(destkey);
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -301,7 +301,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> bitpos(@RedisProtocolSupport.Key final CharSequence key, final long bit) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITPOS, allocator);
@@ -320,7 +320,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> bitpos(@RedisProtocolSupport.Key final CharSequence key, final long bit,
                                @Nullable final Long start, @Nullable final Long end) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (start != null) {
@@ -351,7 +351,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> blpop(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys,
                                      final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -371,7 +371,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> brpop(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys,
                                      final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -392,7 +392,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                      @RedisProtocolSupport.Key final CharSequence destination, final long timeout) {
         requireNonNull(source);
         requireNonNull(destination);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BRPOPLPUSH, allocator);
@@ -413,7 +413,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> bzpopmax(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys,
                                         final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -433,7 +433,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> bzpopmin(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys,
                                         final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -452,7 +452,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> clientKill(@Nullable final Long id, @Nullable final RedisProtocolSupport.ClientKillType type,
                                    @Nullable final CharSequence addrIpPort, @Nullable final CharSequence skipmeYesNo) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (id != null) {
@@ -494,7 +494,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clientList() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -509,7 +509,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clientGetname() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -524,7 +524,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clientPause(final long timeout) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -541,7 +541,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> clientReply(final RedisProtocolSupport.ClientReplyReplyMode replyMode) {
         requireNonNull(replyMode);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -558,7 +558,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> clientSetname(final CharSequence connectionName) {
         requireNonNull(connectionName);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -574,7 +574,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterAddslots(final long slot) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -590,7 +590,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterAddslots(final long slot1, final long slot2) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -607,7 +607,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterAddslots(final long slot1, final long slot2, final long slot3) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -626,7 +626,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> clusterAddslots(final Collection<Long> slots) {
         requireNonNull(slots);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += slots.size();
@@ -644,7 +644,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> clusterCountFailureReports(final CharSequence nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -660,7 +660,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<Long> clusterCountkeysinslot(final long slot) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -676,7 +676,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterDelslots(final long slot) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -692,7 +692,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterDelslots(final long slot1, final long slot2) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -709,7 +709,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterDelslots(final long slot1, final long slot2, final long slot3) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -728,7 +728,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> clusterDelslots(final Collection<Long> slots) {
         requireNonNull(slots);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += slots.size();
@@ -745,7 +745,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterFailover() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -760,7 +760,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterFailover(@Nullable final RedisProtocolSupport.ClusterFailoverOptions options) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (options != null) {
@@ -782,7 +782,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> clusterForget(final CharSequence nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -798,7 +798,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> clusterGetkeysinslot(final long slot, final long count) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -815,7 +815,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterInfo() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -831,7 +831,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> clusterKeyslot(final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -848,7 +848,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> clusterMeet(final CharSequence ip, final long port) {
         requireNonNull(ip);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -865,7 +865,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterNodes() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -881,7 +881,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> clusterReplicate(final CharSequence nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -897,7 +897,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterReset() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -912,7 +912,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterReset(@Nullable final RedisProtocolSupport.ClusterResetResetType resetType) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (resetType != null) {
@@ -933,7 +933,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterSaveconfig() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -948,7 +948,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterSetConfigEpoch(final long configEpoch) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -966,7 +966,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<String> clusterSetslot(final long slot,
                                          final RedisProtocolSupport.ClusterSetslotSubcommand subcommand) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -986,7 +986,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                          final RedisProtocolSupport.ClusterSetslotSubcommand subcommand,
                                          @Nullable final CharSequence nodeId) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (nodeId != null) {
@@ -1010,7 +1010,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> clusterSlaves(final CharSequence nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -1026,7 +1026,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> clusterSlots() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -1041,7 +1041,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> command() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND, allocator);
@@ -1055,7 +1055,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<Long> commandCount() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -1070,7 +1070,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> commandGetkeys() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -1086,7 +1086,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> commandInfo(final CharSequence commandName) {
         requireNonNull(commandName);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -1104,7 +1104,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> commandInfo(final CharSequence commandName1, final CharSequence commandName2) {
         requireNonNull(commandName1);
         requireNonNull(commandName2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -1125,7 +1125,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(commandName1);
         requireNonNull(commandName2);
         requireNonNull(commandName3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -1144,7 +1144,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> commandInfo(final Collection<? extends CharSequence> commandNames) {
         requireNonNull(commandNames);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += commandNames.size();
@@ -1162,7 +1162,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> configGet(final CharSequence parameter) {
         requireNonNull(parameter);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1178,7 +1178,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> configRewrite() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1195,7 +1195,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<String> configSet(final CharSequence parameter, final CharSequence value) {
         requireNonNull(parameter);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1212,7 +1212,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> configResetstat() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1227,7 +1227,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<Long> dbsize() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DBSIZE, allocator);
@@ -1242,7 +1242,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> debugObject(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEBUG,
@@ -1259,7 +1259,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> debugSegfault() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEBUG,
@@ -1275,7 +1275,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> decr(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DECR, allocator);
@@ -1292,7 +1292,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> decrby(@RedisProtocolSupport.Key final CharSequence key, final long decrement) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DECRBY, allocator);
@@ -1310,7 +1310,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> del(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEL, allocator);
@@ -1329,7 +1329,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                             @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEL, allocator);
@@ -1352,7 +1352,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEL, allocator);
@@ -1373,7 +1373,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> del(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -1391,7 +1391,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> dump(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DUMP, allocator);
@@ -1408,7 +1408,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> echo(final CharSequence message) {
         requireNonNull(message);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ECHO, allocator);
@@ -1428,7 +1428,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(script);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1454,7 +1454,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(script);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1480,7 +1480,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(script);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1506,7 +1506,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(sha1);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1532,7 +1532,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(sha1);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1558,7 +1558,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(sha1);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1580,7 +1580,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> exists(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXISTS, allocator);
@@ -1599,7 +1599,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXISTS, allocator);
@@ -1622,7 +1622,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXISTS, allocator);
@@ -1643,7 +1643,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> exists(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -1661,7 +1661,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> expire(@RedisProtocolSupport.Key final CharSequence key, final long seconds) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXPIRE, allocator);
@@ -1679,7 +1679,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> expireat(@RedisProtocolSupport.Key final CharSequence key, final long timestamp) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXPIREAT, allocator);
@@ -1696,7 +1696,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> flushall() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.FLUSHALL, allocator);
@@ -1710,7 +1710,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> flushall(@Nullable final RedisProtocolSupport.FlushallAsync async) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (async != null) {
@@ -1730,7 +1730,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> flushdb() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.FLUSHDB, allocator);
@@ -1744,7 +1744,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> flushdb(@Nullable final RedisProtocolSupport.FlushdbAsync async) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (async != null) {
@@ -1767,7 +1767,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                final double latitude, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOADD, allocator);
@@ -1791,7 +1791,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 8;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOADD, allocator);
@@ -1820,7 +1820,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 11;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOADD, allocator);
@@ -1848,7 +1848,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                final Collection<RedisProtocolSupport.LongitudeLatitudeMember> longitudeLatitudeMembers) {
         requireNonNull(key);
         requireNonNull(longitudeLatitudeMembers);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += RedisProtocolSupport.LongitudeLatitudeMember.SIZE * longitudeLatitudeMembers.size();
@@ -1870,7 +1870,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEODIST, allocator);
@@ -1893,7 +1893,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (unit != null) {
@@ -1920,7 +1920,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> geohash(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOHASH, allocator);
@@ -1941,7 +1941,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOHASH, allocator);
@@ -1964,7 +1964,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOHASH, allocator);
@@ -1986,7 +1986,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                        final Collection<? extends CharSequence> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -2006,7 +2006,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> geopos(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOPOS, allocator);
@@ -2027,7 +2027,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOPOS, allocator);
@@ -2050,7 +2050,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOPOS, allocator);
@@ -2072,7 +2072,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                       final Collection<? extends CharSequence> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -2094,7 +2094,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                          final RedisProtocolSupport.GeoradiusUnit unit) {
         requireNonNull(key);
         requireNonNull(unit);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEORADIUS, allocator);
@@ -2125,7 +2125,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                          @Nullable @RedisProtocolSupport.Key final CharSequence storedistKey) {
         requireNonNull(key);
         requireNonNull(unit);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         if (withcoord != null) {
@@ -2201,7 +2201,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member);
         requireNonNull(unit);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEORADIUSBYMEMBER,
@@ -2233,7 +2233,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member);
         requireNonNull(unit);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         if (withcoord != null) {
@@ -2305,7 +2305,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> get(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GET, allocator);
@@ -2322,7 +2322,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> getbit(@RedisProtocolSupport.Key final CharSequence key, final long offset) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GETBIT, allocator);
@@ -2340,7 +2340,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> getrange(@RedisProtocolSupport.Key final CharSequence key, final long start, final long end) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GETRANGE, allocator);
@@ -2360,7 +2360,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<String> getset(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GETSET, allocator);
@@ -2379,7 +2379,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> hdel(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HDEL, allocator);
@@ -2400,7 +2400,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HDEL, allocator);
@@ -2423,7 +2423,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(field1);
         requireNonNull(field2);
         requireNonNull(field3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HDEL, allocator);
@@ -2445,7 +2445,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                              final Collection<? extends CharSequence> fields) {
         requireNonNull(key);
         requireNonNull(fields);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += fields.size();
@@ -2465,7 +2465,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> hexists(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HEXISTS, allocator);
@@ -2484,7 +2484,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<String> hget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HGET, allocator);
@@ -2502,7 +2502,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> hgetall(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HGETALL, allocator);
@@ -2521,7 +2521,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                 final long increment) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HINCRBY, allocator);
@@ -2542,7 +2542,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                        final double increment) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HINCRBYFLOAT, allocator);
@@ -2562,7 +2562,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> hkeys(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HKEYS, allocator);
@@ -2579,7 +2579,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> hlen(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HLEN, allocator);
@@ -2597,7 +2597,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMGET, allocator);
@@ -2618,7 +2618,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMGET, allocator);
@@ -2641,7 +2641,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(field1);
         requireNonNull(field2);
         requireNonNull(field3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMGET, allocator);
@@ -2663,7 +2663,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                      final Collection<? extends CharSequence> fields) {
         requireNonNull(key);
         requireNonNull(fields);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += fields.size();
@@ -2685,7 +2685,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMSET, allocator);
@@ -2709,7 +2709,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(value1);
         requireNonNull(field2);
         requireNonNull(value2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMSET, allocator);
@@ -2738,7 +2738,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(value2);
         requireNonNull(field3);
         requireNonNull(value3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 8;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMSET, allocator);
@@ -2763,7 +2763,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                 final Collection<RedisProtocolSupport.FieldValue> fieldValues) {
         requireNonNull(key);
         requireNonNull(fieldValues);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += RedisProtocolSupport.FieldValue.SIZE * fieldValues.size();
@@ -2782,7 +2782,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> hscan(@RedisProtocolSupport.Key final CharSequence key, final long cursor) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSCAN, allocator);
@@ -2801,7 +2801,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> hscan(@RedisProtocolSupport.Key final CharSequence key, final long cursor,
                                      @Nullable final CharSequence matchPattern, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (matchPattern != null) {
@@ -2836,7 +2836,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSET, allocator);
@@ -2858,7 +2858,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSETNX, allocator);
@@ -2878,7 +2878,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> hstrlen(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSTRLEN, allocator);
@@ -2896,7 +2896,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> hvals(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HVALS, allocator);
@@ -2913,7 +2913,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> incr(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INCR, allocator);
@@ -2930,7 +2930,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> incrby(@RedisProtocolSupport.Key final CharSequence key, final long increment) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INCRBY, allocator);
@@ -2948,7 +2948,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Double> incrbyfloat(@RedisProtocolSupport.Key final CharSequence key, final double increment) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INCRBYFLOAT, allocator);
@@ -2966,7 +2966,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> info() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INFO, allocator);
@@ -2980,7 +2980,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> info(@Nullable final CharSequence section) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (section != null) {
@@ -3001,7 +3001,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> keys(final CharSequence pattern) {
         requireNonNull(pattern);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.KEYS, allocator);
@@ -3016,7 +3016,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<Long> lastsave() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LASTSAVE, allocator);
@@ -3031,7 +3031,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> lindex(@RedisProtocolSupport.Key final CharSequence key, final long index) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LINDEX, allocator);
@@ -3054,7 +3054,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(where);
         requireNonNull(pivot);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LINSERT, allocator);
@@ -3074,7 +3074,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> llen(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LLEN, allocator);
@@ -3091,7 +3091,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> lpop(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPOP, allocator);
@@ -3109,7 +3109,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> lpush(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSH, allocator);
@@ -3130,7 +3130,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(value1);
         requireNonNull(value2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSH, allocator);
@@ -3153,7 +3153,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(value1);
         requireNonNull(value2);
         requireNonNull(value3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSH, allocator);
@@ -3175,7 +3175,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                               final Collection<? extends CharSequence> values) {
         requireNonNull(key);
         requireNonNull(values);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += values.size();
@@ -3195,7 +3195,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> lpushx(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSHX, allocator);
@@ -3214,7 +3214,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> lrange(@RedisProtocolSupport.Key final CharSequence key, final long start,
                                       final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LRANGE, allocator);
@@ -3235,7 +3235,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                              final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LREM, allocator);
@@ -3256,7 +3256,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LSET, allocator);
@@ -3275,7 +3275,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> ltrim(@RedisProtocolSupport.Key final CharSequence key, final long start, final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LTRIM, allocator);
@@ -3293,7 +3293,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> memoryDoctor() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -3308,7 +3308,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> memoryHelp() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -3323,7 +3323,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> memoryMallocStats() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -3338,7 +3338,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> memoryPurge() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -3353,7 +3353,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> memoryStats() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -3369,7 +3369,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> memoryUsage(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -3388,7 +3388,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> memoryUsage(@RedisProtocolSupport.Key final CharSequence key,
                                     @Nullable final Long samplesCount) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (samplesCount != null) {
@@ -3413,7 +3413,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
@@ -3432,7 +3432,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                     @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
@@ -3455,7 +3455,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
@@ -3476,7 +3476,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -3493,7 +3493,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Publisher<String> monitor() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MONITOR, allocator);
@@ -3507,7 +3507,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> move(@RedisProtocolSupport.Key final CharSequence key, final long db) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MOVE, allocator);
@@ -3526,7 +3526,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<String> mset(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSET, allocator);
@@ -3548,7 +3548,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(value1);
         requireNonNull(key2);
         requireNonNull(value2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSET, allocator);
@@ -3576,7 +3576,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(value2);
         requireNonNull(key3);
         requireNonNull(value3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSET, allocator);
@@ -3600,7 +3600,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> mset(final Collection<RedisProtocolSupport.KeyValue> keyValues) {
         requireNonNull(keyValues);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += RedisProtocolSupport.KeyValue.SIZE * keyValues.size();
@@ -3618,7 +3618,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> msetnx(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSETNX, allocator);
@@ -3640,7 +3640,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(value1);
         requireNonNull(key2);
         requireNonNull(value2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSETNX, allocator);
@@ -3668,7 +3668,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(value2);
         requireNonNull(key3);
         requireNonNull(value3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSETNX, allocator);
@@ -3692,7 +3692,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> msetnx(final Collection<RedisProtocolSupport.KeyValue> keyValues) {
         requireNonNull(keyValues);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += RedisProtocolSupport.KeyValue.SIZE * keyValues.size();
@@ -3708,7 +3708,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<TransactedRedisCommander> multi() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MULTI, allocator);
@@ -3722,7 +3722,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> objectEncoding(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3740,7 +3740,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> objectFreq(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3757,7 +3757,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<List<String>> objectHelp() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3773,7 +3773,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> objectIdletime(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3791,7 +3791,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> objectRefcount(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3809,7 +3809,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> persist(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PERSIST, allocator);
@@ -3826,7 +3826,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> pexpire(@RedisProtocolSupport.Key final CharSequence key, final long milliseconds) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PEXPIRE, allocator);
@@ -3844,7 +3844,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> pexpireat(@RedisProtocolSupport.Key final CharSequence key, final long millisecondsTimestamp) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PEXPIREAT, allocator);
@@ -3863,7 +3863,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> pfadd(@RedisProtocolSupport.Key final CharSequence key, final CharSequence element) {
         requireNonNull(key);
         requireNonNull(element);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFADD, allocator);
@@ -3884,7 +3884,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(element1);
         requireNonNull(element2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFADD, allocator);
@@ -3907,7 +3907,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(element1);
         requireNonNull(element2);
         requireNonNull(element3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFADD, allocator);
@@ -3929,7 +3929,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                               final Collection<? extends CharSequence> elements) {
         requireNonNull(key);
         requireNonNull(elements);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += elements.size();
@@ -3948,7 +3948,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> pfcount(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFCOUNT, allocator);
@@ -3967,7 +3967,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                 @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFCOUNT, allocator);
@@ -3990,7 +3990,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFCOUNT, allocator);
@@ -4011,7 +4011,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> pfcount(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -4031,7 +4031,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                   @RedisProtocolSupport.Key final CharSequence sourcekey) {
         requireNonNull(destkey);
         requireNonNull(sourcekey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFMERGE, allocator);
@@ -4054,7 +4054,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(destkey);
         requireNonNull(sourcekey1);
         requireNonNull(sourcekey2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFMERGE, allocator);
@@ -4081,7 +4081,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(sourcekey1);
         requireNonNull(sourcekey2);
         requireNonNull(sourcekey3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFMERGE, allocator);
@@ -4106,7 +4106,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                   @RedisProtocolSupport.Key final Collection<? extends CharSequence> sourcekeys) {
         requireNonNull(destkey);
         requireNonNull(sourcekeys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += sourcekeys.size();
@@ -4125,7 +4125,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> ping() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PING, allocator);
@@ -4140,7 +4140,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> ping(final CharSequence message) {
         requireNonNull(message);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PING, allocator);
@@ -4158,7 +4158,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                  final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PSETEX, allocator);
@@ -4177,7 +4177,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<PubSubRedisConnection> psubscribe(final CharSequence pattern) {
         requireNonNull(pattern);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PSUBSCRIBE, allocator);
@@ -4192,7 +4192,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> pttl(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PTTL, allocator);
@@ -4210,7 +4210,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> publish(final CharSequence channel, final CharSequence message) {
         requireNonNull(channel);
         requireNonNull(message);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBLISH, allocator);
@@ -4226,7 +4226,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<List<String>> pubsubChannels() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBSUB,
@@ -4241,7 +4241,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<List<String>> pubsubChannels(@Nullable final CharSequence pattern) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (pattern != null) {
@@ -4263,7 +4263,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<List<String>> pubsubChannels(@Nullable final CharSequence pattern1,
                                                @Nullable final CharSequence pattern2) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (pattern1 != null) {
@@ -4292,7 +4292,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<List<String>> pubsubChannels(@Nullable final CharSequence pattern1,
                                                @Nullable final CharSequence pattern2,
                                                @Nullable final CharSequence pattern3) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (pattern1 != null) {
@@ -4326,7 +4326,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<List<String>> pubsubChannels(final Collection<? extends CharSequence> patterns) {
         requireNonNull(patterns);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += patterns.size();
@@ -4343,7 +4343,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> pubsubNumsub() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBSUB,
@@ -4358,7 +4358,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> pubsubNumsub(@Nullable final CharSequence channel) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (channel != null) {
@@ -4380,7 +4380,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> pubsubNumsub(@Nullable final CharSequence channel1,
                                             @Nullable final CharSequence channel2) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (channel1 != null) {
@@ -4409,7 +4409,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> pubsubNumsub(@Nullable final CharSequence channel1,
                                             @Nullable final CharSequence channel2,
                                             @Nullable final CharSequence channel3) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (channel1 != null) {
@@ -4443,7 +4443,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> pubsubNumsub(final Collection<? extends CharSequence> channels) {
         requireNonNull(channels);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += channels.size();
@@ -4460,7 +4460,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<Long> pubsubNumpat() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBSUB,
@@ -4475,7 +4475,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> randomkey() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RANDOMKEY, allocator);
@@ -4489,7 +4489,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> readonly() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.READONLY, allocator);
@@ -4503,7 +4503,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> readwrite() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.READWRITE, allocator);
@@ -4520,7 +4520,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                  @RedisProtocolSupport.Key final CharSequence newkey) {
         requireNonNull(key);
         requireNonNull(newkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RENAME, allocator);
@@ -4541,7 +4541,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                  @RedisProtocolSupport.Key final CharSequence newkey) {
         requireNonNull(key);
         requireNonNull(newkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RENAMENX, allocator);
@@ -4562,7 +4562,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                   final CharSequence serializedValue) {
         requireNonNull(key);
         requireNonNull(serializedValue);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RESTORE, allocator);
@@ -4584,7 +4584,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                   @Nullable final RedisProtocolSupport.RestoreReplace replace) {
         requireNonNull(key);
         requireNonNull(serializedValue);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (replace != null) {
@@ -4608,7 +4608,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> role() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ROLE, allocator);
@@ -4623,7 +4623,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> rpop(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPOP, allocator);
@@ -4642,7 +4642,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                     @RedisProtocolSupport.Key final CharSequence destination) {
         requireNonNull(source);
         requireNonNull(destination);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPOPLPUSH, allocator);
@@ -4662,7 +4662,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> rpush(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSH, allocator);
@@ -4683,7 +4683,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(value1);
         requireNonNull(value2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSH, allocator);
@@ -4706,7 +4706,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(value1);
         requireNonNull(value2);
         requireNonNull(value3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSH, allocator);
@@ -4728,7 +4728,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                               final Collection<? extends CharSequence> values) {
         requireNonNull(key);
         requireNonNull(values);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += values.size();
@@ -4748,7 +4748,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> rpushx(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSHX, allocator);
@@ -4767,7 +4767,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> sadd(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SADD, allocator);
@@ -4788,7 +4788,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SADD, allocator);
@@ -4811,7 +4811,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SADD, allocator);
@@ -4833,7 +4833,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                              final Collection<? extends CharSequence> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -4851,7 +4851,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> save() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SAVE, allocator);
@@ -4865,7 +4865,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> scan(final long cursor) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCAN, allocator);
@@ -4881,7 +4881,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> scan(final long cursor, @Nullable final CharSequence matchPattern,
                                     @Nullable final Long count) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (matchPattern != null) {
@@ -4911,7 +4911,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> scard(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCARD, allocator);
@@ -4928,7 +4928,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> scriptDebug(final RedisProtocolSupport.ScriptDebugMode mode) {
         requireNonNull(mode);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4945,7 +4945,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> scriptExists(final CharSequence sha1) {
         requireNonNull(sha1);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4963,7 +4963,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> scriptExists(final CharSequence sha11, final CharSequence sha12) {
         requireNonNull(sha11);
         requireNonNull(sha12);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4984,7 +4984,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(sha11);
         requireNonNull(sha12);
         requireNonNull(sha13);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -5003,7 +5003,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> scriptExists(final Collection<? extends CharSequence> sha1s) {
         requireNonNull(sha1s);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += sha1s.size();
@@ -5020,7 +5020,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> scriptFlush() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -5035,7 +5035,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> scriptKill() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -5051,7 +5051,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> scriptLoad(final CharSequence script) {
         requireNonNull(script);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -5068,7 +5068,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> sdiff(@RedisProtocolSupport.Key final CharSequence firstkey) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SDIFF, allocator);
@@ -5086,7 +5086,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> sdiff(@RedisProtocolSupport.Key final CharSequence firstkey,
                                      @Nullable @RedisProtocolSupport.Key final CharSequence otherkey) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (otherkey != null) {
@@ -5114,7 +5114,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                      @Nullable @RedisProtocolSupport.Key final CharSequence otherkey1,
                                      @Nullable @RedisProtocolSupport.Key final CharSequence otherkey2) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (otherkey1 != null) {
@@ -5152,7 +5152,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                      @Nullable @RedisProtocolSupport.Key final CharSequence otherkey2,
                                      @Nullable @RedisProtocolSupport.Key final CharSequence otherkey3) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (otherkey1 != null) {
@@ -5198,7 +5198,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                      @RedisProtocolSupport.Key final Collection<? extends CharSequence> otherkeys) {
         requireNonNull(firstkey);
         requireNonNull(otherkeys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += otherkeys.size();
@@ -5220,7 +5220,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                    @RedisProtocolSupport.Key final CharSequence firstkey) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SDIFFSTORE, allocator);
@@ -5242,7 +5242,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                    @Nullable @RedisProtocolSupport.Key final CharSequence otherkey) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (otherkey != null) {
@@ -5274,7 +5274,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                    @Nullable @RedisProtocolSupport.Key final CharSequence otherkey2) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (otherkey1 != null) {
@@ -5316,7 +5316,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                    @Nullable @RedisProtocolSupport.Key final CharSequence otherkey3) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (otherkey1 != null) {
@@ -5366,7 +5366,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(destination);
         requireNonNull(firstkey);
         requireNonNull(otherkeys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += otherkeys.size();
@@ -5387,7 +5387,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> select(final long index) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SELECT, allocator);
@@ -5404,7 +5404,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<String> set(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SET, allocator);
@@ -5425,7 +5425,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                               @Nullable final RedisProtocolSupport.SetCondition condition) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (expireDuration != null) {
@@ -5457,7 +5457,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETBIT, allocator);
@@ -5478,7 +5478,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                 final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETEX, allocator);
@@ -5498,7 +5498,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> setnx(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETNX, allocator);
@@ -5518,7 +5518,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                  final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETRANGE, allocator);
@@ -5536,7 +5536,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> shutdown() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SHUTDOWN, allocator);
@@ -5550,7 +5550,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> shutdown(@Nullable final RedisProtocolSupport.ShutdownSaveMode saveMode) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (saveMode != null) {
@@ -5571,7 +5571,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> sinter(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTER, allocator);
@@ -5590,7 +5590,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                       @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTER, allocator);
@@ -5613,7 +5613,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTER, allocator);
@@ -5634,7 +5634,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> sinter(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -5654,7 +5654,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                     @RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(destination);
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTERSTORE, allocator);
@@ -5677,7 +5677,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(destination);
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTERSTORE, allocator);
@@ -5704,7 +5704,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTERSTORE, allocator);
@@ -5729,7 +5729,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                     @RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -5750,7 +5750,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> sismember(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SISMEMBER, allocator);
@@ -5769,7 +5769,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<String> slaveof(final CharSequence host, final CharSequence port) {
         requireNonNull(host);
         requireNonNull(port);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SLAVEOF, allocator);
@@ -5786,7 +5786,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> slowlog(final CharSequence subcommand) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SLOWLOG, allocator);
@@ -5802,7 +5802,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> slowlog(final CharSequence subcommand, @Nullable final CharSequence argument) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (argument != null) {
@@ -5824,7 +5824,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> smembers(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SMEMBERS, allocator);
@@ -5844,7 +5844,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(source);
         requireNonNull(destination);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SMOVE, allocator);
@@ -5864,7 +5864,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> sort(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SORT, allocator);
@@ -5887,7 +5887,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                     @Nullable final RedisProtocolSupport.SortSorting sorting) {
         requireNonNull(key);
         requireNonNull(getPatterns);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (byPattern != null) {
@@ -5933,7 +5933,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                              @RedisProtocolSupport.Key final CharSequence storeDestination) {
         requireNonNull(key);
         requireNonNull(storeDestination);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SORT, allocator);
@@ -5961,7 +5961,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(storeDestination);
         requireNonNull(getPatterns);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (byPattern != null) {
@@ -6008,7 +6008,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> spop(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SPOP, allocator);
@@ -6025,7 +6025,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> spop(@RedisProtocolSupport.Key final CharSequence key, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -6048,7 +6048,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> srandmember(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SRANDMEMBER, allocator);
@@ -6065,7 +6065,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<List<String>> srandmember(@RedisProtocolSupport.Key final CharSequence key, final long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SRANDMEMBER, allocator);
@@ -6084,7 +6084,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> srem(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SREM, allocator);
@@ -6105,7 +6105,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SREM, allocator);
@@ -6128,7 +6128,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SREM, allocator);
@@ -6150,7 +6150,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                              final Collection<? extends CharSequence> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -6169,7 +6169,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> sscan(@RedisProtocolSupport.Key final CharSequence key, final long cursor) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SSCAN, allocator);
@@ -6188,7 +6188,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> sscan(@RedisProtocolSupport.Key final CharSequence key, final long cursor,
                                      @Nullable final CharSequence matchPattern, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (matchPattern != null) {
@@ -6220,7 +6220,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> strlen(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.STRLEN, allocator);
@@ -6237,7 +6237,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<PubSubRedisConnection> subscribe(final CharSequence channel) {
         requireNonNull(channel);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUBSCRIBE, allocator);
@@ -6252,7 +6252,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> sunion(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNION, allocator);
@@ -6271,7 +6271,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                       @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNION, allocator);
@@ -6294,7 +6294,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNION, allocator);
@@ -6315,7 +6315,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> sunion(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -6335,7 +6335,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                     @RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(destination);
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNIONSTORE, allocator);
@@ -6358,7 +6358,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(destination);
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNIONSTORE, allocator);
@@ -6385,7 +6385,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNIONSTORE, allocator);
@@ -6410,7 +6410,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                     @RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -6429,7 +6429,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> swapdb(final long index, final long index1) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SWAPDB, allocator);
@@ -6445,7 +6445,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> time() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TIME, allocator);
@@ -6460,7 +6460,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> touch(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TOUCH, allocator);
@@ -6479,7 +6479,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                               @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TOUCH, allocator);
@@ -6502,7 +6502,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TOUCH, allocator);
@@ -6523,7 +6523,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> touch(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -6541,7 +6541,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> ttl(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TTL, allocator);
@@ -6558,7 +6558,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> type(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TYPE, allocator);
@@ -6575,7 +6575,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> unlink(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNLINK, allocator);
@@ -6594,7 +6594,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNLINK, allocator);
@@ -6617,7 +6617,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNLINK, allocator);
@@ -6638,7 +6638,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> unlink(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -6655,7 +6655,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> unwatch() {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNWATCH, allocator);
@@ -6669,7 +6669,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
 
     @Override
     public Single<Long> wait(final long numslaves, final long timeout) {
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WAIT, allocator);
@@ -6686,7 +6686,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> watch(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WATCH, allocator);
@@ -6705,7 +6705,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                 @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WATCH, allocator);
@@ -6728,7 +6728,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WATCH, allocator);
@@ -6749,7 +6749,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<String> watch(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -6771,7 +6771,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(id);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XADD, allocator);
@@ -6798,7 +6798,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(value1);
         requireNonNull(field2);
         requireNonNull(value2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XADD, allocator);
@@ -6829,7 +6829,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(value2);
         requireNonNull(field3);
         requireNonNull(value3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 9;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XADD, allocator);
@@ -6856,7 +6856,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(id);
         requireNonNull(fieldValues);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += RedisProtocolSupport.FieldValue.SIZE * fieldValues.size();
@@ -6876,7 +6876,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> xlen(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XLEN, allocator);
@@ -6894,7 +6894,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> xpending(@RedisProtocolSupport.Key final CharSequence key, final CharSequence group) {
         requireNonNull(key);
         requireNonNull(group);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XPENDING, allocator);
@@ -6915,7 +6915,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                         @Nullable final Long count, @Nullable final CharSequence consumer) {
         requireNonNull(key);
         requireNonNull(group);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (start != null) {
@@ -6960,7 +6960,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(start);
         requireNonNull(end);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XRANGE, allocator);
@@ -6982,7 +6982,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(start);
         requireNonNull(end);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (count != null) {
@@ -7010,7 +7010,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                      final Collection<? extends CharSequence> ids) {
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -7034,7 +7034,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                      final Collection<? extends CharSequence> ids) {
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -7073,7 +7073,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(groupConsumer);
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2 + RedisProtocolSupport.GroupConsumer.SIZE;
         len += keys.size();
@@ -7100,7 +7100,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(groupConsumer);
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2 + RedisProtocolSupport.GroupConsumer.SIZE;
         if (count != null) {
@@ -7139,7 +7139,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(end);
         requireNonNull(start);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XREVRANGE, allocator);
@@ -7161,7 +7161,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(end);
         requireNonNull(start);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (count != null) {
@@ -7189,7 +7189,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                              final Collection<RedisProtocolSupport.ScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += RedisProtocolSupport.ScoreMember.SIZE * scoreMembers.size();
@@ -7212,7 +7212,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                              final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (condition != null) {
@@ -7248,7 +7248,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         if (condition != null) {
@@ -7288,7 +7288,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 8;
         if (condition != null) {
@@ -7327,7 +7327,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                              final Collection<RedisProtocolSupport.ScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (condition != null) {
@@ -7360,7 +7360,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                    final Collection<RedisProtocolSupport.ScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += RedisProtocolSupport.ScoreMember.SIZE * scoreMembers.size();
@@ -7385,7 +7385,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                    final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         if (condition != null) {
@@ -7423,7 +7423,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         if (condition != null) {
@@ -7465,7 +7465,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 9;
         if (condition != null) {
@@ -7506,7 +7506,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                    final Collection<RedisProtocolSupport.ScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (condition != null) {
@@ -7539,7 +7539,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> zcard(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZCARD, allocator);
@@ -7556,7 +7556,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public Single<Long> zcount(@RedisProtocolSupport.Key final CharSequence key, final double min, final double max) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZCOUNT, allocator);
@@ -7577,7 +7577,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                   final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZINCRBY, allocator);
@@ -7599,7 +7599,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                     @RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -7625,7 +7625,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(destination);
         requireNonNull(keys);
         requireNonNull(weightses);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -7657,7 +7657,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZLEXCOUNT, allocator);
@@ -7676,7 +7676,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> zpopmax(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZPOPMAX, allocator);
@@ -7693,7 +7693,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> zpopmax(@RedisProtocolSupport.Key final CharSequence key, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -7716,7 +7716,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> zpopmin(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZPOPMIN, allocator);
@@ -7733,7 +7733,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> zpopmin(@RedisProtocolSupport.Key final CharSequence key, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -7757,7 +7757,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> zrange(@RedisProtocolSupport.Key final CharSequence key, final long start,
                                       final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANGE, allocator);
@@ -7778,7 +7778,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                       final long stop,
                                       @Nullable final RedisProtocolSupport.ZrangeWithscores withscores) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -7806,7 +7806,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANGEBYLEX, allocator);
@@ -7829,7 +7829,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (offsetCount != null) {
@@ -7855,7 +7855,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> zrangebyscore(@RedisProtocolSupport.Key final CharSequence key, final double min,
                                              final double max) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANGEBYSCORE,
@@ -7878,7 +7878,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                              @Nullable final RedisProtocolSupport.ZrangebyscoreWithscores withscores,
                                              @Nullable final RedisProtocolSupport.OffsetCount offsetCount) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -7911,7 +7911,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> zrank(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANK, allocator);
@@ -7930,7 +7930,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> zrem(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREM, allocator);
@@ -7951,7 +7951,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREM, allocator);
@@ -7974,7 +7974,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREM, allocator);
@@ -7996,7 +7996,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                              final Collection<? extends CharSequence> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -8018,7 +8018,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREMRANGEBYLEX,
@@ -8039,7 +8039,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> zremrangebyrank(@RedisProtocolSupport.Key final CharSequence key, final long start,
                                         final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREMRANGEBYRANK,
@@ -8060,7 +8060,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> zremrangebyscore(@RedisProtocolSupport.Key final CharSequence key, final double min,
                                          final double max) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREMRANGEBYSCORE,
@@ -8081,7 +8081,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> zrevrange(@RedisProtocolSupport.Key final CharSequence key, final long start,
                                          final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANGE, allocator);
@@ -8102,7 +8102,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                          final long stop,
                                          @Nullable final RedisProtocolSupport.ZrevrangeWithscores withscores) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -8130,7 +8130,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(max);
         requireNonNull(min);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANGEBYLEX,
@@ -8154,7 +8154,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(max);
         requireNonNull(min);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (offsetCount != null) {
@@ -8181,7 +8181,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> zrevrangebyscore(@RedisProtocolSupport.Key final CharSequence key, final double max,
                                                 final double min) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANGEBYSCORE,
@@ -8204,7 +8204,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                                 @Nullable final RedisProtocolSupport.ZrevrangebyscoreWithscores withscores,
                                                 @Nullable final RedisProtocolSupport.OffsetCount offsetCount) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -8237,7 +8237,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Long> zrevrank(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANK, allocator);
@@ -8255,7 +8255,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> zscan(@RedisProtocolSupport.Key final CharSequence key, final long cursor) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZSCAN, allocator);
@@ -8274,7 +8274,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public <T> Single<List<T>> zscan(@RedisProtocolSupport.Key final CharSequence key, final long cursor,
                                      @Nullable final CharSequence matchPattern, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (matchPattern != null) {
@@ -8307,7 +8307,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     public Single<Double> zscore(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZSCORE, allocator);
@@ -8328,7 +8328,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                                     @RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -8354,7 +8354,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         requireNonNull(destination);
         requireNonNull(keys);
         requireNonNull(weightses);
-        final BufferAllocator allocator = partitionedRedisClient.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultPubSubBufferRedisConnection.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultPubSubBufferRedisConnection.java
@@ -62,7 +62,7 @@ final class DefaultPubSubBufferRedisConnection extends PubSubBufferRedisConnecti
 
     @Override
     public Single<PubSubRedisMessage.Pong<Buffer>> ping() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PING, allocator);
@@ -73,7 +73,7 @@ final class DefaultPubSubBufferRedisConnection extends PubSubBufferRedisConnecti
     @Override
     public Single<PubSubRedisMessage.Pong<Buffer>> ping(final Buffer message) {
         requireNonNull(message);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PING, allocator);
@@ -85,7 +85,7 @@ final class DefaultPubSubBufferRedisConnection extends PubSubBufferRedisConnecti
     @Override
     public Single<PubSubBufferRedisConnection> psubscribe(final Buffer pattern) {
         requireNonNull(pattern);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PSUBSCRIBE, allocator);
@@ -98,7 +98,7 @@ final class DefaultPubSubBufferRedisConnection extends PubSubBufferRedisConnecti
     @Override
     public Single<PubSubBufferRedisConnection> subscribe(final Buffer channel) {
         requireNonNull(channel);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUBSCRIBE, allocator);

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultPubSubRedisConnection.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultPubSubRedisConnection.java
@@ -61,7 +61,7 @@ final class DefaultPubSubRedisConnection extends PubSubRedisConnection {
 
     @Override
     public Single<PubSubRedisMessage.Pong<String>> ping() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PING, allocator);
@@ -72,7 +72,7 @@ final class DefaultPubSubRedisConnection extends PubSubRedisConnection {
     @Override
     public Single<PubSubRedisMessage.Pong<String>> ping(final CharSequence message) {
         requireNonNull(message);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PING, allocator);
@@ -84,7 +84,7 @@ final class DefaultPubSubRedisConnection extends PubSubRedisConnection {
     @Override
     public Single<PubSubRedisConnection> psubscribe(final CharSequence pattern) {
         requireNonNull(pattern);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PSUBSCRIBE, allocator);
@@ -97,7 +97,7 @@ final class DefaultPubSubRedisConnection extends PubSubRedisConnection {
     @Override
     public Single<PubSubRedisConnection> subscribe(final CharSequence channel) {
         requireNonNull(channel);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUBSCRIBE, allocator);

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultRedisCommander.java
@@ -61,7 +61,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> append(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.APPEND, allocator);
@@ -75,7 +75,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> auth(final CharSequence password) {
         requireNonNull(password);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.AUTH, allocator);
@@ -87,7 +87,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> bgrewriteaof() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BGREWRITEAOF, allocator);
@@ -98,7 +98,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> bgsave() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BGSAVE, allocator);
@@ -110,7 +110,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> bitcount(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITCOUNT, allocator);
@@ -124,7 +124,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> bitcount(@RedisProtocolSupport.Key final CharSequence key, @Nullable final Long start,
                                  @Nullable final Long end) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (start != null) {
@@ -151,7 +151,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                        final Collection<RedisProtocolSupport.BitfieldOperation> operations) {
         requireNonNull(key);
         requireNonNull(operations);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         final CompositeBuffer cbOps = allocator.newCompositeBuffer();
         final int len = 2 + operations.stream().mapToInt(op -> op.writeTo(cbOps, allocator)).sum();
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITFIELD, allocator);
@@ -169,7 +169,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(operation);
         requireNonNull(destkey);
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITOP, allocator);
@@ -189,7 +189,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(destkey);
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITOP, allocator);
@@ -212,7 +212,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITOP, allocator);
@@ -232,7 +232,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(operation);
         requireNonNull(destkey);
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -248,7 +248,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> bitpos(@RedisProtocolSupport.Key final CharSequence key, final long bit) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITPOS, allocator);
@@ -263,7 +263,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> bitpos(@RedisProtocolSupport.Key final CharSequence key, final long bit,
                                @Nullable final Long start, @Nullable final Long end) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (start != null) {
@@ -290,7 +290,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> blpop(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys,
                                      final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -307,7 +307,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> brpop(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys,
                                      final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -325,7 +325,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                      @RedisProtocolSupport.Key final CharSequence destination, final long timeout) {
         requireNonNull(source);
         requireNonNull(destination);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BRPOPLPUSH, allocator);
@@ -341,7 +341,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> bzpopmax(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys,
                                         final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -358,7 +358,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> bzpopmin(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys,
                                         final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -374,7 +374,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> clientKill(@Nullable final Long id, @Nullable final RedisProtocolSupport.ClientKillType type,
                                    @Nullable final CharSequence addrIpPort, @Nullable final CharSequence skipmeYesNo) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (id != null) {
@@ -413,7 +413,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clientList() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -425,7 +425,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clientGetname() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -437,7 +437,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clientPause(final long timeout) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -451,7 +451,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> clientReply(final RedisProtocolSupport.ClientReplyReplyMode replyMode) {
         requireNonNull(replyMode);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -465,7 +465,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> clientSetname(final CharSequence connectionName) {
         requireNonNull(connectionName);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -478,7 +478,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterAddslots(final long slot) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -491,7 +491,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterAddslots(final long slot1, final long slot2) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -505,7 +505,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterAddslots(final long slot1, final long slot2, final long slot3) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -521,7 +521,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> clusterAddslots(final Collection<Long> slots) {
         requireNonNull(slots);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += slots.size();
@@ -536,7 +536,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> clusterCountFailureReports(final CharSequence nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -549,7 +549,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<Long> clusterCountkeysinslot(final long slot) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -562,7 +562,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterDelslots(final long slot) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -575,7 +575,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterDelslots(final long slot1, final long slot2) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -589,7 +589,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterDelslots(final long slot1, final long slot2, final long slot3) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -605,7 +605,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> clusterDelslots(final Collection<Long> slots) {
         requireNonNull(slots);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += slots.size();
@@ -619,7 +619,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterFailover() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -631,7 +631,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterFailover(@Nullable final RedisProtocolSupport.ClusterFailoverOptions options) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (options != null) {
@@ -650,7 +650,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> clusterForget(final CharSequence nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -663,7 +663,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> clusterGetkeysinslot(final long slot, final long count) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -678,7 +678,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterInfo() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -691,7 +691,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> clusterKeyslot(final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -705,7 +705,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> clusterMeet(final CharSequence ip, final long port) {
         requireNonNull(ip);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -719,7 +719,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterNodes() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -732,7 +732,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> clusterReplicate(final CharSequence nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -745,7 +745,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterReset() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -757,7 +757,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterReset(@Nullable final RedisProtocolSupport.ClusterResetResetType resetType) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (resetType != null) {
@@ -775,7 +775,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterSaveconfig() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -787,7 +787,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> clusterSetConfigEpoch(final long configEpoch) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -802,7 +802,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<String> clusterSetslot(final long slot,
                                          final RedisProtocolSupport.ClusterSetslotSubcommand subcommand) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -819,7 +819,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                          final RedisProtocolSupport.ClusterSetslotSubcommand subcommand,
                                          @Nullable final CharSequence nodeId) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (nodeId != null) {
@@ -840,7 +840,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> clusterSlaves(final CharSequence nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -853,7 +853,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> clusterSlots() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -866,7 +866,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> command() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND, allocator);
@@ -878,7 +878,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<Long> commandCount() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -890,7 +890,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> commandGetkeys() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -904,7 +904,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> commandInfo(final CharSequence commandName) {
         requireNonNull(commandName);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -920,7 +920,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> commandInfo(final CharSequence commandName1, final CharSequence commandName2) {
         requireNonNull(commandName1);
         requireNonNull(commandName2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -939,7 +939,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(commandName1);
         requireNonNull(commandName2);
         requireNonNull(commandName3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -956,7 +956,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> commandInfo(final Collection<? extends CharSequence> commandNames) {
         requireNonNull(commandNames);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += commandNames.size();
@@ -972,7 +972,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> configGet(final CharSequence parameter) {
         requireNonNull(parameter);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -986,7 +986,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> configRewrite() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1000,7 +1000,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<String> configSet(final CharSequence parameter, final CharSequence value) {
         requireNonNull(parameter);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1014,7 +1014,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> configResetstat() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1026,7 +1026,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<Long> dbsize() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DBSIZE, allocator);
@@ -1038,7 +1038,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> debugObject(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEBUG,
@@ -1051,7 +1051,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> debugSegfault() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEBUG,
@@ -1064,7 +1064,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> decr(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DECR, allocator);
@@ -1077,7 +1077,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> decrby(@RedisProtocolSupport.Key final CharSequence key, final long decrement) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DECRBY, allocator);
@@ -1091,7 +1091,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> del(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEL, allocator);
@@ -1106,7 +1106,7 @@ final class DefaultRedisCommander extends RedisCommander {
                             @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEL, allocator);
@@ -1124,7 +1124,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEL, allocator);
@@ -1139,7 +1139,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> del(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -1153,7 +1153,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> dump(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DUMP, allocator);
@@ -1166,7 +1166,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> echo(final CharSequence message) {
         requireNonNull(message);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ECHO, allocator);
@@ -1183,7 +1183,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(script);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1205,7 +1205,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(script);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1228,7 +1228,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(script);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1250,7 +1250,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(sha1);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1272,7 +1272,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(sha1);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1295,7 +1295,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(sha1);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1313,7 +1313,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> exists(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXISTS, allocator);
@@ -1328,7 +1328,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXISTS, allocator);
@@ -1346,7 +1346,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXISTS, allocator);
@@ -1361,7 +1361,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> exists(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -1375,7 +1375,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> expire(@RedisProtocolSupport.Key final CharSequence key, final long seconds) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXPIRE, allocator);
@@ -1389,7 +1389,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> expireat(@RedisProtocolSupport.Key final CharSequence key, final long timestamp) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXPIREAT, allocator);
@@ -1402,7 +1402,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> flushall() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.FLUSHALL, allocator);
@@ -1413,7 +1413,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> flushall(@Nullable final RedisProtocolSupport.FlushallAsync async) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (async != null) {
@@ -1430,7 +1430,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> flushdb() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.FLUSHDB, allocator);
@@ -1441,7 +1441,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> flushdb(@Nullable final RedisProtocolSupport.FlushdbAsync async) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (async != null) {
@@ -1461,7 +1461,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                final double latitude, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOADD, allocator);
@@ -1481,7 +1481,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 8;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOADD, allocator);
@@ -1506,7 +1506,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 11;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOADD, allocator);
@@ -1530,7 +1530,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                final Collection<RedisProtocolSupport.LongitudeLatitudeMember> longitudeLatitudeMembers) {
         requireNonNull(key);
         requireNonNull(longitudeLatitudeMembers);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += RedisProtocolSupport.LongitudeLatitudeMember.SIZE * longitudeLatitudeMembers.size();
@@ -1548,7 +1548,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEODIST, allocator);
@@ -1567,7 +1567,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (unit != null) {
@@ -1590,7 +1590,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> geohash(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOHASH, allocator);
@@ -1608,7 +1608,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOHASH, allocator);
@@ -1628,7 +1628,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOHASH, allocator);
@@ -1647,7 +1647,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                        final Collection<? extends CharSequence> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -1664,7 +1664,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> geopos(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOPOS, allocator);
@@ -1682,7 +1682,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOPOS, allocator);
@@ -1702,7 +1702,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOPOS, allocator);
@@ -1721,7 +1721,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                       final Collection<? extends CharSequence> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -1740,7 +1740,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                          final RedisProtocolSupport.GeoradiusUnit unit) {
         requireNonNull(key);
         requireNonNull(unit);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEORADIUS, allocator);
@@ -1768,7 +1768,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                          @Nullable @RedisProtocolSupport.Key final CharSequence storedistKey) {
         requireNonNull(key);
         requireNonNull(unit);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         if (withcoord != null) {
@@ -1835,7 +1835,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member);
         requireNonNull(unit);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEORADIUSBYMEMBER,
@@ -1864,7 +1864,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member);
         requireNonNull(unit);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         if (withcoord != null) {
@@ -1927,7 +1927,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> get(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GET, allocator);
@@ -1940,7 +1940,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> getbit(@RedisProtocolSupport.Key final CharSequence key, final long offset) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GETBIT, allocator);
@@ -1954,7 +1954,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> getrange(@RedisProtocolSupport.Key final CharSequence key, final long start, final long end) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GETRANGE, allocator);
@@ -1970,7 +1970,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<String> getset(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GETSET, allocator);
@@ -1985,7 +1985,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> hdel(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HDEL, allocator);
@@ -2002,7 +2002,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HDEL, allocator);
@@ -2021,7 +2021,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(field1);
         requireNonNull(field2);
         requireNonNull(field3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HDEL, allocator);
@@ -2039,7 +2039,7 @@ final class DefaultRedisCommander extends RedisCommander {
                              final Collection<? extends CharSequence> fields) {
         requireNonNull(key);
         requireNonNull(fields);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += fields.size();
@@ -2055,7 +2055,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> hexists(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HEXISTS, allocator);
@@ -2070,7 +2070,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<String> hget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HGET, allocator);
@@ -2084,7 +2084,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> hgetall(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HGETALL, allocator);
@@ -2100,7 +2100,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                 final long increment) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HINCRBY, allocator);
@@ -2117,7 +2117,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                        final double increment) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HINCRBYFLOAT, allocator);
@@ -2133,7 +2133,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> hkeys(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HKEYS, allocator);
@@ -2147,7 +2147,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> hlen(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HLEN, allocator);
@@ -2161,7 +2161,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMGET, allocator);
@@ -2179,7 +2179,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMGET, allocator);
@@ -2199,7 +2199,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(field1);
         requireNonNull(field2);
         requireNonNull(field3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMGET, allocator);
@@ -2218,7 +2218,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                      final Collection<? extends CharSequence> fields) {
         requireNonNull(key);
         requireNonNull(fields);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += fields.size();
@@ -2237,7 +2237,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMSET, allocator);
@@ -2257,7 +2257,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(value1);
         requireNonNull(field2);
         requireNonNull(value2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMSET, allocator);
@@ -2282,7 +2282,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(value2);
         requireNonNull(field3);
         requireNonNull(value3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 8;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMSET, allocator);
@@ -2303,7 +2303,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                 final Collection<RedisProtocolSupport.FieldValue> fieldValues) {
         requireNonNull(key);
         requireNonNull(fieldValues);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += RedisProtocolSupport.FieldValue.SIZE * fieldValues.size();
@@ -2318,7 +2318,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> hscan(@RedisProtocolSupport.Key final CharSequence key, final long cursor) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSCAN, allocator);
@@ -2334,7 +2334,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> hscan(@RedisProtocolSupport.Key final CharSequence key, final long cursor,
                                      @Nullable final CharSequence matchPattern, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (matchPattern != null) {
@@ -2366,7 +2366,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSET, allocator);
@@ -2384,7 +2384,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSETNX, allocator);
@@ -2400,7 +2400,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> hstrlen(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSTRLEN, allocator);
@@ -2414,7 +2414,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> hvals(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HVALS, allocator);
@@ -2428,7 +2428,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> incr(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INCR, allocator);
@@ -2441,7 +2441,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> incrby(@RedisProtocolSupport.Key final CharSequence key, final long increment) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INCRBY, allocator);
@@ -2455,7 +2455,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Double> incrbyfloat(@RedisProtocolSupport.Key final CharSequence key, final double increment) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INCRBYFLOAT, allocator);
@@ -2469,7 +2469,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> info() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INFO, allocator);
@@ -2480,7 +2480,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> info(@Nullable final CharSequence section) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (section != null) {
@@ -2498,7 +2498,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> keys(final CharSequence pattern) {
         requireNonNull(pattern);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.KEYS, allocator);
@@ -2511,7 +2511,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<Long> lastsave() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LASTSAVE, allocator);
@@ -2523,7 +2523,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> lindex(@RedisProtocolSupport.Key final CharSequence key, final long index) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LINDEX, allocator);
@@ -2542,7 +2542,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(where);
         requireNonNull(pivot);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LINSERT, allocator);
@@ -2558,7 +2558,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> llen(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LLEN, allocator);
@@ -2571,7 +2571,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> lpop(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPOP, allocator);
@@ -2585,7 +2585,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> lpush(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSH, allocator);
@@ -2602,7 +2602,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(value1);
         requireNonNull(value2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSH, allocator);
@@ -2621,7 +2621,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(value1);
         requireNonNull(value2);
         requireNonNull(value3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSH, allocator);
@@ -2639,7 +2639,7 @@ final class DefaultRedisCommander extends RedisCommander {
                               final Collection<? extends CharSequence> values) {
         requireNonNull(key);
         requireNonNull(values);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += values.size();
@@ -2655,7 +2655,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> lpushx(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSHX, allocator);
@@ -2670,7 +2670,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> lrange(@RedisProtocolSupport.Key final CharSequence key, final long start,
                                       final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LRANGE, allocator);
@@ -2688,7 +2688,7 @@ final class DefaultRedisCommander extends RedisCommander {
                              final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LREM, allocator);
@@ -2705,7 +2705,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LSET, allocator);
@@ -2720,7 +2720,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> ltrim(@RedisProtocolSupport.Key final CharSequence key, final long start, final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LTRIM, allocator);
@@ -2734,7 +2734,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> memoryDoctor() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2746,7 +2746,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> memoryHelp() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2759,7 +2759,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> memoryMallocStats() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2771,7 +2771,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> memoryPurge() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2783,7 +2783,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> memoryStats() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2797,7 +2797,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> memoryUsage(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2812,7 +2812,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> memoryUsage(@RedisProtocolSupport.Key final CharSequence key,
                                     @Nullable final Long samplesCount) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (samplesCount != null) {
@@ -2833,7 +2833,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
@@ -2849,7 +2849,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                     @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
@@ -2868,7 +2868,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
@@ -2884,7 +2884,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -2898,7 +2898,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Publisher<String> monitor() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MONITOR, allocator);
@@ -2910,7 +2910,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> move(@RedisProtocolSupport.Key final CharSequence key, final long db) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MOVE, allocator);
@@ -2925,7 +2925,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<String> mset(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSET, allocator);
@@ -2943,7 +2943,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(value1);
         requireNonNull(key2);
         requireNonNull(value2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSET, allocator);
@@ -2966,7 +2966,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(value2);
         requireNonNull(key3);
         requireNonNull(value3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSET, allocator);
@@ -2984,7 +2984,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> mset(final Collection<RedisProtocolSupport.KeyValue> keyValues) {
         requireNonNull(keyValues);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += RedisProtocolSupport.KeyValue.SIZE * keyValues.size();
@@ -2999,7 +2999,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> msetnx(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSETNX, allocator);
@@ -3017,7 +3017,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(value1);
         requireNonNull(key2);
         requireNonNull(value2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSETNX, allocator);
@@ -3040,7 +3040,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(value2);
         requireNonNull(key3);
         requireNonNull(value3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSETNX, allocator);
@@ -3058,7 +3058,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> msetnx(final Collection<RedisProtocolSupport.KeyValue> keyValues) {
         requireNonNull(keyValues);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += RedisProtocolSupport.KeyValue.SIZE * keyValues.size();
@@ -3071,7 +3071,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<TransactedRedisCommander> multi() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MULTI, allocator);
@@ -3082,7 +3082,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> objectEncoding(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3096,7 +3096,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> objectFreq(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3109,7 +3109,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<List<String>> objectHelp() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3123,7 +3123,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> objectIdletime(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3137,7 +3137,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> objectRefcount(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3151,7 +3151,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> persist(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PERSIST, allocator);
@@ -3164,7 +3164,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> pexpire(@RedisProtocolSupport.Key final CharSequence key, final long milliseconds) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PEXPIRE, allocator);
@@ -3178,7 +3178,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> pexpireat(@RedisProtocolSupport.Key final CharSequence key, final long millisecondsTimestamp) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PEXPIREAT, allocator);
@@ -3193,7 +3193,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> pfadd(@RedisProtocolSupport.Key final CharSequence key, final CharSequence element) {
         requireNonNull(key);
         requireNonNull(element);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFADD, allocator);
@@ -3210,7 +3210,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(element1);
         requireNonNull(element2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFADD, allocator);
@@ -3229,7 +3229,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(element1);
         requireNonNull(element2);
         requireNonNull(element3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFADD, allocator);
@@ -3247,7 +3247,7 @@ final class DefaultRedisCommander extends RedisCommander {
                               final Collection<? extends CharSequence> elements) {
         requireNonNull(key);
         requireNonNull(elements);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += elements.size();
@@ -3262,7 +3262,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> pfcount(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFCOUNT, allocator);
@@ -3277,7 +3277,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                 @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFCOUNT, allocator);
@@ -3295,7 +3295,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFCOUNT, allocator);
@@ -3310,7 +3310,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> pfcount(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -3326,7 +3326,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                   @RedisProtocolSupport.Key final CharSequence sourcekey) {
         requireNonNull(destkey);
         requireNonNull(sourcekey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFMERGE, allocator);
@@ -3344,7 +3344,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(destkey);
         requireNonNull(sourcekey1);
         requireNonNull(sourcekey2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFMERGE, allocator);
@@ -3365,7 +3365,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(sourcekey1);
         requireNonNull(sourcekey2);
         requireNonNull(sourcekey3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFMERGE, allocator);
@@ -3383,7 +3383,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                   @RedisProtocolSupport.Key final Collection<? extends CharSequence> sourcekeys) {
         requireNonNull(destkey);
         requireNonNull(sourcekeys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += sourcekeys.size();
@@ -3397,7 +3397,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> ping() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PING, allocator);
@@ -3409,7 +3409,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> ping(final CharSequence message) {
         requireNonNull(message);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PING, allocator);
@@ -3424,7 +3424,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                  final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PSETEX, allocator);
@@ -3439,7 +3439,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<PubSubRedisConnection> psubscribe(final CharSequence pattern) {
         requireNonNull(pattern);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PSUBSCRIBE, allocator);
@@ -3452,7 +3452,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> pttl(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PTTL, allocator);
@@ -3466,7 +3466,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> publish(final CharSequence channel, final CharSequence message) {
         requireNonNull(channel);
         requireNonNull(message);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBLISH, allocator);
@@ -3479,7 +3479,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<List<String>> pubsubChannels() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBSUB,
@@ -3492,7 +3492,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<List<String>> pubsubChannels(@Nullable final CharSequence pattern) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (pattern != null) {
@@ -3512,7 +3512,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<List<String>> pubsubChannels(@Nullable final CharSequence pattern1,
                                                @Nullable final CharSequence pattern2) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (pattern1 != null) {
@@ -3539,7 +3539,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<List<String>> pubsubChannels(@Nullable final CharSequence pattern1,
                                                @Nullable final CharSequence pattern2,
                                                @Nullable final CharSequence pattern3) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (pattern1 != null) {
@@ -3571,7 +3571,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<List<String>> pubsubChannels(final Collection<? extends CharSequence> patterns) {
         requireNonNull(patterns);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += patterns.size();
@@ -3586,7 +3586,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> pubsubNumsub() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBSUB,
@@ -3599,7 +3599,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> pubsubNumsub(@Nullable final CharSequence channel) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (channel != null) {
@@ -3619,7 +3619,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> pubsubNumsub(@Nullable final CharSequence channel1,
                                             @Nullable final CharSequence channel2) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (channel1 != null) {
@@ -3646,7 +3646,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> pubsubNumsub(@Nullable final CharSequence channel1,
                                             @Nullable final CharSequence channel2,
                                             @Nullable final CharSequence channel3) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (channel1 != null) {
@@ -3678,7 +3678,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> pubsubNumsub(final Collection<? extends CharSequence> channels) {
         requireNonNull(channels);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += channels.size();
@@ -3693,7 +3693,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<Long> pubsubNumpat() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBSUB,
@@ -3705,7 +3705,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> randomkey() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RANDOMKEY, allocator);
@@ -3716,7 +3716,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> readonly() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.READONLY, allocator);
@@ -3727,7 +3727,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> readwrite() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.READWRITE, allocator);
@@ -3741,7 +3741,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                  @RedisProtocolSupport.Key final CharSequence newkey) {
         requireNonNull(key);
         requireNonNull(newkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RENAME, allocator);
@@ -3757,7 +3757,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                  @RedisProtocolSupport.Key final CharSequence newkey) {
         requireNonNull(key);
         requireNonNull(newkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RENAMENX, allocator);
@@ -3773,7 +3773,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                   final CharSequence serializedValue) {
         requireNonNull(key);
         requireNonNull(serializedValue);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RESTORE, allocator);
@@ -3791,7 +3791,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                   @Nullable final RedisProtocolSupport.RestoreReplace replace) {
         requireNonNull(key);
         requireNonNull(serializedValue);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (replace != null) {
@@ -3811,7 +3811,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> role() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ROLE, allocator);
@@ -3824,7 +3824,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> rpop(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPOP, allocator);
@@ -3839,7 +3839,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                     @RedisProtocolSupport.Key final CharSequence destination) {
         requireNonNull(source);
         requireNonNull(destination);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPOPLPUSH, allocator);
@@ -3854,7 +3854,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> rpush(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSH, allocator);
@@ -3871,7 +3871,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(value1);
         requireNonNull(value2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSH, allocator);
@@ -3890,7 +3890,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(value1);
         requireNonNull(value2);
         requireNonNull(value3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSH, allocator);
@@ -3908,7 +3908,7 @@ final class DefaultRedisCommander extends RedisCommander {
                               final Collection<? extends CharSequence> values) {
         requireNonNull(key);
         requireNonNull(values);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += values.size();
@@ -3924,7 +3924,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> rpushx(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSHX, allocator);
@@ -3939,7 +3939,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> sadd(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SADD, allocator);
@@ -3956,7 +3956,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SADD, allocator);
@@ -3975,7 +3975,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SADD, allocator);
@@ -3993,7 +3993,7 @@ final class DefaultRedisCommander extends RedisCommander {
                              final Collection<? extends CharSequence> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -4007,7 +4007,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> save() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SAVE, allocator);
@@ -4018,7 +4018,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> scan(final long cursor) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCAN, allocator);
@@ -4032,7 +4032,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> scan(final long cursor, @Nullable final CharSequence matchPattern,
                                     @Nullable final Long count) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (matchPattern != null) {
@@ -4060,7 +4060,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> scard(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCARD, allocator);
@@ -4073,7 +4073,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> scriptDebug(final RedisProtocolSupport.ScriptDebugMode mode) {
         requireNonNull(mode);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4087,7 +4087,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> scriptExists(final CharSequence sha1) {
         requireNonNull(sha1);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4103,7 +4103,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> scriptExists(final CharSequence sha11, final CharSequence sha12) {
         requireNonNull(sha11);
         requireNonNull(sha12);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4122,7 +4122,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(sha11);
         requireNonNull(sha12);
         requireNonNull(sha13);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4139,7 +4139,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> scriptExists(final Collection<? extends CharSequence> sha1s) {
         requireNonNull(sha1s);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += sha1s.size();
@@ -4154,7 +4154,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> scriptFlush() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4166,7 +4166,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> scriptKill() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4179,7 +4179,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> scriptLoad(final CharSequence script) {
         requireNonNull(script);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4193,7 +4193,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> sdiff(@RedisProtocolSupport.Key final CharSequence firstkey) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SDIFF, allocator);
@@ -4208,7 +4208,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> sdiff(@RedisProtocolSupport.Key final CharSequence firstkey,
                                      @Nullable @RedisProtocolSupport.Key final CharSequence otherkey) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (otherkey != null) {
@@ -4230,7 +4230,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                      @Nullable @RedisProtocolSupport.Key final CharSequence otherkey1,
                                      @Nullable @RedisProtocolSupport.Key final CharSequence otherkey2) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (otherkey1 != null) {
@@ -4259,7 +4259,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                      @Nullable @RedisProtocolSupport.Key final CharSequence otherkey2,
                                      @Nullable @RedisProtocolSupport.Key final CharSequence otherkey3) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (otherkey1 != null) {
@@ -4293,7 +4293,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                      @RedisProtocolSupport.Key final Collection<? extends CharSequence> otherkeys) {
         requireNonNull(firstkey);
         requireNonNull(otherkeys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += otherkeys.size();
@@ -4311,7 +4311,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                    @RedisProtocolSupport.Key final CharSequence firstkey) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SDIFFSTORE, allocator);
@@ -4328,7 +4328,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                    @Nullable @RedisProtocolSupport.Key final CharSequence otherkey) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (otherkey != null) {
@@ -4352,7 +4352,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                    @Nullable @RedisProtocolSupport.Key final CharSequence otherkey2) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (otherkey1 != null) {
@@ -4383,7 +4383,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                    @Nullable @RedisProtocolSupport.Key final CharSequence otherkey3) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (otherkey1 != null) {
@@ -4419,7 +4419,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(destination);
         requireNonNull(firstkey);
         requireNonNull(otherkeys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += otherkeys.size();
@@ -4434,7 +4434,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> select(final long index) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SELECT, allocator);
@@ -4448,7 +4448,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<String> set(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SET, allocator);
@@ -4465,7 +4465,7 @@ final class DefaultRedisCommander extends RedisCommander {
                               @Nullable final RedisProtocolSupport.SetCondition condition) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (expireDuration != null) {
@@ -4493,7 +4493,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETBIT, allocator);
@@ -4510,7 +4510,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                 final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETEX, allocator);
@@ -4526,7 +4526,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> setnx(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETNX, allocator);
@@ -4542,7 +4542,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                  final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETRANGE, allocator);
@@ -4556,7 +4556,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> shutdown() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SHUTDOWN, allocator);
@@ -4567,7 +4567,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> shutdown(@Nullable final RedisProtocolSupport.ShutdownSaveMode saveMode) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (saveMode != null) {
@@ -4585,7 +4585,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> sinter(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTER, allocator);
@@ -4601,7 +4601,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                       @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTER, allocator);
@@ -4620,7 +4620,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTER, allocator);
@@ -4636,7 +4636,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> sinter(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -4653,7 +4653,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                     @RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(destination);
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTERSTORE, allocator);
@@ -4671,7 +4671,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(destination);
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTERSTORE, allocator);
@@ -4692,7 +4692,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTERSTORE, allocator);
@@ -4710,7 +4710,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                     @RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -4726,7 +4726,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> sismember(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SISMEMBER, allocator);
@@ -4741,7 +4741,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<String> slaveof(final CharSequence host, final CharSequence port) {
         requireNonNull(host);
         requireNonNull(port);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SLAVEOF, allocator);
@@ -4755,7 +4755,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> slowlog(final CharSequence subcommand) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SLOWLOG, allocator);
@@ -4769,7 +4769,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> slowlog(final CharSequence subcommand, @Nullable final CharSequence argument) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (argument != null) {
@@ -4789,7 +4789,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> smembers(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SMEMBERS, allocator);
@@ -4806,7 +4806,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(source);
         requireNonNull(destination);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SMOVE, allocator);
@@ -4821,7 +4821,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> sort(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SORT, allocator);
@@ -4841,7 +4841,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                     @Nullable final RedisProtocolSupport.SortSorting sorting) {
         requireNonNull(key);
         requireNonNull(getPatterns);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (byPattern != null) {
@@ -4884,7 +4884,7 @@ final class DefaultRedisCommander extends RedisCommander {
                              @RedisProtocolSupport.Key final CharSequence storeDestination) {
         requireNonNull(key);
         requireNonNull(storeDestination);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SORT, allocator);
@@ -4907,7 +4907,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(storeDestination);
         requireNonNull(getPatterns);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (byPattern != null) {
@@ -4949,7 +4949,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> spop(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SPOP, allocator);
@@ -4962,7 +4962,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> spop(@RedisProtocolSupport.Key final CharSequence key, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -4981,7 +4981,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> srandmember(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SRANDMEMBER, allocator);
@@ -4994,7 +4994,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<List<String>> srandmember(@RedisProtocolSupport.Key final CharSequence key, final long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SRANDMEMBER, allocator);
@@ -5010,7 +5010,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> srem(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SREM, allocator);
@@ -5027,7 +5027,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SREM, allocator);
@@ -5046,7 +5046,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SREM, allocator);
@@ -5064,7 +5064,7 @@ final class DefaultRedisCommander extends RedisCommander {
                              final Collection<? extends CharSequence> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -5079,7 +5079,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> sscan(@RedisProtocolSupport.Key final CharSequence key, final long cursor) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SSCAN, allocator);
@@ -5095,7 +5095,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> sscan(@RedisProtocolSupport.Key final CharSequence key, final long cursor,
                                      @Nullable final CharSequence matchPattern, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (matchPattern != null) {
@@ -5124,7 +5124,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> strlen(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.STRLEN, allocator);
@@ -5137,7 +5137,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<PubSubRedisConnection> subscribe(final CharSequence channel) {
         requireNonNull(channel);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUBSCRIBE, allocator);
@@ -5150,7 +5150,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> sunion(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNION, allocator);
@@ -5166,7 +5166,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                       @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNION, allocator);
@@ -5185,7 +5185,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNION, allocator);
@@ -5201,7 +5201,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> sunion(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -5218,7 +5218,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                     @RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(destination);
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNIONSTORE, allocator);
@@ -5236,7 +5236,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(destination);
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNIONSTORE, allocator);
@@ -5257,7 +5257,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNIONSTORE, allocator);
@@ -5275,7 +5275,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                     @RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -5289,7 +5289,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> swapdb(final long index, final long index1) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SWAPDB, allocator);
@@ -5302,7 +5302,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public <T> Single<List<T>> time() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TIME, allocator);
@@ -5315,7 +5315,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> touch(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TOUCH, allocator);
@@ -5330,7 +5330,7 @@ final class DefaultRedisCommander extends RedisCommander {
                               @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TOUCH, allocator);
@@ -5348,7 +5348,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TOUCH, allocator);
@@ -5363,7 +5363,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> touch(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -5377,7 +5377,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> ttl(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TTL, allocator);
@@ -5390,7 +5390,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> type(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TYPE, allocator);
@@ -5403,7 +5403,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> unlink(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNLINK, allocator);
@@ -5418,7 +5418,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNLINK, allocator);
@@ -5436,7 +5436,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNLINK, allocator);
@@ -5451,7 +5451,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> unlink(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -5464,7 +5464,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<String> unwatch() {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNWATCH, allocator);
@@ -5475,7 +5475,7 @@ final class DefaultRedisCommander extends RedisCommander {
 
     @Override
     public Single<Long> wait(final long numslaves, final long timeout) {
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WAIT, allocator);
@@ -5489,7 +5489,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> watch(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WATCH, allocator);
@@ -5504,7 +5504,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                 @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WATCH, allocator);
@@ -5522,7 +5522,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WATCH, allocator);
@@ -5537,7 +5537,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<String> watch(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -5555,7 +5555,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(id);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XADD, allocator);
@@ -5578,7 +5578,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(value1);
         requireNonNull(field2);
         requireNonNull(value2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XADD, allocator);
@@ -5605,7 +5605,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(value2);
         requireNonNull(field3);
         requireNonNull(value3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 9;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XADD, allocator);
@@ -5628,7 +5628,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(id);
         requireNonNull(fieldValues);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += RedisProtocolSupport.FieldValue.SIZE * fieldValues.size();
@@ -5644,7 +5644,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> xlen(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XLEN, allocator);
@@ -5658,7 +5658,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> xpending(@RedisProtocolSupport.Key final CharSequence key, final CharSequence group) {
         requireNonNull(key);
         requireNonNull(group);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XPENDING, allocator);
@@ -5676,7 +5676,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                         @Nullable final Long count, @Nullable final CharSequence consumer) {
         requireNonNull(key);
         requireNonNull(group);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (start != null) {
@@ -5718,7 +5718,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(start);
         requireNonNull(end);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XRANGE, allocator);
@@ -5737,7 +5737,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(start);
         requireNonNull(end);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (count != null) {
@@ -5762,7 +5762,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                      final Collection<? extends CharSequence> ids) {
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -5783,7 +5783,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                      final Collection<? extends CharSequence> ids) {
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -5819,7 +5819,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(groupConsumer);
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2 + RedisProtocolSupport.GroupConsumer.SIZE;
         len += keys.size();
@@ -5843,7 +5843,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(groupConsumer);
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2 + RedisProtocolSupport.GroupConsumer.SIZE;
         if (count != null) {
@@ -5879,7 +5879,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(end);
         requireNonNull(start);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XREVRANGE, allocator);
@@ -5898,7 +5898,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(end);
         requireNonNull(start);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (count != null) {
@@ -5923,7 +5923,7 @@ final class DefaultRedisCommander extends RedisCommander {
                              final Collection<RedisProtocolSupport.ScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += RedisProtocolSupport.ScoreMember.SIZE * scoreMembers.size();
@@ -5942,7 +5942,7 @@ final class DefaultRedisCommander extends RedisCommander {
                              final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (condition != null) {
@@ -5974,7 +5974,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         if (condition != null) {
@@ -6010,7 +6010,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 8;
         if (condition != null) {
@@ -6045,7 +6045,7 @@ final class DefaultRedisCommander extends RedisCommander {
                              final Collection<RedisProtocolSupport.ScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (condition != null) {
@@ -6074,7 +6074,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                    final Collection<RedisProtocolSupport.ScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += RedisProtocolSupport.ScoreMember.SIZE * scoreMembers.size();
@@ -6095,7 +6095,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                    final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         if (condition != null) {
@@ -6129,7 +6129,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         if (condition != null) {
@@ -6167,7 +6167,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 9;
         if (condition != null) {
@@ -6204,7 +6204,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                    final Collection<RedisProtocolSupport.ScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (condition != null) {
@@ -6233,7 +6233,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> zcard(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZCARD, allocator);
@@ -6246,7 +6246,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public Single<Long> zcount(@RedisProtocolSupport.Key final CharSequence key, final double min, final double max) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZCOUNT, allocator);
@@ -6263,7 +6263,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                   final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZINCRBY, allocator);
@@ -6281,7 +6281,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                     @RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -6302,7 +6302,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(destination);
         requireNonNull(keys);
         requireNonNull(weightses);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -6329,7 +6329,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZLEXCOUNT, allocator);
@@ -6344,7 +6344,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> zpopmax(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZPOPMAX, allocator);
@@ -6358,7 +6358,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> zpopmax(@RedisProtocolSupport.Key final CharSequence key, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -6378,7 +6378,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> zpopmin(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZPOPMIN, allocator);
@@ -6392,7 +6392,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> zpopmin(@RedisProtocolSupport.Key final CharSequence key, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -6413,7 +6413,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> zrange(@RedisProtocolSupport.Key final CharSequence key, final long start,
                                       final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANGE, allocator);
@@ -6431,7 +6431,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                       final long stop,
                                       @Nullable final RedisProtocolSupport.ZrangeWithscores withscores) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -6456,7 +6456,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANGEBYLEX, allocator);
@@ -6476,7 +6476,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (offsetCount != null) {
@@ -6499,7 +6499,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> zrangebyscore(@RedisProtocolSupport.Key final CharSequence key, final double min,
                                              final double max) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANGEBYSCORE,
@@ -6519,7 +6519,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                              @Nullable final RedisProtocolSupport.ZrangebyscoreWithscores withscores,
                                              @Nullable final RedisProtocolSupport.OffsetCount offsetCount) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -6549,7 +6549,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> zrank(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANK, allocator);
@@ -6564,7 +6564,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> zrem(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREM, allocator);
@@ -6581,7 +6581,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREM, allocator);
@@ -6600,7 +6600,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREM, allocator);
@@ -6618,7 +6618,7 @@ final class DefaultRedisCommander extends RedisCommander {
                              final Collection<? extends CharSequence> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -6636,7 +6636,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREMRANGEBYLEX,
@@ -6653,7 +6653,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> zremrangebyrank(@RedisProtocolSupport.Key final CharSequence key, final long start,
                                         final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREMRANGEBYRANK,
@@ -6670,7 +6670,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> zremrangebyscore(@RedisProtocolSupport.Key final CharSequence key, final double min,
                                          final double max) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREMRANGEBYSCORE,
@@ -6687,7 +6687,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> zrevrange(@RedisProtocolSupport.Key final CharSequence key, final long start,
                                          final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANGE, allocator);
@@ -6705,7 +6705,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                          final long stop,
                                          @Nullable final RedisProtocolSupport.ZrevrangeWithscores withscores) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -6730,7 +6730,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(max);
         requireNonNull(min);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANGEBYLEX,
@@ -6751,7 +6751,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(key);
         requireNonNull(max);
         requireNonNull(min);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (offsetCount != null) {
@@ -6775,7 +6775,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> zrevrangebyscore(@RedisProtocolSupport.Key final CharSequence key, final double max,
                                                 final double min) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANGEBYSCORE,
@@ -6795,7 +6795,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                                 @Nullable final RedisProtocolSupport.ZrevrangebyscoreWithscores withscores,
                                                 @Nullable final RedisProtocolSupport.OffsetCount offsetCount) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -6825,7 +6825,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Long> zrevrank(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANK, allocator);
@@ -6839,7 +6839,7 @@ final class DefaultRedisCommander extends RedisCommander {
     @Override
     public <T> Single<List<T>> zscan(@RedisProtocolSupport.Key final CharSequence key, final long cursor) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZSCAN, allocator);
@@ -6855,7 +6855,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public <T> Single<List<T>> zscan(@RedisProtocolSupport.Key final CharSequence key, final long cursor,
                                      @Nullable final CharSequence matchPattern, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (matchPattern != null) {
@@ -6885,7 +6885,7 @@ final class DefaultRedisCommander extends RedisCommander {
     public Single<Double> zscore(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZSCORE, allocator);
@@ -6902,7 +6902,7 @@ final class DefaultRedisCommander extends RedisCommander {
                                     @RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -6923,7 +6923,7 @@ final class DefaultRedisCommander extends RedisCommander {
         requireNonNull(destination);
         requireNonNull(keys);
         requireNonNull(weightses);
-        final BufferAllocator allocator = requester.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultTransactedBufferRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultTransactedBufferRedisCommander.java
@@ -77,7 +77,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> append(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.APPEND, allocator);
@@ -92,7 +92,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<String> auth(final Buffer password) {
         requireNonNull(password);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.AUTH, allocator);
@@ -105,7 +105,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> bgrewriteaof() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BGREWRITEAOF, allocator);
@@ -117,7 +117,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> bgsave() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BGSAVE, allocator);
@@ -130,7 +130,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> bitcount(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITCOUNT, allocator);
@@ -145,7 +145,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> bitcount(@RedisProtocolSupport.Key final Buffer key, @Nullable final Long start,
                                  @Nullable final Long end) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (start != null) {
@@ -173,7 +173,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                        final Collection<RedisProtocolSupport.BitfieldOperation> operations) {
         requireNonNull(key);
         requireNonNull(operations);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         final CompositeBuffer cbOps = allocator.newCompositeBuffer();
         final int len = 2 + operations.stream().mapToInt(op -> op.writeTo(cbOps, allocator)).sum();
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITFIELD, allocator);
@@ -191,7 +191,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(operation);
         requireNonNull(destkey);
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITOP, allocator);
@@ -212,7 +212,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(destkey);
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITOP, allocator);
@@ -235,7 +235,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITOP, allocator);
@@ -256,7 +256,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(operation);
         requireNonNull(destkey);
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -273,7 +273,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> bitpos(@RedisProtocolSupport.Key final Buffer key, final long bit) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITPOS, allocator);
@@ -289,7 +289,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> bitpos(@RedisProtocolSupport.Key final Buffer key, final long bit, @Nullable final Long start,
                                @Nullable final Long end) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (start != null) {
@@ -316,7 +316,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> blpop(@RedisProtocolSupport.Key final Collection<Buffer> keys, final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -332,7 +332,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> brpop(@RedisProtocolSupport.Key final Collection<Buffer> keys, final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -350,7 +350,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                      @RedisProtocolSupport.Key final Buffer destination, final long timeout) {
         requireNonNull(source);
         requireNonNull(destination);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BRPOPLPUSH, allocator);
@@ -366,7 +366,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> bzpopmax(@RedisProtocolSupport.Key final Collection<Buffer> keys, final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -382,7 +382,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> bzpopmin(@RedisProtocolSupport.Key final Collection<Buffer> keys, final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -398,7 +398,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> clientKill(@Nullable final Long id, @Nullable final RedisProtocolSupport.ClientKillType type,
                                    @Nullable final Buffer addrIpPort, @Nullable final Buffer skipmeYesNo) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (id != null) {
@@ -438,7 +438,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<Buffer> clientList() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -451,7 +451,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<Buffer> clientGetname() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -464,7 +464,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> clientPause(final long timeout) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -479,7 +479,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<String> clientReply(final RedisProtocolSupport.ClientReplyReplyMode replyMode) {
         requireNonNull(replyMode);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -494,7 +494,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<String> clientSetname(final Buffer connectionName) {
         requireNonNull(connectionName);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -508,7 +508,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> clusterAddslots(final long slot) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -522,7 +522,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> clusterAddslots(final long slot1, final long slot2) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -537,7 +537,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> clusterAddslots(final long slot1, final long slot2, final long slot3) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -554,7 +554,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<String> clusterAddslots(final Collection<Long> slots) {
         requireNonNull(slots);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += slots.size();
@@ -570,7 +570,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> clusterCountFailureReports(final Buffer nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -584,7 +584,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<Long> clusterCountkeysinslot(final long slot) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -598,7 +598,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> clusterDelslots(final long slot) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -612,7 +612,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> clusterDelslots(final long slot1, final long slot2) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -627,7 +627,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> clusterDelslots(final long slot1, final long slot2, final long slot3) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -644,7 +644,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<String> clusterDelslots(final Collection<Long> slots) {
         requireNonNull(slots);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += slots.size();
@@ -659,7 +659,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> clusterFailover() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -672,7 +672,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> clusterFailover(@Nullable final RedisProtocolSupport.ClusterFailoverOptions options) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (options != null) {
@@ -692,7 +692,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<String> clusterForget(final Buffer nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -706,7 +706,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public <T> Future<List<T>> clusterGetkeysinslot(final long slot, final long count) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -721,7 +721,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<Buffer> clusterInfo() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -735,7 +735,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> clusterKeyslot(final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -750,7 +750,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<String> clusterMeet(final Buffer ip, final long port) {
         requireNonNull(ip);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -765,7 +765,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<Buffer> clusterNodes() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -779,7 +779,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<String> clusterReplicate(final Buffer nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -793,7 +793,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> clusterReset() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -806,7 +806,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> clusterReset(@Nullable final RedisProtocolSupport.ClusterResetResetType resetType) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (resetType != null) {
@@ -825,7 +825,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> clusterSaveconfig() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -838,7 +838,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> clusterSetConfigEpoch(final long configEpoch) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -854,7 +854,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<String> clusterSetslot(final long slot,
                                          final RedisProtocolSupport.ClusterSetslotSubcommand subcommand) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -872,7 +872,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                          final RedisProtocolSupport.ClusterSetslotSubcommand subcommand,
                                          @Nullable final Buffer nodeId) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (nodeId != null) {
@@ -894,7 +894,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Buffer> clusterSlaves(final Buffer nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -908,7 +908,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public <T> Future<List<T>> clusterSlots() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -921,7 +921,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public <T> Future<List<T>> command() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND, allocator);
@@ -933,7 +933,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<Long> commandCount() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -946,7 +946,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public <T> Future<List<T>> commandGetkeys() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -960,7 +960,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> commandInfo(final Buffer commandName) {
         requireNonNull(commandName);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -976,7 +976,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public <T> Future<List<T>> commandInfo(final Buffer commandName1, final Buffer commandName2) {
         requireNonNull(commandName1);
         requireNonNull(commandName2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -995,7 +995,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(commandName1);
         requireNonNull(commandName2);
         requireNonNull(commandName3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -1012,7 +1012,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> commandInfo(final Collection<Buffer> commandNames) {
         requireNonNull(commandNames);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += commandNames.size();
@@ -1028,7 +1028,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> configGet(final Buffer parameter) {
         requireNonNull(parameter);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1042,7 +1042,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> configRewrite() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1057,7 +1057,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<String> configSet(final Buffer parameter, final Buffer value) {
         requireNonNull(parameter);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1072,7 +1072,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> configResetstat() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1085,7 +1085,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<Long> dbsize() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DBSIZE, allocator);
@@ -1098,7 +1098,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<String> debugObject(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEBUG,
@@ -1112,7 +1112,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> debugSegfault() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEBUG,
@@ -1126,7 +1126,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> decr(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DECR, allocator);
@@ -1140,7 +1140,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> decrby(@RedisProtocolSupport.Key final Buffer key, final long decrement) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DECRBY, allocator);
@@ -1155,7 +1155,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> del(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEL, allocator);
@@ -1170,7 +1170,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> del(@RedisProtocolSupport.Key final Buffer key1, @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEL, allocator);
@@ -1188,7 +1188,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEL, allocator);
@@ -1204,7 +1204,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> del(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -1218,7 +1218,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Single<String> discard() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DISCARD, allocator);
@@ -1231,7 +1231,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Buffer> dump(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DUMP, allocator);
@@ -1245,7 +1245,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Buffer> echo(final Buffer message) {
         requireNonNull(message);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ECHO, allocator);
@@ -1262,7 +1262,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(script);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1285,7 +1285,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(script);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1308,7 +1308,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(script);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1331,7 +1331,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(sha1);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1354,7 +1354,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(sha1);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1377,7 +1377,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(sha1);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1395,7 +1395,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Completable exec() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXEC, allocator);
@@ -1408,7 +1408,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> exists(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXISTS, allocator);
@@ -1424,7 +1424,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXISTS, allocator);
@@ -1442,7 +1442,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXISTS, allocator);
@@ -1458,7 +1458,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> exists(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -1473,7 +1473,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> expire(@RedisProtocolSupport.Key final Buffer key, final long seconds) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXPIRE, allocator);
@@ -1488,7 +1488,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> expireat(@RedisProtocolSupport.Key final Buffer key, final long timestamp) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXPIREAT, allocator);
@@ -1502,7 +1502,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> flushall() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.FLUSHALL, allocator);
@@ -1514,7 +1514,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> flushall(@Nullable final RedisProtocolSupport.FlushallAsync async) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (async != null) {
@@ -1532,7 +1532,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> flushdb() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.FLUSHDB, allocator);
@@ -1544,7 +1544,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> flushdb(@Nullable final RedisProtocolSupport.FlushdbAsync async) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (async != null) {
@@ -1565,7 +1565,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                final double latitude, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOADD, allocator);
@@ -1586,7 +1586,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 8;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOADD, allocator);
@@ -1612,7 +1612,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 11;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOADD, allocator);
@@ -1637,7 +1637,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                final Collection<RedisProtocolSupport.BufferLongitudeLatitudeMember> longitudeLatitudeMembers) {
         requireNonNull(key);
         requireNonNull(longitudeLatitudeMembers);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += RedisProtocolSupport.BufferLongitudeLatitudeMember.SIZE * longitudeLatitudeMembers.size();
@@ -1656,7 +1656,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEODIST, allocator);
@@ -1675,7 +1675,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (unit != null) {
@@ -1698,7 +1698,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public <T> Future<List<T>> geohash(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOHASH, allocator);
@@ -1716,7 +1716,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOHASH, allocator);
@@ -1736,7 +1736,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOHASH, allocator);
@@ -1754,7 +1754,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public <T> Future<List<T>> geohash(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -1771,7 +1771,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public <T> Future<List<T>> geopos(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOPOS, allocator);
@@ -1789,7 +1789,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOPOS, allocator);
@@ -1809,7 +1809,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOPOS, allocator);
@@ -1827,7 +1827,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public <T> Future<List<T>> geopos(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -1846,7 +1846,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                          final RedisProtocolSupport.GeoradiusUnit unit) {
         requireNonNull(key);
         requireNonNull(unit);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEORADIUS, allocator);
@@ -1874,7 +1874,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                          @Nullable @RedisProtocolSupport.Key final Buffer storedistKey) {
         requireNonNull(key);
         requireNonNull(unit);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         if (withcoord != null) {
@@ -1941,7 +1941,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(member);
         requireNonNull(unit);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEORADIUSBYMEMBER,
@@ -1970,7 +1970,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(member);
         requireNonNull(unit);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         if (withcoord != null) {
@@ -2033,7 +2033,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Buffer> get(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GET, allocator);
@@ -2047,7 +2047,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> getbit(@RedisProtocolSupport.Key final Buffer key, final long offset) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GETBIT, allocator);
@@ -2062,7 +2062,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Buffer> getrange(@RedisProtocolSupport.Key final Buffer key, final long start, final long end) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GETRANGE, allocator);
@@ -2079,7 +2079,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Buffer> getset(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GETSET, allocator);
@@ -2095,7 +2095,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> hdel(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HDEL, allocator);
@@ -2112,7 +2112,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HDEL, allocator);
@@ -2132,7 +2132,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(field1);
         requireNonNull(field2);
         requireNonNull(field3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HDEL, allocator);
@@ -2150,7 +2150,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> hdel(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
         requireNonNull(key);
         requireNonNull(fields);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += fields.size();
@@ -2167,7 +2167,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> hexists(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HEXISTS, allocator);
@@ -2183,7 +2183,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Buffer> hget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HGET, allocator);
@@ -2198,7 +2198,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> hgetall(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HGETALL, allocator);
@@ -2213,7 +2213,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> hincrby(@RedisProtocolSupport.Key final Buffer key, final Buffer field, final long increment) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HINCRBY, allocator);
@@ -2231,7 +2231,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                        final double increment) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HINCRBYFLOAT, allocator);
@@ -2247,7 +2247,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> hkeys(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HKEYS, allocator);
@@ -2261,7 +2261,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> hlen(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HLEN, allocator);
@@ -2276,7 +2276,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMGET, allocator);
@@ -2294,7 +2294,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMGET, allocator);
@@ -2314,7 +2314,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(field1);
         requireNonNull(field2);
         requireNonNull(field3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMGET, allocator);
@@ -2332,7 +2332,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
         requireNonNull(key);
         requireNonNull(fields);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += fields.size();
@@ -2350,7 +2350,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMSET, allocator);
@@ -2371,7 +2371,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(value1);
         requireNonNull(field2);
         requireNonNull(value2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMSET, allocator);
@@ -2396,7 +2396,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(value2);
         requireNonNull(field3);
         requireNonNull(value3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 8;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMSET, allocator);
@@ -2418,7 +2418,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                 final Collection<RedisProtocolSupport.BufferFieldValue> fieldValues) {
         requireNonNull(key);
         requireNonNull(fieldValues);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += RedisProtocolSupport.BufferFieldValue.SIZE * fieldValues.size();
@@ -2434,7 +2434,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> hscan(@RedisProtocolSupport.Key final Buffer key, final long cursor) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSCAN, allocator);
@@ -2450,7 +2450,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public <T> Future<List<T>> hscan(@RedisProtocolSupport.Key final Buffer key, final long cursor,
                                      @Nullable final Buffer matchPattern, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (matchPattern != null) {
@@ -2481,7 +2481,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSET, allocator);
@@ -2499,7 +2499,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSETNX, allocator);
@@ -2516,7 +2516,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> hstrlen(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSTRLEN, allocator);
@@ -2531,7 +2531,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> hvals(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HVALS, allocator);
@@ -2545,7 +2545,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> incr(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INCR, allocator);
@@ -2559,7 +2559,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> incrby(@RedisProtocolSupport.Key final Buffer key, final long increment) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INCRBY, allocator);
@@ -2574,7 +2574,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Double> incrbyfloat(@RedisProtocolSupport.Key final Buffer key, final double increment) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INCRBYFLOAT, allocator);
@@ -2588,7 +2588,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<Buffer> info() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INFO, allocator);
@@ -2600,7 +2600,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<Buffer> info(@Nullable final Buffer section) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (section != null) {
@@ -2619,7 +2619,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> keys(final Buffer pattern) {
         requireNonNull(pattern);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.KEYS, allocator);
@@ -2632,7 +2632,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<Long> lastsave() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LASTSAVE, allocator);
@@ -2645,7 +2645,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Buffer> lindex(@RedisProtocolSupport.Key final Buffer key, final long index) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LINDEX, allocator);
@@ -2664,7 +2664,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(where);
         requireNonNull(pivot);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LINSERT, allocator);
@@ -2681,7 +2681,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> llen(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LLEN, allocator);
@@ -2695,7 +2695,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Buffer> lpop(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPOP, allocator);
@@ -2710,7 +2710,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> lpush(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSH, allocator);
@@ -2727,7 +2727,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(value1);
         requireNonNull(value2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSH, allocator);
@@ -2747,7 +2747,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(value1);
         requireNonNull(value2);
         requireNonNull(value3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSH, allocator);
@@ -2765,7 +2765,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> lpush(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> values) {
         requireNonNull(key);
         requireNonNull(values);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += values.size();
@@ -2782,7 +2782,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> lpushx(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSHX, allocator);
@@ -2797,7 +2797,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> lrange(@RedisProtocolSupport.Key final Buffer key, final long start, final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LRANGE, allocator);
@@ -2814,7 +2814,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> lrem(@RedisProtocolSupport.Key final Buffer key, final long count, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LREM, allocator);
@@ -2831,7 +2831,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<String> lset(@RedisProtocolSupport.Key final Buffer key, final long index, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LSET, allocator);
@@ -2847,7 +2847,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<String> ltrim(@RedisProtocolSupport.Key final Buffer key, final long start, final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LTRIM, allocator);
@@ -2862,7 +2862,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<Buffer> memoryDoctor() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2875,7 +2875,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public <T> Future<List<T>> memoryHelp() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2888,7 +2888,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<Buffer> memoryMallocStats() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2901,7 +2901,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> memoryPurge() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2914,7 +2914,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public <T> Future<List<T>> memoryStats() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2928,7 +2928,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> memoryUsage(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2943,7 +2943,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> memoryUsage(@RedisProtocolSupport.Key final Buffer key, @Nullable final Long samplesCount) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (samplesCount != null) {
@@ -2965,7 +2965,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
@@ -2981,7 +2981,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                     @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
@@ -3000,7 +3000,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
@@ -3016,7 +3016,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -3031,7 +3031,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> move(@RedisProtocolSupport.Key final Buffer key, final long db) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MOVE, allocator);
@@ -3047,7 +3047,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<String> mset(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSET, allocator);
@@ -3066,7 +3066,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(value1);
         requireNonNull(key2);
         requireNonNull(value2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSET, allocator);
@@ -3090,7 +3090,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(value2);
         requireNonNull(key3);
         requireNonNull(value3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSET, allocator);
@@ -3109,7 +3109,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<String> mset(final Collection<RedisProtocolSupport.BufferKeyValue> keyValues) {
         requireNonNull(keyValues);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += RedisProtocolSupport.BufferKeyValue.SIZE * keyValues.size();
@@ -3125,7 +3125,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> msetnx(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSETNX, allocator);
@@ -3144,7 +3144,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(value1);
         requireNonNull(key2);
         requireNonNull(value2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSETNX, allocator);
@@ -3168,7 +3168,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(value2);
         requireNonNull(key3);
         requireNonNull(value3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSETNX, allocator);
@@ -3187,7 +3187,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> msetnx(final Collection<RedisProtocolSupport.BufferKeyValue> keyValues) {
         requireNonNull(keyValues);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += RedisProtocolSupport.BufferKeyValue.SIZE * keyValues.size();
@@ -3202,7 +3202,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Buffer> objectEncoding(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3217,7 +3217,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> objectFreq(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3231,7 +3231,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<List<String>> objectHelp() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3245,7 +3245,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> objectIdletime(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3260,7 +3260,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> objectRefcount(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3275,7 +3275,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> persist(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PERSIST, allocator);
@@ -3289,7 +3289,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> pexpire(@RedisProtocolSupport.Key final Buffer key, final long milliseconds) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PEXPIRE, allocator);
@@ -3304,7 +3304,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> pexpireat(@RedisProtocolSupport.Key final Buffer key, final long millisecondsTimestamp) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PEXPIREAT, allocator);
@@ -3320,7 +3320,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> pfadd(@RedisProtocolSupport.Key final Buffer key, final Buffer element) {
         requireNonNull(key);
         requireNonNull(element);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFADD, allocator);
@@ -3338,7 +3338,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(element1);
         requireNonNull(element2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFADD, allocator);
@@ -3358,7 +3358,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(element1);
         requireNonNull(element2);
         requireNonNull(element3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFADD, allocator);
@@ -3376,7 +3376,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> pfadd(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> elements) {
         requireNonNull(key);
         requireNonNull(elements);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += elements.size();
@@ -3392,7 +3392,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> pfcount(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFCOUNT, allocator);
@@ -3408,7 +3408,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                 @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFCOUNT, allocator);
@@ -3427,7 +3427,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFCOUNT, allocator);
@@ -3443,7 +3443,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> pfcount(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -3460,7 +3460,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                   @RedisProtocolSupport.Key final Buffer sourcekey) {
         requireNonNull(destkey);
         requireNonNull(sourcekey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFMERGE, allocator);
@@ -3479,7 +3479,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(destkey);
         requireNonNull(sourcekey1);
         requireNonNull(sourcekey2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFMERGE, allocator);
@@ -3501,7 +3501,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(sourcekey1);
         requireNonNull(sourcekey2);
         requireNonNull(sourcekey3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFMERGE, allocator);
@@ -3520,7 +3520,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                   @RedisProtocolSupport.Key final Collection<Buffer> sourcekeys) {
         requireNonNull(destkey);
         requireNonNull(sourcekeys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += sourcekeys.size();
@@ -3535,7 +3535,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> ping() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PING, allocator);
@@ -3548,7 +3548,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Buffer> ping(final Buffer message) {
         requireNonNull(message);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PING, allocator);
@@ -3564,7 +3564,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                  final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PSETEX, allocator);
@@ -3580,7 +3580,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> pttl(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PTTL, allocator);
@@ -3595,7 +3595,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> publish(final Buffer channel, final Buffer message) {
         requireNonNull(channel);
         requireNonNull(message);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBLISH, allocator);
@@ -3609,7 +3609,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<List<String>> pubsubChannels() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBSUB,
@@ -3622,7 +3622,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<List<String>> pubsubChannels(@Nullable final Buffer pattern) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (pattern != null) {
@@ -3641,7 +3641,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<List<String>> pubsubChannels(@Nullable final Buffer pattern1, @Nullable final Buffer pattern2) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (pattern1 != null) {
@@ -3667,7 +3667,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<List<String>> pubsubChannels(@Nullable final Buffer pattern1, @Nullable final Buffer pattern2,
                                                @Nullable final Buffer pattern3) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (pattern1 != null) {
@@ -3699,7 +3699,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<List<String>> pubsubChannels(final Collection<Buffer> patterns) {
         requireNonNull(patterns);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += patterns.size();
@@ -3714,7 +3714,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public <T> Future<List<T>> pubsubNumsub() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBSUB,
@@ -3727,7 +3727,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public <T> Future<List<T>> pubsubNumsub(@Nullable final Buffer channel) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (channel != null) {
@@ -3746,7 +3746,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public <T> Future<List<T>> pubsubNumsub(@Nullable final Buffer channel1, @Nullable final Buffer channel2) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (channel1 != null) {
@@ -3772,7 +3772,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> pubsubNumsub(@Nullable final Buffer channel1, @Nullable final Buffer channel2,
                                             @Nullable final Buffer channel3) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (channel1 != null) {
@@ -3804,7 +3804,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> pubsubNumsub(final Collection<Buffer> channels) {
         requireNonNull(channels);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += channels.size();
@@ -3819,7 +3819,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<Long> pubsubNumpat() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBSUB,
@@ -3832,7 +3832,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<Buffer> randomkey() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RANDOMKEY, allocator);
@@ -3844,7 +3844,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> readonly() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.READONLY, allocator);
@@ -3856,7 +3856,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> readwrite() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.READWRITE, allocator);
@@ -3871,7 +3871,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                  @RedisProtocolSupport.Key final Buffer newkey) {
         requireNonNull(key);
         requireNonNull(newkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RENAME, allocator);
@@ -3888,7 +3888,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                  @RedisProtocolSupport.Key final Buffer newkey) {
         requireNonNull(key);
         requireNonNull(newkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RENAMENX, allocator);
@@ -3905,7 +3905,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                   final Buffer serializedValue) {
         requireNonNull(key);
         requireNonNull(serializedValue);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RESTORE, allocator);
@@ -3924,7 +3924,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                   @Nullable final RedisProtocolSupport.RestoreReplace replace) {
         requireNonNull(key);
         requireNonNull(serializedValue);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (replace != null) {
@@ -3945,7 +3945,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public <T> Future<List<T>> role() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ROLE, allocator);
@@ -3958,7 +3958,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Buffer> rpop(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPOP, allocator);
@@ -3974,7 +3974,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                     @RedisProtocolSupport.Key final Buffer destination) {
         requireNonNull(source);
         requireNonNull(destination);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPOPLPUSH, allocator);
@@ -3990,7 +3990,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> rpush(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSH, allocator);
@@ -4007,7 +4007,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(value1);
         requireNonNull(value2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSH, allocator);
@@ -4027,7 +4027,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(value1);
         requireNonNull(value2);
         requireNonNull(value3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSH, allocator);
@@ -4045,7 +4045,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> rpush(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> values) {
         requireNonNull(key);
         requireNonNull(values);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += values.size();
@@ -4062,7 +4062,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> rpushx(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSHX, allocator);
@@ -4078,7 +4078,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> sadd(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SADD, allocator);
@@ -4095,7 +4095,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SADD, allocator);
@@ -4115,7 +4115,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SADD, allocator);
@@ -4133,7 +4133,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> sadd(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -4148,7 +4148,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> save() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SAVE, allocator);
@@ -4160,7 +4160,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public <T> Future<List<T>> scan(final long cursor) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCAN, allocator);
@@ -4174,7 +4174,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> scan(final long cursor, @Nullable final Buffer matchPattern,
                                     @Nullable final Long count) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (matchPattern != null) {
@@ -4202,7 +4202,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> scard(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCARD, allocator);
@@ -4216,7 +4216,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<String> scriptDebug(final RedisProtocolSupport.ScriptDebugMode mode) {
         requireNonNull(mode);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4231,7 +4231,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> scriptExists(final Buffer sha1) {
         requireNonNull(sha1);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4247,7 +4247,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public <T> Future<List<T>> scriptExists(final Buffer sha11, final Buffer sha12) {
         requireNonNull(sha11);
         requireNonNull(sha12);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4265,7 +4265,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(sha11);
         requireNonNull(sha12);
         requireNonNull(sha13);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4282,7 +4282,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> scriptExists(final Collection<Buffer> sha1s) {
         requireNonNull(sha1s);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += sha1s.size();
@@ -4297,7 +4297,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> scriptFlush() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4310,7 +4310,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> scriptKill() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4324,7 +4324,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Buffer> scriptLoad(final Buffer script) {
         requireNonNull(script);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4339,7 +4339,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> sdiff(@RedisProtocolSupport.Key final Buffer firstkey) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SDIFF, allocator);
@@ -4354,7 +4354,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public <T> Future<List<T>> sdiff(@RedisProtocolSupport.Key final Buffer firstkey,
                                      @Nullable @RedisProtocolSupport.Key final Buffer otherkey) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (otherkey != null) {
@@ -4376,7 +4376,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                      @Nullable @RedisProtocolSupport.Key final Buffer otherkey1,
                                      @Nullable @RedisProtocolSupport.Key final Buffer otherkey2) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (otherkey1 != null) {
@@ -4405,7 +4405,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                      @Nullable @RedisProtocolSupport.Key final Buffer otherkey2,
                                      @Nullable @RedisProtocolSupport.Key final Buffer otherkey3) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (otherkey1 != null) {
@@ -4439,7 +4439,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                      @RedisProtocolSupport.Key final Collection<Buffer> otherkeys) {
         requireNonNull(firstkey);
         requireNonNull(otherkeys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += otherkeys.size();
@@ -4457,7 +4457,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                    @RedisProtocolSupport.Key final Buffer firstkey) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SDIFFSTORE, allocator);
@@ -4475,7 +4475,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                    @Nullable @RedisProtocolSupport.Key final Buffer otherkey) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (otherkey != null) {
@@ -4500,7 +4500,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                    @Nullable @RedisProtocolSupport.Key final Buffer otherkey2) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (otherkey1 != null) {
@@ -4532,7 +4532,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                    @Nullable @RedisProtocolSupport.Key final Buffer otherkey3) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (otherkey1 != null) {
@@ -4569,7 +4569,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(destination);
         requireNonNull(firstkey);
         requireNonNull(otherkeys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += otherkeys.size();
@@ -4585,7 +4585,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> select(final long index) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SELECT, allocator);
@@ -4600,7 +4600,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<String> set(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SET, allocator);
@@ -4618,7 +4618,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                               @Nullable final RedisProtocolSupport.SetCondition condition) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (expireDuration != null) {
@@ -4646,7 +4646,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> setbit(@RedisProtocolSupport.Key final Buffer key, final long offset, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETBIT, allocator);
@@ -4663,7 +4663,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<String> setex(@RedisProtocolSupport.Key final Buffer key, final long seconds, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETEX, allocator);
@@ -4680,7 +4680,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> setnx(@RedisProtocolSupport.Key final Buffer key, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETNX, allocator);
@@ -4696,7 +4696,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> setrange(@RedisProtocolSupport.Key final Buffer key, final long offset, final Buffer value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETRANGE, allocator);
@@ -4711,7 +4711,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> shutdown() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SHUTDOWN, allocator);
@@ -4723,7 +4723,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> shutdown(@Nullable final RedisProtocolSupport.ShutdownSaveMode saveMode) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (saveMode != null) {
@@ -4742,7 +4742,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> sinter(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTER, allocator);
@@ -4758,7 +4758,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                       @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTER, allocator);
@@ -4777,7 +4777,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTER, allocator);
@@ -4793,7 +4793,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> sinter(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -4810,7 +4810,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                     @RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(destination);
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTERSTORE, allocator);
@@ -4829,7 +4829,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(destination);
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTERSTORE, allocator);
@@ -4851,7 +4851,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTERSTORE, allocator);
@@ -4870,7 +4870,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                     @RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -4887,7 +4887,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> sismember(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SISMEMBER, allocator);
@@ -4903,7 +4903,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<String> slaveof(final Buffer host, final Buffer port) {
         requireNonNull(host);
         requireNonNull(port);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SLAVEOF, allocator);
@@ -4918,7 +4918,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> slowlog(final Buffer subcommand) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SLOWLOG, allocator);
@@ -4932,7 +4932,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> slowlog(final Buffer subcommand, @Nullable final Buffer argument) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (argument != null) {
@@ -4952,7 +4952,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> smembers(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SMEMBERS, allocator);
@@ -4969,7 +4969,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(source);
         requireNonNull(destination);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SMOVE, allocator);
@@ -4985,7 +4985,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> sort(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SORT, allocator);
@@ -5004,7 +5004,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                     @Nullable final RedisProtocolSupport.SortSorting sorting) {
         requireNonNull(key);
         requireNonNull(getPatterns);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (byPattern != null) {
@@ -5047,7 +5047,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                              @RedisProtocolSupport.Key final Buffer storeDestination) {
         requireNonNull(key);
         requireNonNull(storeDestination);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SORT, allocator);
@@ -5069,7 +5069,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(storeDestination);
         requireNonNull(getPatterns);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (byPattern != null) {
@@ -5112,7 +5112,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Buffer> spop(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SPOP, allocator);
@@ -5126,7 +5126,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Buffer> spop(@RedisProtocolSupport.Key final Buffer key, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -5146,7 +5146,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Buffer> srandmember(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SRANDMEMBER, allocator);
@@ -5160,7 +5160,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<List<String>> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SRANDMEMBER, allocator);
@@ -5176,7 +5176,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> srem(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SREM, allocator);
@@ -5193,7 +5193,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SREM, allocator);
@@ -5213,7 +5213,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SREM, allocator);
@@ -5231,7 +5231,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> srem(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -5247,7 +5247,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> sscan(@RedisProtocolSupport.Key final Buffer key, final long cursor) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SSCAN, allocator);
@@ -5263,7 +5263,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public <T> Future<List<T>> sscan(@RedisProtocolSupport.Key final Buffer key, final long cursor,
                                      @Nullable final Buffer matchPattern, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (matchPattern != null) {
@@ -5292,7 +5292,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> strlen(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.STRLEN, allocator);
@@ -5306,7 +5306,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> sunion(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNION, allocator);
@@ -5322,7 +5322,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                       @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNION, allocator);
@@ -5341,7 +5341,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNION, allocator);
@@ -5357,7 +5357,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> sunion(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -5374,7 +5374,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                     @RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(destination);
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNIONSTORE, allocator);
@@ -5393,7 +5393,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(destination);
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNIONSTORE, allocator);
@@ -5415,7 +5415,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNIONSTORE, allocator);
@@ -5434,7 +5434,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                     @RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -5449,7 +5449,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> swapdb(final long index, final long index1) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SWAPDB, allocator);
@@ -5463,7 +5463,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public <T> Future<List<T>> time() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TIME, allocator);
@@ -5476,7 +5476,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> touch(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TOUCH, allocator);
@@ -5492,7 +5492,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                               @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TOUCH, allocator);
@@ -5510,7 +5510,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TOUCH, allocator);
@@ -5526,7 +5526,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> touch(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -5541,7 +5541,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> ttl(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TTL, allocator);
@@ -5555,7 +5555,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<String> type(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TYPE, allocator);
@@ -5569,7 +5569,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> unlink(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNLINK, allocator);
@@ -5585,7 +5585,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNLINK, allocator);
@@ -5603,7 +5603,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNLINK, allocator);
@@ -5619,7 +5619,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> unlink(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -5633,7 +5633,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<String> unwatch() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNWATCH, allocator);
@@ -5645,7 +5645,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
 
     @Override
     public Future<Long> wait(final long numslaves, final long timeout) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WAIT, allocator);
@@ -5660,7 +5660,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<String> watch(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WATCH, allocator);
@@ -5676,7 +5676,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                 @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WATCH, allocator);
@@ -5695,7 +5695,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WATCH, allocator);
@@ -5711,7 +5711,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<String> watch(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -5730,7 +5730,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(id);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XADD, allocator);
@@ -5753,7 +5753,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(value1);
         requireNonNull(field2);
         requireNonNull(value2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XADD, allocator);
@@ -5781,7 +5781,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(value2);
         requireNonNull(field3);
         requireNonNull(value3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 9;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XADD, allocator);
@@ -5805,7 +5805,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(id);
         requireNonNull(fieldValues);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += RedisProtocolSupport.BufferFieldValue.SIZE * fieldValues.size();
@@ -5822,7 +5822,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> xlen(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XLEN, allocator);
@@ -5837,7 +5837,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public <T> Future<List<T>> xpending(@RedisProtocolSupport.Key final Buffer key, final Buffer group) {
         requireNonNull(key);
         requireNonNull(group);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XPENDING, allocator);
@@ -5855,7 +5855,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                         @Nullable final Long count, @Nullable final Buffer consumer) {
         requireNonNull(key);
         requireNonNull(group);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (start != null) {
@@ -5897,7 +5897,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(start);
         requireNonNull(end);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XRANGE, allocator);
@@ -5916,7 +5916,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(start);
         requireNonNull(end);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (count != null) {
@@ -5941,7 +5941,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                      final Collection<Buffer> ids) {
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -5962,7 +5962,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                      final Collection<Buffer> ids) {
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -5998,7 +5998,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(groupConsumer);
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2 + RedisProtocolSupport.BufferGroupConsumer.SIZE;
         len += keys.size();
@@ -6022,7 +6022,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(groupConsumer);
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2 + RedisProtocolSupport.BufferGroupConsumer.SIZE;
         if (count != null) {
@@ -6058,7 +6058,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(end);
         requireNonNull(start);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XREVRANGE, allocator);
@@ -6077,7 +6077,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(end);
         requireNonNull(start);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (count != null) {
@@ -6102,7 +6102,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                              final Collection<RedisProtocolSupport.BufferScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += RedisProtocolSupport.BufferScoreMember.SIZE * scoreMembers.size();
@@ -6122,7 +6122,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                              final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (condition != null) {
@@ -6155,7 +6155,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         if (condition != null) {
@@ -6192,7 +6192,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 8;
         if (condition != null) {
@@ -6228,7 +6228,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                              final Collection<RedisProtocolSupport.BufferScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (condition != null) {
@@ -6258,7 +6258,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                    final Collection<RedisProtocolSupport.BufferScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += RedisProtocolSupport.BufferScoreMember.SIZE * scoreMembers.size();
@@ -6279,7 +6279,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                    final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         if (condition != null) {
@@ -6313,7 +6313,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         if (condition != null) {
@@ -6351,7 +6351,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 9;
         if (condition != null) {
@@ -6388,7 +6388,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                    final Collection<RedisProtocolSupport.BufferScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (condition != null) {
@@ -6417,7 +6417,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> zcard(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZCARD, allocator);
@@ -6431,7 +6431,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> zcount(@RedisProtocolSupport.Key final Buffer key, final double min, final double max) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZCOUNT, allocator);
@@ -6449,7 +6449,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                   final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZINCRBY, allocator);
@@ -6467,7 +6467,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                     @RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -6489,7 +6489,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(destination);
         requireNonNull(keys);
         requireNonNull(weightses);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -6516,7 +6516,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZLEXCOUNT, allocator);
@@ -6532,7 +6532,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> zpopmax(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZPOPMAX, allocator);
@@ -6546,7 +6546,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> zpopmax(@RedisProtocolSupport.Key final Buffer key, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -6566,7 +6566,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> zpopmin(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZPOPMIN, allocator);
@@ -6580,7 +6580,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> zpopmin(@RedisProtocolSupport.Key final Buffer key, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -6600,7 +6600,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> zrange(@RedisProtocolSupport.Key final Buffer key, final long start, final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANGE, allocator);
@@ -6617,7 +6617,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public <T> Future<List<T>> zrange(@RedisProtocolSupport.Key final Buffer key, final long start, final long stop,
                                       @Nullable final RedisProtocolSupport.ZrangeWithscores withscores) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -6642,7 +6642,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANGEBYLEX, allocator);
@@ -6662,7 +6662,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (offsetCount != null) {
@@ -6685,7 +6685,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public <T> Future<List<T>> zrangebyscore(@RedisProtocolSupport.Key final Buffer key, final double min,
                                              final double max) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANGEBYSCORE,
@@ -6705,7 +6705,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                              @Nullable final RedisProtocolSupport.ZrangebyscoreWithscores withscores,
                                              @Nullable final RedisProtocolSupport.OffsetCount offsetCount) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -6735,7 +6735,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> zrank(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANK, allocator);
@@ -6751,7 +6751,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> zrem(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREM, allocator);
@@ -6768,7 +6768,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREM, allocator);
@@ -6788,7 +6788,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREM, allocator);
@@ -6806,7 +6806,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> zrem(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -6824,7 +6824,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREMRANGEBYLEX,
@@ -6841,7 +6841,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public Future<Long> zremrangebyrank(@RedisProtocolSupport.Key final Buffer key, final long start, final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREMRANGEBYRANK,
@@ -6859,7 +6859,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> zremrangebyscore(@RedisProtocolSupport.Key final Buffer key, final double min,
                                          final double max) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREMRANGEBYSCORE,
@@ -6877,7 +6877,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public <T> Future<List<T>> zrevrange(@RedisProtocolSupport.Key final Buffer key, final long start,
                                          final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANGE, allocator);
@@ -6894,7 +6894,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public <T> Future<List<T>> zrevrange(@RedisProtocolSupport.Key final Buffer key, final long start, final long stop,
                                          @Nullable final RedisProtocolSupport.ZrevrangeWithscores withscores) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -6919,7 +6919,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(max);
         requireNonNull(min);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANGEBYLEX,
@@ -6940,7 +6940,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(key);
         requireNonNull(max);
         requireNonNull(min);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (offsetCount != null) {
@@ -6964,7 +6964,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public <T> Future<List<T>> zrevrangebyscore(@RedisProtocolSupport.Key final Buffer key, final double max,
                                                 final double min) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANGEBYSCORE,
@@ -6984,7 +6984,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                                 @Nullable final RedisProtocolSupport.ZrevrangebyscoreWithscores withscores,
                                                 @Nullable final RedisProtocolSupport.OffsetCount offsetCount) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -7014,7 +7014,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Long> zrevrank(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANK, allocator);
@@ -7029,7 +7029,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     @Override
     public <T> Future<List<T>> zscan(@RedisProtocolSupport.Key final Buffer key, final long cursor) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZSCAN, allocator);
@@ -7045,7 +7045,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public <T> Future<List<T>> zscan(@RedisProtocolSupport.Key final Buffer key, final long cursor,
                                      @Nullable final Buffer matchPattern, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (matchPattern != null) {
@@ -7075,7 +7075,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     public Future<Double> zscore(@RedisProtocolSupport.Key final Buffer key, final Buffer member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZSCORE, allocator);
@@ -7092,7 +7092,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
                                     @RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -7114,7 +7114,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         requireNonNull(destination);
         requireNonNull(keys);
         requireNonNull(weightses);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultTransactedRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultTransactedRedisCommander.java
@@ -77,7 +77,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> append(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.APPEND, allocator);
@@ -92,7 +92,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> auth(final CharSequence password) {
         requireNonNull(password);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.AUTH, allocator);
@@ -105,7 +105,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> bgrewriteaof() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BGREWRITEAOF, allocator);
@@ -117,7 +117,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> bgsave() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BGSAVE, allocator);
@@ -130,7 +130,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> bitcount(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITCOUNT, allocator);
@@ -145,7 +145,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> bitcount(@RedisProtocolSupport.Key final CharSequence key, @Nullable final Long start,
                                  @Nullable final Long end) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (start != null) {
@@ -173,7 +173,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                        final Collection<RedisProtocolSupport.BitfieldOperation> operations) {
         requireNonNull(key);
         requireNonNull(operations);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         final CompositeBuffer cbOps = allocator.newCompositeBuffer();
         final int len = 2 + operations.stream().mapToInt(op -> op.writeTo(cbOps, allocator)).sum();
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITFIELD, allocator);
@@ -191,7 +191,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(operation);
         requireNonNull(destkey);
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITOP, allocator);
@@ -212,7 +212,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(destkey);
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITOP, allocator);
@@ -236,7 +236,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITOP, allocator);
@@ -257,7 +257,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(operation);
         requireNonNull(destkey);
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -274,7 +274,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> bitpos(@RedisProtocolSupport.Key final CharSequence key, final long bit) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BITPOS, allocator);
@@ -290,7 +290,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> bitpos(@RedisProtocolSupport.Key final CharSequence key, final long bit,
                                @Nullable final Long start, @Nullable final Long end) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (start != null) {
@@ -318,7 +318,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> blpop(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys,
                                      final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -335,7 +335,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> brpop(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys,
                                      final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -353,7 +353,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                      @RedisProtocolSupport.Key final CharSequence destination, final long timeout) {
         requireNonNull(source);
         requireNonNull(destination);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.BRPOPLPUSH, allocator);
@@ -370,7 +370,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> bzpopmax(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys,
                                         final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -387,7 +387,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> bzpopmin(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys,
                                         final long timeout) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -403,7 +403,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> clientKill(@Nullable final Long id, @Nullable final RedisProtocolSupport.ClientKillType type,
                                    @Nullable final CharSequence addrIpPort, @Nullable final CharSequence skipmeYesNo) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (id != null) {
@@ -443,7 +443,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> clientList() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -456,7 +456,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> clientGetname() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -469,7 +469,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> clientPause(final long timeout) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -484,7 +484,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> clientReply(final RedisProtocolSupport.ClientReplyReplyMode replyMode) {
         requireNonNull(replyMode);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -499,7 +499,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> clientSetname(final CharSequence connectionName) {
         requireNonNull(connectionName);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLIENT,
@@ -513,7 +513,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> clusterAddslots(final long slot) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -527,7 +527,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> clusterAddslots(final long slot1, final long slot2) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -542,7 +542,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> clusterAddslots(final long slot1, final long slot2, final long slot3) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -559,7 +559,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> clusterAddslots(final Collection<Long> slots) {
         requireNonNull(slots);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += slots.size();
@@ -575,7 +575,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> clusterCountFailureReports(final CharSequence nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -589,7 +589,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<Long> clusterCountkeysinslot(final long slot) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -603,7 +603,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> clusterDelslots(final long slot) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -617,7 +617,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> clusterDelslots(final long slot1, final long slot2) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -632,7 +632,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> clusterDelslots(final long slot1, final long slot2, final long slot3) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -649,7 +649,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> clusterDelslots(final Collection<Long> slots) {
         requireNonNull(slots);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += slots.size();
@@ -664,7 +664,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> clusterFailover() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -677,7 +677,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> clusterFailover(@Nullable final RedisProtocolSupport.ClusterFailoverOptions options) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (options != null) {
@@ -697,7 +697,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> clusterForget(final CharSequence nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -711,7 +711,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public <T> Future<List<T>> clusterGetkeysinslot(final long slot, final long count) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -726,7 +726,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> clusterInfo() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -740,7 +740,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> clusterKeyslot(final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -755,7 +755,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> clusterMeet(final CharSequence ip, final long port) {
         requireNonNull(ip);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -770,7 +770,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> clusterNodes() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -784,7 +784,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> clusterReplicate(final CharSequence nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -798,7 +798,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> clusterReset() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -811,7 +811,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> clusterReset(@Nullable final RedisProtocolSupport.ClusterResetResetType resetType) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (resetType != null) {
@@ -830,7 +830,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> clusterSaveconfig() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -843,7 +843,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> clusterSetConfigEpoch(final long configEpoch) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -859,7 +859,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<String> clusterSetslot(final long slot,
                                          final RedisProtocolSupport.ClusterSetslotSubcommand subcommand) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -877,7 +877,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                          final RedisProtocolSupport.ClusterSetslotSubcommand subcommand,
                                          @Nullable final CharSequence nodeId) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (nodeId != null) {
@@ -899,7 +899,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> clusterSlaves(final CharSequence nodeId) {
         requireNonNull(nodeId);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -913,7 +913,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public <T> Future<List<T>> clusterSlots() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CLUSTER,
@@ -926,7 +926,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public <T> Future<List<T>> command() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND, allocator);
@@ -938,7 +938,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<Long> commandCount() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -951,7 +951,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public <T> Future<List<T>> commandGetkeys() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -965,7 +965,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> commandInfo(final CharSequence commandName) {
         requireNonNull(commandName);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -981,7 +981,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> commandInfo(final CharSequence commandName1, final CharSequence commandName2) {
         requireNonNull(commandName1);
         requireNonNull(commandName2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -1000,7 +1000,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(commandName1);
         requireNonNull(commandName2);
         requireNonNull(commandName3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.COMMAND,
@@ -1017,7 +1017,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> commandInfo(final Collection<? extends CharSequence> commandNames) {
         requireNonNull(commandNames);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += commandNames.size();
@@ -1033,7 +1033,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> configGet(final CharSequence parameter) {
         requireNonNull(parameter);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1047,7 +1047,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> configRewrite() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1062,7 +1062,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<String> configSet(final CharSequence parameter, final CharSequence value) {
         requireNonNull(parameter);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1077,7 +1077,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> configResetstat() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.CONFIG,
@@ -1090,7 +1090,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<Long> dbsize() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DBSIZE, allocator);
@@ -1103,7 +1103,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> debugObject(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEBUG,
@@ -1117,7 +1117,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> debugSegfault() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEBUG,
@@ -1131,7 +1131,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> decr(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DECR, allocator);
@@ -1145,7 +1145,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> decrby(@RedisProtocolSupport.Key final CharSequence key, final long decrement) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DECRBY, allocator);
@@ -1160,7 +1160,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> del(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEL, allocator);
@@ -1176,7 +1176,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                             @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEL, allocator);
@@ -1195,7 +1195,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DEL, allocator);
@@ -1211,7 +1211,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> del(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -1225,7 +1225,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Single<String> discard() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DISCARD, allocator);
@@ -1238,7 +1238,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> dump(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.DUMP, allocator);
@@ -1252,7 +1252,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> echo(final CharSequence message) {
         requireNonNull(message);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ECHO, allocator);
@@ -1270,7 +1270,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(script);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1293,7 +1293,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(script);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1316,7 +1316,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(script);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1339,7 +1339,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(sha1);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1362,7 +1362,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(sha1);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1385,7 +1385,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(sha1);
         requireNonNull(keys);
         requireNonNull(args);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -1403,7 +1403,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Completable exec() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXEC, allocator);
@@ -1417,7 +1417,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> exists(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXISTS, allocator);
@@ -1433,7 +1433,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXISTS, allocator);
@@ -1452,7 +1452,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXISTS, allocator);
@@ -1468,7 +1468,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> exists(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -1483,7 +1483,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> expire(@RedisProtocolSupport.Key final CharSequence key, final long seconds) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXPIRE, allocator);
@@ -1498,7 +1498,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> expireat(@RedisProtocolSupport.Key final CharSequence key, final long timestamp) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.EXPIREAT, allocator);
@@ -1512,7 +1512,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> flushall() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.FLUSHALL, allocator);
@@ -1524,7 +1524,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> flushall(@Nullable final RedisProtocolSupport.FlushallAsync async) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (async != null) {
@@ -1542,7 +1542,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> flushdb() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.FLUSHDB, allocator);
@@ -1554,7 +1554,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> flushdb(@Nullable final RedisProtocolSupport.FlushdbAsync async) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (async != null) {
@@ -1575,7 +1575,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                final double latitude, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOADD, allocator);
@@ -1596,7 +1596,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 8;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOADD, allocator);
@@ -1622,7 +1622,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 11;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOADD, allocator);
@@ -1647,7 +1647,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                final Collection<RedisProtocolSupport.LongitudeLatitudeMember> longitudeLatitudeMembers) {
         requireNonNull(key);
         requireNonNull(longitudeLatitudeMembers);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += RedisProtocolSupport.LongitudeLatitudeMember.SIZE * longitudeLatitudeMembers.size();
@@ -1666,7 +1666,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEODIST, allocator);
@@ -1685,7 +1685,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (unit != null) {
@@ -1708,7 +1708,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> geohash(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOHASH, allocator);
@@ -1726,7 +1726,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOHASH, allocator);
@@ -1746,7 +1746,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOHASH, allocator);
@@ -1765,7 +1765,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                        final Collection<? extends CharSequence> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -1782,7 +1782,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> geopos(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOPOS, allocator);
@@ -1800,7 +1800,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOPOS, allocator);
@@ -1820,7 +1820,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEOPOS, allocator);
@@ -1839,7 +1839,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                       final Collection<? extends CharSequence> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -1858,7 +1858,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                          final RedisProtocolSupport.GeoradiusUnit unit) {
         requireNonNull(key);
         requireNonNull(unit);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEORADIUS, allocator);
@@ -1886,7 +1886,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                          @Nullable @RedisProtocolSupport.Key final CharSequence storedistKey) {
         requireNonNull(key);
         requireNonNull(unit);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         if (withcoord != null) {
@@ -1953,7 +1953,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(member);
         requireNonNull(unit);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GEORADIUSBYMEMBER,
@@ -1982,7 +1982,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(member);
         requireNonNull(unit);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         if (withcoord != null) {
@@ -2045,7 +2045,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> get(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GET, allocator);
@@ -2059,7 +2059,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> getbit(@RedisProtocolSupport.Key final CharSequence key, final long offset) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GETBIT, allocator);
@@ -2074,7 +2074,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> getrange(@RedisProtocolSupport.Key final CharSequence key, final long start, final long end) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GETRANGE, allocator);
@@ -2091,7 +2091,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<String> getset(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.GETSET, allocator);
@@ -2107,7 +2107,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> hdel(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HDEL, allocator);
@@ -2125,7 +2125,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HDEL, allocator);
@@ -2145,7 +2145,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(field1);
         requireNonNull(field2);
         requireNonNull(field3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HDEL, allocator);
@@ -2164,7 +2164,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                              final Collection<? extends CharSequence> fields) {
         requireNonNull(key);
         requireNonNull(fields);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += fields.size();
@@ -2181,7 +2181,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> hexists(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HEXISTS, allocator);
@@ -2197,7 +2197,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<String> hget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HGET, allocator);
@@ -2212,7 +2212,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> hgetall(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HGETALL, allocator);
@@ -2228,7 +2228,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                 final long increment) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HINCRBY, allocator);
@@ -2246,7 +2246,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                        final double increment) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HINCRBYFLOAT, allocator);
@@ -2262,7 +2262,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> hkeys(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HKEYS, allocator);
@@ -2276,7 +2276,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> hlen(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HLEN, allocator);
@@ -2291,7 +2291,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMGET, allocator);
@@ -2309,7 +2309,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMGET, allocator);
@@ -2329,7 +2329,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(field1);
         requireNonNull(field2);
         requireNonNull(field3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMGET, allocator);
@@ -2348,7 +2348,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                      final Collection<? extends CharSequence> fields) {
         requireNonNull(key);
         requireNonNull(fields);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += fields.size();
@@ -2367,7 +2367,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMSET, allocator);
@@ -2388,7 +2388,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(value1);
         requireNonNull(field2);
         requireNonNull(value2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMSET, allocator);
@@ -2414,7 +2414,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(value2);
         requireNonNull(field3);
         requireNonNull(value3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 8;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HMSET, allocator);
@@ -2436,7 +2436,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                 final Collection<RedisProtocolSupport.FieldValue> fieldValues) {
         requireNonNull(key);
         requireNonNull(fieldValues);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += RedisProtocolSupport.FieldValue.SIZE * fieldValues.size();
@@ -2452,7 +2452,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> hscan(@RedisProtocolSupport.Key final CharSequence key, final long cursor) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSCAN, allocator);
@@ -2468,7 +2468,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> hscan(@RedisProtocolSupport.Key final CharSequence key, final long cursor,
                                      @Nullable final CharSequence matchPattern, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (matchPattern != null) {
@@ -2500,7 +2500,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSET, allocator);
@@ -2519,7 +2519,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSETNX, allocator);
@@ -2536,7 +2536,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> hstrlen(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         requireNonNull(key);
         requireNonNull(field);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HSTRLEN, allocator);
@@ -2551,7 +2551,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> hvals(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.HVALS, allocator);
@@ -2565,7 +2565,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> incr(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INCR, allocator);
@@ -2579,7 +2579,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> incrby(@RedisProtocolSupport.Key final CharSequence key, final long increment) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INCRBY, allocator);
@@ -2594,7 +2594,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Double> incrbyfloat(@RedisProtocolSupport.Key final CharSequence key, final double increment) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INCRBYFLOAT, allocator);
@@ -2608,7 +2608,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> info() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.INFO, allocator);
@@ -2620,7 +2620,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> info(@Nullable final CharSequence section) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (section != null) {
@@ -2639,7 +2639,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> keys(final CharSequence pattern) {
         requireNonNull(pattern);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.KEYS, allocator);
@@ -2652,7 +2652,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<Long> lastsave() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LASTSAVE, allocator);
@@ -2665,7 +2665,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> lindex(@RedisProtocolSupport.Key final CharSequence key, final long index) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LINDEX, allocator);
@@ -2685,7 +2685,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(where);
         requireNonNull(pivot);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LINSERT, allocator);
@@ -2702,7 +2702,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> llen(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LLEN, allocator);
@@ -2716,7 +2716,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> lpop(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPOP, allocator);
@@ -2731,7 +2731,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> lpush(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSH, allocator);
@@ -2749,7 +2749,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(value1);
         requireNonNull(value2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSH, allocator);
@@ -2769,7 +2769,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(value1);
         requireNonNull(value2);
         requireNonNull(value3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSH, allocator);
@@ -2788,7 +2788,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                               final Collection<? extends CharSequence> values) {
         requireNonNull(key);
         requireNonNull(values);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += values.size();
@@ -2805,7 +2805,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> lpushx(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LPUSHX, allocator);
@@ -2821,7 +2821,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> lrange(@RedisProtocolSupport.Key final CharSequence key, final long start,
                                       final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LRANGE, allocator);
@@ -2839,7 +2839,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                              final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LREM, allocator);
@@ -2857,7 +2857,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LSET, allocator);
@@ -2873,7 +2873,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> ltrim(@RedisProtocolSupport.Key final CharSequence key, final long start, final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.LTRIM, allocator);
@@ -2888,7 +2888,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> memoryDoctor() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2901,7 +2901,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public <T> Future<List<T>> memoryHelp() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2914,7 +2914,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> memoryMallocStats() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2927,7 +2927,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> memoryPurge() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2940,7 +2940,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public <T> Future<List<T>> memoryStats() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2954,7 +2954,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> memoryUsage(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MEMORY,
@@ -2970,7 +2970,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> memoryUsage(@RedisProtocolSupport.Key final CharSequence key,
                                     @Nullable final Long samplesCount) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (samplesCount != null) {
@@ -2992,7 +2992,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
@@ -3008,7 +3008,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                     @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
@@ -3027,7 +3027,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
@@ -3043,7 +3043,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -3058,7 +3058,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> move(@RedisProtocolSupport.Key final CharSequence key, final long db) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MOVE, allocator);
@@ -3074,7 +3074,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<String> mset(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSET, allocator);
@@ -3093,7 +3093,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(value1);
         requireNonNull(key2);
         requireNonNull(value2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSET, allocator);
@@ -3117,7 +3117,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(value2);
         requireNonNull(key3);
         requireNonNull(value3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSET, allocator);
@@ -3136,7 +3136,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> mset(final Collection<RedisProtocolSupport.KeyValue> keyValues) {
         requireNonNull(keyValues);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += RedisProtocolSupport.KeyValue.SIZE * keyValues.size();
@@ -3152,7 +3152,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> msetnx(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSETNX, allocator);
@@ -3171,7 +3171,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(value1);
         requireNonNull(key2);
         requireNonNull(value2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSETNX, allocator);
@@ -3195,7 +3195,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(value2);
         requireNonNull(key3);
         requireNonNull(value3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MSETNX, allocator);
@@ -3214,7 +3214,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> msetnx(final Collection<RedisProtocolSupport.KeyValue> keyValues) {
         requireNonNull(keyValues);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += RedisProtocolSupport.KeyValue.SIZE * keyValues.size();
@@ -3229,7 +3229,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> objectEncoding(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3244,7 +3244,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> objectFreq(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3258,7 +3258,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<List<String>> objectHelp() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3272,7 +3272,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> objectIdletime(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3287,7 +3287,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> objectRefcount(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.OBJECT,
@@ -3302,7 +3302,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> persist(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PERSIST, allocator);
@@ -3316,7 +3316,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> pexpire(@RedisProtocolSupport.Key final CharSequence key, final long milliseconds) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PEXPIRE, allocator);
@@ -3331,7 +3331,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> pexpireat(@RedisProtocolSupport.Key final CharSequence key, final long millisecondsTimestamp) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PEXPIREAT, allocator);
@@ -3347,7 +3347,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> pfadd(@RedisProtocolSupport.Key final CharSequence key, final CharSequence element) {
         requireNonNull(key);
         requireNonNull(element);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFADD, allocator);
@@ -3365,7 +3365,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(element1);
         requireNonNull(element2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFADD, allocator);
@@ -3385,7 +3385,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(element1);
         requireNonNull(element2);
         requireNonNull(element3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFADD, allocator);
@@ -3404,7 +3404,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                               final Collection<? extends CharSequence> elements) {
         requireNonNull(key);
         requireNonNull(elements);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += elements.size();
@@ -3420,7 +3420,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> pfcount(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFCOUNT, allocator);
@@ -3436,7 +3436,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                 @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFCOUNT, allocator);
@@ -3455,7 +3455,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFCOUNT, allocator);
@@ -3471,7 +3471,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> pfcount(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -3488,7 +3488,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                   @RedisProtocolSupport.Key final CharSequence sourcekey) {
         requireNonNull(destkey);
         requireNonNull(sourcekey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFMERGE, allocator);
@@ -3507,7 +3507,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(destkey);
         requireNonNull(sourcekey1);
         requireNonNull(sourcekey2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFMERGE, allocator);
@@ -3529,7 +3529,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(sourcekey1);
         requireNonNull(sourcekey2);
         requireNonNull(sourcekey3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PFMERGE, allocator);
@@ -3548,7 +3548,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                   @RedisProtocolSupport.Key final Collection<? extends CharSequence> sourcekeys) {
         requireNonNull(destkey);
         requireNonNull(sourcekeys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += sourcekeys.size();
@@ -3563,7 +3563,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> ping() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PING, allocator);
@@ -3576,7 +3576,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> ping(final CharSequence message) {
         requireNonNull(message);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PING, allocator);
@@ -3592,7 +3592,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                  final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PSETEX, allocator);
@@ -3608,7 +3608,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> pttl(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PTTL, allocator);
@@ -3623,7 +3623,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> publish(final CharSequence channel, final CharSequence message) {
         requireNonNull(channel);
         requireNonNull(message);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBLISH, allocator);
@@ -3637,7 +3637,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<List<String>> pubsubChannels() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBSUB,
@@ -3650,7 +3650,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<List<String>> pubsubChannels(@Nullable final CharSequence pattern) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (pattern != null) {
@@ -3670,7 +3670,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<List<String>> pubsubChannels(@Nullable final CharSequence pattern1,
                                                @Nullable final CharSequence pattern2) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (pattern1 != null) {
@@ -3697,7 +3697,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<List<String>> pubsubChannels(@Nullable final CharSequence pattern1,
                                                @Nullable final CharSequence pattern2,
                                                @Nullable final CharSequence pattern3) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (pattern1 != null) {
@@ -3729,7 +3729,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<List<String>> pubsubChannels(final Collection<? extends CharSequence> patterns) {
         requireNonNull(patterns);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += patterns.size();
@@ -3744,7 +3744,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public <T> Future<List<T>> pubsubNumsub() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBSUB,
@@ -3757,7 +3757,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public <T> Future<List<T>> pubsubNumsub(@Nullable final CharSequence channel) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (channel != null) {
@@ -3777,7 +3777,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> pubsubNumsub(@Nullable final CharSequence channel1,
                                             @Nullable final CharSequence channel2) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (channel1 != null) {
@@ -3804,7 +3804,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> pubsubNumsub(@Nullable final CharSequence channel1,
                                             @Nullable final CharSequence channel2,
                                             @Nullable final CharSequence channel3) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (channel1 != null) {
@@ -3836,7 +3836,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> pubsubNumsub(final Collection<? extends CharSequence> channels) {
         requireNonNull(channels);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += channels.size();
@@ -3851,7 +3851,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<Long> pubsubNumpat() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.PUBSUB,
@@ -3864,7 +3864,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> randomkey() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RANDOMKEY, allocator);
@@ -3876,7 +3876,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> readonly() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.READONLY, allocator);
@@ -3888,7 +3888,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> readwrite() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.READWRITE, allocator);
@@ -3903,7 +3903,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                  @RedisProtocolSupport.Key final CharSequence newkey) {
         requireNonNull(key);
         requireNonNull(newkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RENAME, allocator);
@@ -3920,7 +3920,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                  @RedisProtocolSupport.Key final CharSequence newkey) {
         requireNonNull(key);
         requireNonNull(newkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RENAMENX, allocator);
@@ -3937,7 +3937,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                   final CharSequence serializedValue) {
         requireNonNull(key);
         requireNonNull(serializedValue);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RESTORE, allocator);
@@ -3956,7 +3956,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                   @Nullable final RedisProtocolSupport.RestoreReplace replace) {
         requireNonNull(key);
         requireNonNull(serializedValue);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (replace != null) {
@@ -3977,7 +3977,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public <T> Future<List<T>> role() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ROLE, allocator);
@@ -3990,7 +3990,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> rpop(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPOP, allocator);
@@ -4006,7 +4006,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                     @RedisProtocolSupport.Key final CharSequence destination) {
         requireNonNull(source);
         requireNonNull(destination);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPOPLPUSH, allocator);
@@ -4022,7 +4022,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> rpush(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSH, allocator);
@@ -4040,7 +4040,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(value1);
         requireNonNull(value2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSH, allocator);
@@ -4060,7 +4060,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(value1);
         requireNonNull(value2);
         requireNonNull(value3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSH, allocator);
@@ -4079,7 +4079,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                               final Collection<? extends CharSequence> values) {
         requireNonNull(key);
         requireNonNull(values);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += values.size();
@@ -4096,7 +4096,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> rpushx(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.RPUSHX, allocator);
@@ -4112,7 +4112,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> sadd(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SADD, allocator);
@@ -4130,7 +4130,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SADD, allocator);
@@ -4150,7 +4150,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SADD, allocator);
@@ -4169,7 +4169,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                              final Collection<? extends CharSequence> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -4184,7 +4184,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> save() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SAVE, allocator);
@@ -4196,7 +4196,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public <T> Future<List<T>> scan(final long cursor) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCAN, allocator);
@@ -4210,7 +4210,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> scan(final long cursor, @Nullable final CharSequence matchPattern,
                                     @Nullable final Long count) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (matchPattern != null) {
@@ -4238,7 +4238,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> scard(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCARD, allocator);
@@ -4252,7 +4252,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> scriptDebug(final RedisProtocolSupport.ScriptDebugMode mode) {
         requireNonNull(mode);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4267,7 +4267,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> scriptExists(final CharSequence sha1) {
         requireNonNull(sha1);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4283,7 +4283,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> scriptExists(final CharSequence sha11, final CharSequence sha12) {
         requireNonNull(sha11);
         requireNonNull(sha12);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4302,7 +4302,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(sha11);
         requireNonNull(sha12);
         requireNonNull(sha13);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4319,7 +4319,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> scriptExists(final Collection<? extends CharSequence> sha1s) {
         requireNonNull(sha1s);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += sha1s.size();
@@ -4334,7 +4334,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> scriptFlush() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4347,7 +4347,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> scriptKill() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4361,7 +4361,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> scriptLoad(final CharSequence script) {
         requireNonNull(script);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SCRIPT,
@@ -4376,7 +4376,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> sdiff(@RedisProtocolSupport.Key final CharSequence firstkey) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SDIFF, allocator);
@@ -4391,7 +4391,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> sdiff(@RedisProtocolSupport.Key final CharSequence firstkey,
                                      @Nullable @RedisProtocolSupport.Key final CharSequence otherkey) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (otherkey != null) {
@@ -4413,7 +4413,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                      @Nullable @RedisProtocolSupport.Key final CharSequence otherkey1,
                                      @Nullable @RedisProtocolSupport.Key final CharSequence otherkey2) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (otherkey1 != null) {
@@ -4442,7 +4442,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                      @Nullable @RedisProtocolSupport.Key final CharSequence otherkey2,
                                      @Nullable @RedisProtocolSupport.Key final CharSequence otherkey3) {
         requireNonNull(firstkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (otherkey1 != null) {
@@ -4476,7 +4476,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                      @RedisProtocolSupport.Key final Collection<? extends CharSequence> otherkeys) {
         requireNonNull(firstkey);
         requireNonNull(otherkeys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += otherkeys.size();
@@ -4494,7 +4494,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                    @RedisProtocolSupport.Key final CharSequence firstkey) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SDIFFSTORE, allocator);
@@ -4512,7 +4512,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                    @Nullable @RedisProtocolSupport.Key final CharSequence otherkey) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (otherkey != null) {
@@ -4537,7 +4537,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                    @Nullable @RedisProtocolSupport.Key final CharSequence otherkey2) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (otherkey1 != null) {
@@ -4569,7 +4569,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                    @Nullable @RedisProtocolSupport.Key final CharSequence otherkey3) {
         requireNonNull(destination);
         requireNonNull(firstkey);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (otherkey1 != null) {
@@ -4606,7 +4606,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(destination);
         requireNonNull(firstkey);
         requireNonNull(otherkeys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += otherkeys.size();
@@ -4622,7 +4622,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> select(final long index) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SELECT, allocator);
@@ -4637,7 +4637,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<String> set(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SET, allocator);
@@ -4655,7 +4655,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                               @Nullable final RedisProtocolSupport.SetCondition condition) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (expireDuration != null) {
@@ -4684,7 +4684,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETBIT, allocator);
@@ -4702,7 +4702,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                 final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETEX, allocator);
@@ -4719,7 +4719,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> setnx(@RedisProtocolSupport.Key final CharSequence key, final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETNX, allocator);
@@ -4736,7 +4736,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                  final CharSequence value) {
         requireNonNull(key);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SETRANGE, allocator);
@@ -4751,7 +4751,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> shutdown() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SHUTDOWN, allocator);
@@ -4763,7 +4763,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> shutdown(@Nullable final RedisProtocolSupport.ShutdownSaveMode saveMode) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         if (saveMode != null) {
@@ -4782,7 +4782,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> sinter(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTER, allocator);
@@ -4798,7 +4798,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                       @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTER, allocator);
@@ -4817,7 +4817,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTER, allocator);
@@ -4833,7 +4833,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> sinter(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -4850,7 +4850,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                     @RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(destination);
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTERSTORE, allocator);
@@ -4869,7 +4869,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(destination);
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTERSTORE, allocator);
@@ -4891,7 +4891,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SINTERSTORE, allocator);
@@ -4910,7 +4910,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                     @RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -4927,7 +4927,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> sismember(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SISMEMBER, allocator);
@@ -4943,7 +4943,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<String> slaveof(final CharSequence host, final CharSequence port) {
         requireNonNull(host);
         requireNonNull(port);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SLAVEOF, allocator);
@@ -4958,7 +4958,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> slowlog(final CharSequence subcommand) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SLOWLOG, allocator);
@@ -4972,7 +4972,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> slowlog(final CharSequence subcommand, @Nullable final CharSequence argument) {
         requireNonNull(subcommand);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (argument != null) {
@@ -4992,7 +4992,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> smembers(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SMEMBERS, allocator);
@@ -5009,7 +5009,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(source);
         requireNonNull(destination);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SMOVE, allocator);
@@ -5025,7 +5025,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> sort(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SORT, allocator);
@@ -5045,7 +5045,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                     @Nullable final RedisProtocolSupport.SortSorting sorting) {
         requireNonNull(key);
         requireNonNull(getPatterns);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (byPattern != null) {
@@ -5088,7 +5088,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                              @RedisProtocolSupport.Key final CharSequence storeDestination) {
         requireNonNull(key);
         requireNonNull(storeDestination);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SORT, allocator);
@@ -5112,7 +5112,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(storeDestination);
         requireNonNull(getPatterns);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (byPattern != null) {
@@ -5155,7 +5155,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> spop(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SPOP, allocator);
@@ -5169,7 +5169,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> spop(@RedisProtocolSupport.Key final CharSequence key, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -5189,7 +5189,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> srandmember(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SRANDMEMBER, allocator);
@@ -5203,7 +5203,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<List<String>> srandmember(@RedisProtocolSupport.Key final CharSequence key, final long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SRANDMEMBER, allocator);
@@ -5219,7 +5219,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> srem(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SREM, allocator);
@@ -5237,7 +5237,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SREM, allocator);
@@ -5257,7 +5257,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SREM, allocator);
@@ -5276,7 +5276,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                              final Collection<? extends CharSequence> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -5292,7 +5292,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> sscan(@RedisProtocolSupport.Key final CharSequence key, final long cursor) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SSCAN, allocator);
@@ -5308,7 +5308,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> sscan(@RedisProtocolSupport.Key final CharSequence key, final long cursor,
                                      @Nullable final CharSequence matchPattern, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (matchPattern != null) {
@@ -5337,7 +5337,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> strlen(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.STRLEN, allocator);
@@ -5351,7 +5351,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> sunion(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNION, allocator);
@@ -5367,7 +5367,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                       @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNION, allocator);
@@ -5386,7 +5386,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNION, allocator);
@@ -5402,7 +5402,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> sunion(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -5419,7 +5419,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                     @RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(destination);
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNIONSTORE, allocator);
@@ -5438,7 +5438,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(destination);
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNIONSTORE, allocator);
@@ -5460,7 +5460,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SUNIONSTORE, allocator);
@@ -5479,7 +5479,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                     @RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -5494,7 +5494,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> swapdb(final long index, final long index1) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.SWAPDB, allocator);
@@ -5508,7 +5508,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public <T> Future<List<T>> time() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TIME, allocator);
@@ -5521,7 +5521,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> touch(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TOUCH, allocator);
@@ -5537,7 +5537,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                               @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TOUCH, allocator);
@@ -5556,7 +5556,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TOUCH, allocator);
@@ -5572,7 +5572,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> touch(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -5587,7 +5587,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> ttl(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TTL, allocator);
@@ -5601,7 +5601,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> type(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.TYPE, allocator);
@@ -5615,7 +5615,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> unlink(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNLINK, allocator);
@@ -5631,7 +5631,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNLINK, allocator);
@@ -5650,7 +5650,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNLINK, allocator);
@@ -5666,7 +5666,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> unlink(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -5680,7 +5680,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<String> unwatch() {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.UNWATCH, allocator);
@@ -5692,7 +5692,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
 
     @Override
     public Future<Long> wait(final long numslaves, final long timeout) {
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WAIT, allocator);
@@ -5707,7 +5707,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> watch(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WATCH, allocator);
@@ -5723,7 +5723,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                 @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WATCH, allocator);
@@ -5742,7 +5742,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.WATCH, allocator);
@@ -5758,7 +5758,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<String> watch(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 1;
         len += keys.size();
@@ -5777,7 +5777,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(id);
         requireNonNull(field);
         requireNonNull(value);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XADD, allocator);
@@ -5801,7 +5801,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(value1);
         requireNonNull(field2);
         requireNonNull(value2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XADD, allocator);
@@ -5829,7 +5829,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(value2);
         requireNonNull(field3);
         requireNonNull(value3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 9;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XADD, allocator);
@@ -5853,7 +5853,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(id);
         requireNonNull(fieldValues);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += RedisProtocolSupport.FieldValue.SIZE * fieldValues.size();
@@ -5870,7 +5870,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> xlen(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XLEN, allocator);
@@ -5885,7 +5885,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> xpending(@RedisProtocolSupport.Key final CharSequence key, final CharSequence group) {
         requireNonNull(key);
         requireNonNull(group);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XPENDING, allocator);
@@ -5903,7 +5903,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                         @Nullable final Long count, @Nullable final CharSequence consumer) {
         requireNonNull(key);
         requireNonNull(group);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (start != null) {
@@ -5945,7 +5945,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(start);
         requireNonNull(end);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XRANGE, allocator);
@@ -5964,7 +5964,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(start);
         requireNonNull(end);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (count != null) {
@@ -5989,7 +5989,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                      final Collection<? extends CharSequence> ids) {
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += keys.size();
@@ -6010,7 +6010,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                      final Collection<? extends CharSequence> ids) {
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -6046,7 +6046,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(groupConsumer);
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2 + RedisProtocolSupport.GroupConsumer.SIZE;
         len += keys.size();
@@ -6070,7 +6070,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(groupConsumer);
         requireNonNull(keys);
         requireNonNull(ids);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2 + RedisProtocolSupport.GroupConsumer.SIZE;
         if (count != null) {
@@ -6106,7 +6106,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(end);
         requireNonNull(start);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.XREVRANGE, allocator);
@@ -6125,7 +6125,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(end);
         requireNonNull(start);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (count != null) {
@@ -6150,7 +6150,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                              final Collection<RedisProtocolSupport.ScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += RedisProtocolSupport.ScoreMember.SIZE * scoreMembers.size();
@@ -6170,7 +6170,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                              final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (condition != null) {
@@ -6203,7 +6203,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 6;
         if (condition != null) {
@@ -6240,7 +6240,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 8;
         if (condition != null) {
@@ -6276,7 +6276,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                              final Collection<RedisProtocolSupport.ScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (condition != null) {
@@ -6306,7 +6306,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                    final Collection<RedisProtocolSupport.ScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += RedisProtocolSupport.ScoreMember.SIZE * scoreMembers.size();
@@ -6327,7 +6327,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                    final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         if (condition != null) {
@@ -6361,7 +6361,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 7;
         if (condition != null) {
@@ -6399,7 +6399,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 9;
         if (condition != null) {
@@ -6436,7 +6436,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                    final Collection<RedisProtocolSupport.ScoreMember> scoreMembers) {
         requireNonNull(key);
         requireNonNull(scoreMembers);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (condition != null) {
@@ -6465,7 +6465,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> zcard(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZCARD, allocator);
@@ -6479,7 +6479,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public Future<Long> zcount(@RedisProtocolSupport.Key final CharSequence key, final double min, final double max) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZCOUNT, allocator);
@@ -6497,7 +6497,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                   final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZINCRBY, allocator);
@@ -6515,7 +6515,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                     @RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -6537,7 +6537,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(destination);
         requireNonNull(keys);
         requireNonNull(weightses);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -6565,7 +6565,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZLEXCOUNT, allocator);
@@ -6581,7 +6581,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> zpopmax(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZPOPMAX, allocator);
@@ -6595,7 +6595,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> zpopmax(@RedisProtocolSupport.Key final CharSequence key, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -6615,7 +6615,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> zpopmin(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZPOPMIN, allocator);
@@ -6629,7 +6629,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> zpopmin(@RedisProtocolSupport.Key final CharSequence key, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         if (count != null) {
@@ -6650,7 +6650,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> zrange(@RedisProtocolSupport.Key final CharSequence key, final long start,
                                       final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANGE, allocator);
@@ -6668,7 +6668,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                       final long stop,
                                       @Nullable final RedisProtocolSupport.ZrangeWithscores withscores) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -6693,7 +6693,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANGEBYLEX, allocator);
@@ -6713,7 +6713,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (offsetCount != null) {
@@ -6736,7 +6736,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> zrangebyscore(@RedisProtocolSupport.Key final CharSequence key, final double min,
                                              final double max) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANGEBYSCORE,
@@ -6756,7 +6756,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                              @Nullable final RedisProtocolSupport.ZrangebyscoreWithscores withscores,
                                              @Nullable final RedisProtocolSupport.OffsetCount offsetCount) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -6786,7 +6786,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> zrank(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZRANK, allocator);
@@ -6802,7 +6802,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> zrem(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREM, allocator);
@@ -6820,7 +6820,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(member1);
         requireNonNull(member2);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREM, allocator);
@@ -6840,7 +6840,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(member1);
         requireNonNull(member2);
         requireNonNull(member3);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 5;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREM, allocator);
@@ -6859,7 +6859,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                              final Collection<? extends CharSequence> members) {
         requireNonNull(key);
         requireNonNull(members);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 2;
         len += members.size();
@@ -6878,7 +6878,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(min);
         requireNonNull(max);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREMRANGEBYLEX,
@@ -6896,7 +6896,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> zremrangebyrank(@RedisProtocolSupport.Key final CharSequence key, final long start,
                                         final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREMRANGEBYRANK,
@@ -6914,7 +6914,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> zremrangebyscore(@RedisProtocolSupport.Key final CharSequence key, final double min,
                                          final double max) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREMRANGEBYSCORE,
@@ -6932,7 +6932,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> zrevrange(@RedisProtocolSupport.Key final CharSequence key, final long start,
                                          final long stop) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANGE, allocator);
@@ -6950,7 +6950,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                          final long stop,
                                          @Nullable final RedisProtocolSupport.ZrevrangeWithscores withscores) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -6975,7 +6975,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(max);
         requireNonNull(min);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANGEBYLEX,
@@ -6996,7 +6996,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(key);
         requireNonNull(max);
         requireNonNull(min);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (offsetCount != null) {
@@ -7020,7 +7020,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> zrevrangebyscore(@RedisProtocolSupport.Key final CharSequence key, final double max,
                                                 final double min) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANGEBYSCORE,
@@ -7040,7 +7040,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                                 @Nullable final RedisProtocolSupport.ZrevrangebyscoreWithscores withscores,
                                                 @Nullable final RedisProtocolSupport.OffsetCount offsetCount) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 4;
         if (withscores != null) {
@@ -7070,7 +7070,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Long> zrevrank(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZREVRANK, allocator);
@@ -7085,7 +7085,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     @Override
     public <T> Future<List<T>> zscan(@RedisProtocolSupport.Key final CharSequence key, final long cursor) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZSCAN, allocator);
@@ -7101,7 +7101,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public <T> Future<List<T>> zscan(@RedisProtocolSupport.Key final CharSequence key, final long cursor,
                                      @Nullable final CharSequence matchPattern, @Nullable final Long count) {
         requireNonNull(key);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         if (matchPattern != null) {
@@ -7131,7 +7131,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     public Future<Double> zscore(@RedisProtocolSupport.Key final CharSequence key, final CharSequence member) {
         requireNonNull(key);
         requireNonNull(member);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.ZSCORE, allocator);
@@ -7148,7 +7148,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
                                     @RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(destination);
         requireNonNull(keys);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();
@@ -7170,7 +7170,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         requireNonNull(destination);
         requireNonNull(keys);
         requireNonNull(weightses);
-        final BufferAllocator allocator = reservedCnx.getExecutionContext().bufferAllocator();
+        final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
         int len = 3;
         len += keys.size();

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/LoadBalancerReadyRedisClient.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/LoadBalancerReadyRedisClient.java
@@ -68,8 +68,8 @@ public final class LoadBalancerReadyRedisClient extends RedisClient {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return next.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return next.executionContext();
     }
 
     @Override

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/PartitionedRedisClient.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/PartitionedRedisClient.java
@@ -81,13 +81,13 @@ public abstract class PartitionedRedisClient implements ListenableAsyncCloseable
      * unless that was how this object was built.
      * @return the {@link ExecutionContext} used during construction of this object.
      */
-    public abstract ExecutionContext getExecutionContext();
+    public abstract ExecutionContext executionContext();
 
     /**
      * Get the {@link Function} that is responsible for generating a {@link RedisPartitionAttributesBuilder} for each {@link Command}.
      * @return the {@link Function} that is responsible for generating a {@link RedisPartitionAttributesBuilder} for each {@link Command}.
      */
-    protected abstract Function<Command, RedisPartitionAttributesBuilder> getRedisPartitionAttributesBuilderFactory();
+    protected abstract Function<Command, RedisPartitionAttributesBuilder> redisPartitionAttributesBuilderFunction();
 
     /**
      * Provides an alternative java API to this {@link PartitionedRedisClient}. The {@link RedisCommander} return value has
@@ -100,7 +100,7 @@ public abstract class PartitionedRedisClient implements ListenableAsyncCloseable
     public final RedisCommander asCommander() {
         RedisCommander redisCommander = this.redisCommander;
         if (redisCommander == null) {
-            redisCommander = new DefaultPartitionedRedisCommander(this, getRedisPartitionAttributesBuilderFactory());
+            redisCommander = new DefaultPartitionedRedisCommander(this, redisPartitionAttributesBuilderFunction());
             if (!redisCommanderUpdater.compareAndSet(this, null, redisCommander)) {
                 redisCommander = this.redisCommander;
                 assert redisCommander != null : "RedisCommander can not be null.";
@@ -121,7 +121,7 @@ public abstract class PartitionedRedisClient implements ListenableAsyncCloseable
     public final BufferRedisCommander asBufferCommander() {
         BufferRedisCommander redisBufferCommander = this.redisBufferCommander;
         if (redisBufferCommander == null) {
-            redisBufferCommander = new DefaultPartitionedBufferRedisCommander(this, getRedisPartitionAttributesBuilderFactory());
+            redisBufferCommander = new DefaultPartitionedBufferRedisCommander(this, redisPartitionAttributesBuilderFunction());
             if (!redisBufferCommanderUpdater.compareAndSet(this, null, redisBufferCommander)) {
                 redisBufferCommander = this.redisBufferCommander;
                 assert redisBufferCommander != null : "BufferRedisCommander can not be null.";

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisConnection.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisConnection.java
@@ -31,7 +31,7 @@ public abstract class RedisConnection extends RedisRequester {
      *
      * @return the {@link ConnectionContext}.
      */
-    public abstract ConnectionContext getConnectionContext();
+    public abstract ConnectionContext connectionContext();
 
     /**
      * Returns a {@link Publisher} that gives the current value of the setting as well as subsequent changes to the setting
@@ -41,7 +41,7 @@ public abstract class RedisConnection extends RedisRequester {
      * @param <T> Type of the setting value.
      * @return {@link Publisher} for the setting values.
      */
-    public abstract <T> Publisher<T> getSettingStream(SettingKey<T> settingKey);
+    public abstract <T> Publisher<T> settingStream(SettingKey<T> settingKey);
 
     /**
      * A key which identifies a configuration setting for a connection. Setting values may change over time.

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisRequester.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisRequester.java
@@ -74,7 +74,7 @@ public abstract class RedisRequester implements ListenableAsyncCloseable {
      *
      * @return the {@link ExecutionContext} used during construction of this object.
      */
-    public abstract ExecutionContext getExecutionContext();
+    public abstract ExecutionContext executionContext();
 
     /**
      * Send a {@code request} which expects the specified response type.

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisRequesterUtils.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisRequesterUtils.java
@@ -156,7 +156,7 @@ final class RedisRequesterUtils {
                         aggregator = null;
                     } else if (aggregator == null) {
                         if (redisData instanceof RedisData.SimpleString) {
-                            aggregator = requester.getExecutionContext().bufferAllocator()
+                            aggregator = requester.executionContext().bufferAllocator()
                                     .fromUtf8(redisData.getCharSequenceValue());
                         } else if (redisData instanceof RedisData.BulkStringChunk) {
                             aggregator = redisData.getBufferValue();
@@ -198,7 +198,7 @@ final class RedisRequesterUtils {
 
                 private void reallocateAggregator(int extraBytes) {
                     assert aggregator != null;
-                    aggregator = requester.getExecutionContext().bufferAllocator()
+                    aggregator = requester.executionContext().bufferAllocator()
                             .newBuffer(extraBytes + aggregator.getReadableBytes()).writeBytes(aggregator);
                 }
             });
@@ -305,7 +305,7 @@ final class RedisRequesterUtils {
                         if (aggregator == null) {
                             aggregator = redisData.getBufferValue();
                             if (!aggregator.tryEnsureWritable(bulkStringSize - aggregator.getReadableBytes(), false)) {
-                                aggregator = requester.getExecutionContext().bufferAllocator()
+                                aggregator = requester.executionContext().bufferAllocator()
                                         .newBuffer(bulkStringSize).writeBytes(aggregator);
                             }
                         } else {

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/StandAloneReservedRedisConnection.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/StandAloneReservedRedisConnection.java
@@ -51,13 +51,13 @@ final class StandAloneReservedRedisConnection extends RedisClient.ReservedRedisC
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
-        return delegate.getConnectionContext();
+    public ConnectionContext connectionContext() {
+        return delegate.connectionContext();
     }
 
     @Override
-    public <T> Publisher<T> getSettingStream(SettingKey<T> settingKey) {
-        return delegate.getSettingStream(settingKey);
+    public <T> Publisher<T> settingStream(SettingKey<T> settingKey) {
+        return delegate.settingStream(settingKey);
     }
 
     @Override
@@ -66,8 +66,8 @@ final class StandAloneReservedRedisConnection extends RedisClient.ReservedRedisC
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return delegate.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return delegate.executionContext();
     }
 
     @Override

--- a/servicetalk-redis-api/src/test/java/io/servicetalk/redis/api/RedisRequesterUtilsTest.java
+++ b/servicetalk-redis-api/src/test/java/io/servicetalk/redis/api/RedisRequesterUtilsTest.java
@@ -74,8 +74,8 @@ public class RedisRequesterUtilsTest {
         requestor = mock(RedisRequester.class);
         request = mock(RedisRequest.class);
         allocator = DEFAULT_ALLOCATOR;
-        when(requestor.getExecutionContext()).thenReturn(executionContext);
-        when(requestor.getExecutionContext().bufferAllocator()).thenReturn(allocator);
+        when(requestor.executionContext()).thenReturn(executionContext);
+        when(requestor.executionContext().bufferAllocator()).thenReturn(allocator);
         when(requestor.request(any())).thenReturn(publisher.getPublisher());
     }
 

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/AbstractRedisConnection.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/AbstractRedisConnection.java
@@ -95,7 +95,7 @@ abstract class AbstractRedisConnection extends RedisConnection {
     public final Publisher<RedisData> request(final RedisRequest request) {
         // We are writing request content on the connection. control path will be on the EventLoop, so offload to the
         // provided Executor.
-        return handleRequest(request.transformContent(c -> c.subscribeOn(getExecutionContext().executor())))
+        return handleRequest(request.transformContent(c -> c.subscribeOn(executionContext().executor())))
                 // Since data will be emitted on the EventLoop, offload the data path to avoid blocking EventLoop
                 .publishOn(executionContext.executor());
     }
@@ -103,13 +103,13 @@ abstract class AbstractRedisConnection extends RedisConnection {
     abstract Publisher<RedisData> handleRequest(RedisRequest request);
 
     @Override
-    public final ExecutionContext getExecutionContext() {
+    public final ExecutionContext executionContext() {
         return executionContext;
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public final <T> Publisher<T> getSettingStream(SettingKey<T> settingKey) {
+    public final <T> Publisher<T> settingStream(SettingKey<T> settingKey) {
         if (settingKey == MAX_CONCURRENCY) {
             return (Publisher<T>) maxConcurrencySetting;
         }

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/DefaultPartitionedRedisClientBuilder.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/DefaultPartitionedRedisClientBuilder.java
@@ -413,12 +413,12 @@ public class DefaultPartitionedRedisClientBuilder<ResolvedAddress>
         }
 
         @Override
-        public ExecutionContext getExecutionContext() {
+        public ExecutionContext executionContext() {
             return executionContext;
         }
 
         @Override
-        protected Function<Command, RedisPartitionAttributesBuilder> getRedisPartitionAttributesBuilderFactory() {
+        protected Function<Command, RedisPartitionAttributesBuilder> redisPartitionAttributesBuilderFunction() {
             return redisPartitionAttributesBuilderFactory;
         }
 
@@ -515,7 +515,7 @@ public class DefaultPartitionedRedisClientBuilder<ResolvedAddress>
                 @Override
                 protected void handleSubscribe(Subscriber subscriber) {
                     RedisClient oldClient = clientUpdater.getAndSet(Partition.this,
-                            new NoopRedisClient(client.getExecutionContext()));
+                            new NoopRedisClient(client.executionContext()));
                     if (oldClient != null) {
                         oldClient.closeAsync().subscribe(subscriber);
                     } else {
@@ -550,7 +550,7 @@ public class DefaultPartitionedRedisClientBuilder<ResolvedAddress>
         }
 
         @Override
-        public ExecutionContext getExecutionContext() {
+        public ExecutionContext executionContext() {
             return executionContext;
         }
 

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/DefaultRedisClientBuilder.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/DefaultRedisClientBuilder.java
@@ -251,7 +251,7 @@ public final class DefaultRedisClientBuilder<ResolvedAddress>
         }
 
         @Override
-        public ExecutionContext getExecutionContext() {
+        public ExecutionContext executionContext() {
             return executionContext;
         }
 

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/InternalSubscribedRedisConnection.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/InternalSubscribedRedisConnection.java
@@ -84,7 +84,7 @@ final class InternalSubscribedRedisConnection extends AbstractRedisConnection {
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
+    public ConnectionContext connectionContext() {
         return connection;
     }
 

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/LoadBalancedRedisConnection.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/LoadBalancedRedisConnection.java
@@ -39,8 +39,8 @@ final class LoadBalancedRedisConnection extends ReservedRedisConnection
     }
 
     @Override
-    public <T> Publisher<T> getSettingStream(SettingKey<T> settingKey) {
-        return delegate.getSettingStream(settingKey);
+    public <T> Publisher<T> settingStream(SettingKey<T> settingKey) {
+        return delegate.settingStream(settingKey);
     }
 
     @Override
@@ -49,13 +49,13 @@ final class LoadBalancedRedisConnection extends ReservedRedisConnection
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return delegate.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return delegate.executionContext();
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
-        return delegate.getConnectionContext();
+    public ConnectionContext connectionContext() {
+        return delegate.connectionContext();
     }
 
     @Override

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/PipelinedLBRedisConnectionFactory.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/PipelinedLBRedisConnectionFactory.java
@@ -43,7 +43,7 @@ final class PipelinedLBRedisConnectionFactory<ResolvedAddress> extends AbstractL
                                           final Function<RedisConnection, RedisConnection> connectionFilterFactory) {
         return buildForPipelined(executionContext, resolvedAddress, config, connectionFilterFactory)
                 .map(filteredConnection -> new LoadBalancedRedisConnection(filteredConnection,
-                        newController(filteredConnection.getSettingStream(MAX_CONCURRENCY),
+                        newController(filteredConnection.settingStream(MAX_CONCURRENCY),
                                    filteredConnection.onClose(),
                                    config.getMaxPipelinedRequests())));
     }

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/PipelinedRedisConnection.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/PipelinedRedisConnection.java
@@ -119,7 +119,7 @@ final class PipelinedRedisConnection extends AbstractRedisConnection {
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
+    public ConnectionContext connectionContext() {
         return connection;
     }
 

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/RedisConnectionConcurrentRequestsFilter.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/RedisConnectionConcurrentRequestsFilter.java
@@ -46,8 +46,8 @@ final class RedisConnectionConcurrentRequestsFilter extends RedisConnection {
                                             int defaultMaxPipelinedRequests) {
         this.next = requireNonNull(next);
         limiter = defaultMaxPipelinedRequests == 1 ?
-                newSingleController(next.getSettingStream(MAX_CONCURRENCY), next.onClose()) :
-                newController(next.getSettingStream(MAX_CONCURRENCY), next.onClose(), defaultMaxPipelinedRequests);
+                newSingleController(next.settingStream(MAX_CONCURRENCY), next.onClose()) :
+                newController(next.settingStream(MAX_CONCURRENCY), next.onClose(), defaultMaxPipelinedRequests);
     }
 
     @Override
@@ -82,18 +82,18 @@ final class RedisConnectionConcurrentRequestsFilter extends RedisConnection {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return next.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return next.executionContext();
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
-        return next.getConnectionContext();
+    public ConnectionContext connectionContext() {
+        return next.connectionContext();
     }
 
     @Override
-    public <T> Publisher<T> getSettingStream(SettingKey<T> settingKey) {
-        return next.getSettingStream(settingKey);
+    public <T> Publisher<T> settingStream(SettingKey<T> settingKey) {
+        return next.settingStream(settingKey);
     }
 
     @Override

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/RedisIdleConnectionReaper.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/RedisIdleConnectionReaper.java
@@ -74,7 +74,7 @@ final class RedisIdleConnectionReaper implements UnaryOperator<RedisConnection> 
     @Override
     public RedisConnection apply(final RedisConnection redisConnection) {
         Completable timer = toNettyIoExecutor(
-                redisConnection.getConnectionContext().executionContext().ioExecutor())
+                redisConnection.connectionContext().executionContext().ioExecutor())
                         .asExecutor().timer(idleTimeoutNanos, NANOSECONDS);
         return new IdleAwareRedisConnection(redisConnection, timer::subscribe);
     }
@@ -130,13 +130,13 @@ final class RedisIdleConnectionReaper implements UnaryOperator<RedisConnection> 
         }
 
         @Override
-        public <T> Publisher<T> getSettingStream(SettingKey<T> settingKey) {
-            return delegate.getSettingStream(settingKey);
+        public <T> Publisher<T> settingStream(SettingKey<T> settingKey) {
+            return delegate.settingStream(settingKey);
         }
 
         @Override
-        public ConnectionContext getConnectionContext() {
-            return delegate.getConnectionContext();
+        public ConnectionContext connectionContext() {
+            return delegate.connectionContext();
         }
 
         @Override
@@ -162,8 +162,8 @@ final class RedisIdleConnectionReaper implements UnaryOperator<RedisConnection> 
         }
 
         @Override
-        public ExecutionContext getExecutionContext() {
-            return delegate.getExecutionContext();
+        public ExecutionContext executionContext() {
+            return delegate.executionContext();
         }
 
         @Override

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/RedisSubscribedConcurrencyLimitingFilter.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/RedisSubscribedConcurrencyLimitingFilter.java
@@ -57,18 +57,18 @@ final class RedisSubscribedConcurrencyLimitingFilter extends RedisConnection {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return next.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return next.executionContext();
     }
 
     @Override
-    public ConnectionContext getConnectionContext() {
-        return next.getConnectionContext();
+    public ConnectionContext connectionContext() {
+        return next.connectionContext();
     }
 
     @Override
-    public <T> Publisher<T> getSettingStream(RedisConnection.SettingKey<T> settingKey) {
-        return next.getSettingStream(settingKey);
+    public <T> Publisher<T> settingStream(RedisConnection.SettingKey<T> settingKey) {
+        return next.settingStream(settingKey);
     }
 
     @Override

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/AbstractPartitionedRedisClientTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/AbstractPartitionedRedisClientTest.java
@@ -203,6 +203,6 @@ public abstract class AbstractPartitionedRedisClientTest {
     }
 
     protected Buffer buf(final CharSequence cs) {
-        return client.getExecutionContext().bufferAllocator().fromUtf8(cs);
+        return client.executionContext().bufferAllocator().fromUtf8(cs);
     }
 }

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/AbstractRedisConnectionTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/AbstractRedisConnectionTest.java
@@ -152,7 +152,7 @@ public final class AbstractRedisConnectionTest {
         }
 
         @Override
-        public ConnectionContext getConnectionContext() {
+        public ConnectionContext connectionContext() {
             return context;
         }
 

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BaseRedisClientTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BaseRedisClientTest.java
@@ -57,7 +57,7 @@ public abstract class BaseRedisClientTest {
     }
 
     protected static Buffer buf(final CharSequence cs) {
-        return getEnv().client.getExecutionContext().bufferAllocator().fromUtf8(cs);
+        return getEnv().client.executionContext().bufferAllocator().fromUtf8(cs);
     }
 
     protected static RedisTestEnvironment getEnv() {

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BlockingPartitionedRedisClientTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BlockingPartitionedRedisClientTest.java
@@ -123,12 +123,12 @@ public class BlockingPartitionedRedisClientTest extends AbstractPartitionedRedis
             }
 
             @Override
-            public ExecutionContext getExecutionContext() {
-                return delegate.getExecutionContext();
+            public ExecutionContext executionContext() {
+                return delegate.executionContext();
             }
 
             @Override
-            protected Function<RedisProtocolSupport.Command, RedisPartitionAttributesBuilder> getRedisPartitionAttributesBuilderFactory() {
+            protected Function<RedisProtocolSupport.Command, RedisPartitionAttributesBuilder> redisPartitionAttributesBuilderFunction() {
                 return getPartitionAttributesBuilderFactory();
             }
 

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/InternalSubscribedRedisConnectionTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/InternalSubscribedRedisConnectionTest.java
@@ -107,7 +107,7 @@ public class InternalSubscribedRedisConnectionTest {
         assert connection != null;
 
         final RedisRequest subReq = newRequest(SUBSCRIBE,
-                new CompleteBulkString(connection.getExecutionContext().bufferAllocator().fromUtf8("FOO")));
+                new CompleteBulkString(connection.executionContext().bufferAllocator().fromUtf8("FOO")));
 
         Publisher<RedisData> subscriptionRequest = connection.request(subReq)
                 .doAfterCancel(requestStreamCancelled::countDown);
@@ -131,7 +131,7 @@ public class InternalSubscribedRedisConnectionTest {
 
         CharSequence channelToSubscribe = randomStringOfLength(32);
         final RedisRequest subReq = newRequest(SUBSCRIBE,
-                new CompleteBulkString(connection.getExecutionContext().bufferAllocator()
+                new CompleteBulkString(connection.executionContext().bufferAllocator()
                         .fromUtf8(channelToSubscribe)));
 
         Publisher<RedisData> subscriptionRequest = connection.request(subReq)

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/LoadBalancedRedisConnectionTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/LoadBalancedRedisConnectionTest.java
@@ -44,7 +44,7 @@ public class LoadBalancedRedisConnectionTest {
         RedisConnection delegate = mock(RedisConnection.class);
         when(delegate.onClose()).thenReturn(never());
         when(delegate.closeAsync()).thenReturn(completed());
-        when(delegate.getSettingStream(any(SettingKey.class))).thenReturn(maxRequestsPublisher);
+        when(delegate.settingStream(any(SettingKey.class))).thenReturn(maxRequestsPublisher);
         when(delegate.request(any(RedisRequest.class))).thenReturn(just(PONG));
         LoadBalancedRedisConnection connection = new LoadBalancedRedisConnection(delegate,
                 ReservableRequestConcurrencyControllers.newController(just(1), never(), 1));

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/PartitionedRedisClientTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/PartitionedRedisClientTest.java
@@ -126,12 +126,12 @@ public class PartitionedRedisClientTest extends AbstractPartitionedRedisClientTe
             }
 
             @Override
-            public ExecutionContext getExecutionContext() {
-                return delegate.getExecutionContext();
+            public ExecutionContext executionContext() {
+                return delegate.executionContext();
             }
 
             @Override
-            protected Function<RedisProtocolSupport.Command, RedisPartitionAttributesBuilder> getRedisPartitionAttributesBuilderFactory() {
+            protected Function<RedisProtocolSupport.Command, RedisPartitionAttributesBuilder> redisPartitionAttributesBuilderFunction() {
                 return getPartitionAttributesBuilderFactory();
             }
 

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisClientOffloadingTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisClientOffloadingTest.java
@@ -89,7 +89,7 @@ public class RedisClientOffloadingTest {
         errors = new ConcurrentLinkedQueue<>();
         terminated = new CountDownLatch(1);
         connectionContext = awaitIndefinitelyNonNull(getEnv().client.reserveConnection(newRequest(PING)))
-                .getConnectionContext();
+                .connectionContext();
     }
 
     @Test
@@ -151,7 +151,7 @@ public class RedisClientOffloadingTest {
         final ReservedRedisConnection connection =
                 awaitIndefinitelyNonNull(getEnv().client.reserveConnection(newRequest(PING)));
         subscribeTo(getEnv()::isInClientEventLoop, errors,
-                connection.getSettingStream(MAX_CONCURRENCY).doAfterFinally(terminated::countDown),
+                connection.settingStream(MAX_CONCURRENCY).doAfterFinally(terminated::countDown),
                 "Client settings stream: ");
         awaitIndefinitely(connection.closeAsyncGracefully());
         terminated.await();

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisClientTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisClientTest.java
@@ -155,16 +155,16 @@ public class RedisClientTest extends BaseRedisClientTest {
 
     @Test
     public void bufferRequest() throws Exception {
-        Buffer reqBuf = getEnv().client.getExecutionContext().bufferAllocator().newBuffer(33);
+        Buffer reqBuf = getEnv().client.executionContext().bufferAllocator().newBuffer(33);
         reqBuf.writeAscii("*2\r\n")
-                .writeBytes(PING.toRESPArgument(getEnv().client.getExecutionContext().bufferAllocator()))
+                .writeBytes(PING.toRESPArgument(getEnv().client.executionContext().bufferAllocator()))
                 .writeAscii("$12\r\nbufreq-pong1\r\n");
 
         assertThat(awaitIndefinitely(getEnv().client.request(newRequest(PING, reqBuf), Buffer.class)), is(buf("bufreq-pong1")));
 
-        reqBuf = getEnv().client.getExecutionContext().bufferAllocator().newBuffer(33);
+        reqBuf = getEnv().client.executionContext().bufferAllocator().newBuffer(33);
         reqBuf.writeAscii("*2\r\n")
-                .writeBytes(PING.toRESPArgument(getEnv().client.getExecutionContext().bufferAllocator()))
+                .writeBytes(PING.toRESPArgument(getEnv().client.executionContext().bufferAllocator()))
                 .writeAscii("$12\r\nbufreq-pong2\r\n");
 
         assertThat(awaitIndefinitely(getEnv().client.request(newRequest(PING, reqBuf), CharSequence.class)), is("bufreq-pong2"));
@@ -172,7 +172,7 @@ public class RedisClientTest extends BaseRedisClientTest {
 
     @Test
     public void unknownCommandNoCoercion() throws Exception {
-        Buffer reqBuf = getEnv().client.getExecutionContext().bufferAllocator().newBuffer(33);
+        Buffer reqBuf = getEnv().client.executionContext().bufferAllocator().newBuffer(33);
         reqBuf.writeAscii("*2\r\n$6\r\nFOOBAR\r\n$12\r\nbufreq-pong1\r\n");
 
         // We use PING to build the request object, which doesn't matter here: FOOBAR is the actual command sent on the wire
@@ -181,7 +181,7 @@ public class RedisClientTest extends BaseRedisClientTest {
 
     @Test
     public void unknownCommandAnyCoercion() throws Exception {
-        Buffer reqBuf = getEnv().client.getExecutionContext().bufferAllocator().newBuffer(33);
+        Buffer reqBuf = getEnv().client.executionContext().bufferAllocator().newBuffer(33);
         reqBuf.writeAscii("*2\r\n$6\r\nFOOBAR\r\n$12\r\nbufreq-pong1\r\n");
 
         Class<?>[] coercionTypes = {CharSequence.class, Buffer.class, Long.class, ListWithBuffersCoercedToCharSequences.class, List.class};
@@ -214,8 +214,8 @@ public class RedisClientTest extends BaseRedisClientTest {
             }
 
             @Override
-            public ExecutionContext getExecutionContext() {
-                return delegate.getExecutionContext();
+            public ExecutionContext executionContext() {
+                return delegate.executionContext();
             }
 
             @Override
@@ -273,9 +273,9 @@ public class RedisClientTest extends BaseRedisClientTest {
     @Test
     public void requestSingleBufferIsRepeatable() throws ExecutionException, InterruptedException {
         BufferRedisCommander commander = getEnv().client.asBufferCommander();
-        final Buffer key = getEnv().client.getExecutionContext().bufferAllocator().newBuffer(4).writeInt(Integer.MAX_VALUE);
-        final Buffer v1 = getEnv().client.getExecutionContext().bufferAllocator().newBuffer(4).writeInt(Integer.MIN_VALUE);
-        final Buffer v2 = getEnv().client.getExecutionContext().bufferAllocator().newBuffer(4).writeInt(12345678);
+        final Buffer key = getEnv().client.executionContext().bufferAllocator().newBuffer(4).writeInt(Integer.MAX_VALUE);
+        final Buffer v1 = getEnv().client.executionContext().bufferAllocator().newBuffer(4).writeInt(Integer.MIN_VALUE);
+        final Buffer v2 = getEnv().client.executionContext().bufferAllocator().newBuffer(4).writeInt(12345678);
         awaitIndefinitely(commander.del(key.slice()));
         assertThat(awaitIndefinitely(commander.sadd(key.slice(), v1.slice())), is(1L));
         assertThat(awaitIndefinitely(commander.sadd(key.slice(), v2.slice())), is(1L));
@@ -290,12 +290,12 @@ public class RedisClientTest extends BaseRedisClientTest {
     @Test
     public void requestSingleListIsRepeatable() throws ExecutionException, InterruptedException {
         BufferRedisCommander commander = getEnv().client.asBufferCommander();
-        final Buffer key1 = getEnv().client.getExecutionContext().bufferAllocator().newBuffer(4).writeInt(Integer.MAX_VALUE);
-        final Buffer v1 = getEnv().client.getExecutionContext().bufferAllocator().newBuffer(4).writeInt(Integer.MIN_VALUE);
-        final Buffer v2 = getEnv().client.getExecutionContext().bufferAllocator().newBuffer(4).writeInt(12345678);
-        final Buffer key2 = getEnv().client.getExecutionContext().bufferAllocator().newBuffer(4).writeInt(77777);
-        final Buffer v3 = getEnv().client.getExecutionContext().bufferAllocator().newBuffer(4).writeInt(123);
-        final Buffer v4 = getEnv().client.getExecutionContext().bufferAllocator().newBuffer(4).writeInt(55667);
+        final Buffer key1 = getEnv().client.executionContext().bufferAllocator().newBuffer(4).writeInt(Integer.MAX_VALUE);
+        final Buffer v1 = getEnv().client.executionContext().bufferAllocator().newBuffer(4).writeInt(Integer.MIN_VALUE);
+        final Buffer v2 = getEnv().client.executionContext().bufferAllocator().newBuffer(4).writeInt(12345678);
+        final Buffer key2 = getEnv().client.executionContext().bufferAllocator().newBuffer(4).writeInt(77777);
+        final Buffer v3 = getEnv().client.executionContext().bufferAllocator().newBuffer(4).writeInt(123);
+        final Buffer v4 = getEnv().client.executionContext().bufferAllocator().newBuffer(4).writeInt(55667);
         awaitIndefinitely(commander.del(key1.slice()));
         awaitIndefinitely(commander.del(key2.slice()));
         assertThat(awaitIndefinitely(commander.sadd(key1.slice(), v1.slice())), is(1L));

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisConnectionTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisConnectionTest.java
@@ -83,7 +83,7 @@ public class RedisConnectionTest extends BaseRedisClientTest {
 
     @Test
     public void unrecoverableError() throws Exception {
-        final Buffer reqBuf = getEnv().client.getExecutionContext().bufferAllocator().fromAscii("*1\r\n+PING\r\n");
+        final Buffer reqBuf = getEnv().client.executionContext().bufferAllocator().fromAscii("*1\r\n+PING\r\n");
 
         thrown.expect(ExecutionException.class);
         thrown.expectCause(is(instanceOf(RedisServerException.class)));
@@ -119,7 +119,7 @@ public class RedisConnectionTest extends BaseRedisClientTest {
 
         getEnv().client.reserveConnection(pingRequest)
                 .flatMapPublisher(cnx -> {
-                    cnx.getConnectionContext().onClose().subscribe(new Completable.Subscriber() {
+                    cnx.connectionContext().onClose().subscribe(new Completable.Subscriber() {
                         @Override
                         public void onSubscribe(final Cancellable cancellable) {
                         }
@@ -319,13 +319,13 @@ public class RedisConnectionTest extends BaseRedisClientTest {
         }
 
         @Override
-        public ConnectionContext getConnectionContext() {
-            return delegate.getConnectionContext();
+        public ConnectionContext connectionContext() {
+            return delegate.connectionContext();
         }
 
         @Override
-        public <T> Publisher<T> getSettingStream(SettingKey<T> settingKey) {
-            return delegate.getSettingStream(settingKey);
+        public <T> Publisher<T> settingStream(SettingKey<T> settingKey) {
+            return delegate.settingStream(settingKey);
         }
 
         @Override
@@ -335,8 +335,8 @@ public class RedisConnectionTest extends BaseRedisClientTest {
         }
 
         @Override
-        public ExecutionContext getExecutionContext() {
-            return delegate.getExecutionContext();
+        public ExecutionContext executionContext() {
+            return delegate.executionContext();
         }
 
         @Override

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisIdleConnectionReaperTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisIdleConnectionReaperTest.java
@@ -103,8 +103,8 @@ public class RedisIdleConnectionReaperTest {
         when(delegateConnection.closeAsync()).thenReturn(delegateConnectionOnCloseCompletable);
         when(delegateConnection.onClose()).thenReturn(delegateConnectionOnCloseCompletable);
         when(delegateConnection.request(any(RedisRequest.class))).thenReturn(just(NULL));
-        when(delegateConnection.getConnectionContext()).thenReturn(connectionContext);
-        when(delegateConnection.getExecutionContext()).thenReturn(mockExecutionCtx);
+        when(delegateConnection.connectionContext()).thenReturn(connectionContext);
+        when(delegateConnection.executionContext()).thenReturn(mockExecutionCtx);
         when(mockExecutionCtx.bufferAllocator()).thenReturn(DEFAULT_ALLOCATOR);
         when(connectionContext.executionContext()).thenReturn(mockExecutionCtx);
         when(mockExecutionCtx.ioExecutor()).thenReturn(ioExecutor);
@@ -121,7 +121,7 @@ public class RedisIdleConnectionReaperTest {
 
         verify(delegateConnection).onClose();
         verify(mockExecutor).schedule(any(Runnable.class), eq(1_000_000_000L), eq(NANOSECONDS));
-        verify(delegateConnection).getConnectionContext();
+        verify(delegateConnection).connectionContext();
         verify(mockExecutionCtx).ioExecutor();
         verify(connectionContext).executionContext();
     }
@@ -161,7 +161,7 @@ public class RedisIdleConnectionReaperTest {
         completeTimer();
         completeTimer();
         verify(mockExecutor, times(3)).schedule(any(Runnable.class), eq(1_000_000_000L), eq(NANOSECONDS));
-        verify(delegateConnection, times(1)).getConnectionContext();
+        verify(delegateConnection, times(1)).connectionContext();
         verify(mockExecutionCtx, times(1)).ioExecutor();
         assertThat("Unexpected timer subscriptions.", timerSubscribed.get(), is(3));
         verify(delegateConnection).request(any(RedisRequest.class));
@@ -177,7 +177,7 @@ public class RedisIdleConnectionReaperTest {
         completeTimer();
         completeTimer();
         verify(mockExecutor, times(2)).schedule(any(Runnable.class), eq(1_000_000_000L), eq(NANOSECONDS));
-        verify(delegateConnection, times(1)).getConnectionContext();
+        verify(delegateConnection, times(1)).connectionContext();
         verify(mockExecutionCtx, times(1)).ioExecutor();
         assertThat("Unexpected timer subscriptions.", timerSubscribed.get(), is(2));
         verify(delegateConnection).request(any(RedisRequest.class));
@@ -193,8 +193,8 @@ public class RedisIdleConnectionReaperTest {
 
         completeTimer();
         verify(mockExecutor, times(2)).schedule(any(Runnable.class), eq(1_000_000_000L), eq(NANOSECONDS));
-        verify(delegateConnection, times(1)).getExecutionContext();
-        verify(delegateConnection, times(1)).getConnectionContext();
+        verify(delegateConnection, times(1)).executionContext();
+        verify(delegateConnection, times(1)).connectionContext();
         verify(mockExecutionCtx, times(1)).ioExecutor();
         assertThat("Unexpected timer subscriptions.", timerSubscribed.get(), is(2));
         verify(delegateConnection).request(any(RedisRequest.class), eq(String.class));

--- a/servicetalk-redis-utils/src/main/java/io/servicetalk/redis/utils/DelegatingRedisClient.java
+++ b/servicetalk-redis-utils/src/main/java/io/servicetalk/redis/utils/DelegatingRedisClient.java
@@ -47,8 +47,8 @@ public abstract class DelegatingRedisClient extends RedisClient {
     }
 
     @Override
-    public ExecutionContext getExecutionContext() {
-        return wrapped.getExecutionContext();
+    public ExecutionContext executionContext() {
+        return wrapped.executionContext();
     }
 
     @Override

--- a/servicetalk-redis-utils/src/main/java/io/servicetalk/redis/utils/RedisAuthConnectionFactory.java
+++ b/servicetalk-redis-utils/src/main/java/io/servicetalk/redis/utils/RedisAuthConnectionFactory.java
@@ -53,7 +53,7 @@ public class RedisAuthConnectionFactory<ResolvedAddress> implements ConnectionFa
     @Override
     public Single<RedisConnection> newConnection(ResolvedAddress resolvedAddress) {
         return delegate.newConnection(resolvedAddress)
-                .flatMap(cnx -> cnx.asBufferCommander().auth(addressToPassword.apply(cnx.getConnectionContext()))
+                .flatMap(cnx -> cnx.asBufferCommander().auth(addressToPassword.apply(cnx.connectionContext()))
                         .onErrorResume(cause -> {
                             cnx.closeAsync().subscribe();
                             return error(new RedisAuthorizationException("Failed to authenticate on connection " + cnx + " to address " + resolvedAddress, cause));


### PR DESCRIPTION
Motivation:
We have decided to remove get/set prefixes from accessors/modifiers. We should continue the trend on the client APIs.

Modifications:
- Remove get/set accessors from HTTP and Redis client side APIs.

Result:
More consistent API for accessors/modifiers.