### PR TITLE
Fix synchronous resubscribe on NettyChannelPublisher

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
@@ -129,7 +129,7 @@ final class NettyChannelPublisher<T> extends Publisher<T> {
 
     // All private methods MUST be invoked from the eventloop.
 
-    void requestN(long n, SubscriptionImpl forSubscription) {
+    private void requestN(long n, SubscriptionImpl forSubscription) {
         if (forSubscription != subscription) {
             // Subscriptions shares common state hence a requestN after termination/cancellation must be ignored
             return;
@@ -149,7 +149,7 @@ final class NettyChannelPublisher<T> extends Publisher<T> {
         }
     }
 
-    boolean processPending(SubscriptionImpl target) {
+    private boolean processPending(SubscriptionImpl target) {
         // Should always be called from eventloop. (assert done before calling)
         if (inProcessPending || pending == null) {
             // Guard against re-entrance.
@@ -170,13 +170,12 @@ final class NettyChannelPublisher<T> extends Publisher<T> {
                     return true;
                 }
                 if (emit(target, p)) {
-                    SubscriptionImpl s = subscription;
-                    if (s == target || s == null) {
+                    if (subscription == target || subscription == null) {
                         // stop draining the pending events if the current Subscription is still the same for which we
                         // started draining, continue emitting the remaining data if there is a new Subscriber
                         return true;
                     }
-                    target = s;
+                    target = subscription;
                 }
             }
             if (pending.peek() instanceof TerminalNotification) {

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherTest.java
@@ -31,7 +31,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -459,10 +458,8 @@ public class NettyChannelPublisherTest {
         ).request(2);
 
         subscriber.verifyItems(1).verifyFailure(DELIBERATE_EXCEPTION);
-        ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
-        subscriber2.verifyFailure(captor);
         // only the active subscriber sees the initial exception, subsequent subscribers will observe a closed channel
-        assertThat(captor.getValue(), instanceOf(ClosedChannelException.class));
+        subscriber2.verifyFailure(ClosedChannelException.class);
     }
 
     private void testChannelReadThrows(boolean requestLate) {


### PR DESCRIPTION
__Motivation__

In a scenario with multiple payloads or data and an error queued up in NettyChannelPublisher, when a new Subscriber synchronously re-subscribes and demands data from the terminal event, the draining loop exits early and ignores the demand. In the case of pipelined HTTP requests, this lead to the eagerly requested metadata never getting delivered.

__Modifications__

Make sure NettyChannelPublisher continues draining the queue in the event that the subscriber is changed as part of delivering the terminal event.

__Result__

Responses to a pipelined request don't appear to get stuck when queued up.