### PR TITLE
Simplify customizing `ConnectionFactory`.

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.client.api.ConnectionFactory;
+import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.LoadBalancerFactory;
 import io.servicetalk.client.api.ServiceDiscoverer;
@@ -24,7 +25,6 @@ import io.servicetalk.transport.api.ExecutionContext;
 
 import java.net.SocketOption;
 import java.util.function.Function;
-import java.util.function.UnaryOperator;
 
 /**
  * A builder of {@link HttpClient} objects.
@@ -162,11 +162,10 @@ public interface HttpClientBuilder<U, R> {
      * <pre>
      *     filter1 =&gt; filter2 =&gt; filter3 =&gt; original connection factory
      * </pre>
-     * @param factory {@link UnaryOperator} to decorate a {@link ConnectionFactory} for the purpose of filtering.
+     * @param factory {@link ConnectionFactoryFilter} to use.
      * @return {@code this}
      */
-    HttpClientBuilder<U, R> appendConnectionFactoryFilter(
-            UnaryOperator<ConnectionFactory<R, ? extends StreamingHttpConnection>> factory);
+    HttpClientBuilder<U, R> appendConnectionFactoryFilter(ConnectionFactoryFilter<R, StreamingHttpConnection> factory);
 
     /**
      * Disable automatically setting {@code Host} headers by inferring from the address or {@link StreamingHttpRequest}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.client.api.ConnectionFactory;
+import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.LoadBalancerFactory;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
@@ -74,7 +74,7 @@ public interface MultiAddressHttpClientBuilder<U, R> extends HttpClientBuilder<U
 
     @Override
     MultiAddressHttpClientBuilder<U, R> appendConnectionFactoryFilter(
-            UnaryOperator<ConnectionFactory<R, ? extends StreamingHttpConnection>> factory);
+            ConnectionFactoryFilter<R, StreamingHttpConnection> factory);
 
     @Override
     MultiAddressHttpClientBuilder<U, R> disableHostHeaderFallback();

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.client.api.ConnectionFactory;
+import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.LoadBalancerFactory;
 import io.servicetalk.client.api.ServiceDiscoverer;
@@ -27,7 +27,6 @@ import io.servicetalk.transport.api.SslConfig;
 import java.io.InputStream;
 import java.net.SocketOption;
 import java.util.function.BiFunction;
-import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
 
 /**
@@ -75,7 +74,7 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
 
     @Override
     SingleAddressHttpClientBuilder<U, R> appendConnectionFactoryFilter(
-            UnaryOperator<ConnectionFactory<R, ? extends StreamingHttpConnection>> factory);
+            ConnectionFactoryFilter<R, StreamingHttpConnection> factory);
 
     @Override
     SingleAddressHttpClientBuilder<U, R> disableHostHeaderFallback();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.client.api.ConnectionFactory;
+import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.DefaultGroupKey;
 import io.servicetalk.client.api.GroupKey;
 import io.servicetalk.client.api.LoadBalancerFactory;
@@ -57,7 +57,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
@@ -383,7 +382,7 @@ final class DefaultMultiAddressUrlHttpClientBuilder
 
     @Override
     public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> appendConnectionFactoryFilter(
-            final UnaryOperator<ConnectionFactory<InetSocketAddress, ? extends StreamingHttpConnection>> factory) {
+            final ConnectionFactoryFilter<InetSocketAddress, StreamingHttpConnection> factory) {
         builderTemplate.appendConnectionFactoryFilter(factory);
         return this;
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.ConnectionFactory;
+import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.LoadBalancerFactory;
 import io.servicetalk.client.api.ServiceDiscoverer;
@@ -39,7 +40,6 @@ import io.servicetalk.transport.api.SslConfig;
 import java.net.InetSocketAddress;
 import java.net.SocketOption;
 import java.util.function.Function;
-import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
@@ -75,8 +75,8 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     private HttpConnectionFilterFactory connectionFilterFunction = HttpConnectionFilterFactory.identity();
     private HttpClientFilterFactory clientFilterFunction = HttpClientFilterFactory.identity();
     private HttpClientFilterFactory lbReadyFilter = LB_READY_FILTER;
-    private UnaryOperator<ConnectionFactory<R, ? extends StreamingHttpConnection>> connectionFilterFactory =
-            UnaryOperator.identity();
+    private ConnectionFactoryFilter<R, StreamingHttpConnection> connectionFactoryFilter =
+            ConnectionFactoryFilter.identity();
 
     DefaultSingleAddressHttpClientBuilder(
             final ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer, final U address) {
@@ -96,7 +96,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         connectionFilterFunction = from.connectionFilterFunction;
         hostHeaderFilterFunction = from.hostHeaderFilterFunction;
         lbReadyFilter = from.lbReadyFilter;
-        connectionFilterFactory = from.connectionFilterFactory;
+        connectionFactoryFilter = from.connectionFactoryFilter;
     }
 
     DefaultSingleAddressHttpClientBuilder<U, R> copy() {
@@ -135,7 +135,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
 
             // closed by the LoadBalancer
             ConnectionFactory<R, ? extends StreamingHttpConnection> connectionFactory =
-                    connectionFilterFactory.apply(closeOnException.prepend(roConfig.getMaxPipelinedRequests() == 1 ?
+                    connectionFactoryFilter.apply(closeOnException.prepend(roConfig.getMaxPipelinedRequests() == 1 ?
                             new NonPipelinedLBHttpConnectionFactory<>(roConfig, exec, connectionFilters, reqRespFactory) :
                             new PipelinedLBHttpConnectionFactory<>(roConfig, exec, connectionFilters, reqRespFactory)));
 
@@ -234,8 +234,8 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
 
     @Override
     public SingleAddressHttpClientBuilder<U, R> appendConnectionFactoryFilter(
-            final UnaryOperator<ConnectionFactory<R, ? extends StreamingHttpConnection>> factory) {
-        connectionFilterFactory = factory;
+            final ConnectionFactoryFilter<R, StreamingHttpConnection> factory) {
+        connectionFactoryFilter = connectionFactoryFilter.append(factory);
         return this;
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
@@ -27,7 +27,6 @@ import io.servicetalk.http.api.StreamingHttpRequestFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpService;
-import io.servicetalk.loadbalancer.RoundRobinLoadBalancer;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.ExecutionContextRule;
 
@@ -47,7 +46,6 @@ import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpResponseStatuses.OK;
 import static io.servicetalk.http.netty.HttpServers.newHttpServerBuilder;
-import static java.util.Comparator.comparingInt;
 import static java.util.Objects.requireNonNull;
 import static org.junit.Assert.assertEquals;
 
@@ -86,9 +84,7 @@ public class HttpAuthConnectionFactoryClientTest {
                         });
         client = HttpClients.forSingleAddress("localhost",
                 ((InetSocketAddress) serverContext.listenAddress()).getPort())
-                .loadBalancerFactory(
-                        (eventPublisher, connectionFactory) -> new RoundRobinLoadBalancer<>(eventPublisher,
-                                new TestHttpAuthConnectionFactory<>(connectionFactory), comparingInt(Object::hashCode)))
+                .appendConnectionFactoryFilter(TestHttpAuthConnectionFactory::new)
                 .executionContext(CTX)
                 .buildStreaming();
 


### PR DESCRIPTION
__Motivation__

It is non-trivial to customize a `ConnectionFactory` for a client since the users have to also know about `LoadBalancerFactory`.
We can make it simpler.

__Modification__

Added a `appendConnectionFactoryFilter()` method on `HttpClientBuilder` which can be used to customize the `ConnectionFactory`.

__Result__

`ConnectionFactory` can be easily customized.