### PR TITLE
Buffer remove get/set

### DIFF
--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/AbstractBuffer.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/AbstractBuffer.java
@@ -47,12 +47,12 @@ abstract class AbstractBuffer implements Buffer {
     }
 
     @Override
-    public final int getReaderIndex() {
+    public final int readerIndex() {
         return readerIndex;
     }
 
     @Override
-    public final Buffer setReaderIndex(int readerIndex) {
+    public final Buffer readerIndex(int readerIndex) {
         if (readerIndex > 0 || readerIndex > writerIndex) {
             throw new IndexOutOfBoundsException("readerIndex must be in the range[0," + writerIndex + ") but was: " +
                     readerIndex);
@@ -62,22 +62,22 @@ abstract class AbstractBuffer implements Buffer {
     }
 
     @Override
-    public final int getWriterIndex() {
+    public final int writerIndex() {
         return writerIndex;
     }
 
     @Override
-    public final Buffer setWriterIndex(int writerIndex) {
-        if (writerIndex < readerIndex || writerIndex > getCapacity()) {
+    public final Buffer writerIndex(int writerIndex) {
+        if (writerIndex < readerIndex || writerIndex > capacity()) {
             throw new IndexOutOfBoundsException("writerIndex must be in the range[" + readerIndex + "," +
-                    getCapacity() + "] but was: " + writerIndex);
+                    capacity() + "] but was: " + writerIndex);
         }
         this.writerIndex = writerIndex;
         return this;
     }
 
     @Override
-    public final int getReadableBytes() {
+    public final int readableBytes() {
         return writerIndex - readerIndex;
     }
 
@@ -238,14 +238,14 @@ abstract class AbstractBuffer implements Buffer {
 
     @Override
     public final Buffer getBytes(int index, Buffer dst) {
-        getBytes(index, dst, dst.getWritableBytes());
+        getBytes(index, dst, dst.writableBytes());
         return this;
     }
 
     @Override
     public final Buffer getBytes(int index, Buffer dst, int length) {
-        getBytes(index, dst, dst.getWriterIndex(), length);
-        dst.setWriterIndex(dst.getWriterIndex() + length);
+        getBytes(index, dst, dst.writerIndex(), length);
+        dst.writerIndex(dst.writerIndex() + length);
         return this;
     }
 
@@ -415,18 +415,18 @@ abstract class AbstractBuffer implements Buffer {
 
     @Override
     public final Buffer readBytes(Buffer dst) {
-        readBytes(dst, dst.getWritableBytes());
+        readBytes(dst, dst.writableBytes());
         return this;
     }
 
     @Override
     public final Buffer readBytes(Buffer dst, int length) {
-        if (length > dst.getWritableBytes()) {
+        if (length > dst.writableBytes()) {
             throw new IndexOutOfBoundsException(String.format(
-                    "length(%d) exceeds dst.writableBytes(%d) where dst is: %s", length, dst.getWritableBytes(), dst));
+                    "length(%d) exceeds dst.writableBytes(%d) where dst is: %s", length, dst.writableBytes(), dst));
         }
-        readBytes(dst, dst.getWriterIndex(), length);
-        dst.setWriterIndex(dst.getWriterIndex() + length);
+        readBytes(dst, dst.writerIndex(), length);
+        dst.writerIndex(dst.writerIndex() + length);
         return this;
     }
 
@@ -460,7 +460,7 @@ abstract class AbstractBuffer implements Buffer {
 
     @Override
     public final int bytesBefore(byte value) {
-        return bytesBefore(readerIndex, getReadableBytes(), value);
+        return bytesBefore(readerIndex, readableBytes(), value);
     }
 
     @Override
@@ -512,12 +512,12 @@ abstract class AbstractBuffer implements Buffer {
 
     @Override
     public final Buffer copy() {
-        return copy(readerIndex, getReadableBytes());
+        return copy(readerIndex, readableBytes());
     }
 
     @Override
     public final Buffer slice() {
-        return slice(readerIndex, getReadableBytes());
+        return slice(readerIndex, readableBytes());
     }
 
     private int forEachByteDesc0(int rStart, final int rEnd, ByteProcessor processor) {
@@ -545,12 +545,12 @@ abstract class AbstractBuffer implements Buffer {
 
     @Override
     public ByteBuffer toNioBuffer() {
-        return toNioBuffer(readerIndex, getReadableBytes());
+        return toNioBuffer(readerIndex, readableBytes());
     }
 
     @Override
     public final ByteBuffer[] toNioBuffers() {
-        return toNioBuffers(readerIndex, getReadableBytes());
+        return toNioBuffers(readerIndex, readableBytes());
     }
 
     @Override
@@ -563,13 +563,13 @@ abstract class AbstractBuffer implements Buffer {
         }
 
         Buffer that = (Buffer) o;
-        final int readableBytes = getReadableBytes();
-        if (readableBytes != that.getReadableBytes()) {
+        final int readableBytes = readableBytes();
+        if (readableBytes != that.readableBytes()) {
             return false;
         }
 
-        int aStartIndex = getReaderIndex();
-        int bStartIndex = that.getReaderIndex();
+        int aStartIndex = readerIndex();
+        int bStartIndex = that.readerIndex();
         final int longCount = readableBytes >>> 3;
         final int byteCount = readableBytes & 7;
         // TODO(scott): take into account endianness? we currently don't have order() on Buffer.
@@ -594,7 +594,7 @@ abstract class AbstractBuffer implements Buffer {
 
     @Override
     public int hashCode() {
-        final int aLen = getReadableBytes();
+        final int aLen = readableBytes();
         final int longCount = aLen >>> 3;
         final int byteCount = aLen & 3;
 
@@ -623,9 +623,9 @@ abstract class AbstractBuffer implements Buffer {
                 .append(getClass().getSimpleName())
                 .append("(ridx: ").append(readerIndex)
                 .append(", widx: ").append(writerIndex)
-                .append(", cap: ").append(getCapacity());
-        if (getMaxCapacity() != Integer.MAX_VALUE) {
-            buf.append('/').append(getMaxCapacity());
+                .append(", cap: ").append(capacity());
+        if (maxCapacity() != Integer.MAX_VALUE) {
+            buf.append('/').append(maxCapacity());
         }
 
         buf.append(')');
@@ -634,7 +634,7 @@ abstract class AbstractBuffer implements Buffer {
 
     @Override
     public final String toString(Charset charset) {
-        return toString(readerIndex, getReadableBytes(), charset);
+        return toString(readerIndex, readableBytes(), charset);
     }
 
     final void checkReadableBytes0(int minimumReadableBytes) {
@@ -646,9 +646,9 @@ abstract class AbstractBuffer implements Buffer {
     }
 
     final void checkIndex0(int index, int fieldLength) {
-        if (isOutOfBounds(index, fieldLength, getCapacity())) {
+        if (isOutOfBounds(index, fieldLength, capacity())) {
             throw new IndexOutOfBoundsException(String.format(
-                    "index: %d, length: %d (expected: range(0, %d))", index, fieldLength, getCapacity()));
+                    "index: %d, length: %d (expected: range(0, %d))", index, fieldLength, capacity()));
         }
     }
 

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/Buffer.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/Buffer.java
@@ -32,7 +32,7 @@ public interface Buffer {
      *
      * @return the number of bytes (octets) this buffer can contain.
      */
-    int getCapacity();
+    int capacity();
 
     /**
      * Sets the capacity of this buffer.  If the {@code newCapacity} is less than the current
@@ -43,23 +43,23 @@ public interface Buffer {
      * @param newCapacity the new capacity.
      * @return itself.
      */
-    Buffer setCapacity(int newCapacity);
+    Buffer capacity(int newCapacity);
 
     /**
      * Returns the maximum allowed capacity of this buffer.  If a user attempts to increase the
-     * capacity of this buffer beyond the maximum capacity using {@link #setCapacity(int)}, those methods will raise an
+     * capacity of this buffer beyond the maximum capacity using {@link #capacity(int)}, those methods will raise an
      * {@link IllegalArgumentException}.
      *
      * @return the max capacity of this buffer.
      */
-    int getMaxCapacity();
+    int maxCapacity();
 
     /**
      * Returns the {@code readerIndex} of this buffer.
      *
      * @return the {@code readerIndex} of this buffer.
      */
-    int getReaderIndex();
+    int readerIndex();
 
     /**
      * Sets the {@code readerIndex} of this buffer.
@@ -71,14 +71,14 @@ public interface Buffer {
      *            less than {@code 0} or
      *            greater than {@code this.writerIndex}
      */
-    Buffer setReaderIndex(int readerIndex);
+    Buffer readerIndex(int readerIndex);
 
     /**
      * Returns the {@code writerIndex} of this buffer.
      *
      * @return the {@code writerIndex} of this buffer.
      */
-    int getWriterIndex();
+    int writerIndex();
 
     /**
      * Sets the {@code writerIndex} of this buffer.
@@ -90,7 +90,7 @@ public interface Buffer {
      *            less than {@code this.readerIndex} or
      *            greater than {@code this.capacity}
      */
-    Buffer setWriterIndex(int writerIndex);
+    Buffer writerIndex(int writerIndex);
 
     /**
      * Returns the number of readable bytes which is equal to
@@ -98,7 +98,7 @@ public interface Buffer {
      *
      * @return the number of readables bytes in this buffer.
      */
-    int getReadableBytes();
+    int readableBytes();
 
     /**
      * Returns the number of writable bytes which is equal to
@@ -106,7 +106,7 @@ public interface Buffer {
      *
      * @return the number of writable bytes in this buffer.
      */
-    int getWritableBytes();
+    int writableBytes();
 
     /**
      * Returns the maximum possible number of writable bytes, which is equal to
@@ -114,10 +114,10 @@ public interface Buffer {
      *
      * @return the maximum possible number of writable bytes in this buffer.
      */
-    int getMaxWritableBytes();
+    int maxWritableBytes();
 
     /**
-     * Makes sure the number of {@linkplain #getWritableBytes() the writable bytes}
+     * Makes sure the number of {@linkplain #writableBytes() the writable bytes}
      * is equal to or greater than the specified value. If there is enough
      * writable bytes in this buffer, this method returns with no side effect.
      * Otherwise, it raises an {@link IllegalArgumentException}.
@@ -126,21 +126,21 @@ public interface Buffer {
      *        the expected minimum number of writable bytes
      * @return this object.
      * @throws IndexOutOfBoundsException
-     *         if {@link #getWriterIndex()} + {@code minWritableBytes} &gt; {@link #getMaxCapacity()}
+     *         if {@link #writerIndex()} + {@code minWritableBytes} &gt; {@link #maxCapacity()}
      */
     Buffer ensureWritable(int minWritableBytes);
 
     /**
-     * Tries to make sure the number of {@linkplain #getWritableBytes() the writable bytes}
+     * Tries to make sure the number of {@linkplain #writableBytes() the writable bytes}
      * is equal to or greater than the specified value. Unlike {@link #ensureWritable(int)},
      * this method does not raise an exception but returns a code.
      *
      * @param minWritableBytes
      *        the expected minimum number of writable bytes
      * @param force
-     *        When {@link #getWriterIndex()} + {@code minWritableBytes} &gt; {@link #getMaxCapacity()}:
+     *        When {@link #writerIndex()} + {@code minWritableBytes} &gt; {@link #maxCapacity()}:
      *        <ul>
-     *        <li>{@code true} - the capacity of the buffer is expanded to {@link #getMaxCapacity()}</li>
+     *        <li>{@code true} - the capacity of the buffer is expanded to {@link #maxCapacity()}</li>
      *        <li>{@code false} - the capacity of the buffer is unchanged</li>
      *        </ul>
      * @return {@code 0} if the buffer has enough writable bytes, and its capacity is unchanged.
@@ -152,16 +152,16 @@ public interface Buffer {
     int ensureWritable(int minWritableBytes, boolean force);
 
     /**
-     * Tries to make sure the number of {@linkplain #getWritableBytes() the writable bytes}
+     * Tries to make sure the number of {@linkplain #writableBytes() the writable bytes}
      * is equal to or greater than the specified value. Unlike {@link #ensureWritable(int)},
      * this method does not raise an exception but returns a code.
      *
      * @param minWritableBytes
      *        the expected minimum number of writable bytes
      * @param force
-     *        When {@link #getWriterIndex()} + {@code minWritableBytes} &gt; {@link #getMaxCapacity()}:
+     *        When {@link #writerIndex()} + {@code minWritableBytes} &gt; {@link #maxCapacity()}:
      *        <ul>
-     *        <li>{@code true} - the capacity of the buffer is expanded to {@link #getMaxCapacity()}</li>
+     *        <li>{@code true} - the capacity of the buffer is expanded to {@link #maxCapacity()}</li>
      *        <li>{@code false} - the capacity of the buffer is unchanged</li>
      *        </ul>
      * @return {@code true} if this {@link Buffer} has at least {@code minWritableBytes} writable bytes after this call.
@@ -1713,7 +1713,7 @@ public interface Buffer {
      * @see #toNioBuffers()
      * @see #toNioBuffers(int, int)
      */
-    int getNioBufferCount();
+    int nioBufferCount();
 
     /**
      * Exposes this buffer's readable bytes as an NIO {@link ByteBuffer}.  The returned buffer
@@ -1728,7 +1728,7 @@ public interface Buffer {
      * @throws UnsupportedOperationException
      *         if this buffer cannot create a {@link ByteBuffer} that shares the content with itself
      *
-     * @see #getNioBufferCount()
+     * @see #nioBufferCount()
      * @see #toNioBuffers()
      * @see #toNioBuffers(int, int)
      */
@@ -1748,7 +1748,7 @@ public interface Buffer {
      * @throws UnsupportedOperationException
      *         if this buffer cannot create a {@link ByteBuffer} that shares the content with itself
      *
-     * @see #getNioBufferCount()
+     * @see #nioBufferCount()
      * @see #toNioBuffers()
      * @see #toNioBuffers(int, int)
      */
@@ -1767,7 +1767,7 @@ public interface Buffer {
      * @throws UnsupportedOperationException
      *         if this buffer cannot create a {@link ByteBuffer} that shares the content with itself
      *
-     * @see #getNioBufferCount()
+     * @see #nioBufferCount()
      * @see #toNioBuffer()
      * @see #toNioBuffer(int, int)
      */
@@ -1787,7 +1787,7 @@ public interface Buffer {
      * @throws UnsupportedOperationException
      *         if this buffer cannot create a {@link ByteBuffer} that shares the content with itself
      *
-     * @see #getNioBufferCount()
+     * @see #nioBufferCount()
      * @see #toNioBuffer()
      * @see #toNioBuffer(int, int)
      */
@@ -1814,8 +1814,8 @@ public interface Buffer {
 
     /**
      * Returns {@code true} if and only if this buffer has a backing byte array.
-     * If this method returns true, you can safely call {@link #getArray()} and
-     * {@link #getArrayOffset()}.
+     * If this method returns true, you can safely call {@link #array()} and
+     * {@link #arrayOffset()}.
      *
      * @return {@code true} if backed by an byte array.
      */
@@ -1828,7 +1828,7 @@ public interface Buffer {
      * @throws UnsupportedOperationException
      *         if there no accessible backing byte array
      */
-    byte[] getArray();
+    byte[] array();
 
     /**
      * Returns the offset of the first byte within the backing byte array of
@@ -1838,7 +1838,7 @@ public interface Buffer {
      * @throws UnsupportedOperationException
      *         if there no accessible backing byte array
      */
-    int getArrayOffset();
+    int arrayOffset();
 
     /**
      * Iterates over the readable bytes of this buffer with the specified {@code processor} in ascending order.
@@ -1898,8 +1898,8 @@ public interface Buffer {
      * <li>the size of the contents of the two buffers are same and</li>
      * <li>every single byte of the content of the two buffers are same.</li>
      * </ul>
-     * Please note that it does not compare {@link #getReaderIndex()} nor
-     * {@link #getWriterIndex()}.  This method also returns {@code false} for
+     * Please note that it does not compare {@link #readerIndex()} nor
+     * {@link #writerIndex()}.  This method also returns {@code false} for
      * {@code null} and an object which is not an instance of
      * {@link Buffer} type.
      */
@@ -1909,8 +1909,8 @@ public interface Buffer {
     /**
      * Returns the string representation of this buffer.  This method does not
      * necessarily return the whole content of the buffer but returns
-     * the values of the key properties such as {@link #getReaderIndex()},
-     * {@link #getWriterIndex()} and {@link #getCapacity()}.
+     * the values of the key properties such as {@link #readerIndex()},
+     * {@link #writerIndex()} and {@link #capacity()}.
      */
     @Override
     String toString();

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/BufferHolder.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/BufferHolder.java
@@ -23,7 +23,7 @@ public interface BufferHolder {
      * The buffer contained by this object.
      * @return The buffer contained by this object.
      */
-    Buffer getContent();
+    Buffer content();
 
     /**
      * Duplicates this {@link BufferHolder}.
@@ -33,7 +33,7 @@ public interface BufferHolder {
 
     /**
      * Returns a new {@link BufferHolder} which contains the specified {@code content}.
-     * @param content The {@link Buffer} to replace what is currently returned by {@link #getContent()}.
+     * @param content The {@link Buffer} to replace what is currently returned by {@link #content()}.
      * @return a new {@link BufferHolder} which contains the specified {@code content}.
      */
     BufferHolder replace(Buffer content);

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/BufferInputStream.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/BufferInputStream.java
@@ -29,7 +29,7 @@ final class BufferInputStream extends InputStream {
 
     @Override
     public int read() {
-        if (buffer.getReadableBytes() == 0) {
+        if (buffer.readableBytes() == 0) {
             return -1;
         }
         return buffer.readByte() & 0xff;
@@ -37,7 +37,7 @@ final class BufferInputStream extends InputStream {
 
     @Override
     public int read(byte[] b, int off, int len) {
-        int readableBytes = buffer.getReadableBytes();
+        int readableBytes = buffer.readableBytes();
         if (readableBytes == 0) {
             return -1;
         }
@@ -48,13 +48,13 @@ final class BufferInputStream extends InputStream {
 
     @Override
     public long skip(long n) {
-        int skipped = min(buffer.getReadableBytes(), (int) min(Integer.MAX_VALUE, n));
+        int skipped = min(buffer.readableBytes(), (int) min(Integer.MAX_VALUE, n));
         buffer.skipBytes(skipped);
         return skipped;
     }
 
     @Override
     public int available() {
-        return buffer.getReadableBytes();
+        return buffer.readableBytes();
     }
 }

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CompositeBuffer.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CompositeBuffer.java
@@ -64,13 +64,13 @@ public interface CompositeBuffer extends Buffer {
     CompositeBuffer discardSomeReadBytes();
 
     @Override
-    CompositeBuffer setCapacity(int newCapacity);
+    CompositeBuffer capacity(int newCapacity);
 
     @Override
-    CompositeBuffer setReaderIndex(int readerIndex);
+    CompositeBuffer readerIndex(int readerIndex);
 
     @Override
-    CompositeBuffer setWriterIndex(int writerIndex);
+    CompositeBuffer writerIndex(int writerIndex);
 
     @Override
     CompositeBuffer clear();

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/EmptyBuffer.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/EmptyBuffer.java
@@ -39,54 +39,54 @@ public final class EmptyBuffer implements Buffer {
     }
 
     @Override
-    public int getCapacity() {
+    public int capacity() {
         return 0;
     }
 
     @Override
-    public Buffer setCapacity(int newCapacity) {
+    public Buffer capacity(int newCapacity) {
         throw new ReadOnlyBufferException();
     }
 
     @Override
-    public int getMaxCapacity() {
+    public int maxCapacity() {
         return 0;
     }
 
     @Override
-    public int getReaderIndex() {
+    public int readerIndex() {
         return 0;
     }
 
     @Override
-    public Buffer setReaderIndex(int readerIndex) {
+    public Buffer readerIndex(int readerIndex) {
         checkIndex(readerIndex);
         return this;
     }
 
     @Override
-    public int getWriterIndex() {
+    public int writerIndex() {
         return 0;
     }
 
     @Override
-    public Buffer setWriterIndex(int writerIndex) {
+    public Buffer writerIndex(int writerIndex) {
         checkIndex(writerIndex);
         return this;
     }
 
     @Override
-    public int getReadableBytes() {
+    public int readableBytes() {
         return 0;
     }
 
     @Override
-    public int getWritableBytes() {
+    public int writableBytes() {
         return 0;
     }
 
     @Override
-    public int getMaxWritableBytes() {
+    public int maxWritableBytes() {
         return 0;
     }
 
@@ -318,7 +318,7 @@ public final class EmptyBuffer implements Buffer {
 
     @Override
     public Buffer setBytes(int index, Buffer src) {
-        checkIndex(index, src.getReadableBytes());
+        checkIndex(index, src.readableBytes());
         return this;
     }
 
@@ -478,20 +478,20 @@ public final class EmptyBuffer implements Buffer {
 
     @Override
     public Buffer readBytes(Buffer dst) {
-        checkLength(dst.getWritableBytes());
+        checkLength(dst.writableBytes());
         return this;
     }
 
     @Override
     public Buffer readBytes(Buffer dst, int length) {
-        checkLength(dst.getWritableBytes());
+        checkLength(dst.writableBytes());
         checkLength(length);
         return this;
     }
 
     @Override
     public Buffer readBytes(Buffer dst, int dstIndex, int length) {
-        checkLength(dst.getWritableBytes());
+        checkLength(dst.writableBytes());
         checkLength(length);
         return this;
     }
@@ -588,20 +588,20 @@ public final class EmptyBuffer implements Buffer {
 
     @Override
     public Buffer writeBytes(Buffer src) {
-        checkLength(src.getReadableBytes());
+        checkLength(src.readableBytes());
         return this;
     }
 
     @Override
     public Buffer writeBytes(Buffer src, int length) {
-        checkLength(src.getReadableBytes());
+        checkLength(src.readableBytes());
         checkLength(length);
         return this;
     }
 
     @Override
     public Buffer writeBytes(Buffer src, int srcIndex, int length) {
-        checkLength(src.getReadableBytes());
+        checkLength(src.readableBytes());
         checkLength(length);
         return this;
     }
@@ -698,7 +698,7 @@ public final class EmptyBuffer implements Buffer {
     }
 
     @Override
-    public int getNioBufferCount() {
+    public int nioBufferCount() {
         return 1;
     }
 
@@ -746,12 +746,12 @@ public final class EmptyBuffer implements Buffer {
     }
 
     @Override
-    public byte[] getArray() {
+    public byte[] array() {
         return EMPTY_BYTES;
     }
 
     @Override
-    public int getArrayOffset() {
+    public int arrayOffset() {
         return 0;
     }
 

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/ReadOnlyByteBuffer.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/ReadOnlyByteBuffer.java
@@ -57,28 +57,28 @@ final class ReadOnlyByteBuffer extends AbstractBuffer {
     }
 
     @Override
-    public int getCapacity() {
+    public int capacity() {
         return buffer.capacity();
     }
 
     @Override
-    public Buffer setCapacity(int newCapacity) {
+    public Buffer capacity(int newCapacity) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public int getMaxCapacity() {
-        return getCapacity();
+    public int maxCapacity() {
+        return capacity();
     }
 
     @Override
-    public int getWritableBytes() {
+    public int writableBytes() {
         // TODO(scott): this buffer is not writable, so returning 0 seems more correct, but Netty doesn't do this
         return 0;
     }
 
     @Override
-    public int getMaxWritableBytes() {
+    public int maxWritableBytes() {
         // TODO(scott): this buffer is not writable, so returning 0 seems more correct, but Netty doesn't do this
         return 0;
     }
@@ -118,10 +118,10 @@ final class ReadOnlyByteBuffer extends AbstractBuffer {
 
     @Override
     public Buffer getBytes(int index, Buffer dst, int dstIndex, int length) {
-        checkDstIndex(index, length, dstIndex, dst.getCapacity());
+        checkDstIndex(index, length, dstIndex, dst.capacity());
         if (dst.hasArray()) {
-            getBytes(index, dst.getArray(), dst.getArrayOffset() + dstIndex, length);
-        } else if (dst.getNioBufferCount() > 0) {
+            getBytes(index, dst.array(), dst.arrayOffset() + dstIndex, length);
+        } else if (dst.nioBufferCount() > 0) {
             for (ByteBuffer bb : dst.toNioBuffers(dstIndex, length)) {
                 int bbLen = bb.remaining();
                 getBytes(index, bb);
@@ -155,7 +155,7 @@ final class ReadOnlyByteBuffer extends AbstractBuffer {
             throw new NullPointerException("dst");
         }
 
-        int bytesToCopy = Math.min(getCapacity() - index, dst.remaining());
+        int bytesToCopy = Math.min(capacity() - index, dst.remaining());
         ByteBuffer tmpBuf = buffer.duplicate();
         tmpBuf.position(index).limit(index + bytesToCopy);
         dst.put(tmpBuf);
@@ -388,7 +388,7 @@ final class ReadOnlyByteBuffer extends AbstractBuffer {
             return EMPTY_BUFFER;
         }
         checkReadableBytes0(length);
-        Buffer buf = new ReadOnlyByteBuffer(sliceByteBuffer0(getReaderIndex(), length));
+        Buffer buf = new ReadOnlyByteBuffer(sliceByteBuffer0(readerIndex(), length));
         skipBytes0(length);
         return buf;
     }
@@ -420,17 +420,17 @@ final class ReadOnlyByteBuffer extends AbstractBuffer {
 
     @Override
     public Buffer duplicate() {
-        return new ReadOnlyByteBuffer(sliceByteBuffer0(0, getCapacity()));
+        return new ReadOnlyByteBuffer(sliceByteBuffer0(0, capacity()));
     }
 
     @Override
-    public int getNioBufferCount() {
+    public int nioBufferCount() {
         return 1;
     }
 
     @Override
     public ByteBuffer toNioBuffer() {
-        return sliceByteBuffer0(getReaderIndex(), getReadableBytes());
+        return sliceByteBuffer0(readerIndex(), readableBytes());
     }
 
     @Override
@@ -464,12 +464,12 @@ final class ReadOnlyByteBuffer extends AbstractBuffer {
     }
 
     @Override
-    public byte[] getArray() {
+    public byte[] array() {
         return buffer.array();
     }
 
     @Override
-    public int getArrayOffset() {
+    public int arrayOffset() {
         return buffer.arrayOffset();
     }
 

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/ReadOnlyByteBufferTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/ReadOnlyByteBufferTest.java
@@ -36,12 +36,12 @@ public class ReadOnlyByteBufferTest {
         assertEquals(buffer1, buffer2);
         assertEquals(expectedBuffer, buffer1.toNioBuffer());
         assertEquals(expectedBuffer, buffer2.toNioBuffer());
-        assertEquals(expectedBuffer, buffer1.toNioBuffer(buffer1.getReaderIndex(), buffer1.getWriterIndex()));
-        assertEquals(expectedBuffer, buffer2.toNioBuffer(buffer2.getReaderIndex(), buffer2.getWriterIndex()));
+        assertEquals(expectedBuffer, buffer1.toNioBuffer(buffer1.readerIndex(), buffer1.writerIndex()));
+        assertEquals(expectedBuffer, buffer2.toNioBuffer(buffer2.readerIndex(), buffer2.writerIndex()));
         assertEquals(expectedBuffer, buffer1.toNioBuffers()[0]);
         assertEquals(expectedBuffer, buffer2.toNioBuffers()[0]);
-        assertEquals(expectedBuffer, buffer1.toNioBuffers(buffer1.getReaderIndex(), buffer1.getWriterIndex())[0]);
-        assertEquals(expectedBuffer, buffer2.toNioBuffers(buffer2.getReaderIndex(), buffer2.getWriterIndex())[0]);
+        assertEquals(expectedBuffer, buffer1.toNioBuffers(buffer1.readerIndex(), buffer1.writerIndex())[0]);
+        assertEquals(expectedBuffer, buffer2.toNioBuffers(buffer2.readerIndex(), buffer2.writerIndex())[0]);
         assertEquals("testing", buffer1.toString(US_ASCII));
     }
 
@@ -51,6 +51,6 @@ public class ReadOnlyByteBufferTest {
         expectedBuffer.putLong(Long.MAX_VALUE);
         expectedBuffer.flip();
         Buffer buffer1 = DEFAULT_RO_ALLOCATOR.wrap(expectedBuffer);
-        assertEquals(Long.MAX_VALUE, buffer1.getLong(buffer1.getReaderIndex()));
+        assertEquals(Long.MAX_VALUE, buffer1.getLong(buffer1.readerIndex()));
     }
 }

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/BufferUtil.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/BufferUtil.java
@@ -64,14 +64,14 @@ public final class BufferUtil {
         ByteBuf buf = toByteBufNoThrow(buffer);
         if (buf == null) {
             if (buffer.hasArray()) {
-                ByteBuf byteBuf = Unpooled.wrappedBuffer(buffer.getArray(), buffer.getArrayOffset(), buffer.getCapacity());
-                byteBuf.readerIndex(buffer.getReaderIndex()).writerIndex(buffer.getWriterIndex());
+                ByteBuf byteBuf = Unpooled.wrappedBuffer(buffer.array(), buffer.arrayOffset(), buffer.capacity());
+                byteBuf.readerIndex(buffer.readerIndex()).writerIndex(buffer.writerIndex());
                 return byteBuf;
             } else {
-                byte[] data = new byte[buffer.getCapacity()];
+                byte[] data = new byte[buffer.capacity()];
                 buffer.getBytes(0, data, 0, data.length);
                 ByteBuf byteBuf = Unpooled.wrappedBuffer(data);
-                byteBuf.readerIndex(buffer.getReaderIndex()).writerIndex(buffer.getWriterIndex());
+                byteBuf.readerIndex(buffer.readerIndex()).writerIndex(buffer.writerIndex());
                 return byteBuf;
             }
         }

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/NettyBuffer.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/NettyBuffer.java
@@ -40,55 +40,55 @@ class NettyBuffer<T extends ByteBuf> implements Buffer {
     }
 
     @Override
-    public int getCapacity() {
+    public int capacity() {
         return buffer.capacity();
     }
 
     @Override
-    public Buffer setCapacity(int newCapacity) {
+    public Buffer capacity(int newCapacity) {
         buffer.capacity(newCapacity);
         return this;
     }
 
     @Override
-    public int getMaxCapacity() {
+    public int maxCapacity() {
         return buffer.maxCapacity();
     }
 
     @Override
-    public int getReaderIndex() {
+    public int readerIndex() {
         return buffer.readerIndex();
     }
 
     @Override
-    public Buffer setReaderIndex(int readerIndex) {
+    public Buffer readerIndex(int readerIndex) {
         buffer.readerIndex(readerIndex);
         return this;
     }
 
     @Override
-    public int getWriterIndex() {
+    public int writerIndex() {
         return buffer.writerIndex();
     }
 
     @Override
-    public Buffer setWriterIndex(int writerIndex) {
+    public Buffer writerIndex(int writerIndex) {
         buffer.writerIndex(writerIndex);
         return this;
     }
 
     @Override
-    public int getReadableBytes() {
+    public int readableBytes() {
         return buffer.readableBytes();
     }
 
     @Override
-    public int getWritableBytes() {
+    public int writableBytes() {
         return buffer.writableBytes();
     }
 
     @Override
-    public int getMaxWritableBytes() {
+    public int maxWritableBytes() {
         return buffer.maxWritableBytes();
     }
 
@@ -211,14 +211,14 @@ class NettyBuffer<T extends ByteBuf> implements Buffer {
 
     @Override
     public Buffer getBytes(int index, Buffer dst) {
-        getBytes(index, dst, dst.getWritableBytes());
+        getBytes(index, dst, dst.writableBytes());
         return this;
     }
 
     @Override
     public Buffer getBytes(int index, Buffer dst, int length) {
-        getBytes(index, dst, dst.getWriterIndex(), length);
-        dst.setWriterIndex(dst.getWriterIndex() + length);
+        getBytes(index, dst, dst.writerIndex(), length);
+        dst.writerIndex(dst.writerIndex() + length);
         return this;
     }
 
@@ -331,14 +331,14 @@ class NettyBuffer<T extends ByteBuf> implements Buffer {
 
     @Override
     public Buffer setBytes(int index, Buffer src) {
-        setBytes(index, src, src.getReadableBytes());
+        setBytes(index, src, src.readableBytes());
         return this;
     }
 
     @Override
     public Buffer setBytes(int index, Buffer src, int length) {
-        setBytes(index, src, src.getReaderIndex(), length);
-        src.setReaderIndex(src.getReaderIndex() + length);
+        setBytes(index, src, src.readerIndex(), length);
+        src.readerIndex(src.readerIndex() + length);
         return this;
     }
 
@@ -516,7 +516,7 @@ class NettyBuffer<T extends ByteBuf> implements Buffer {
 
     @Override
     public Buffer readBytes(Buffer dst, int length) {
-        readBytes(dst, dst.getReaderIndex(), length);
+        readBytes(dst, dst.readerIndex(), length);
         return this;
     }
 
@@ -636,13 +636,13 @@ class NettyBuffer<T extends ByteBuf> implements Buffer {
 
     @Override
     public Buffer writeBytes(Buffer src) {
-        writeBytes(src, src.getReadableBytes());
+        writeBytes(src, src.readableBytes());
         return this;
     }
 
     @Override
     public Buffer writeBytes(Buffer src, int length) {
-        writeBytes(src, src.getReaderIndex(), length);
+        writeBytes(src, src.readerIndex(), length);
         return this;
     }
 
@@ -747,7 +747,7 @@ class NettyBuffer<T extends ByteBuf> implements Buffer {
     }
 
     @Override
-    public int getNioBufferCount() {
+    public int nioBufferCount() {
         return buffer.nioBufferCount();
     }
 
@@ -792,12 +792,12 @@ class NettyBuffer<T extends ByteBuf> implements Buffer {
     }
 
     @Override
-    public byte[] getArray() {
+    public byte[] array() {
         return buffer.array();
     }
 
     @Override
-    public int getArrayOffset() {
+    public int arrayOffset() {
         return buffer.arrayOffset();
     }
 

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/NettyCompositeBuffer.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/NettyCompositeBuffer.java
@@ -53,20 +53,20 @@ final class NettyCompositeBuffer extends NettyBuffer<CompositeByteBuf> implement
     }
 
     @Override
-    public CompositeBuffer setCapacity(int newCapacity) {
-        super.setCapacity(newCapacity);
+    public CompositeBuffer capacity(int newCapacity) {
+        super.capacity(newCapacity);
         return this;
     }
 
     @Override
-    public CompositeBuffer setReaderIndex(int readerIndex) {
-        super.setReaderIndex(readerIndex);
+    public CompositeBuffer readerIndex(int readerIndex) {
+        super.readerIndex(readerIndex);
         return this;
     }
 
     @Override
-    public CompositeBuffer setWriterIndex(int writerIndex) {
-        super.setWriterIndex(writerIndex);
+    public CompositeBuffer writerIndex(int writerIndex) {
+        super.writerIndex(writerIndex);
         return this;
     }
 

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/ReadOnlyBuffer.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/ReadOnlyBuffer.java
@@ -56,48 +56,48 @@ final class ReadOnlyBuffer extends WrappedBuffer {
     }
 
     @Override
-    public byte[] getArray() {
+    public byte[] array() {
         throw new ReadOnlyBufferException();
     }
 
     @Override
-    public int getArrayOffset() {
+    public int arrayOffset() {
         throw new ReadOnlyBufferException();
     }
 
     @Override
-    public int getWritableBytes() {
+    public int writableBytes() {
         return 0;
     }
 
     @Override
-    public int getMaxWritableBytes() {
+    public int maxWritableBytes() {
         return 0;
     }
 
     @Override
-    public int getWriterIndex() {
-        return getReaderIndex();
+    public int writerIndex() {
+        return readerIndex();
     }
 
     @Override
-    public Buffer setWriterIndex(int writerIndex) {
+    public Buffer writerIndex(int writerIndex) {
         throw new ReadOnlyBufferException();
     }
 
     @Override
-    public Buffer setCapacity(int newCapacity) {
+    public Buffer capacity(int newCapacity) {
         throw new ReadOnlyBufferException();
     }
 
     @Override
-    public int getCapacity() {
-        return getWriterIndex();
+    public int capacity() {
+        return writerIndex();
     }
 
     @Override
-    public int getMaxCapacity() {
-        return getCapacity();
+    public int maxCapacity() {
+        return capacity();
     }
 
     @Override

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/WrappedBuffer.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/WrappedBuffer.java
@@ -34,56 +34,56 @@ class WrappedBuffer implements Buffer {
     }
 
     @Override
-    public int getCapacity() {
-        return buffer.getCapacity();
+    public int capacity() {
+        return buffer.capacity();
     }
 
     @Override
-    public Buffer setCapacity(int newCapacity) {
-        buffer.setCapacity(newCapacity);
+    public Buffer capacity(int newCapacity) {
+        buffer.capacity(newCapacity);
         return this;
     }
 
     @Override
-    public int getMaxCapacity() {
-        return buffer.getMaxCapacity();
+    public int maxCapacity() {
+        return buffer.maxCapacity();
     }
 
     @Override
-    public int getReaderIndex() {
-        return buffer.getReaderIndex();
+    public int readerIndex() {
+        return buffer.readerIndex();
     }
 
     @Override
-    public Buffer setReaderIndex(int readerIndex) {
-        buffer.setReaderIndex(readerIndex);
+    public Buffer readerIndex(int readerIndex) {
+        buffer.readerIndex(readerIndex);
         return this;
     }
 
     @Override
-    public int getWriterIndex() {
-        return buffer.getWriterIndex();
+    public int writerIndex() {
+        return buffer.writerIndex();
     }
 
     @Override
-    public Buffer setWriterIndex(int writerIndex) {
-        buffer.setWriterIndex(writerIndex);
+    public Buffer writerIndex(int writerIndex) {
+        buffer.writerIndex(writerIndex);
         return this;
     }
 
     @Override
-    public int getReadableBytes() {
-        return buffer.getReadableBytes();
+    public int readableBytes() {
+        return buffer.readableBytes();
     }
 
     @Override
-    public int getWritableBytes() {
-        return buffer.getWritableBytes();
+    public int writableBytes() {
+        return buffer.writableBytes();
     }
 
     @Override
-    public int getMaxWritableBytes() {
-        return buffer.getMaxWritableBytes();
+    public int maxWritableBytes() {
+        return buffer.maxWritableBytes();
     }
 
     @Override
@@ -698,8 +698,8 @@ class WrappedBuffer implements Buffer {
     }
 
     @Override
-    public int getNioBufferCount() {
-        return buffer.getNioBufferCount();
+    public int nioBufferCount() {
+        return buffer.nioBufferCount();
     }
 
     @Override
@@ -743,13 +743,13 @@ class WrappedBuffer implements Buffer {
     }
 
     @Override
-    public byte[] getArray() {
-        return buffer.getArray();
+    public byte[] array() {
+        return buffer.array();
     }
 
     @Override
-    public int getArrayOffset() {
-        return buffer.getArrayOffset();
+    public int arrayOffset() {
+        return buffer.arrayOffset();
     }
 
     @Override

--- a/servicetalk-data-jackson/src/main/java/io/servicetalk/data/jackson/ByteArrayJacksonDeserializer.java
+++ b/servicetalk-data-jackson/src/main/java/io/servicetalk/data/jackson/ByteArrayJacksonDeserializer.java
@@ -39,10 +39,10 @@ final class ByteArrayJacksonDeserializer<T> extends AbstractJacksonDeserializer<
     @Nonnull
     Iterable<T> doDeserialize(final Buffer buffer, @Nullable List<T> resultHolder) throws IOException {
         if (buffer.hasArray()) {
-            feeder.feedInput(buffer.getArray(), buffer.getArrayOffset(),
-                    buffer.getArrayOffset() + buffer.getReadableBytes());
+            feeder.feedInput(buffer.array(), buffer.arrayOffset(),
+                    buffer.arrayOffset() + buffer.readableBytes());
         } else {
-            int readableBytes = buffer.getReadableBytes();
+            int readableBytes = buffer.readableBytes();
             if (readableBytes != 0) {
                 byte[] copy = new byte[readableBytes];
                 buffer.readBytes(copy);

--- a/servicetalk-data-jackson/src/test/java/io/servicetalk/data/jackson/JacksonSerializationProviderTest.java
+++ b/servicetalk-data-jackson/src/test/java/io/servicetalk/data/jackson/JacksonSerializationProviderTest.java
@@ -90,7 +90,7 @@ public class JacksonSerializationProviderTest {
         TestPojo expected = new TestPojo(true, (byte) -2, (short) -3, 'a', 2, 5, 3.2f, -8.5, null, new String[] {"bar"},
                 null);
         final Buffer serialized = serializePojo(expected);
-        serialized.setByte(serialized.getWriterIndex() - 1, serialized.getByte(serialized.getWriterIndex() - 1) + 1);
+        serialized.setByte(serialized.writerIndex() - 1, serialized.getByte(serialized.writerIndex() - 1) + 1);
 
         final StreamingDeserializer<TestPojo> deserializer = serializationProvider.getDeserializer(TestPojo.class);
         try {
@@ -153,7 +153,7 @@ public class JacksonSerializationProviderTest {
         final Buffer buffer1 = serializePojo(expected1);
         final Buffer buffer2 = serializePojo(expected2);
 
-        Buffer composite = DEFAULT_ALLOCATOR.newBuffer(buffer1.getReadableBytes() + buffer2.getReadableBytes());
+        Buffer composite = DEFAULT_ALLOCATOR.newBuffer(buffer1.readableBytes() + buffer2.readableBytes());
         composite.writeBytes(buffer1).writeBytes(buffer2);
 
         final StreamingDeserializer<TestPojo> deserializer = serializationProvider.getDeserializer(TestPojo.class);
@@ -193,7 +193,7 @@ public class JacksonSerializationProviderTest {
                 null);
         final Buffer buffer = serializePojo(expected);
         final StreamingDeserializer<TestPojo> deSerializer = serializationProvider.getDeserializer(TestPojo.class);
-        deSerializer.deserialize(buffer.readBytes(buffer.getReadableBytes() - 1));
+        deSerializer.deserialize(buffer.readBytes(buffer.readableBytes() - 1));
         try {
             deSerializer.close();
             fail();
@@ -249,10 +249,10 @@ public class JacksonSerializationProviderTest {
 
     private void deserializeChunks(final TestPojo expected1, final Buffer req1Buffer,
                                    final StreamingDeserializer<TestPojo> deSerializer) {
-        for (int i = req1Buffer.getReaderIndex(); i < req1Buffer.getWriterIndex(); ++i) {
+        for (int i = req1Buffer.readerIndex(); i < req1Buffer.writerIndex(); ++i) {
             Buffer buffer = DEFAULT_ALLOCATOR.newBuffer(1).writeByte(req1Buffer.getByte(i));
             final Iterator<TestPojo> iter = deSerializer.deserialize(buffer).iterator();
-            if (i == req1Buffer.getWriterIndex() - 1) {
+            if (i == req1Buffer.writerIndex() - 1) {
                 assertTrue(iter.hasNext());
                 assertEquals(expected1, iter.next());
             } else {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AsciiBuffer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AsciiBuffer.java
@@ -57,7 +57,7 @@ final class AsciiBuffer implements CharSequence {
 
     @Override
     public int length() {
-        return buffer.getReadableBytes();
+        return buffer.readableBytes();
     }
 
     @Override
@@ -79,7 +79,7 @@ final class AsciiBuffer implements CharSequence {
     public int hashCode() {
         int h = hash;
         if (h == 0) {
-            hash = h = hashCodeAscii(buffer, buffer.getReaderIndex(), buffer.getReadableBytes());
+            hash = h = hashCodeAscii(buffer, buffer.readerIndex(), buffer.readableBytes());
         }
         return h;
     }
@@ -118,7 +118,7 @@ final class AsciiBuffer implements CharSequence {
      * @throws NullPointerException if {@code subString} is {@code null}.
      */
     int indexOf(char ch, int start) {
-        return buffer.indexOf(start, buffer.getWriterIndex(), (byte) ch);
+        return buffer.indexOf(start, buffer.writerIndex(), (byte) ch);
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpProtocolVersion.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpProtocolVersion.java
@@ -43,21 +43,21 @@ final class DefaultHttpProtocolVersion implements HttpProtocolVersion {
     DefaultHttpProtocolVersion(final Buffer httpVersion) {
         // We could delay the parsing of major/minor but this is currently used during decode to validate the
         // correct form of the request.
-        if (httpVersion.getReadableBytes() < 8) {
+        if (httpVersion.readableBytes() < 8) {
             throw new IllegalArgumentException("Incorrect httpVersion: " + httpVersion.toString(US_ASCII) +
                     ". Too small, expected 8 or more bytes.");
         }
-        if (httpVersion.getByte(httpVersion.getReaderIndex() + 6) != (byte) '.') {
-            char ch = (char) httpVersion.getByte(httpVersion.getReaderIndex() + 6);
+        if (httpVersion.getByte(httpVersion.readerIndex() + 6) != (byte) '.') {
+            char ch = (char) httpVersion.getByte(httpVersion.readerIndex() + 6);
             throw new IllegalArgumentException("Incorrect httpVersion: " + httpVersion.toString(US_ASCII) +
                     ". Invalid character found '" + ch + "' at position 6 (expected '.')");
         }
-        this.major = httpVersion.getByte(httpVersion.getReaderIndex() + 5) - '0';
+        this.major = httpVersion.getByte(httpVersion.readerIndex() + 5) - '0';
         if (major < 0 || major > 9) {
             throw new IllegalArgumentException("Incorrect httpVersion: " + httpVersion.toString(US_ASCII) +
                     ". Illegal major version: " + major + ", (expected [0-9])");
         }
-        this.minor = httpVersion.getByte(httpVersion.getReaderIndex() + 7) - '0';
+        this.minor = httpVersion.getByte(httpVersion.readerIndex() + 7) - '0';
         if (minor < 0 || minor > 9) {
             throw new IllegalArgumentException("Incorrect httpVersion: " + httpVersion.toString(US_ASCII) +
                     ". Illegal minor version: " + minor + ", (expected [0-9])");
@@ -77,7 +77,7 @@ final class DefaultHttpProtocolVersion implements HttpProtocolVersion {
 
     @Override
     public void writeHttpVersionTo(final Buffer buffer) {
-        buffer.writeBytes(httpVersion, httpVersion.getReaderIndex(), httpVersion.getReadableBytes());
+        buffer.writeBytes(httpVersion, httpVersion.readerIndex(), httpVersion.readableBytes());
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequestMethod.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequestMethod.java
@@ -39,7 +39,7 @@ final class DefaultHttpRequestMethod implements HttpRequestMethod {
 
     @Override
     public void writeNameTo(final Buffer buffer) {
-        buffer.writeBytes(name, name.getReaderIndex(), name.getReadableBytes());
+        buffer.writeBytes(name, name.readerIndex(), name.readableBytes());
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponseStatus.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponseStatus.java
@@ -46,12 +46,12 @@ final class DefaultHttpResponseStatus implements HttpResponseStatus {
 
     @Override
     public void writeCodeTo(final Buffer buffer) {
-        buffer.writeBytes(statusCodeBuffer, statusCodeBuffer.getReaderIndex(), statusCodeBuffer.getReadableBytes());
+        buffer.writeBytes(statusCodeBuffer, statusCodeBuffer.readerIndex(), statusCodeBuffer.readableBytes());
     }
 
     @Override
     public void writeReasonPhraseTo(final Buffer buffer) {
-        buffer.writeBytes(reasonPhrase, reasonPhrase.getReaderIndex(), reasonPhrase.getReadableBytes());
+        buffer.writeBytes(reasonPhrase, reasonPhrase.readerIndex(), reasonPhrase.readableBytes());
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpProtocolVersions.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpProtocolVersions.java
@@ -77,7 +77,7 @@ public enum HttpProtocolVersions implements HttpProtocolVersion {
 
     @Override
     public void writeHttpVersionTo(final Buffer buffer) {
-        buffer.writeBytes(httpVersion, httpVersion.getReaderIndex(), httpVersion.getReadableBytes());
+        buffer.writeBytes(httpVersion, httpVersion.readerIndex(), httpVersion.readableBytes());
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMethods.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMethods.java
@@ -61,7 +61,7 @@ public enum HttpRequestMethods implements HttpRequestMethod {
 
     @Override
     public void writeNameTo(final Buffer buffer) {
-        buffer.writeBytes(methodName, methodName.getReaderIndex(), methodName.getReadableBytes());
+        buffer.writeBytes(methodName, methodName.readerIndex(), methodName.readableBytes());
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponseStatuses.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponseStatuses.java
@@ -338,12 +338,12 @@ public enum HttpResponseStatuses implements HttpResponseStatus {
 
     @Override
     public void writeCodeTo(final Buffer buffer) {
-        buffer.writeBytes(statusCodeBuffer, statusCodeBuffer.getReaderIndex(), statusCodeBuffer.getReadableBytes());
+        buffer.writeBytes(statusCodeBuffer, statusCodeBuffer.readerIndex(), statusCodeBuffer.readableBytes());
     }
 
     @Override
     public void writeReasonPhraseTo(final Buffer buffer) {
-        buffer.writeBytes(reasonPhrase, reasonPhrase.getReaderIndex(), reasonPhrase.getReadableBytes());
+        buffer.writeBytes(reasonPhrase, reasonPhrase.readerIndex(), reasonPhrase.readableBytes());
     }
 
     /**
@@ -360,7 +360,7 @@ public enum HttpResponseStatuses implements HttpResponseStatus {
     public static HttpResponseStatus getResponseStatus(final int statusCode, final Buffer reasonPhrase) {
         final HttpResponseStatuses responseStatus = valueOf(statusCode);
         if (responseStatus != null &&
-                (reasonPhrase.getReadableBytes() == 0 || responseStatus.reasonPhrase.equals(reasonPhrase))) {
+                (reasonPhrase.readableBytes() == 0 || responseStatus.reasonPhrase.equals(reasonPhrase))) {
             return responseStatus;
         }
         return new DefaultHttpResponseStatus(statusCode, reasonPhrase);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectEncoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectEncoder.java
@@ -145,7 +145,7 @@ abstract class HttpObjectEncoder<T extends HttpMetaData> extends ChannelOutbound
             ctx.write(byteBuf, promise);
         } else if (msg instanceof Buffer) {
             final Buffer stBuffer = (Buffer) msg;
-            if (stBuffer.getReadableBytes() == 0) {
+            if (stBuffer.readableBytes() == 0) {
                 // Bypass the encoder in case of an empty buffer, so that the following idiom works:
                 //
                 //     ch.write(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
@@ -324,7 +324,7 @@ abstract class HttpObjectEncoder<T extends HttpMetaData> extends ChannelOutbound
 
     private static long contentLength(Buffer msg) {
         // TODO(scott): add support for file region
-        return msg.getReadableBytes();
+        return msg.readableBytes();
     }
 
     private static ByteBuf encodeAndRetain(Buffer msg) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -218,7 +218,7 @@ public abstract class AbstractNettyHttpServerTest {
         assertEquals(version, response.version());
 
         final int size = awaitIndefinitelyNonNull(
-                response.payloadBody().reduce(() -> 0, (is, c) -> is + c.getReadableBytes()));
+                response.payloadBody().reduce(() -> 0, (is, c) -> is + c.readableBytes()));
         assertEquals(expectedSize, size);
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionEmptyPayloadTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionEmptyPayloadTest.java
@@ -105,7 +105,7 @@ public class HttpConnectionEmptyPayloadTest {
             Buffer buffer = awaitIndefinitelyNonNull(response.payloadBody().reduce(
                     () -> connection.connectionContext().executionContext().bufferAllocator().newBuffer(),
                     Buffer::writeBytes));
-            byte[] actualBytes = new byte[buffer.getReadableBytes()];
+            byte[] actualBytes = new byte[buffer.readableBytes()];
             buffer.readBytes(actualBytes);
             assertArrayEquals(expectedPayload, actualBytes);
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
@@ -355,7 +355,7 @@ public class HttpRequestDecoderTest {
         if (expectedContentLength >= 0) {
             assertSingleHeaderValue(request.headers(), CONTENT_LENGTH, String.valueOf(expectedContentLength));
             Buffer chunk = channel.readInbound();
-            assertEquals(expectedContentLength, chunk.getReadableBytes());
+            assertEquals(expectedContentLength, chunk.readableBytes());
             HttpHeaders trailers = channel.readInbound();
             assertTrue(trailers.isEmpty());
         } else {
@@ -369,7 +369,7 @@ public class HttpRequestDecoderTest {
                     break;
                 }
             }
-            assertEquals(-expectedContentLength, actual.getReadableBytes());
+            assertEquals(-expectedContentLength, actual.readableBytes());
             HttpHeaders lastChunk = (HttpHeaders) chunk;
             if (containsTrailers) {
                 assertSingleHeaderValue(lastChunk, "TrailerStatus", "good");

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -178,7 +178,7 @@ public class HttpRequestEncoderTest {
         assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains(
                 "  " + USER_AGENT + "   :     unit-test   " + "\r\n"));
         assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains(
-                CONTENT_LENGTH + ": " + valueOf(buffer.getReadableBytes()) + "\r\n"));
+                CONTENT_LENGTH + ": " + valueOf(buffer.readableBytes()) + "\r\n"));
         assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.endsWith("\r\n" + "\r\n"));
         byteBuf = channel.readOutbound();
         assertEquals(buffer.toNioBuffer(), byteBuf.nioBuffer());
@@ -339,9 +339,9 @@ public class HttpRequestEncoderTest {
             case Chunked:
                 assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains(
                         TRANSFER_ENCODING + ": " + CHUNKED + "\r\n"));
-                if (buffer.getReadableBytes() != 0) {
+                if (buffer.readableBytes() != 0) {
                     byteBuf = channel.readOutbound();
-                    assertEquals(toHexString(buffer.getReadableBytes()) + "\r\n", byteBuf.toString(US_ASCII));
+                    assertEquals(toHexString(buffer.readableBytes()) + "\r\n", byteBuf.toString(US_ASCII));
                     byteBuf.release();
 
                     byteBuf = channel.readOutbound();
@@ -369,7 +369,7 @@ public class HttpRequestEncoderTest {
                 break;
             case ContentLength:
                 assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains(
-                        CONTENT_LENGTH + ": " + valueOf(buffer.getReadableBytes()) + "\r\n"));
+                        CONTENT_LENGTH + ": " + valueOf(buffer.readableBytes()) + "\r\n"));
                 byteBuf = channel.readOutbound();
                 assertEquals(buffer.toNioBuffer(), byteBuf.nioBuffer());
                 consumeEmptyBufferFromTrailers(channel);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
@@ -342,7 +342,7 @@ public class HttpResponseDecoderTest {
         if (expectedContentLength >= 0) {
             assertSingleHeaderValue(response.headers(), CONTENT_LENGTH, String.valueOf(expectedContentLength));
             Buffer chunk = channel.readInbound();
-            assertEquals(expectedContentLength, chunk.getReadableBytes());
+            assertEquals(expectedContentLength, chunk.readableBytes());
             HttpHeaders trailers = channel.readInbound();
             assertTrue(trailers.isEmpty());
         } else {
@@ -356,7 +356,7 @@ public class HttpResponseDecoderTest {
                     break;
                 }
             }
-            assertEquals(-expectedContentLength, actual.getReadableBytes());
+            assertEquals(-expectedContentLength, actual.readableBytes());
             HttpHeaders lastChunk = (HttpHeaders) chunk;
             if (containsTrailers) {
                 assertSingleHeaderValue(lastChunk, "TrailerStatus", "good");

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseEncoderTest.java
@@ -106,7 +106,7 @@ public class HttpResponseEncoderTest {
         assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains("HTTP/1.1 200 OK" + "\r\n"));
         assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains(" " + CONNECTION + " :  " + KEEP_ALIVE + "\r\n"));
         assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains("  " + SERVER + "   :     unit-test   " + "\r\n"));
-        assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains(CONTENT_LENGTH + ": " + valueOf(buffer.getReadableBytes()) + "\r\n"));
+        assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains(CONTENT_LENGTH + ": " + valueOf(buffer.readableBytes()) + "\r\n"));
         assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.endsWith("\r\n" + "\r\n"));
         byteBuf = channel.readOutbound();
         assertEquals(buffer.toNioBuffer(), byteBuf.nioBuffer());
@@ -255,9 +255,9 @@ public class HttpResponseEncoderTest {
         switch (encoding) {
             case Chunked:
                 assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains(TRANSFER_ENCODING + ": " + CHUNKED + "\r\n"));
-                if (buffer.getReadableBytes() != 0) {
+                if (buffer.readableBytes() != 0) {
                     byteBuf = channel.readOutbound();
-                    assertEquals(toHexString(buffer.getReadableBytes()) + "\r\n", byteBuf.toString(US_ASCII));
+                    assertEquals(toHexString(buffer.readableBytes()) + "\r\n", byteBuf.toString(US_ASCII));
                     byteBuf.release();
 
                     byteBuf = channel.readOutbound();
@@ -284,7 +284,7 @@ public class HttpResponseEncoderTest {
                 }
                 break;
             case ContentLength:
-                assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains(CONTENT_LENGTH + ": " + valueOf(buffer.getReadableBytes()) + "\r\n"));
+                assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains(CONTENT_LENGTH + ": " + valueOf(buffer.readableBytes()) + "\r\n"));
                 byteBuf = channel.readOutbound();
                 assertEquals(buffer.toNioBuffer(), byteBuf.nioBuffer());
                 consumeEmptyBufferFromTrailers(channel);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TestServiceStreaming.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TestServiceStreaming.java
@@ -162,7 +162,7 @@ final class TestServiceStreaming extends StreamingHttpService {
                                                    final StreamingHttpResponseFactory factory) {
         final Publisher<Buffer> responseBody = req.payloadBody().map(buffer -> {
             // Do an ASCII-only ROT13
-            for (int i = buffer.getReaderIndex(); i < buffer.getWriterIndex(); i++) {
+            for (int i = buffer.readerIndex(); i < buffer.writerIndex(); i++) {
                 final byte c = buffer.getByte(i);
                 if (c >= 'a' && c <= 'm' || c >= 'A' && c <= 'M') {
                     buffer.setByte(i, c + 13);

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/BufferMessageBodyReaderWriter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/BufferMessageBodyReaderWriter.java
@@ -118,7 +118,7 @@ final class BufferMessageBodyReaderWriter implements MessageBodyReader<Buffer>, 
                         final MediaType mediaType,
                         final MultivaluedMap<String, Object> httpHeaders,
                         final OutputStream entityStream) {
-        httpHeaders.putSingle(CONTENT_LENGTH, buffer.getReadableBytes());
+        httpHeaders.putSingle(CONTENT_LENGTH, buffer.readableBytes());
         setResponseBufferPublisher(Publisher.from(buffer), requestCtxProvider.get());
     }
 }

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/BufferPublisherInputStream.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/BufferPublisherInputStream.java
@@ -148,14 +148,14 @@ public final class BufferPublisherInputStream extends InputStream {
 
     @Nullable
     private static byte[] getBytes(final Buffer content) {
-        final int readableBytes = content.getReadableBytes();
+        final int readableBytes = content.readableBytes();
 
         if (readableBytes == 0) {
             return null;
         }
 
-        if (content.hasArray() && content.getArrayOffset() == 0 && content.getArray().length == readableBytes) {
-            return content.getArray();
+        if (content.hasArray() && content.arrayOffset() == 0 && content.array().length == readableBytes) {
+            return content.array();
         }
 
         final byte[] bytes = new byte[readableBytes];

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractFilterInterceptorTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractFilterInterceptorTest.java
@@ -329,10 +329,10 @@ public abstract class AbstractFilterInterceptorTest extends AbstractJerseyStream
     }
 
     private static Buffer oTo0(final Buffer buf) {
-        for (int i = 0; i < buf.getReadableBytes(); i++) {
-            final byte b = buf.getByte(buf.getReaderIndex() + i);
+        for (int i = 0; i < buf.readableBytes(); i++) {
+            final byte b = buf.getByte(buf.readerIndex() + i);
             if (b == 'o' || b == 'O') {
-                buf.setByte(buf.getReaderIndex() + i, '0');
+                buf.setByte(buf.readerIndex() + i, '0');
             }
         }
         return buf;

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractJerseyStreamingHttpServiceTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractJerseyStreamingHttpServiceTest.java
@@ -178,7 +178,7 @@ public abstract class AbstractJerseyStreamingHttpServiceTest {
         final StreamingHttpRequest req = httpClient.newRequest(method, testUri(path)).payloadBody(just(content));
         req.headers().set(HOST, host());
         req.headers().set(CONTENT_TYPE, contentType);
-        req.headers().set(CONTENT_LENGTH, Integer.toString(content.getReadableBytes()));
+        req.headers().set(CONTENT_LENGTH, Integer.toString(content.readableBytes()));
         return req;
     }
 

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/ExceptionMapperTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/ExceptionMapperTest.java
@@ -78,7 +78,7 @@ public class ExceptionMapperTest extends AbstractJerseyStreamingHttpServiceTest 
                 final Buffer buf = DEFAULT_ALLOCATOR.fromAscii(exception.getClass().getName());
                 return status(555)
                         .header(CONTENT_TYPE, TEXT_PLAIN)
-                        .header(CONTENT_LENGTH, buf.getReadableBytes())
+                        .header(CONTENT_LENGTH, buf.readableBytes())
                         .entity(buf)
                         .build();
             }
@@ -89,7 +89,7 @@ public class ExceptionMapperTest extends AbstractJerseyStreamingHttpServiceTest 
                 final Buffer buf = DEFAULT_ALLOCATOR.fromAscii(exception.getClass().getName());
                 return status(555)
                         .header(CONTENT_TYPE, TEXT_PLAIN)
-                        .header(CONTENT_LENGTH, buf.getReadableBytes())
+                        .header(CONTENT_LENGTH, buf.readableBytes())
                         .entity(new GenericEntity<Single<Buffer>>(success(buf)) { })
                         .build();
             }

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisData.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisData.java
@@ -228,7 +228,7 @@ public interface RedisData {
 
         @Override
         public Buffer toRESPArgument(final BufferAllocator allocator) {
-            return allocator.newBuffer(getValue().getReadableBytes() + EOL_LENGTH)
+            return allocator.newBuffer(getValue().readableBytes() + EOL_LENGTH)
                     .writeBytes(getValue())
                     .writeShort(EOL_SHORT);
         }

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisRequesterUtils.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisRequesterUtils.java
@@ -171,7 +171,7 @@ final class RedisRequesterUtils {
                         }
                         aggregator.writeUtf8(redisData.getCharSequenceValue());
                     } else if (redisData instanceof RedisData.BulkStringChunk) {
-                        int redisDataBytes = redisData.getBufferValue().getReadableBytes();
+                        int redisDataBytes = redisData.getBufferValue().readableBytes();
                         if (!aggregator.tryEnsureWritable(redisDataBytes, false)) {
                             reallocateAggregator(redisDataBytes);
                         }
@@ -199,7 +199,7 @@ final class RedisRequesterUtils {
                 private void reallocateAggregator(int extraBytes) {
                     assert aggregator != null;
                     aggregator = requester.executionContext().bufferAllocator()
-                            .newBuffer(extraBytes + aggregator.getReadableBytes()).writeBytes(aggregator);
+                            .newBuffer(extraBytes + aggregator.readableBytes()).writeBytes(aggregator);
                 }
             });
         }
@@ -304,7 +304,7 @@ final class RedisRequesterUtils {
                     } else if (RedisData.BulkStringChunk.class.equals(redisData.getClass())) {
                         if (aggregator == null) {
                             aggregator = redisData.getBufferValue();
-                            if (!aggregator.tryEnsureWritable(bulkStringSize - aggregator.getReadableBytes(), false)) {
+                            if (!aggregator.tryEnsureWritable(bulkStringSize - aggregator.readableBytes(), false)) {
                                 aggregator = requester.executionContext().bufferAllocator()
                                         .newBuffer(bulkStringSize).writeBytes(aggregator);
                             }

--- a/servicetalk-redis-internal/src/main/java/io/servicetalk/redis/internal/RedisUtils.java
+++ b/servicetalk-redis-internal/src/main/java/io/servicetalk/redis/internal/RedisUtils.java
@@ -63,7 +63,7 @@ public final class RedisUtils {
      * @return {@link Buffer} containing the array size.
      */
     public static Buffer toRespBulkString(final Buffer buf, final BufferAllocator allocator) {
-        final byte[] size = toAsciiBytes(buf.getReadableBytes());
+        final byte[] size = toAsciiBytes(buf.readableBytes());
         return allocator.newBuffer(1 + size.length + TWICE_EOL_LENGTH)
                 .writeByte('$')
                 .writeBytes(size)

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/SubscribedChannelReadStream.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/SubscribedChannelReadStream.java
@@ -296,7 +296,7 @@ final class SubscribedChannelReadStream extends Publisher<SubscribedChannelReadS
             }
 
             if (data instanceof CompleteRedisData) {
-                if (currentDataBuffer != null && currentDataBuffer.getReadableBytes() > 0) {
+                if (currentDataBuffer != null && currentDataBuffer.readableBytes() > 0) {
                     throw new IllegalStateException("Incomplete buffer exists " + currentDataBuffer.toString(defaultCharset())
                             + " but got " + data.getClass().getSimpleName() + ", current state: " + aggregationState);
                 }

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BaseRedisClientTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BaseRedisClientTest.java
@@ -72,7 +72,7 @@ public abstract class BaseRedisClientTest {
             @Override
             public boolean matches(final Object argument) {
                 return argument instanceof Buffer &&
-                        ((Buffer) argument).slice(0, buf.getReadableBytes()).equals(buf);
+                        ((Buffer) argument).slice(0, buf.readableBytes()).equals(buf);
             }
 
             @Override

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BlockingBufferRedisCommanderTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BlockingBufferRedisCommanderTest.java
@@ -200,7 +200,7 @@ public class BlockingBufferRedisCommanderTest extends BaseRedisClientTest {
 
     @Test
     public void infoWithAggregationDoesNotThrow() throws Exception {
-        assertThat(commandClient.info().getReadableBytes(), is(greaterThan(0)));
+        assertThat(commandClient.info().readableBytes(), is(greaterThan(0)));
     }
 
     @SuppressWarnings("unchecked")

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BufferRedisCommanderTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BufferRedisCommanderTest.java
@@ -201,7 +201,7 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
 
     @Test
     public void infoWithAggregationDoesNotThrow() throws ExecutionException, InterruptedException {
-        assertThat(awaitIndefinitely(commandClient.info()).getReadableBytes(), is(greaterThan(0)));
+        assertThat(awaitIndefinitely(commandClient.info()).readableBytes(), is(greaterThan(0)));
     }
 
     @SuppressWarnings("unchecked")

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BufferHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BufferHandler.java
@@ -70,7 +70,7 @@ public final class BufferHandler extends RefCountedTrapper {
         if (msg instanceof Buffer) {
             ctx.write(extractByteBufOrCreate((Buffer) msg), promise);
         } else if (msg instanceof BufferHolder) {
-            ctx.write(extractByteBufOrCreate(((BufferHolder) msg).getContent()), promise);
+            ctx.write(extractByteBufOrCreate(((BufferHolder) msg).content()), promise);
         } else {
             ctx.write(msg, promise);
         }


### PR DESCRIPTION
Motivation:
We have been removing get/set prefixes from accessors/modifiers, but have not yet updated Buffer.

Modifications:
- Remove get/set prefixes from accessors/modifiers in Buffer with the exception of getting/setting data of primitive types or bulk byte operations. The get/set prefix has a special semantic meaning where the indexes are not advanced (as opposed to read/write).

Result:
More consistent get/set usage in Buffer.