### PR TITLE
AsyncContextMap and PartitionAttributes Key factory method simplify

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/concurrent/AsyncContextMapBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/concurrent/AsyncContextMapBenchmark.java
@@ -36,7 +36,7 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-import static io.servicetalk.concurrent.api.AsyncContextMap.Key.newKeyWithDebugToString;
+import static io.servicetalk.concurrent.api.AsyncContextMap.Key.newKey;
 import static java.util.Collections.unmodifiableSet;
 
 @Fork(2)
@@ -44,14 +44,14 @@ import static java.util.Collections.unmodifiableSet;
 @Warmup(iterations = 10, time = 2)
 @Measurement(iterations = 10, time = 2)
 public class AsyncContextMapBenchmark {
-    private static final Key<String> K1 = newKeyWithDebugToString("k1");
-    private static final Key<String> K2 = newKeyWithDebugToString("k2");
-    private static final Key<String> K3 = newKeyWithDebugToString("k3");
-    private static final Key<String> K4 = newKeyWithDebugToString("k4");
-    private static final Key<String> K5 = newKeyWithDebugToString("k5");
-    private static final Key<String> K6 = newKeyWithDebugToString("k6");
-    private static final Key<String> K7 = newKeyWithDebugToString("k7");
-    private static final Key<String> K8 = newKeyWithDebugToString("k8");
+    private static final Key<String> K1 = newKey("k1");
+    private static final Key<String> K2 = newKey("k2");
+    private static final Key<String> K3 = newKey("k3");
+    private static final Key<String> K4 = newKey("k4");
+    private static final Key<String> K5 = newKey("k5");
+    private static final Key<String> K6 = newKey("k6");
+    private static final Key<String> K7 = newKey("k7");
+    private static final Key<String> K8 = newKey("k8");
 
     @Setup(Level.Invocation)
     public final void setup() {

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/partition/PartitionAttributes.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/partition/PartitionAttributes.java
@@ -24,10 +24,10 @@ import static java.lang.String.valueOf;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Provide a way to describe a partition using a collection of of attributes. Typically only a single type of any particular
- * {@link Key} exists in each {@link PartitionAttributes}. For example:
+ * Provide a way to describe a partition using a collection of of attributes. Typically only a single type of any
+ * particular {@link Key} exists in each {@link PartitionAttributes}. For example:
  * <pre>
- * PartitionAttributes = { [Key(shard) = "shard X"], [Key(data center) = "data center X"], [Key(is master) = "false/true"] }
+ * { [Key(shard) = "shard X"], [Key(data center) = "data center X"], [Key(is master) = "false/true"] }
  * </pre>
  * This construct allows for the attributes to partially specify a partition and preform "wild card" type matching.
  */
@@ -53,15 +53,18 @@ public interface PartitionAttributes {
         }
 
         /**
-         * Create a new {@link Key} which has a {@link String} used only in the {@link #toString()} method for debugging visibility.
+         * Create a new {@link Key} which has a {@link String} used only in the {@link #toString()} method for debugging
+         * visibility.
          * <p>
          * Comparison between {@link Key} objects should be assumed to be on an instance basis.
-         * In general {@code newKeyWithDebugToString(str) != newKeyWithDebugToString(str)}.
-         * @param toString The value to use in {@link #toString()}. This <strong>WILL NOT</strong> be used in comparisons between {@link Key} objects.
+         * In general {@code newKey(str) != newKey(str)}.
+         * @param toString The value to use in {@link #toString()}. This <strong>WILL NOT</strong> be used in
+         * comparisons between {@link Key} objects.
          * @param <T> The value type associated with the {@link Key}.
-         * @return a new {@link Key} which has a {@link String} used only in the {@link #toString()} method for debugging visibility.
+         * @return a new {@link Key} which has a {@link String} used only in the {@link #toString()} method for
+         * debugging visibility.
          */
-        public static <T> Key<T> newKeyWithDebugToString(String toString) {
+        public static <T> Key<T> newKey(String toString) {
             return new Key<>(toString);
         }
 

--- a/servicetalk-client-internal/src/test/java/io/servicetalk/client/internal/partition/DefaultPartitionAttributesBuilderTest.java
+++ b/servicetalk-client-internal/src/test/java/io/servicetalk/client/internal/partition/DefaultPartitionAttributesBuilderTest.java
@@ -29,11 +29,11 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
 public class DefaultPartitionAttributesBuilderTest {
-    private static final Key<String> SHARD_KEY = Key.newKeyWithDebugToString("shard");
-    private static final Key<String> DC_KEY = Key.newKeyWithDebugToString("dc");
-    private static final Key<Boolean> MASTER_KEY = Key.newKeyWithDebugToString("master");
-    private static final Key<Integer> OTHER_KEY = Key.newKeyWithDebugToString("other");
-    private static final Key<Integer> OTHER_KEY2 = Key.newKeyWithDebugToString("other2");
+    private static final Key<String> SHARD_KEY = Key.newKey("shard");
+    private static final Key<String> DC_KEY = Key.newKey("dc");
+    private static final Key<Boolean> MASTER_KEY = Key.newKey("master");
+    private static final Key<Integer> OTHER_KEY = Key.newKey("other");
+    private static final Key<Integer> OTHER_KEY2 = Key.newKey("other2");
     private static final String DEFAULT_SHARD = "myshard";
     private static final String DEFAULT_DC = "mydc";
 

--- a/servicetalk-client-internal/src/test/java/io/servicetalk/client/internal/partition/PowerSetPartitionMapTest.java
+++ b/servicetalk-client-internal/src/test/java/io/servicetalk/client/internal/partition/PowerSetPartitionMapTest.java
@@ -33,11 +33,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class PowerSetPartitionMapTest {
-    private static final Key<Integer> DC_ID = Key.newKeyWithDebugToString("dc");
-    private static final Key<String> APP_ID = Key.newKeyWithDebugToString("app");
-    private static final Key<Integer> SHARD_ID = Key.newKeyWithDebugToString("shard");
-    private static final Key<Boolean> IS_MASTER = Key.newKeyWithDebugToString("master");
-    private static final Key<Boolean> EXTRA = Key.newKeyWithDebugToString("extra");
+    private static final Key<Integer> DC_ID = Key.newKey("dc");
+    private static final Key<String> APP_ID = Key.newKey("app");
+    private static final Key<Integer> SHARD_ID = Key.newKey("shard");
+    private static final Key<Boolean> IS_MASTER = Key.newKey("master");
+    private static final Key<Boolean> EXTRA = Key.newKey("extra");
     private static final ListenableAsyncCloseable VALUE = new ListenableAsyncCloseable() {
         private final CompletableProcessor close = new CompletableProcessor();
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextMap.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextMap.java
@@ -48,14 +48,14 @@ public interface AsyncContextMap {
          * visibility.
          * <p>
          * Comparison between {@link Key} objects should be assumed to be on an instance basis.
-         * In general {@code newKeyWithDebugToString(str) != newKeyWithDebugToString(str)}.
+         * In general {@code newKey(str) != newKey(str)}.
          * @param toString The value to use in {@link #toString()}. This <strong>WILL NOT</strong> be used in
          * comparisons between {@link Key} objects.
          * @param <T> The value type associated with the {@link Key}.
          * @return a new {@link Key} which has a {@link String} used only in the {@link #toString()} method for
          * debugging visibility.
          */
-        public static <T> Key<T> newKeyWithDebugToString(String toString) {
+        public static <T> Key<T> newKey(String toString) {
             return new Key<>(toString);
         }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultAsyncContextProviderTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultAsyncContextProviderTest.java
@@ -68,14 +68,14 @@ public class DefaultAsyncContextProviderTest {
     @Rule
     public final Timeout timeout = new ServiceTalkTestTimeout();
 
-    private static final Key<String> K1 = Key.newKeyWithDebugToString("k1");
-    private static final Key<String> K2 = Key.newKeyWithDebugToString("k2");
-    private static final Key<String> K3 = Key.newKeyWithDebugToString("k3");
-    private static final Key<String> K4 = Key.newKeyWithDebugToString("k4");
-    private static final Key<String> K5 = Key.newKeyWithDebugToString("k5");
-    private static final Key<String> K6 = Key.newKeyWithDebugToString("k6");
-    private static final Key<String> K7 = Key.newKeyWithDebugToString("k7");
-    private static final Key<String> K8 = Key.newKeyWithDebugToString("k8");
+    private static final Key<String> K1 = Key.newKey("k1");
+    private static final Key<String> K2 = Key.newKey("k2");
+    private static final Key<String> K3 = Key.newKey("k3");
+    private static final Key<String> K4 = Key.newKey("k4");
+    private static final Key<String> K5 = Key.newKey("k5");
+    private static final Key<String> K6 = Key.newKey("k6");
+    private static final Key<String> K7 = Key.newKey("k7");
+    private static final Key<String> K8 = Key.newKey("k8");
 
     private static ScheduledExecutorService executor;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CompletionStageAsyncContextTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CompletionStageAsyncContextTest.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static io.servicetalk.concurrent.api.AsyncContextMap.Key.newKeyWithDebugToString;
+import static io.servicetalk.concurrent.api.AsyncContextMap.Key.newKey;
 import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
 import static io.servicetalk.concurrent.api.Single.fromStage;
 import static java.lang.Thread.NORM_PRIORITY;
@@ -45,7 +45,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class CompletionStageAsyncContextTest {
-    private static final Key<Integer> K1 = newKeyWithDebugToString("k1");
+    private static final Key<Integer> K1 = newKey("k1");
     @Rule
     public final ExecutorRule executorRule = new ExecutorRule(() ->
             newCachedThreadExecutor(new DefaultThreadFactory(ST_THREAD_PREFIX_NAME, true, NORM_PRIORITY)));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServiceAsyncContextTest.java
@@ -58,7 +58,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class HttpServiceAsyncContextTest {
-    private static final Key<CharSequence> K1 = Key.newKeyWithDebugToString("k1");
+    private static final Key<CharSequence> K1 = Key.newKey("k1");
     private static final CharSequence REQUEST_ID_HEADER = newAsciiString("request-id");
     private static final InetSocketAddress LOCAL_0 = new InetSocketAddress(getLoopbackAddress(), 0);
     @Rule

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/auth/BasicAuthStreamingHttpServiceBuilderTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/auth/BasicAuthStreamingHttpServiceBuilderTest.java
@@ -41,7 +41,7 @@ import org.junit.rules.Timeout;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
-import static io.servicetalk.concurrent.api.AsyncContextMap.Key.newKeyWithDebugToString;
+import static io.servicetalk.concurrent.api.AsyncContextMap.Key.newKey;
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Publisher.just;
 import static io.servicetalk.concurrent.api.Single.error;
@@ -72,7 +72,7 @@ import static org.mockito.Mockito.when;
 public class BasicAuthStreamingHttpServiceBuilderTest {
 
     private static final CharSequence USER_ID_HEADER_NAME = newAsciiString("test-userid");
-    private static final Key<BasicUserInfo> USER_INFO_KEY = newKeyWithDebugToString("basicUserInfo");
+    private static final Key<BasicUserInfo> USER_INFO_KEY = newKey("basicUserInfo");
     private static final class BasicUserInfo {
 
         private final String userId;

--- a/servicetalk-log4j2-mdc-internal/src/main/java/io/servicetalk/log4j2/mdc/internal/ServiceTalkThreadContextMap.java
+++ b/servicetalk-log4j2-mdc-internal/src/main/java/io/servicetalk/log4j2/mdc/internal/ServiceTalkThreadContextMap.java
@@ -38,7 +38,7 @@ import static java.util.Collections.unmodifiableMap;
  * A {@link ThreadContext} that provides storage for MDC based upon {@link AsyncContext}.
  */
 public class ServiceTalkThreadContextMap implements ReadOnlyThreadContextMap, CleanableThreadContextMap {
-    private static final Key<Map<String, String>> key = Key.newKeyWithDebugToString("log4j2Mdc");
+    private static final Key<Map<String, String>> key = Key.newKey("log4j2Mdc");
 
     @Override
     public final void put(String key, String value) {

--- a/servicetalk-opentracing-core/src/main/java/io/servicetalk/opentracing/core/AsyncContextInMemoryScopeManager.java
+++ b/servicetalk-opentracing-core/src/main/java/io/servicetalk/opentracing/core/AsyncContextInMemoryScopeManager.java
@@ -24,13 +24,13 @@ import io.servicetalk.opentracing.core.internal.ListenableInMemoryScopeManager;
 
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.AsyncContextMap.Key.newKeyWithDebugToString;
+import static io.servicetalk.concurrent.api.AsyncContextMap.Key.newKey;
 
 /**
  * A {@link ListenableInMemoryScopeManager} that uses {@link AsyncContext} as the backing storage.
  */
 public final class AsyncContextInMemoryScopeManager extends AbstractListenableInMemoryScopeManager {
-    private static final Key<InMemoryScope> SCOPE_KEY = newKeyWithDebugToString("opentracing");
+    private static final Key<InMemoryScope> SCOPE_KEY = newKey("opentracing");
     public static final ListenableInMemoryScopeManager SCOPE_MANAGER = new AsyncContextInMemoryScopeManager();
 
     /**

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/AbstractPartitionedRedisClientTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/AbstractPartitionedRedisClientTest.java
@@ -71,8 +71,8 @@ public abstract class AbstractPartitionedRedisClientTest {
     public final PublisherRule<PartitionedServiceDiscovererEvent<InetSocketAddress>> serviceDiscoveryPublisher =
             new PublisherRule<>();
 
-    private static final Key<Boolean> MASTER_KEY = Key.newKeyWithDebugToString("master");
-    private static final Key<Integer> SHARD_KEY = Key.newKeyWithDebugToString("shard");
+    private static final Key<Boolean> MASTER_KEY = Key.newKey("master");
+    private static final Key<Integer> SHARD_KEY = Key.newKey("shard");
     private static final Map<String, Integer> keyToShardMap;
 
     static {

--- a/servicetalk-rxjava-context/src/test/java/io/servicetalk/rxjava/context/RxJavaContextHooksTest.java
+++ b/servicetalk-rxjava-context/src/test/java/io/servicetalk/rxjava/context/RxJavaContextHooksTest.java
@@ -53,8 +53,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class RxJavaContextHooksTest {
-    private static final Key<String> K1 = Key.newKeyWithDebugToString("k1");
-    private static final Key<String> K2 = Key.newKeyWithDebugToString("k2");
+    private static final Key<String> K1 = Key.newKey("k1");
+    private static final Key<String> K2 = Key.newKey("k2");
 
     private static ScheduledExecutorService executor;
     private static Observable<String> sharedObservable;


### PR DESCRIPTION
Motivation:
AsyncContextMap and PartitionAttributes have inner class Key which is compared by reference. However for debugging and visibility there is a factory method that allows a string to be provided. The method name is newKeyWithDebugToString to emphasize the String value will not be used in comparisons. However this is seen as overly verbose and the javadocs clarify the purpose adequately.

Modifications:
- rename newKeyWithDebugToString to newKey

Result:
Less verbose Key creation.