### PR TITLE
Predicate router should allow handlers to be added.

### DIFF
--- a/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilder.java
+++ b/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilder.java
@@ -18,6 +18,7 @@ package io.servicetalk.http.router.predicate;
 import io.servicetalk.http.api.HttpCookie;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequestHandler;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.router.predicate.dsl.CookieMatcher;
 import io.servicetalk.http.router.predicate.dsl.RouteContinuation;
@@ -236,9 +237,9 @@ public final class HttpPredicateRouterBuilder implements RouteStarter {
         }
 
         @Override
-        public RouteStarter thenRouteTo(final StreamingHttpService service) {
+        public RouteStarter thenRouteTo(final StreamingHttpRequestHandler handler) {
             assert predicate != null;
-            predicateServicePairs.add(new PredicateServicePair(predicate, service));
+            predicateServicePairs.add(new PredicateServicePair(predicate, handler.asStreamingService()));
             predicate = null;
             return HttpPredicateRouterBuilder.this;
         }

--- a/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/dsl/RouteContinuation.java
+++ b/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/dsl/RouteContinuation.java
@@ -15,12 +15,16 @@
  */
 package io.servicetalk.http.router.predicate.dsl;
 
+import io.servicetalk.http.api.BlockingHttpRequestHandler;
 import io.servicetalk.http.api.BlockingHttpService;
+import io.servicetalk.http.api.BlockingStreamingHttpRequestHandler;
 import io.servicetalk.http.api.BlockingStreamingHttpService;
 import io.servicetalk.http.api.HttpCookie;
+import io.servicetalk.http.api.HttpRequestHandler;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.HttpService;
 import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequestHandler;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.transport.api.ConnectionContext;
 
@@ -153,21 +157,21 @@ public interface RouteContinuation {
      * Completes the route by specifying the {@link StreamingHttpService} to route requests to that match the previously
      * specified criteria. Each call to {@code thenRouteTo} resets the criteria, prior to building the next route.
      *
-     * @param service the {@link StreamingHttpService} to route requests to.
+     * @param handler the {@link StreamingHttpRequestHandler} to route requests to.
      * @return {@link RouteStarter} for building another route.
      */
-    RouteStarter thenRouteTo(StreamingHttpService service);
+    RouteStarter thenRouteTo(StreamingHttpRequestHandler handler);
 
     /**
      * Completes the route by specifying the {@link HttpService} to route requests to that match the
      * previously specified criteria. Each call to {@code thenRouteTo} resets the criteria, prior to building the next
      * route.
      *
-     * @param service the {@link HttpService} to route requests to.
+     * @param handler the {@link HttpRequestHandler} to route requests to.
      * @return {@link RouteStarter} for building another route.
      */
-    default RouteStarter thenRouteTo(HttpService service) {
-        return thenRouteTo(service.asStreamingService());
+    default RouteStarter thenRouteTo(HttpRequestHandler handler) {
+        return thenRouteTo(handler.asService().asStreamingService());
     }
 
     /**
@@ -175,21 +179,21 @@ public interface RouteContinuation {
      * previously specified criteria. Each call to {@code thenRouteTo} resets the criteria, prior to building the next
      * route.
      *
-     * @param service the {@link BlockingHttpService} to route requests to.
+     * @param handler the {@link BlockingHttpRequestHandler} to route requests to.
      * @return {@link RouteStarter} for building another route.
      */
-    default RouteStarter thenRouteTo(BlockingHttpService service) {
-        return thenRouteTo(service.asStreamingService());
+    default RouteStarter thenRouteTo(BlockingHttpRequestHandler handler) {
+        return thenRouteTo(handler.asBlockingService().asStreamingService());
     }
 
     /**
      * Completes the route by specifying the {@link BlockingStreamingHttpService} to route requests to that match the previously
      * specified criteria. Each call to {@code thenRouteTo} resets the criteria, prior to building the next route.
      *
-     * @param service the {@link BlockingStreamingHttpService} to route requests to.
+     * @param handler the {@link BlockingStreamingHttpRequestHandler} to route requests to.
      * @return {@link RouteStarter} for building another route.
      */
-    default RouteStarter thenRouteTo(BlockingStreamingHttpService service) {
-        return thenRouteTo(service.asStreamingService());
+    default RouteStarter thenRouteTo(BlockingStreamingHttpRequestHandler handler) {
+        return thenRouteTo(handler.asBlockingStreamingService().asStreamingService());
     }
 }


### PR DESCRIPTION
__Motivation__

We added `*RequestHandler` interfaces to be used as lambdas in place of the broader `*HttpService` APIs.
Predicate router should use these interfaces also.

__Modification__

Use `*RequestHandler` instead of `*HttpService` as routes.

__Result__

Predicate router can use `*RequestHandler`