### PR TITLE
HTTP client/server response logging filters

### DIFF
--- a/servicetalk-http-utils/build.gradle
+++ b/servicetalk-http-utils/build.gradle
@@ -35,10 +35,12 @@ dependencies {
   api "io.servicetalk:servicetalk-concurrent-api:$project.version"
 
   implementation "com.google.code.findbugs:jsr305"
+  implementation "io.netty:netty-common" // NetUtil
   implementation "io.servicetalk:servicetalk-annotations:$project.version"
   implementation "io.servicetalk:servicetalk-concurrent-internal:$project.version"
   implementation "org.slf4j:slf4j-api"
 
+  testImplementation "io.servicetalk:servicetalk-http-api-testFixtures:$project.version"
   testImplementation "io.servicetalk:servicetalk-buffer-netty:$project.version"
   testImplementation "io.servicetalk:servicetalk-concurrent-internal-testFixtures:$project.version"
   testImplementation "io.servicetalk:servicetalk-test-resources:$project.version"

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingUtils.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+import io.servicetalk.buffer.api.Buffer;
+
+import io.netty.util.NetUtil;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+final class LoggingUtils {
+    private LoggingUtils() {
+        // no instances.
+    }
+
+    static int estimateSize(Object o) {
+        if (o instanceof Buffer) {
+            return ((Buffer) o).getReadableBytes();
+        }
+        return 0;
+    }
+
+    static String formatCanonicalAddress(SocketAddress address) {
+        // Try to return the "raw" address (without resolved host name, etc)
+        if (address instanceof InetSocketAddress) {
+            InetSocketAddress inetSocketAddress = (InetSocketAddress) address;
+            InetAddress inetAddress = inetSocketAddress.getAddress();
+            // inetAddress could be null if SocketAddress is in an unresolved form
+            if (inetAddress == null) {
+                return address.toString();
+            } else if (inetAddress instanceof Inet6Address) {
+                return '[' + NetUtil.toAddressString(inetAddress) + "]:" + inetSocketAddress.getPort();
+            } else {
+                return NetUtil.toAddressString(inetAddress) + ':' + inetSocketAddress.getPort();
+            }
+        }
+        return address != null ? address.toString() : "null";
+    }
+}

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/ResponseStatusLoggingStreamingHttpConnectionFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/ResponseStatusLoggingStreamingHttpConnectionFilter.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.HttpProtocolVersion;
+import io.servicetalk.http.api.HttpRequestMethod;
+import io.servicetalk.http.api.StreamingHttpConnection;
+import io.servicetalk.http.api.StreamingHttpConnectionAdapter;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.servicetalk.http.utils.LoggingUtils.estimateSize;
+import static io.servicetalk.http.utils.LoggingUtils.formatCanonicalAddress;
+import static java.lang.System.nanoTime;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+/**
+ * A {@link StreamingHttpConnection} that logs when interesting events occur during the request/response lifecycle.
+ */
+public final class ResponseStatusLoggingStreamingHttpConnectionFilter extends
+                                                                      StreamingHttpConnectionAdapter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(
+            ResponseStatusLoggingStreamingHttpConnectionFilter.class);
+    private final CharSequence name;
+
+    /**
+     * Create a new instance.
+     * @param name The name to use during logging.
+     * @param next The next {@link StreamingHttpConnection} in the filter chain.
+     */
+    public ResponseStatusLoggingStreamingHttpConnectionFilter(final CharSequence name,
+                                                              final StreamingHttpConnection next) {
+        super(next);
+        this.name = requireNonNull(name);
+    }
+
+    @Override
+    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+        return new Single<StreamingHttpResponse>() {
+            @Override
+            protected void handleSubscribe(final Subscriber<? super StreamingHttpResponse> subscriber) {
+                final long startTime = nanoTime();
+                final HttpRequestMethod method = request.method();
+                final String path = request.path();
+                final HttpProtocolVersion version = request.version();
+                delegate().request(request).map(resp -> {
+                    final int responseCode = resp.status().code();
+                    return resp.transformRawPayloadBody(pub ->
+                            pub.doAfterSubscriber(() -> new org.reactivestreams.Subscriber<Object>() {
+                                private int responseSize;
+
+                                @Override
+                                public void onSubscribe(final Subscription s) {
+                                }
+
+                                @Override
+                                public void onNext(final Object o) {
+                                    responseSize += estimateSize(o);
+                                }
+
+                                @Override
+                                public void onError(final Throwable t) {
+                                    LOGGER.debug(
+                                        "failed name={} SRC={} DST={} line=\"{} {} {}\" code={} size={} duration={}ms",
+                                            name,
+                                            formatCanonicalAddress(connectionContext().localAddress()),
+                                            formatCanonicalAddress(connectionContext().remoteAddress()),
+                                            method, path, version, responseCode, responseSize,
+                                            NANOSECONDS.toMillis(nanoTime() - startTime), t);
+                                }
+
+                                @Override
+                                public void onComplete() {
+                                    LOGGER.debug(
+                                            "name={} SRC={} DST={} line=\"{} {} {}\" code={} size={} duration={}ms",
+                                            name,
+                                            formatCanonicalAddress(connectionContext().localAddress()),
+                                            formatCanonicalAddress(connectionContext().remoteAddress()),
+                                            method, path, version, responseCode, responseSize,
+                                            NANOSECONDS.toMillis(nanoTime() - startTime));
+                                }
+                            }));
+                }).doOnError(cause ->
+                        LOGGER.debug(
+                            "failed name={} SRC={} DST={} line=\"{} {} {}\" duration={}ms",
+                            name,
+                            formatCanonicalAddress(connectionContext().localAddress()),
+                            formatCanonicalAddress(connectionContext().remoteAddress()),
+                            method, path, version, NANOSECONDS.toMillis(nanoTime() - startTime), cause)
+                ).subscribe(subscriber);
+            }
+        };
+    }
+}

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/ResponseStatusLoggingStreamingHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/ResponseStatusLoggingStreamingHttpServiceFilter.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.HttpProtocolVersion;
+import io.servicetalk.http.api.HttpRequestMethod;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpService;
+
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.servicetalk.http.utils.LoggingUtils.estimateSize;
+import static io.servicetalk.http.utils.LoggingUtils.formatCanonicalAddress;
+import static java.lang.System.nanoTime;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+/**
+ * A {@link StreamingHttpService} that logs when interesting events occur during the request/response lifecycle.
+ */
+public final class ResponseStatusLoggingStreamingHttpServiceFilter extends StreamingHttpService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(
+            ResponseStatusLoggingStreamingHttpServiceFilter.class);
+    private final StreamingHttpService next;
+    private final CharSequence name;
+
+    /**
+     * Create a new instance.
+     * @param name The name to use during logging.
+     * @param next The next {@link StreamingHttpService} in the filter chain.
+     */
+    public ResponseStatusLoggingStreamingHttpServiceFilter(final CharSequence name,
+                                                           final StreamingHttpService next) {
+        this.next = requireNonNull(next);
+        this.name = requireNonNull(name);
+    }
+
+    @Override
+    public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
+                                                final StreamingHttpRequest request,
+                                                final StreamingHttpResponseFactory responseFactory) {
+        return new Single<StreamingHttpResponse>() {
+            @Override
+            protected void handleSubscribe(final Subscriber<? super StreamingHttpResponse> subscriber) {
+                final long startTime = nanoTime();
+                final HttpRequestMethod method = request.method();
+                final String path = request.path();
+                final HttpProtocolVersion version = request.version();
+                next.handle(ctx, request, responseFactory).map(resp -> {
+                    final int responseCode = resp.status().code();
+                    return resp.transformRawPayloadBody(pub ->
+                            pub.doAfterSubscriber(() -> new org.reactivestreams.Subscriber<Object>() {
+                                private int responseSize;
+
+                                @Override
+                                public void onSubscribe(final Subscription s) {
+                                }
+
+                                @Override
+                                public void onNext(final Object o) {
+                                    responseSize += estimateSize(o);
+                                }
+
+                                @Override
+                                public void onError(final Throwable t) {
+                                    LOGGER.debug(
+                                        "failed name={} SRC={} DST={} line=\"{} {} {}\" code={} size={} duration={}ms",
+                                            name,
+                                            formatCanonicalAddress(ctx.remoteAddress()),
+                                            formatCanonicalAddress(ctx.localAddress()),
+                                            method, path, version, responseCode, responseSize,
+                                            NANOSECONDS.toMillis(nanoTime() - startTime), t);
+                                }
+
+                                @Override
+                                public void onComplete() {
+                                    LOGGER.debug(
+                                            "name={} SRC={} DST={} line=\"{} {} {}\" code={} size={} duration={}ms",
+                                            name,
+                                            formatCanonicalAddress(ctx.remoteAddress()),
+                                            formatCanonicalAddress(ctx.localAddress()),
+                                            method, path, version, responseCode, responseSize,
+                                            NANOSECONDS.toMillis(nanoTime() - startTime));
+                                }
+                            }));
+                }).doOnError(cause ->
+                        LOGGER.debug("failed name={} SRC={} DST={} line=\"{} {} {}\" duration={}ms",
+                        name,
+                        formatCanonicalAddress(ctx.remoteAddress()),
+                        formatCanonicalAddress(ctx.localAddress()),
+                        method, path, version, NANOSECONDS.toMillis(nanoTime() - startTime), cause)
+                ).subscribe(subscriber);
+            }
+        };
+    }
+
+    @Override
+    public Completable closeAsync() {
+        return next.closeAsync();
+    }
+
+    @Override
+    public Completable closeAsyncGracefully() {
+        return next.closeAsyncGracefully();
+    }
+}

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/ResponseStatusLoggingStreamingHttpConnectionFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/ResponseStatusLoggingStreamingHttpConnectionFilterTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.http.api.DefaultHttpHeadersFactory;
+import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
+import io.servicetalk.http.api.StreamingHttpConnection;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.TestStreamingHttpConnection;
+import io.servicetalk.transport.api.ConnectionContext;
+import io.servicetalk.transport.api.ExecutionContext;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutionException;
+
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static org.mockito.Mockito.when;
+
+public class ResponseStatusLoggingStreamingHttpConnectionFilterTest {
+    private static final BufferAllocator allocator = DEFAULT_ALLOCATOR;
+    private static final StreamingHttpRequestResponseFactory reqRespFactory =
+            new DefaultStreamingHttpRequestResponseFactory(allocator, DefaultHttpHeadersFactory.INSTANCE);
+
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+
+    @Mock
+    private ExecutionContext executionContext;
+
+    @Mock
+    private ConnectionContext connectionContext;
+
+    @Mock
+    private StreamingHttpRequest mockRequest;
+
+    private StreamingHttpConnection testConnection;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        InetSocketAddress localAddress = new InetSocketAddress(0);
+        InetSocketAddress remoteAddress = new InetSocketAddress(0);
+        when(connectionContext.localAddress()).thenReturn(localAddress);
+        when(connectionContext.remoteAddress()).thenReturn(remoteAddress);
+        testConnection =
+                new TestStreamingHttpConnection(reqRespFactory, executionContext, connectionContext) {
+                    @Override
+                    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+                        return Single.success(httpResponseFactory().ok());
+                    }
+                };
+    }
+
+    @Test
+    public void successfulRequestResponse() throws ExecutionException, InterruptedException {
+        new ResponseStatusLoggingStreamingHttpConnectionFilter("testClient", testConnection)
+                .request(mockRequest)
+                .toFuture().get().payloadBody().ignoreElements().toFuture().get();
+        // we are not asserting that the log methods are actually called, but instead just verified code paths
+        // execute "normally".
+    }
+}

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/ResponseStatusLoggingStreamingHttpServiceFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/ResponseStatusLoggingStreamingHttpServiceFilterTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequestHandler;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.ExecutionException;
+import java.util.function.UnaryOperator;
+
+import static io.servicetalk.concurrent.api.Publisher.empty;
+import static io.servicetalk.concurrent.api.Single.success;
+import static io.servicetalk.http.api.HttpResponseStatuses.OK;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+public class ResponseStatusLoggingStreamingHttpServiceFilterTest {
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+
+    @Mock
+    private HttpServiceContext mockCtx;
+
+    @Mock
+    private StreamingHttpRequest mockRequest;
+
+    @Mock
+    private StreamingHttpResponseFactory mockFactory;
+
+    @Mock
+    private StreamingHttpResponse mockResponse;
+    @Mock
+    private StreamingHttpResponse mockResponse2;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        when(mockFactory.ok()).thenReturn(mockResponse);
+        when(mockResponse.payloadBody()).thenReturn(empty());
+        when(mockResponse.transformRawPayloadBody(any())).thenReturn(mockResponse);
+        doAnswer((Answer<StreamingHttpResponse>) invocation -> {
+            UnaryOperator<Publisher<?>> transformer = invocation.getArgument(0);
+            when(mockResponse2.payloadBodyAndTrailers()).thenReturn(transformer.apply(empty())
+                    .map(o -> (Object) o));
+            return mockResponse2;
+        }).when(mockResponse).transformRawPayloadBody(any());
+        when(mockResponse.status()).thenReturn(OK);
+    }
+
+    @Test
+    public void successfulRequestResponse() throws ExecutionException, InterruptedException {
+        new ResponseStatusLoggingStreamingHttpServiceFilter("testServer",
+                        ((StreamingHttpRequestHandler) (ctx, request, responseFactory) ->
+                                success(responseFactory.ok())).asStreamingService())
+                .handle(mockCtx, mockRequest, mockFactory)
+                .toFuture().get().payloadBodyAndTrailers().ignoreElements().toFuture().get();
+        // we are not asserting that the log methods are actually called, but instead just verified code paths
+        // execute "normally".
+    }
+}


### PR DESCRIPTION
Motivation:
Users may want to have visibility into the request/response life cycle
events. It would be useful to have a common logging filter that logs
details of the request/response.

Modifications:
- Implement a http logging filter

Result:
HTTP client/server response logging filters exist.