### PR TITLE
New add/set methods for headers and query params

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractHttpMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractHttpMetaData.java
@@ -50,6 +50,18 @@ abstract class AbstractHttpMetaData implements HttpMetaData {
     }
 
     @Override
+    public HttpMetaData addHeaderField(final CharSequence name, final CharSequence value) {
+        headers.add(name, value);
+        return this;
+    }
+
+    @Override
+    public HttpMetaData setHeaderField(final CharSequence name, final CharSequence value) {
+        headers.set(name, value);
+        return this;
+    }
+
+    @Override
     public boolean equals(final Object o) {
         if (this == o) {
             return true;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClientToStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClientToStreamingHttpClient.java
@@ -273,6 +273,20 @@ final class BlockingStreamingHttpClientToStreamingHttpClient extends StreamingHt
         }
 
         @Override
+        public BlockingToUpgradableStreamingHttpResponse addHeaderField(final CharSequence name,
+                                                                        final CharSequence value) {
+            upgradeResponse.addHeaderField(name, value);
+            return this;
+        }
+
+        @Override
+        public BlockingToUpgradableStreamingHttpResponse setHeaderField(final CharSequence name,
+                                                                        final CharSequence value) {
+            upgradeResponse.setHeaderField(name, value);
+            return this;
+        }
+
+        @Override
         public String toString(final BiFunction<? super CharSequence, ? super CharSequence, CharSequence>
                                                headerFilter) {
             return upgradeResponse.toString(headerFilter);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
@@ -214,6 +214,12 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     BlockingStreamingHttpRequest path(String path);
 
     @Override
+    BlockingStreamingHttpRequest addQueryParameter(String key, String value);
+
+    @Override
+    BlockingStreamingHttpRequest setQueryParameter(String key, String value);
+
+    @Override
     BlockingStreamingHttpRequest rawQuery(String query);
 
     @Override
@@ -224,4 +230,10 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
 
     @Override
     BlockingStreamingHttpRequest requestTarget(String requestTarget);
+
+    @Override
+    BlockingStreamingHttpRequest addHeaderField(CharSequence name, CharSequence value);
+
+    @Override
+    BlockingStreamingHttpRequest setHeaderField(CharSequence name, CharSequence value);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
@@ -213,4 +213,10 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
 
     @Override
     BlockingStreamingHttpResponse status(HttpResponseStatus status);
+
+    @Override
+    BlockingStreamingHttpResponse addHeaderField(CharSequence name, CharSequence value);
+
+    @Override
+    BlockingStreamingHttpResponse setHeaderField(CharSequence name, CharSequence value);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BufferHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BufferHttpRequest.java
@@ -104,6 +104,30 @@ final class BufferHttpRequest extends DefaultHttpRequestMetaData implements Http
     }
 
     @Override
+    public HttpRequest addHeaderField(final CharSequence name, final CharSequence value) {
+        super.addHeaderField(name, value);
+        return this;
+    }
+
+    @Override
+    public HttpRequest setHeaderField(final CharSequence name, final CharSequence value) {
+        super.setHeaderField(name, value);
+        return this;
+    }
+
+    @Override
+    public HttpRequest addQueryParameter(final String key, final String value) {
+        super.addQueryParameter(key, value);
+        return this;
+    }
+
+    @Override
+    public HttpRequest setQueryParameter(final String key, final String value) {
+        super.setQueryParameter(key, value);
+        return this;
+    }
+
+    @Override
     public HttpRequest requestTarget(final String requestTarget) {
         super.requestTarget(requestTarget);
         return this;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BufferHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BufferHttpResponse.java
@@ -66,6 +66,18 @@ final class BufferHttpResponse extends DefaultHttpResponseMetaData implements Ht
     }
 
     @Override
+    public HttpResponse addHeaderField(final CharSequence name, final CharSequence value) {
+        super.addHeaderField(name, value);
+        return this;
+    }
+
+    @Override
+    public HttpResponse setHeaderField(final CharSequence name, final CharSequence value) {
+        super.setHeaderField(name, value);
+        return this;
+    }
+
+    @Override
     public Buffer payloadBody() {
         return payloadBody;
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
@@ -95,6 +95,18 @@ class DefaultBlockingStreamingHttpRequest<P> extends DefaultHttpRequestMetaData 
     }
 
     @Override
+    public BlockingStreamingHttpRequest addHeaderField(final CharSequence name, final CharSequence value) {
+        super.addHeaderField(name, value);
+        return this;
+    }
+
+    @Override
+    public BlockingStreamingHttpRequest setHeaderField(final CharSequence name, final CharSequence value) {
+        super.setHeaderField(name, value);
+        return this;
+    }
+
+    @Override
     public final BlockingStreamingHttpRequest requestTarget(final String requestTarget) {
         super.requestTarget(requestTarget);
         return this;
@@ -109,6 +121,18 @@ class DefaultBlockingStreamingHttpRequest<P> extends DefaultHttpRequestMetaData 
     @Override
     public final BlockingStreamingHttpRequest rawPath(final String path) {
         super.rawPath(path);
+        return this;
+    }
+
+    @Override
+    public BlockingStreamingHttpRequest addQueryParameter(final String key, final String value) {
+        super.addQueryParameter(key, value);
+        return this;
+    }
+
+    @Override
+    public BlockingStreamingHttpRequest setQueryParameter(final String key, final String value) {
+        super.setQueryParameter(key, value);
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpResponse.java
@@ -176,6 +176,18 @@ class DefaultBlockingStreamingHttpResponse<P> extends DefaultHttpResponseMetaDat
     }
 
     @Override
+    public final BlockingStreamingHttpResponse addHeaderField(final CharSequence name, final CharSequence value) {
+        super.addHeaderField(name, value);
+        return this;
+    }
+
+    @Override
+    public final BlockingStreamingHttpResponse setHeaderField(final CharSequence name, final CharSequence value) {
+        super.setHeaderField(name, value);
+        return this;
+    }
+
+    @Override
     public boolean equals(final Object o) {
         if (this == o) {
             return true;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpQuery.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpQuery.java
@@ -159,7 +159,7 @@ public final class DefaultHttpQuery implements HttpQuery {
     }
 
     @Override
-    public boolean empty() {
+    public boolean isEmpty() {
         return size() > 0;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequestMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequestMetaData.java
@@ -89,6 +89,18 @@ class DefaultHttpRequestMetaData extends AbstractHttpMetaData implements HttpReq
     }
 
     @Override
+    public HttpRequestMetaData addHeaderField(final CharSequence name, final CharSequence value) {
+        super.addHeaderField(name, value);
+        return this;
+    }
+
+    @Override
+    public HttpRequestMetaData setHeaderField(final CharSequence name, final CharSequence value) {
+        super.setHeaderField(name, value);
+        return this;
+    }
+
+    @Override
     public final String requestTarget() {
         return requestTarget;
     }
@@ -161,6 +173,18 @@ class DefaultHttpRequestMetaData extends AbstractHttpMetaData implements HttpReq
     @Override
     public final HttpQuery parseQuery() {
         return new DefaultHttpQuery(lazyParseQueryString(), this::setQueryParams);
+    }
+
+    @Override
+    public HttpRequestMetaData addQueryParameter(final String key, final String value) {
+        parseQuery().add(key, value).encodeToRequestTarget();
+        return this;
+    }
+
+    @Override
+    public HttpRequestMetaData setQueryParameter(final String key, final String value) {
+        parseQuery().set(key, value).encodeToRequestTarget();
+        return this;
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponseMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponseMetaData.java
@@ -53,6 +53,18 @@ class DefaultHttpResponseMetaData extends AbstractHttpMetaData implements HttpRe
     }
 
     @Override
+    public HttpResponseMetaData addHeaderField(final CharSequence name, final CharSequence value) {
+        super.addHeaderField(name, value);
+        return this;
+    }
+
+    @Override
+    public HttpResponseMetaData setHeaderField(final CharSequence name, final CharSequence value) {
+        super.setHeaderField(name, value);
+        return this;
+    }
+
+    @Override
     public final String toString(
             final BiFunction<? super CharSequence, ? super CharSequence, CharSequence> headerFilter) {
         return version() + " " + status() + lineSeparator()

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpRequest.java
@@ -91,6 +91,18 @@ class DefaultStreamingHttpRequest<P> extends DefaultHttpRequestMetaData implemen
     }
 
     @Override
+    public final StreamingHttpRequest addHeaderField(final CharSequence name, final CharSequence value) {
+        super.addHeaderField(name, value);
+        return this;
+    }
+
+    @Override
+    public final StreamingHttpRequest setHeaderField(final CharSequence name, final CharSequence value) {
+        super.setHeaderField(name, value);
+        return this;
+    }
+
+    @Override
     public final StreamingHttpRequest requestTarget(final String requestTarget) {
         super.requestTarget(requestTarget);
         return this;
@@ -105,6 +117,18 @@ class DefaultStreamingHttpRequest<P> extends DefaultHttpRequestMetaData implemen
     @Override
     public final StreamingHttpRequest rawPath(final String path) {
         super.rawPath(path);
+        return this;
+    }
+
+    @Override
+    public final StreamingHttpRequest addQueryParameter(final String key, final String value) {
+        super.addQueryParameter(key, value);
+        return this;
+    }
+
+    @Override
+    public final StreamingHttpRequest setQueryParameter(final String key, final String value) {
+        super.setQueryParameter(key, value);
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpResponse.java
@@ -88,6 +88,18 @@ class DefaultStreamingHttpResponse<P> extends DefaultHttpResponseMetaData implem
     }
 
     @Override
+    public final StreamingHttpResponse addHeaderField(final CharSequence name, final CharSequence value) {
+        super.addHeaderField(name, value);
+        return this;
+    }
+
+    @Override
+    public final StreamingHttpResponse setHeaderField(final CharSequence name, final CharSequence value) {
+        super.setHeaderField(name, value);
+        return this;
+    }
+
+    @Override
     public Publisher<Buffer> payloadBody() {
         return payloadBody.liftSynchronous(HttpBufferFilterOperator.INSTANCE);
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientToStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientToStreamingHttpClient.java
@@ -278,6 +278,18 @@ final class HttpClientToStreamingHttpClient extends StreamingHttpClient {
         }
 
         @Override
+        public UpgradableStreamingHttpResponse addHeaderField(final CharSequence name, final CharSequence value) {
+            upgradableResponse.addHeaderField(name, value);
+            return this;
+        }
+
+        @Override
+        public UpgradableStreamingHttpResponse setHeaderField(final CharSequence name, final CharSequence value) {
+            upgradableResponse.setHeaderField(name, value);
+            return this;
+        }
+
+        @Override
         public String toString(
                 final BiFunction<? super CharSequence, ? super CharSequence, CharSequence> headerFilter) {
             return upgradableResponse.toString(headerFilter);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpMetaData.java
@@ -45,6 +45,25 @@ public interface HttpMetaData {
     HttpHeaders headers();
 
     /**
+     * Adds a new header with the specified {@code name} and {@code value}.
+     *
+     * @param name the name of the header.
+     * @param value the value of the header.
+     * @return {@code this}.
+     */
+    HttpMetaData addHeaderField(CharSequence name, CharSequence value);
+
+    /**
+     * Sets a header with the specified {@code name} and {@code value}. Any existing headers with the same name are
+     * overwritten.
+     *
+     * @param name the header name.
+     * @param value the value of the header.
+     * @return {@code this}.
+     */
+    HttpMetaData setHeaderField(CharSequence name, CharSequence value);
+
+    /**
      * Returns a string representation of the message. To avoid accidentally logging sensitive information,
      * implementations should not return any header or content.
      *

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpQuery.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpQuery.java
@@ -182,7 +182,7 @@ public interface HttpQuery extends Iterable<Map.Entry<String, String>> {
      * Returns {@code true} if {@link #size()} equals {@code 0}.
      * @return {@code true} if {@link #size()} equals {@code 0}.
      */
-    boolean empty();
+    boolean isEmpty();
 
     /**
      * Sets the <a href="https://tools.ietf.org/html/rfc3986#section-3.4">query component</a> on the request that this

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequest.java
@@ -78,6 +78,12 @@ public interface HttpRequest extends HttpRequestMetaData {
     HttpRequest path(String path);
 
     @Override
+    HttpRequest addQueryParameter(String key, String value);
+
+    @Override
+    HttpRequest setQueryParameter(String key, String value);
+
+    @Override
     HttpRequest rawQuery(String query);
 
     @Override
@@ -88,4 +94,10 @@ public interface HttpRequest extends HttpRequestMetaData {
 
     @Override
     HttpRequest requestTarget(String requestTarget);
+
+    @Override
+    HttpRequest addHeaderField(CharSequence name, CharSequence value);
+
+    @Override
+    HttpRequest setHeaderField(CharSequence name, CharSequence value);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMetaData.java
@@ -159,6 +159,25 @@ public interface HttpRequestMetaData extends HttpMetaData {
     HttpQuery parseQuery();
 
     /**
+     * Adds a new query parameter with the specified {@code key} and {@code value}.
+     *
+     * @param key the query parameter key.
+     * @param value the query parameter value.
+     * @return {@code this}.
+     */
+    HttpRequestMetaData addQueryParameter(String key, String value);
+
+    /**
+     * Sets a query parameter with the specified {@code key} and {@code value}. Any existing query parameters with
+     * the same key are overwritten.
+     *
+     * @param key the query parameter key.
+     * @param value the query parameter value.
+     * @return {@code this}.
+     */
+    HttpRequestMetaData setQueryParameter(String key, String value);
+
+    /**
      * The <a href="https://tools.ietf.org/html/rfc3986#section-3.4">query component</a> derived
      * from {@link #requestTarget()}.
      * <p>
@@ -207,4 +226,10 @@ public interface HttpRequestMetaData extends HttpMetaData {
 
     @Override
     HttpRequestMetaData version(HttpProtocolVersion version);
+
+    @Override
+    HttpRequestMetaData addHeaderField(CharSequence name, CharSequence value);
+
+    @Override
+    HttpRequestMetaData setHeaderField(CharSequence name, CharSequence value);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponse.java
@@ -76,4 +76,10 @@ public interface HttpResponse extends HttpResponseMetaData {
 
     @Override
     HttpResponse status(HttpResponseStatus status);
+
+    @Override
+    HttpResponse addHeaderField(CharSequence name, CharSequence value);
+
+    @Override
+    HttpResponse setHeaderField(CharSequence name, CharSequence value);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponseMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponseMetaData.java
@@ -38,4 +38,10 @@ public interface HttpResponseMetaData extends HttpMetaData {
 
     @Override
     HttpResponseMetaData version(HttpProtocolVersion version);
+
+    @Override
+    HttpResponseMetaData addHeaderField(CharSequence name, CharSequence value);
+
+    @Override
+    HttpResponseMetaData setHeaderField(CharSequence name, CharSequence value);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingStreamingHttpClient.java
@@ -270,6 +270,20 @@ final class StreamingHttpClientToBlockingStreamingHttpClient extends BlockingStr
         }
 
         @Override
+        public UpgradableStreamingHttpResponseToBlockingStreaming addHeaderField(final CharSequence name,
+                                                                                 final CharSequence value) {
+            upgradeResponse.addHeaderField(name, value);
+            return this;
+        }
+
+        @Override
+        public UpgradableStreamingHttpResponseToBlockingStreaming setHeaderField(final CharSequence name,
+                                                                                 final CharSequence value) {
+            upgradeResponse.setHeaderField(name, value);
+            return this;
+        }
+
+        @Override
         public String toString(
                 final BiFunction<? super CharSequence, ? super CharSequence, CharSequence> headerFilter) {
             return upgradeResponse.toString(headerFilter);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToHttpClient.java
@@ -208,6 +208,18 @@ final class StreamingHttpClientToHttpClient extends HttpClient {
         }
 
         @Override
+        public UpgradableHttpResponse addHeaderField(final CharSequence name, final CharSequence value) {
+            upgradableResponse.addHeaderField(name, value);
+            return this;
+        }
+
+        @Override
+        public UpgradableHttpResponse setHeaderField(final CharSequence name, final CharSequence value) {
+            upgradableResponse.setHeaderField(name, value);
+            return this;
+        }
+
+        @Override
         public String toString() {
             return upgradableResponse.toString();
         }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequest.java
@@ -177,6 +177,12 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
     StreamingHttpRequest path(String path);
 
     @Override
+    StreamingHttpRequest addQueryParameter(String key, String value);
+
+    @Override
+    StreamingHttpRequest setQueryParameter(String key, String value);
+
+    @Override
     StreamingHttpRequest rawQuery(String query);
 
     @Override
@@ -187,4 +193,10 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
 
     @Override
     StreamingHttpRequest requestTarget(String requestTarget);
+
+    @Override
+    StreamingHttpRequest addHeaderField(CharSequence name, CharSequence value);
+
+    @Override
+    StreamingHttpRequest setHeaderField(CharSequence name, CharSequence value);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpResponse.java
@@ -176,4 +176,10 @@ public interface StreamingHttpResponse extends HttpResponseMetaData {
 
     @Override
     StreamingHttpResponse status(HttpResponseStatus status);
+
+    @Override
+    StreamingHttpResponse addHeaderField(CharSequence name, CharSequence value);
+
+    @Override
+    StreamingHttpResponse setHeaderField(CharSequence name, CharSequence value);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/TransportStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/TransportStreamingHttpRequest.java
@@ -59,6 +59,18 @@ final class TransportStreamingHttpRequest extends DefaultHttpRequestMetaData imp
     }
 
     @Override
+    public StreamingHttpRequest addHeaderField(final CharSequence name, final CharSequence value) {
+        super.addHeaderField(name, value);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest setHeaderField(final CharSequence name, final CharSequence value) {
+        super.setHeaderField(name, value);
+        return this;
+    }
+
+    @Override
     public StreamingHttpRequest requestTarget(final String requestTarget) {
         super.requestTarget(requestTarget);
         return this;
@@ -73,6 +85,18 @@ final class TransportStreamingHttpRequest extends DefaultHttpRequestMetaData imp
     @Override
     public StreamingHttpRequest rawPath(final String path) {
         super.rawPath(path);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest addQueryParameter(final String key, final String value) {
+        super.addQueryParameter(key, value);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest setQueryParameter(final String key, final String value) {
+        super.setQueryParameter(key, value);
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/TransportStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/TransportStreamingHttpResponse.java
@@ -61,6 +61,18 @@ final class TransportStreamingHttpResponse extends DefaultHttpResponseMetaData i
     }
 
     @Override
+    public TransportStreamingHttpResponse addHeaderField(final CharSequence name, final CharSequence value) {
+        super.addHeaderField(name, value);
+        return this;
+    }
+
+    @Override
+    public TransportStreamingHttpResponse setHeaderField(final CharSequence name, final CharSequence value) {
+        super.setHeaderField(name, value);
+        return this;
+    }
+
+    @Override
     public Publisher<Buffer> payloadBody() {
         return payloadAndTrailers.liftSynchronous(HttpTransportBufferFilterOperator.INSTANCE);
     }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
@@ -318,6 +318,16 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
     }
 
     @Test
+    public void testUpdateQuery() {
+        createFixture("/some/path?foo=bar&abc=def&foo=baz");
+
+        fixture.addQueryParameter("abc", "ghi")
+                .setQueryParameter("foo", "jkl");
+
+        assertEquals("/some/path?foo=jkl&abc=def&abc=ghi", fixture.requestTarget());
+    }
+
+    @Test
     public void testUriDoesNotChangeUntilReencode() {
         createFixture("/some/path?foo=bar&abc=def&foo=baz");
         final HttpQuery query = fixture.parseQuery();
@@ -453,6 +463,15 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
 
         assertEquals("my.site.com", fixture.effectiveHost());
         assertEquals(-1, fixture.effectivePort());
+    }
+
+    @Test
+    public void testHeadersOperations() {
+        createFixture("/some/path");
+        fixture.addHeaderField("hdr1", "val1")
+                .setHeaderField("hdr2", "val2");
+
+        assertEquals(fixture.headers().size(), 2);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Motivation

The `HttpRequestMetaData` class offers methods for easily updating the path section of the request target but requires a complex `parseQuery/encodeToRequestTarget` dance to add/set query params.

Moreover adding/setting headers implies breaking out of method chaining, reducing the fluidity of the API.

## Modifications

- Add `addQueryParameter` and `setQueryParameter` to `HttpRequestMetaData`
- Add `addHeaderField` and `setHeaderField` to `HttpMetaData`
- Add implementation and builder-type-preserving `@Override`s.

## Results

Users can add/set headers/query params in a fluent manner.
