### PR TITLE
Simplify filter names

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ConcurrentRequestsHttpConnectionFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ConcurrentRequestsHttpConnectionFilter.java
@@ -28,11 +28,11 @@ import static io.servicetalk.client.internal.RequestConcurrencyControllers.newSi
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.http.api.StreamingHttpConnection.SettingKey.MAX_CONCURRENCY;
 
-final class StreamingHttpConnectionConcurrentRequestsFilter extends StreamingHttpConnectionAdapter {
+final class ConcurrentRequestsHttpConnectionFilter extends StreamingHttpConnectionAdapter {
     private final RequestConcurrencyController limiter;
 
-    StreamingHttpConnectionConcurrentRequestsFilter(StreamingHttpConnection next,
-                                                    int defaultMaxPipelinedRequests) {
+    ConcurrentRequestsHttpConnectionFilter(StreamingHttpConnection next,
+                                           int defaultMaxPipelinedRequests) {
         super(next);
         limiter = defaultMaxPipelinedRequests == 1 ?
                 newSingleController(next.settingStream(MAX_CONCURRENCY), next.onClose()) :
@@ -51,7 +51,7 @@ final class StreamingHttpConnectionConcurrentRequestsFilter extends StreamingHtt
                     subscriber.onSubscribe(IGNORE_CANCEL);
                     subscriber.onError(new MaxRequestLimitExceededRejectedSubscribeException(
                             "Max concurrent requests saturated for: " +
-                                    StreamingHttpConnectionConcurrentRequestsFilter.this));
+                                    ConcurrentRequestsHttpConnectionFilter.this));
                 }
             }
         };

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpConnectionBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpConnectionBuilder.java
@@ -86,7 +86,7 @@ public final class DefaultHttpConnectionBuilder<ResolvedAddress> implements Http
                         reqRespFactory)
                 : buildForPipelined(executionContext, resolvedAddress, roConfig, connectionFilterFunction,
                 reqRespFactory))
-                    .map(filteredConnection -> new StreamingHttpConnectionConcurrentRequestsFilter(filteredConnection,
+                    .map(filteredConnection -> new ConcurrentRequestsHttpConnectionFilter(filteredConnection,
                             roConfig.getMaxPipelinedRequests()));
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -152,10 +152,10 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
 
     private static <U> HttpConnectionFilterFactory defaultHostClientFilterFactory(final U address) {
         if (address instanceof CharSequence) {
-            return c -> new StreamingHttpConnectionHostHeaderFilter((CharSequence) address, c);
+            return c -> new HostHeaderHttpConnectionFilter((CharSequence) address, c);
         }
         if (address instanceof HostAndPort) {
-            return c -> new StreamingHttpConnectionHostHeaderFilter((HostAndPort) address, c);
+            return c -> new HostHeaderHttpConnectionFilter((HostAndPort) address, c);
         }
         throw new IllegalArgumentException("Unsupported host header address type, provide an override");
     }
@@ -245,7 +245,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     @Override
     public SingleAddressHttpClientBuilder<U, R> enableHostHeaderFallback(final CharSequence hostHeader) {
         hostHeaderFilterFunction = address -> connection ->
-                new StreamingHttpConnectionHostHeaderFilter(hostHeader, connection);
+                new HostHeaderHttpConnectionFilter(hostHeader, connection);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HostHeaderHttpConnectionFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HostHeaderHttpConnectionFilter.java
@@ -33,7 +33,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * A filter which will apply a fallback value for the {@link HttpHeaderNames#HOST} header if one is not present.
  */
-final class StreamingHttpConnectionHostHeaderFilter extends StreamingHttpConnectionAdapter {
+final class HostHeaderHttpConnectionFilter extends StreamingHttpConnectionAdapter {
     private final CharSequence fallbackHost;
 
     /**
@@ -41,7 +41,7 @@ final class StreamingHttpConnectionHostHeaderFilter extends StreamingHttpConnect
      * @param fallbackHost The address to use as a fallback if a {@link HttpHeaderNames#HOST} header is not present.
      * @param next The next {@link StreamingHttpConnection} in the filter chain.
      */
-    StreamingHttpConnectionHostHeaderFilter(HostAndPort fallbackHost, StreamingHttpConnection next) {
+    HostHeaderHttpConnectionFilter(HostAndPort fallbackHost, StreamingHttpConnection next) {
         this(fallbackHost.getHostName(), fallbackHost.getPort(), next);
     }
 
@@ -52,8 +52,8 @@ final class StreamingHttpConnectionHostHeaderFilter extends StreamingHttpConnect
      * @param fallbackPort The port to use as a fallback if a {@link HttpHeaderNames#HOST} header is not present.
      * @param next The next {@link StreamingHttpConnection} in the filter chain.
      */
-    StreamingHttpConnectionHostHeaderFilter(String fallbackHostName, int fallbackPort,
-                                            StreamingHttpConnection next) {
+    HostHeaderHttpConnectionFilter(String fallbackHostName, int fallbackPort,
+                                   StreamingHttpConnection next) {
         super(next);
         this.fallbackHost = requireNonNull(newAsciiString(toSocketAddressString(fallbackHostName, fallbackPort)));
     }
@@ -63,7 +63,7 @@ final class StreamingHttpConnectionHostHeaderFilter extends StreamingHttpConnect
      * @param fallbackHost The address to use as a fallback if a {@link HttpHeaderNames#HOST} header is not present.
      * @param next The next {@link StreamingHttpConnection} in the filter chain.
      */
-    StreamingHttpConnectionHostHeaderFilter(CharSequence fallbackHost, StreamingHttpConnection next) {
+    HostHeaderHttpConnectionFilter(CharSequence fallbackHost, StreamingHttpConnection next) {
         super(next);
         this.fallbackHost = newAsciiString(isValidIpV6Address(fallbackHost) && fallbackHost.charAt(0) != '[' ?
                 "[" + fallbackHost + "]" : fallbackHost.toString());

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HostHeaderHttpConnectionFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HostHeaderHttpConnectionFilterTest.java
@@ -33,7 +33,7 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.Assert.assertEquals;
 
 @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
-public class StreamingHttpConnectionHostHeaderFilterTest {
+public class HostHeaderHttpConnectionFilterTest {
     @Test
     public void ipv4NotEscaped() throws Exception {
         doHostHeaderTest("1.2.3.4", "1.2.3.4");

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionConcurrentRequestsFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionConcurrentRequestsFilterTest.java
@@ -96,7 +96,7 @@ public class HttpConnectionConcurrentRequestsFilterTest {
             }
         };
         StreamingHttpConnection limitedConnection =
-                new StreamingHttpConnectionConcurrentRequestsFilter(mockConnection, 2);
+                new ConcurrentRequestsHttpConnectionFilter(mockConnection, 2);
         StreamingHttpResponse resp1 = awaitIndefinitelyNonNull(
                 limitedConnection.request(limitedConnection.get("/foo")));
         awaitIndefinitelyNonNull(limitedConnection.request(limitedConnection.get("/bar")));

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpConnectionFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpConnectionFilter.java
@@ -32,7 +32,7 @@ import static io.opentracing.tag.Tags.HTTP_METHOD;
 import static io.opentracing.tag.Tags.HTTP_URL;
 import static io.opentracing.tag.Tags.SPAN_KIND;
 import static io.opentracing.tag.Tags.SPAN_KIND_CLIENT;
-import static io.servicetalk.opentracing.http.OpenTracingHttpHeadersFormatter.traceStateFormatter;
+import static io.servicetalk.opentracing.http.TracingHttpHeadersFormatter.traceStateFormatter;
 import static io.servicetalk.opentracing.http.TracingUtils.tagErrorAndClose;
 import static io.servicetalk.opentracing.http.TracingUtils.tracingMapper;
 import static java.util.Objects.requireNonNull;
@@ -40,7 +40,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * A {@link StreamingHttpConnection} that supports open tracing.
  */
-public class OpenTracingStreamingHttpConnectionFilter extends StreamingHttpConnectionAdapter {
+public class TracingHttpConnectionFilter extends StreamingHttpConnectionAdapter {
     private final Tracer tracer;
     private final String componentName;
     private final InMemoryTraceStateFormat<HttpHeaders> formatter;
@@ -51,9 +51,9 @@ public class OpenTracingStreamingHttpConnectionFilter extends StreamingHttpConne
      * @param componentName The component name used during building new spans.
      * @param next The next {@link StreamingHttpConnection} in the filter chain.
      */
-    public OpenTracingStreamingHttpConnectionFilter(Tracer tracer,
-                                                    String componentName,
-                                                    StreamingHttpConnection next) {
+    public TracingHttpConnectionFilter(Tracer tracer,
+                                       String componentName,
+                                       StreamingHttpConnection next) {
         this(tracer, componentName, next, true);
     }
 
@@ -64,10 +64,10 @@ public class OpenTracingStreamingHttpConnectionFilter extends StreamingHttpConne
      * @param validateTraceKeyFormat {@code true} to validate the contents of the trace ids.
      * @param next The next {@link StreamingHttpConnection} in the filter chain.
      */
-    public OpenTracingStreamingHttpConnectionFilter(Tracer tracer,
-                                                    String componentName,
-                                                    StreamingHttpConnection next,
-                                                    boolean validateTraceKeyFormat) {
+    public TracingHttpConnectionFilter(Tracer tracer,
+                                       String componentName,
+                                       StreamingHttpConnection next,
+                                       boolean validateTraceKeyFormat) {
         super(next);
         this.tracer = requireNonNull(tracer);
         this.componentName = requireNonNull(componentName);
@@ -91,7 +91,7 @@ public class OpenTracingStreamingHttpConnectionFilter extends StreamingHttpConne
                 Scope childScope = spanBuilder.startActive(true);
                 tracer.inject(childScope.span().context(), formatter, request.headers());
                 delegate().request(request).map(
-                        tracingMapper(childScope, OpenTracingStreamingHttpConnectionFilter.this::isError)
+                        tracingMapper(childScope, TracingHttpConnectionFilter.this::isError)
                 ).doOnError(cause -> tagErrorAndClose(childScope))
                  .doOnCancel(() -> tagErrorAndClose(childScope))
                  .subscribe(subscriber);

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpHeadersFormatter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpHeadersFormatter.java
@@ -31,15 +31,15 @@ import static io.servicetalk.http.api.CharSequences.newAsciiString;
 import static io.servicetalk.opentracing.core.internal.HexUtil.validateHexBytes;
 import static java.lang.String.valueOf;
 
-final class OpenTracingHttpHeadersFormatter implements InMemoryTraceStateFormat<HttpHeaders> {
-    private static final Logger logger = LoggerFactory.getLogger(OpenTracingHttpHeadersFormatter.class);
+final class TracingHttpHeadersFormatter implements InMemoryTraceStateFormat<HttpHeaders> {
+    private static final Logger logger = LoggerFactory.getLogger(TracingHttpHeadersFormatter.class);
     private static final CharSequence TRACE_ID = newAsciiString(ZipkinHeaderNames.TRACE_ID);
     private static final CharSequence SPAN_ID = newAsciiString(ZipkinHeaderNames.SPAN_ID);
     private static final CharSequence PARENT_SPAN_ID = newAsciiString(ZipkinHeaderNames.PARENT_SPAN_ID);
     private static final CharSequence SAMPLED = newAsciiString(ZipkinHeaderNames.SAMPLED);
-    static final InMemoryTraceStateFormat<HttpHeaders> FORMATTER_VALIDATION = new OpenTracingHttpHeadersFormatter(true);
+    static final InMemoryTraceStateFormat<HttpHeaders> FORMATTER_VALIDATION = new TracingHttpHeadersFormatter(true);
     static final InMemoryTraceStateFormat<HttpHeaders> FORMATTER_NO_VALIDATION =
-            new OpenTracingHttpHeadersFormatter(false);
+            new TracingHttpHeadersFormatter(false);
 
     private final boolean verifyExtractedValues;
 
@@ -49,7 +49,7 @@ final class OpenTracingHttpHeadersFormatter implements InMemoryTraceStateFormat<
      * @param verifyExtractedValues {@code true} to make a best effort verification that the extracted values are of the
      * correct format.
      */
-    private OpenTracingHttpHeadersFormatter(boolean verifyExtractedValues) {
+    private TracingHttpHeadersFormatter(boolean verifyExtractedValues) {
         this.verifyExtractedValues = verifyExtractedValues;
     }
 

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpServiceFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpServiceFilter.java
@@ -38,7 +38,7 @@ import static io.opentracing.tag.Tags.HTTP_METHOD;
 import static io.opentracing.tag.Tags.HTTP_URL;
 import static io.opentracing.tag.Tags.SPAN_KIND;
 import static io.opentracing.tag.Tags.SPAN_KIND_SERVER;
-import static io.servicetalk.opentracing.http.OpenTracingHttpHeadersFormatter.traceStateFormatter;
+import static io.servicetalk.opentracing.http.TracingHttpHeadersFormatter.traceStateFormatter;
 import static io.servicetalk.opentracing.http.TracingUtils.tagErrorAndClose;
 import static io.servicetalk.opentracing.http.TracingUtils.tracingMapper;
 import static java.util.Objects.requireNonNull;
@@ -46,7 +46,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * A {@link StreamingHttpService} that supports open tracing.
  */
-public class OpenTracingStreamingHttpServiceFilter extends StreamingHttpService {
+public class TracingHttpServiceFilter extends StreamingHttpService {
     private final StreamingHttpService next;
     private final Tracer tracer;
     private final String componentName;
@@ -58,9 +58,9 @@ public class OpenTracingStreamingHttpServiceFilter extends StreamingHttpService 
      * @param componentName The component name used during building new spans.
      * @param next The next {@link StreamingHttpService} in the filter chain.
      */
-    public OpenTracingStreamingHttpServiceFilter(Tracer tracer,
-                                                 String componentName,
-                                                 StreamingHttpService next) {
+    public TracingHttpServiceFilter(Tracer tracer,
+                                    String componentName,
+                                    StreamingHttpService next) {
         this(tracer, componentName, next, true);
     }
 
@@ -71,10 +71,10 @@ public class OpenTracingStreamingHttpServiceFilter extends StreamingHttpService 
      * @param validateTraceKeyFormat {@code true} to validate the contents of the trace ids.
      * @param next The next {@link StreamingHttpService} in the filter chain.
      */
-    public OpenTracingStreamingHttpServiceFilter(Tracer tracer,
-                                                 String componentName,
-                                                 StreamingHttpService next,
-                                                 boolean validateTraceKeyFormat) {
+    public TracingHttpServiceFilter(Tracer tracer,
+                                    String componentName,
+                                    StreamingHttpService next,
+                                    boolean validateTraceKeyFormat) {
         this.tracer = requireNonNull(tracer);
         this.componentName = requireNonNull(componentName);
         this.next = requireNonNull(next);
@@ -102,7 +102,7 @@ public class OpenTracingStreamingHttpServiceFilter extends StreamingHttpService 
                     if (injectSpanContextIntoResponse(parentSpanContext)) {
                         tracer.inject(currentScope.span().context(), formatter, resp.headers());
                     }
-                    return tracingMapper(resp, currentScope, OpenTracingStreamingHttpServiceFilter.this::isError);
+                    return tracingMapper(resp, currentScope, TracingHttpServiceFilter.this::isError);
                 }).doOnError(cause -> tagErrorAndClose(currentScope))
                   .doOnCancel(() -> tagErrorAndClose(currentScope))
                   .subscribe(subscriber);

--- a/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpConnectionFilterTest.java
+++ b/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpConnectionFilterTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
-public class OpenTracingStreamingHttpConnectionFilterTest {
+public class TracingHttpConnectionFilterTest {
     @Rule
     public final Timeout timeout = new ServiceTalkTestTimeout();
     private static final HttpSerializationProvider httpSerializer = jsonSerializer(new JacksonSerializationProvider());
@@ -59,7 +59,7 @@ public class OpenTracingStreamingHttpConnectionFilterTest {
         DefaultInMemoryTracer tracer = new DefaultInMemoryTracer.Builder(SCOPE_MANAGER).build();
         try (ServerContext context = buildServer()) {
             try (HttpClient client = forSingleAddress(of((InetSocketAddress) context.listenAddress()))
-                    .appendConnectionFilter(conn -> new OpenTracingStreamingHttpConnectionFilter(
+                    .appendConnectionFilter(conn -> new TracingHttpConnectionFilter(
                             tracer, "testClient", conn)).build()) {
                 HttpResponse response = client.request(client.get("/")).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(httpSerializer.deserializerFor(
@@ -80,7 +80,7 @@ public class OpenTracingStreamingHttpConnectionFilterTest {
         DefaultInMemoryTracer tracer = new DefaultInMemoryTracer.Builder(SCOPE_MANAGER).build();
         try (ServerContext context = buildServer()) {
             try (HttpClient client = forSingleAddress(of((InetSocketAddress) context.listenAddress()))
-                    .appendConnectionFilter(conn -> new OpenTracingStreamingHttpConnectionFilter(
+                    .appendConnectionFilter(conn -> new TracingHttpConnectionFilter(
                             tracer, "testClient", conn)).build()) {
                 try (InMemoryScope clientScope = tracer.buildSpan("test").startActive(true)) {
                     HttpResponse response = client.request(client.get("/")).toFuture().get();

--- a/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpServiceFilterTest.java
+++ b/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpServiceFilterTest.java
@@ -53,7 +53,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public class OpenTracingStreamingHttpServiceFilterTest {
+public class TracingHttpServiceFilterTest {
 
     @Rule
     public final Timeout timeout = new ServiceTalkTestTimeout();
@@ -62,7 +62,7 @@ public class OpenTracingStreamingHttpServiceFilterTest {
     private ServerContext buildServer() throws Exception {
         DefaultInMemoryTracer tracer = new DefaultInMemoryTracer.Builder(SCOPE_MANAGER).build();
         return HttpServers.newHttpServerBuilder(0)
-                .listenStreamingAndAwait(new OpenTracingStreamingHttpServiceFilter(tracer, "testServer",
+                .listenStreamingAndAwait(new TracingHttpServiceFilter(tracer, "testServer",
                         ((StreamingHttpRequestHandler) (ctx, request, responseFactory) -> {
                     InMemorySpan span = tracer.activeSpan();
                     if (span == null) {


### PR DESCRIPTION
Motivation:
Filter names are verbose and pedantic. This creates noise in user code for minimal value, so we should simplify where possible.

Modifications:
- OpenTracing filters can be simplified
- Filters with Streaming in the name can be simplified

Result:
Less verbose filter names, and easier to comprehend concepts.