### PR TITLE
Unify HttpServers API with HttpClients

### DIFF
--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/async/HelloWorldServer.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/async/HelloWorldServer.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.examples.http.helloworld.async;
 
-import io.servicetalk.http.api.HttpRequestHandler;
 import io.servicetalk.http.netty.HttpServers;
 
 import static io.servicetalk.concurrent.api.Single.success;
@@ -24,7 +23,7 @@ import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
 public final class HelloWorldServer {
 
     public static void main(String[] args) throws Exception {
-        HttpServers.newHttpServerBuilder(8080)
+        HttpServers.forPort(8080)
                 .listenAndAwait((ctx, request, responseFactory) ->
                         success(responseFactory.ok()
                                 .payloadBody("Hello World!", textSerializer())))

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/async/streaming/HelloWorldStreamingServer.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/async/streaming/HelloWorldStreamingServer.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.examples.http.helloworld.async.streaming;
 
-import io.servicetalk.http.api.StreamingHttpRequestHandler;
 import io.servicetalk.http.netty.HttpServers;
 
 import static io.servicetalk.concurrent.api.Publisher.from;
@@ -24,7 +23,7 @@ import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
 
 public final class HelloWorldStreamingServer {
     public static void main(String[] args) throws Exception {
-        HttpServers.newHttpServerBuilder(8080)
+        HttpServers.forPort(8080)
                 .listenStreamingAndAwait((ctx, request, responseFactory) ->
                         success(responseFactory.ok()
                                 .payloadBody(from("Hello\n", "World\n", "From\n", "ServiceTalk\n"), textSerializer())))

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/blocking/BlockingHelloWorldServer.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/blocking/BlockingHelloWorldServer.java
@@ -21,7 +21,7 @@ import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
 
 public class BlockingHelloWorldServer {
     public static void main(String[] args) throws Exception {
-        HttpServers.newHttpServerBuilder(8080)
+        HttpServers.forPort(8080)
                 .listenBlockingAndAwait((ctx, request, responseFactory) ->
                         responseFactory.ok().payloadBody("Hello World!", textSerializer()))
                 .awaitShutdown();

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/blocking/streaming/BlockingHelloWorldStreamingServer.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/helloworld/blocking/streaming/BlockingHelloWorldStreamingServer.java
@@ -15,15 +15,14 @@
  */
 package io.servicetalk.examples.http.helloworld.blocking.streaming;
 
-import io.servicetalk.http.api.BlockingStreamingHttpRequestHandler;
+import io.servicetalk.http.netty.HttpServers;
 
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
-import static io.servicetalk.http.netty.HttpServers.newHttpServerBuilder;
 import static java.util.Arrays.asList;
 
 public final class BlockingHelloWorldStreamingServer {
     public static void main(String[] args) throws Exception {
-        newHttpServerBuilder(8080)
+        HttpServers.forPort(8080)
                 .listenBlockingStreamingAndAwait((ctx, request, responseFactory) ->
                         responseFactory.ok().payloadBody(
                                 asList("Hello\n", "World\n", "From\n", "ServiceTalk\n"), textSerializer()))

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/jaxrs/HelloWorldJaxRsServer.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/jaxrs/HelloWorldJaxRsServer.java
@@ -42,7 +42,7 @@ public final class HelloWorldJaxRsServer {
      */
     public static void main(String[] args) throws Exception {
         // Create configurable starter for HTTP server.
-        ServerContext serverContext = HttpServers.newHttpServerBuilder(8080)
+        ServerContext serverContext = HttpServers.forPort(8080)
                 .listenStreamingAndAwait(new HttpJerseyRouterBuilder().build(new HelloWorldJaxrsApplication()));
 
         LOGGER.info("listening on {}", serverContext.listenAddress());

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/serialization/async/PojoServer.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/serialization/async/PojoServer.java
@@ -18,7 +18,6 @@ package io.servicetalk.examples.http.serialization.async;
 import io.servicetalk.data.jackson.JacksonSerializationProvider;
 import io.servicetalk.examples.http.serialization.MyPojo;
 import io.servicetalk.examples.http.serialization.PojoRequest;
-import io.servicetalk.http.api.HttpRequestHandler;
 import io.servicetalk.http.api.HttpSerializationProvider;
 import io.servicetalk.http.netty.HttpServers;
 
@@ -29,7 +28,7 @@ public final class PojoServer {
 
     public static void main(String[] args) throws Exception {
         HttpSerializationProvider serializer = jsonSerializer(new JacksonSerializationProvider());
-        HttpServers.newHttpServerBuilder(8080)
+        HttpServers.forPort(8080)
                 .listenAndAwait((ctx, request, responseFactory) -> {
                     PojoRequest req = request.payloadBody(serializer.deserializerFor(PojoRequest.class));
                     return success(responseFactory.ok()

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/serialization/async/streaming/PojoStreamingServer.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/serialization/async/streaming/PojoStreamingServer.java
@@ -19,17 +19,16 @@ import io.servicetalk.data.jackson.JacksonSerializationProvider;
 import io.servicetalk.examples.http.serialization.MyPojo;
 import io.servicetalk.examples.http.serialization.PojoRequest;
 import io.servicetalk.http.api.HttpSerializationProvider;
-import io.servicetalk.http.api.StreamingHttpRequestHandler;
+import io.servicetalk.http.netty.HttpServers;
 
 import static io.servicetalk.concurrent.api.Single.success;
 import static io.servicetalk.http.api.HttpSerializationProviders.jsonSerializer;
-import static io.servicetalk.http.netty.HttpServers.newHttpServerBuilder;
 
 public class PojoStreamingServer {
 
     public static void main(String[] args) throws Exception {
         HttpSerializationProvider serializer = jsonSerializer(new JacksonSerializationProvider());
-        newHttpServerBuilder(8080)
+        HttpServers.forPort(8080)
                 .listenStreamingAndAwait((ctx, request, responseFactory) ->
                         success(responseFactory.ok()
                                 .payloadBody(request.payloadBody(serializer.deserializerFor(PojoRequest.class))

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/serialization/blocking/BlockingPojoServer.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/serialization/blocking/BlockingPojoServer.java
@@ -18,7 +18,6 @@ package io.servicetalk.examples.http.serialization.blocking;
 import io.servicetalk.data.jackson.JacksonSerializationProvider;
 import io.servicetalk.examples.http.serialization.MyPojo;
 import io.servicetalk.examples.http.serialization.PojoRequest;
-import io.servicetalk.http.api.BlockingHttpRequestHandler;
 import io.servicetalk.http.api.HttpSerializationProvider;
 import io.servicetalk.http.netty.HttpServers;
 
@@ -28,7 +27,7 @@ public class BlockingPojoServer {
 
     public static void main(String[] args) throws Exception {
         HttpSerializationProvider serializer = jsonSerializer(new JacksonSerializationProvider());
-        HttpServers.newHttpServerBuilder(8080)
+        HttpServers.forPort(8080)
                 .listenBlockingAndAwait((ctx, request, responseFactory) -> {
                     PojoRequest req = request.payloadBody(serializer.deserializerFor(PojoRequest.class));
                     return responseFactory.ok()

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/serialization/blocking/streaming/BlockingPojoStreamingServer.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/serialization/blocking/streaming/BlockingPojoStreamingServer.java
@@ -20,20 +20,19 @@ import io.servicetalk.concurrent.BlockingIterator;
 import io.servicetalk.data.jackson.JacksonSerializationProvider;
 import io.servicetalk.examples.http.serialization.MyPojo;
 import io.servicetalk.examples.http.serialization.PojoRequest;
-import io.servicetalk.http.api.BlockingStreamingHttpRequestHandler;
 import io.servicetalk.http.api.HttpSerializationProvider;
+import io.servicetalk.http.netty.HttpServers;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static io.servicetalk.http.api.HttpSerializationProviders.jsonSerializer;
-import static io.servicetalk.http.netty.HttpServers.newHttpServerBuilder;
 
 public class BlockingPojoStreamingServer {
 
     public static void main(String[] args) throws Exception {
         HttpSerializationProvider serializer = jsonSerializer(new JacksonSerializationProvider());
-        newHttpServerBuilder(8080)
+        HttpServers.forPort(8080)
                 .listenBlockingStreamingAndAwait((ctx, request, responseFactory) -> {
                     BlockingIterable<PojoRequest> ids = request.payloadBody(serializer.deserializerFor(PojoRequest.class));
                     List<MyPojo> pojos = new ArrayList<>();

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/GatewayServer.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/GatewayServer.java
@@ -103,7 +103,7 @@ public final class GatewayServer {
 
             // Create configurable starter for HTTP server.
             // Starting the server will start listening for incoming client requests.
-            ServerContext serverContext = HttpServers.newHttpServerBuilder(8080)
+            ServerContext serverContext = HttpServers.forPort(8080)
                     .ioExecutor(ioExecutor)
                     .listenStreamingAndAwait(gatewayService);
 

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/backends/BackendStarter.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/backends/BackendStarter.java
@@ -18,13 +18,13 @@ package io.servicetalk.examples.http.service.composition.backends;
 import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.http.api.HttpService;
 import io.servicetalk.http.api.StreamingHttpService;
+import io.servicetalk.http.netty.HttpServers;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.servicetalk.http.netty.HttpServers.newHttpServerBuilder;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -44,7 +44,7 @@ final class BackendStarter {
 
     ServerContext start(int listenPort, String name, StreamingHttpService service) throws Exception {
         // Starting the server will start listening for incoming client requests.
-        final ServerContext ctx = newHttpServerBuilder(listenPort)
+        final ServerContext ctx = HttpServers.forPort(listenPort)
                 .ioExecutor(ioExecutor)
                 .listenStreamingAndAwait(service);
         LOGGER.info("Started {} listening on {}.", name, ctx.listenAddress());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpServers.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpServers.java
@@ -37,7 +37,7 @@ public final class HttpServers {
      * @return a new builder.
      * @see HttpServerBuilder#port(int)
      */
-    public static HttpServerBuilder newHttpServerBuilder(int port) {
+    public static HttpServerBuilder forPort(int port) {
         return new DefaultHttpServerBuilder(new InetSocketAddress(port));
     }
 
@@ -48,7 +48,7 @@ public final class HttpServers {
      * @return a new builder.
      * @see HttpServerBuilder#address(SocketAddress)
      */
-    public static HttpServerBuilder newHttpServerBuilder(SocketAddress socketAddress) {
+    public static HttpServerBuilder forAddress(SocketAddress socketAddress) {
         return new DefaultHttpServerBuilder(socketAddress);
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractEchoServerBasedHttpRequesterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractEchoServerBasedHttpRequesterTest.java
@@ -44,7 +44,6 @@ import static io.servicetalk.concurrent.internal.Await.awaitIndefinitely;
 import static io.servicetalk.concurrent.internal.Await.awaitIndefinitelyNonNull;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.http.api.HttpRequestMethods.GET;
-import static io.servicetalk.http.netty.HttpServers.newHttpServerBuilder;
 import static io.servicetalk.transport.netty.internal.ExecutionContextRule.immediate;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -63,7 +62,7 @@ public abstract class AbstractEchoServerBasedHttpRequesterTest {
 
     @BeforeClass
     public static void startServer() throws Exception {
-        serverContext = newHttpServerBuilder(0)
+        serverContext = HttpServers.forPort(0)
                 .ioExecutor(CTX.ioExecutor())
                 .executor(CTX.executor())
                 .listenStreamingAndAwait(new EchoServiceStreaming());

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -135,7 +135,7 @@ public abstract class AbstractNettyHttpServerTest {
         // A small SNDBUF is needed to test that the server defers closing the connection until writes are complete.
         // However, if it is too small, tests that expect certain chunks of data will see those chunks broken up
         // differently.
-        final HttpServerBuilder serverBuilder = HttpServers.newHttpServerBuilder(bindAddress)
+        final HttpServerBuilder serverBuilder = HttpServers.forAddress(bindAddress)
                 .socketOption(StandardSocketOptions.SO_SNDBUF, 100);
         if (sslEnabled) {
             final SslConfig sslConfig = SslConfigBuilder.forServer(

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOverrideTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOverrideTest.java
@@ -72,7 +72,7 @@ public class FlushStrategyOverrideTest {
     @Before
     public void setUp() throws Exception {
         service = new FlushingService();
-        serverCtx = HttpServers.newHttpServerBuilder(0)
+        serverCtx = HttpServers.forPort(0)
                 .ioExecutor(ctx.ioExecutor())
                 .executor(ctx.executor())
                 .listenStreaming(service)

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HostHeaderHttpConnectionFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HostHeaderHttpConnectionFilterTest.java
@@ -56,7 +56,7 @@ public class HostHeaderHttpConnectionFilterTest {
     }
 
     private ServerContext buildServer() throws Exception {
-        return HttpServers.newHttpServerBuilder(0)
+        return HttpServers.forPort(0)
                 .listenStreamingAndAwait((ctx, request, responseFactory) ->
                             success(responseFactory.ok().payloadBody(
                                     just(requireNonNull(request.headers().get(HOST)).toString()), textSerializer())));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
@@ -45,7 +45,6 @@ import static io.servicetalk.concurrent.internal.Await.awaitIndefinitely;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpResponseStatuses.OK;
-import static io.servicetalk.http.netty.HttpServers.newHttpServerBuilder;
 import static java.util.Objects.requireNonNull;
 import static org.junit.Assert.assertEquals;
 
@@ -71,7 +70,7 @@ public class HttpAuthConnectionFactoryClientTest {
 
     @Test
     public void simulateAuth() throws Exception {
-        serverContext = newHttpServerBuilder(0)
+        serverContext = HttpServers.forPort(0)
                 .ioExecutor(CTX.ioExecutor())
                 .executor(CTX.executor())
                 .listenStreamingAndAwait(

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionEmptyPayloadTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionEmptyPayloadTest.java
@@ -43,7 +43,6 @@ import static io.servicetalk.concurrent.internal.Await.awaitIndefinitelyNonNull;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpRequestMethods.HEAD;
 import static io.servicetalk.http.api.HttpResponseStatuses.OK;
-import static io.servicetalk.http.netty.HttpServers.newHttpServerBuilder;
 import static io.servicetalk.transport.netty.internal.ExecutionContextRule.immediate;
 import static java.lang.Integer.parseInt;
 import static org.junit.Assert.assertArrayEquals;
@@ -62,7 +61,7 @@ public class HttpConnectionEmptyPayloadTest {
             final int expectedContentLength = 128;
             byte[] expectedPayload = new byte[expectedContentLength];
             ThreadLocalRandom.current().nextBytes(expectedPayload);
-            ServerContext serverContext = closeable.merge(newHttpServerBuilder(0)
+            ServerContext serverContext = closeable.merge(HttpServers.forPort(0)
                     .ioExecutor(executionContextRule.ioExecutor())
                     .executor(executionContextRule.executor())
                     .listenStreamingAndAwait(

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
@@ -60,7 +60,6 @@ import static io.servicetalk.concurrent.internal.Await.awaitIndefinitelyNonNull;
 import static io.servicetalk.http.api.HttpResponseStatuses.OK;
 import static io.servicetalk.http.api.StreamingHttpConnection.SettingKey.MAX_CONCURRENCY;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
-import static io.servicetalk.http.netty.HttpServers.newHttpServerBuilder;
 import static io.servicetalk.transport.netty.internal.ExecutionContextRule.cached;
 import static java.lang.Long.MAX_VALUE;
 import static java.lang.Thread.currentThread;
@@ -96,7 +95,7 @@ public class HttpOffloadingTest {
     public void beforeTest() throws Exception {
         final InetSocketAddress bindAddress = new InetSocketAddress(LOOPBACK_ADDRESS, 0);
         service = new OffloadingVerifyingServiceStreaming();
-        serverContext = newHttpServerBuilder(bindAddress)
+        serverContext = HttpServers.forAddress(bindAddress)
                 .ioExecutor(SERVER_CTX.ioExecutor())
                 .executor(SERVER_CTX.executor())
                 .listenStreamingAndAwait(service);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServerFilterOrderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServerFilterOrderTest.java
@@ -28,7 +28,6 @@ import java.net.InetSocketAddress;
 
 import static io.servicetalk.http.api.HttpResponseStatuses.OK;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
-import static io.servicetalk.http.netty.HttpServers.newHttpServerBuilder;
 import static io.servicetalk.transport.api.HostAndPort.of;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -43,7 +42,7 @@ public class HttpServerFilterOrderTest {
     public void prependOrder() throws Exception {
         StreamingHttpRequestHandler filter1 = newMockHandler();
         StreamingHttpRequestHandler filter2 = newMockHandler();
-        ServerContext serverContext = newHttpServerBuilder(0)
+        ServerContext serverContext = HttpServers.forPort(0)
                 .appendServiceFilter(addFilter(filter1))
                 .appendServiceFilter(addFilter(filter2))
                 .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServerMultipleRequestsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServerMultipleRequestsTest.java
@@ -88,7 +88,7 @@ public class HttpServerMultipleRequestsTest {
         final int concurrency = 10;
         final int numRequests = 10;
         CompositeCloseable compositeCloseable = AsyncCloseables.newCompositeCloseable();
-        ServerContext ctx = compositeCloseable.append(HttpServers.newHttpServerBuilder(LOCAL_0)
+        ServerContext ctx = compositeCloseable.append(HttpServers.forAddress(LOCAL_0)
                 .ioExecutor(serverExecution.ioExecutor())
                 .executor(serverExecution.executor())
                 .listenStreamingAndAwait(service));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServiceAsyncContextTest.java
@@ -51,7 +51,6 @@ import static io.servicetalk.http.api.CharSequences.newAsciiString;
 import static io.servicetalk.http.api.HttpResponseStatuses.BAD_REQUEST;
 import static io.servicetalk.http.api.HttpResponseStatuses.INTERNAL_SERVER_ERROR;
 import static io.servicetalk.http.api.HttpResponseStatuses.OK;
-import static io.servicetalk.http.netty.HttpServers.newHttpServerBuilder;
 import static java.net.InetAddress.getLoopbackAddress;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -79,7 +78,7 @@ public class HttpServiceAsyncContextTest {
     private void newRequestsGetFreshContext(boolean useImmediate) throws Exception {
         StreamingHttpService service = newEmptyAsyncContextService();
         CompositeCloseable compositeCloseable = AsyncCloseables.newCompositeCloseable();
-        HttpServerBuilder serverBuilder = newHttpServerBuilder(LOCAL_0);
+        HttpServerBuilder serverBuilder = HttpServers.forAddress(LOCAL_0);
         ServerContext ctx = (useImmediate ? serverBuilder.executor(immediateExecutor.executor()) : serverBuilder)
                 .listenStreamingAndAwait(service);
 
@@ -152,7 +151,7 @@ public class HttpServiceAsyncContextTest {
             }
         };
         CompositeCloseable compositeCloseable = AsyncCloseables.newCompositeCloseable();
-        ServerContext ctx = compositeCloseable.append(newHttpServerBuilder(LOCAL_0)
+        ServerContext ctx = compositeCloseable.append(HttpServers.forAddress(LOCAL_0)
                 .listenStreamingAndAwait(filter));
         try {
             StreamingHttpConnection connection = compositeCloseable.append(new DefaultHttpConnectionBuilder<SocketAddress>()
@@ -167,7 +166,7 @@ public class HttpServiceAsyncContextTest {
     public void connectionContextFilterContextDoesNotLeak() throws Exception {
         StreamingHttpService service = newEmptyAsyncContextService();
         CompositeCloseable compositeCloseable = AsyncCloseables.newCompositeCloseable();
-        ServerContext ctx = compositeCloseable.append(HttpServers.newHttpServerBuilder(LOCAL_0)
+        ServerContext ctx = compositeCloseable.append(HttpServers.forAddress(LOCAL_0)
                 .contextFilter(context -> {
                     AsyncContext.put(K1, "v1");
                     return success(true);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientSslTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientSslTest.java
@@ -58,7 +58,6 @@ import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpResponseStatuses.OK;
 import static io.servicetalk.http.api.SslConfigProviders.plainByDefault;
 import static io.servicetalk.http.api.SslConfigProviders.secureByDefault;
-import static io.servicetalk.http.netty.HttpServers.newHttpServerBuilder;
 import static io.servicetalk.transport.api.SslConfigBuilder.forClient;
 import static io.servicetalk.transport.netty.internal.ExecutionContextRule.immediate;
 import static java.lang.String.format;
@@ -108,7 +107,7 @@ public class MultiAddressUrlHttpClientSslTest {
                 });
         when(STREAMING_HTTP_SERVICE.closeAsync()).thenReturn(completed());
         when(STREAMING_HTTP_SERVICE.closeAsyncGracefully()).thenReturn(completed());
-        serverCtx = newHttpServerBuilder(new InetSocketAddress(HOSTNAME, 0))
+        serverCtx = HttpServers.forAddress(new InetSocketAddress(HOSTNAME, 0))
                 .ioExecutor(CTX.ioExecutor())
                 .executor(CTX.executor())
                 .listenStreamingAndAwait(STREAMING_HTTP_SERVICE);
@@ -125,7 +124,7 @@ public class MultiAddressUrlHttpClientSslTest {
                 });
         when(SECURE_STREAMING_HTTP_SERVICE.closeAsync()).thenReturn(completed());
         when(SECURE_STREAMING_HTTP_SERVICE.closeAsyncGracefully()).thenReturn(completed());
-        secureServerCtx = newHttpServerBuilder(new InetSocketAddress(HOSTNAME, 0))
+        secureServerCtx = HttpServers.forAddress(new InetSocketAddress(HOSTNAME, 0))
                 .sslConfig(SslConfigBuilder.forServer(DefaultTestCerts::loadServerPem,
                         DefaultTestCerts::loadServerKey).build())
                 .ioExecutor(CTX.ioExecutor())

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
@@ -67,7 +67,6 @@ import static io.servicetalk.http.api.HttpResponseStatuses.OK;
 import static io.servicetalk.http.api.HttpResponseStatuses.PERMANENT_REDIRECT;
 import static io.servicetalk.http.api.HttpResponseStatuses.SEE_OTHER;
 import static io.servicetalk.http.api.HttpResponseStatuses.UNAUTHORIZED;
-import static io.servicetalk.http.netty.HttpServers.newHttpServerBuilder;
 import static io.servicetalk.transport.netty.internal.ExecutionContextRule.immediate;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -277,7 +276,7 @@ public class MultiAddressUrlHttpClientTest {
 
     private static ServerContext startNewLocalServer(final StreamingHttpService httpService,
                                                      final CompositeCloseable closeables) throws Exception {
-        return closeables.append(newHttpServerBuilder(new InetSocketAddress(HOSTNAME, 0))
+        return closeables.append(HttpServers.forAddress(new InetSocketAddress(HOSTNAME, 0))
                 .ioExecutor(CTX.ioExecutor())
                 .executor(CTX.executor())
                 .listenStreamingAndAwait(httpService));

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractJerseyStreamingHttpServiceTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractJerseyStreamingHttpServiceTest.java
@@ -27,6 +27,7 @@ import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.netty.HttpClients;
+import io.servicetalk.http.netty.HttpServers;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.IoThreadFactory;
@@ -66,7 +67,6 @@ import static io.servicetalk.http.api.HttpRequestMethods.HEAD;
 import static io.servicetalk.http.api.HttpRequestMethods.OPTIONS;
 import static io.servicetalk.http.api.HttpRequestMethods.POST;
 import static io.servicetalk.http.api.HttpRequestMethods.PUT;
-import static io.servicetalk.http.netty.HttpServers.newHttpServerBuilder;
 import static io.servicetalk.http.router.jersey.TestUtils.getContentAsString;
 import static io.servicetalk.transport.api.HostAndPort.of;
 import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
@@ -103,7 +103,7 @@ public abstract class AbstractJerseyStreamingHttpServiceTest {
                 String.class).toLowerCase().contains("servicetalk");
 
         ExecutionContext serverExecutionContext = getServerExecutionContext();
-        serverContext = newHttpServerBuilder(0)
+        serverContext = HttpServers.forPort(0)
                 .ioExecutor(serverExecutionContext.ioExecutor())
                 .executor(serverExecutionContext.executor())
                 .bufferAllocator(serverExecutionContext.bufferAllocator())

--- a/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpConnectionFilterTest.java
+++ b/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpConnectionFilterTest.java
@@ -138,7 +138,7 @@ public class TracingHttpConnectionFilterTest {
     }
 
     private ServerContext buildServer() throws Exception {
-        return HttpServers.newHttpServerBuilder(0)
+        return HttpServers.forPort(0)
                 .listenStreamingAndAwait((ctx, request, responseFactory) ->
                         success(responseFactory.ok().payloadBody(just(new TestSpanState(
                         valueOf(request.headers().get(TRACE_ID)),

--- a/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpServiceFilterTest.java
+++ b/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpServiceFilterTest.java
@@ -76,7 +76,7 @@ public class TracingHttpServiceFilterTest {
 
     private ServerContext buildServer() throws Exception {
         DefaultInMemoryTracer tracer = new DefaultInMemoryTracer.Builder(SCOPE_MANAGER).build();
-        return HttpServers.newHttpServerBuilder(0)
+        return HttpServers.forPort(0)
                 .listenStreamingAndAwait(new TracingHttpServiceFilter(tracer, "testServer",
                         ((StreamingHttpRequestHandler) (ctx, request, responseFactory) -> {
                     InMemorySpan span = tracer.activeSpan();
@@ -135,7 +135,7 @@ public class TracingHttpServiceFilterTest {
     @Test
     public void tracerThrowsReturnsErrorResponse() throws Exception {
         when(mockTracer.buildSpan(any())).thenThrow(DELIBERATE_EXCEPTION);
-        try (ServerContext context = HttpServers.newHttpServerBuilder(0)
+        try (ServerContext context = HttpServers.forPort(0)
                 .listenStreamingAndAwait(new TracingHttpServiceFilter(mockTracer, "testServer",
                         ((StreamingHttpRequestHandler) (ctx, request, responseFactory) ->
                                 success(responseFactory.forbidden())).asStreamingService()))) {


### PR DESCRIPTION
## Motivation

Methods names in `HttpServers` are explicit enough so they can be statically imported while methods in `HttpClients` are not. Moreover "builder" is mentioned in `HttpServers` names while it's not in `HttpClients`.

Compare for ex. `newHttpServerBuilder` versus `HttpClients.forSingleAddress`

We should unify such top level highly visible APIs.

## Modifications

Adopt `HttpClients#for*` name parttern in `HttpServers`.

## Results

More homogeneous APIs.
