### PR TITLE
Update to netty 4.1.30.Final

### DIFF
--- a/servicetalk-bom-internal/gradle.properties
+++ b/servicetalk-bom-internal/gradle.properties
@@ -17,7 +17,7 @@
 group=io.servicetalk
 version=0.4.0-SNAPSHOT
 
-nettyVersion=4.1.29.Final
+nettyVersion=4.1.30.Final
 jsr305Version=3.0.2
 
 log4jVersion=2.11.0


### PR DESCRIPTION
Motivation:

Netty 4.1.30.Final was released with bug-fixes and performance improvements.

Modifications:

Bump up netty version.

Result:

Use latest stable release.