### PR TITLE
Add missed source wrappers in JacksonSerializerMessageBodyReaderWriter

### DIFF
--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/BufferPublisherMessageBodyReaderWriter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/BufferPublisherMessageBodyReaderWriter.java
@@ -17,7 +17,7 @@ package io.servicetalk.http.router.jersey;
 
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.http.router.jersey.SourceWrappers.PublisherSource;
+import io.servicetalk.http.router.jersey.internal.SourceWrappers.PublisherSource;
 
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/BufferSingleMessageBodyReaderWriter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/BufferSingleMessageBodyReaderWriter.java
@@ -18,7 +18,7 @@ package io.servicetalk.http.router.jersey;
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.buffer.api.CompositeBuffer;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.http.router.jersey.SourceWrappers.SingleSource;
+import io.servicetalk.http.router.jersey.internal.SourceWrappers.SingleSource;
 
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractFilterInterceptorTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractFilterInterceptorTest.java
@@ -77,20 +77,24 @@ public abstract class AbstractFilterInterceptorTest extends AbstractJerseyStream
             if (isSourceOfType(responseCtx.getEntityType(), Publisher.class, Buffer.class)) {
                 final Publisher<Buffer> contentWith0 =
                         ((Publisher<Buffer>) responseCtx.getEntity()).map(AbstractFilterInterceptorTest::oTo0);
-                responseCtx.setEntity(new GenericEntity<Publisher<Buffer>>(contentWith0) { });
+                responseCtx.setEntity(new GenericEntity<Publisher<Buffer>>(contentWith0) {
+                });
             } else if (isSourceOfType(responseCtx.getEntityType(), Single.class, Buffer.class)) {
                 final Single<Buffer> contentWith0 =
                         ((Single<Buffer>) responseCtx.getEntity()).map(AbstractFilterInterceptorTest::oTo0);
-                responseCtx.setEntity(new GenericEntity<Single<Buffer>>(contentWith0) { });
+                responseCtx.setEntity(new GenericEntity<Single<Buffer>>(contentWith0) {
+                });
             } else if (isSourceOfType(responseCtx.getEntityType(), Single.class, Map.class)) {
                 final Single<Map> contentWith0 =
                         ((Single<Map>) responseCtx.getEntity()).map(AbstractFilterInterceptorTest::oTo0);
-                responseCtx.setEntity(new GenericEntity<Single<Map>>(contentWith0) { });
+                responseCtx.setEntity(new GenericEntity<Single<Map>>(contentWith0) {
+                });
             } else if (responseCtx.getEntity() instanceof Buffer) {
                 responseCtx.setEntity(oTo0(((Buffer) responseCtx.getEntity())));
             } else if (responseCtx.getEntity() instanceof Map) {
                 final Map<String, Object> contentWith0 = oTo0(((Map<String, Object>) responseCtx.getEntity()));
-                responseCtx.setEntity(new GenericEntity<Map<String, Object>>(contentWith0) { });
+                responseCtx.setEntity(new GenericEntity<Map<String, Object>>(contentWith0) {
+                });
             } else if (responseCtx.getEntity() instanceof TestPojo) {
                 final TestPojo contentWith0 = (TestPojo) responseCtx.getEntity();
                 contentWith0.setaString(oTo0(contentWith0.getaString()));
@@ -264,32 +268,62 @@ public abstract class AbstractFilterInterceptorTest extends AbstractJerseyStream
     }
 
     public static class UpperCaseInputStream extends FilterInputStream {
+        private boolean closed;
+
         public UpperCaseInputStream(final InputStream in) {
             super(in);
         }
 
         @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
+
+        @Override
         public int read() throws IOException {
+            ensureNotClosed();
+
             return toUpperCase(super.read());
         }
 
         @Override
         public int read(final byte[] b, final int off, final int len) throws IOException {
+            ensureNotClosed();
+
             final int read = super.read(b, off, len);
             for (int i = 0; i < read; i++) {
                 b[off + i] = (byte) toUpperCase((int) b[off + i]);
             }
             return read;
         }
+
+        private void ensureNotClosed() throws IOException {
+            if (closed) {
+                throw new IOException("Stream is closed");
+            }
+        }
     }
 
     private static class Oto0OutputStream extends FilterOutputStream {
+        private boolean closed;
+
         protected Oto0OutputStream(final OutputStream out) {
             super(out);
         }
 
         @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
+
+        @Override
         public void write(final int b) throws IOException {
+            if (closed) {
+                throw new IOException("Stream is closed");
+            }
+
             super.write(b == 'o' || b == 'O' ? '0' : b);
         }
     }


### PR DESCRIPTION
## Motivation

We need to use `SourceWrapper`s to wrap the `Single` and `Publisher` returned by `JacksonSerializerMessageBodyReaderWriter#readFrom` for the lambdas that deal with `InputStream` to prevent untimely closure by Jersey.

## Modifications

- Add missing wrappers in `JacksonSerializerMessageBodyReaderWriter#readFrom`
- Make `InputStream` decorators used in filters fail if they have been closed, making the need for this fix more apparent.
- Also make `Outputstream` decorators used in filters fail if they have been closed for symmetry (i.e. increase strictness of our tests).

## Results

Users that use filters that decorate `InputStream` entities will not face unexpected close-related issues when using our streaming JSON support.