### PR TITLE
Replace CompositeBuffer with Buffer in Jersey body readers

### DIFF
--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/AbstractMessageBodyReaderWriter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/AbstractMessageBodyReaderWriter.java
@@ -123,6 +123,15 @@ abstract class AbstractMessageBodyReaderWriter<Source, T, SourceOfT, WrappedSour
                 contentClass.isAssignableFrom((Class<?>) typeArgument);
     }
 
+    static int getRequestContentLength(final Provider<ContainerRequestContext> requestCtxProvider) {
+        return requestCtxProvider.get().getLength();
+    }
+
+    static Buffer newBufferForRequestContent(final int contentLength,
+                                             final BufferAllocator allocator) {
+        return contentLength == -1 ? allocator.newBuffer() : allocator.newBuffer(contentLength);
+    }
+
     @Nullable
     private static Type getSingleTypeArgumentOrNull(final ParameterizedType parameterizedType) {
         final Type[] typeArguments = parameterizedType.getActualTypeArguments();


### PR DESCRIPTION
## Motivation

Currently, we use unbounded `CompositeBuffer`s when we need to aggregate `Buffer`s in Jersey body readers. We can do better by using a regular `Buffer` initially sized to the request content-length (when one is available).

## Modifications

Replace `CompositeBuffer` with `Buffer` in Jersey body readers

## Results

Less usage of `CompositeBuffer`s.