### PR TITLE
Provide helper methods to create JAX-RS ContextResolver for custom JSON serialization

### DIFF
--- a/servicetalk-data-jackson-jersey/README.md
+++ b/servicetalk-data-jackson-jersey/README.md
@@ -1,0 +1,25 @@
+# ServiceTalk Data Jackson Jersey
+
+This module provides Jackson-based JSON serialization and deserialization for ServiceTalk Jersey router.
+It is a replacement for `jersey-media-json-jackson` and allows avoiding the input stream adaptation that kicks in
+with out-of-the-box body readers and also allows accepting/returning `Single<Pojo>` and `Publisher<Pojo>`
+from resource methods.
+
+## Using a custom ObjectMapper
+
+If you have configured a Jackson `ObjectMapper` and want to use it with this module, you need to provide it to the
+JAX-RS runtime as
+a [`ContextResolver`](https://jax-rs.github.io/apidocs/2.1/index.html?javax/ws/rs/ext/ContextResolver.html).
+To help with this, `ServiceTalkJacksonSerializerFeature` provides a helper method named `contextResolverFor` that
+can build a `ContextResolver<JacksonSerializationProvider>` from an `ObjectMapper` instance.
+
+It is up to the user to properly register this `ContextResolver` with their application.
+
+## Using a custom JacksonSerializationProvider
+
+Like with `ObjectMapper`, if you want to use a custom `ServiceTalkJacksonSerializerFeature` you need to provide it as
+a [`ContextResolver`](https://jax-rs.github.io/apidocs/2.1/index.html?javax/ws/rs/ext/ContextResolver.html).
+`ServiceTalkJacksonSerializerFeature` provides a helper method named `contextResolverFor` that
+can build a `ContextResolver<JacksonSerializationProvider>` from an `ServiceTalkJacksonSerializerFeature` instance.
+
+It is up to the user to properly register this `ContextResolver` with their application.

--- a/servicetalk-data-jackson-jersey/src/main/java/io/servicetalk/data/jackson/jersey/JacksonSerializationProviderContextResolver.java
+++ b/servicetalk-data-jackson-jersey/src/main/java/io/servicetalk/data/jackson/jersey/JacksonSerializationProviderContextResolver.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.data.jackson.jersey;
+
+import io.servicetalk.data.jackson.JacksonSerializationProvider;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.ext.ContextResolver;
+
+final class JacksonSerializationProviderContextResolver implements ContextResolver<JacksonSerializationProvider> {
+    private final JacksonSerializationProvider jacksonSerializationProvider;
+
+    JacksonSerializationProviderContextResolver(final JacksonSerializationProvider jacksonSerializationProvider) {
+        this.jacksonSerializationProvider = jacksonSerializationProvider;
+    }
+
+    @Nullable
+    @Override
+    public JacksonSerializationProvider getContext(final Class<?> type) {
+        if (!JacksonSerializationProvider.class.isAssignableFrom(type)) {
+            return null;
+        }
+
+        return jacksonSerializationProvider;
+    }
+}

--- a/servicetalk-data-jackson-jersey/src/main/java/io/servicetalk/data/jackson/jersey/ServiceTalkJacksonSerializerFeature.java
+++ b/servicetalk-data-jackson-jersey/src/main/java/io/servicetalk/data/jackson/jersey/ServiceTalkJacksonSerializerFeature.java
@@ -15,13 +15,18 @@
  */
 package io.servicetalk.data.jackson.jersey;
 
+import io.servicetalk.data.jackson.JacksonSerializationProvider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.ext.ContextResolver;
 
+import static java.util.Objects.requireNonNull;
 import static org.glassfish.jersey.CommonProperties.getValue;
 import static org.glassfish.jersey.internal.InternalProperties.JSON_FEATURE;
 import static org.glassfish.jersey.internal.util.PropertiesHelper.getPropertyNameForRuntime;
@@ -60,5 +65,26 @@ public final class ServiceTalkJacksonSerializerFeature implements Feature {
         }
 
         return true;
+    }
+
+    /**
+     * Create a new {@link ContextResolver} for {@link JacksonSerializationProvider} used by this feature.
+     *
+     * @param objectMapper the {@link ObjectMapper} to use for creating a {@link JacksonSerializationProvider}.
+     * @return a {@link ContextResolver}.
+     */
+    public static ContextResolver<JacksonSerializationProvider> contextResolverFor(final ObjectMapper objectMapper) {
+        return contextResolverFor(new JacksonSerializationProvider(objectMapper));
+    }
+
+    /**
+     * Create a new {@link ContextResolver} for {@link JacksonSerializationProvider} used by this feature.
+     *
+     * @param serializationProvider the {@link JacksonSerializationProvider} to use.
+     * @return a {@link ContextResolver}.
+     */
+    public static ContextResolver<JacksonSerializationProvider> contextResolverFor(
+            final JacksonSerializationProvider serializationProvider) {
+        return new JacksonSerializationProviderContextResolver(requireNonNull(serializationProvider));
     }
 }

--- a/servicetalk-data-jackson-jersey/src/test/java/io/servicetalk/data/jackson/jersey/CustomJacksonSerializationProviderTest.java
+++ b/servicetalk-data-jackson-jersey/src/test/java/io/servicetalk/data/jackson/jersey/CustomJacksonSerializationProviderTest.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.data.jackson.jersey;
 
-import io.servicetalk.data.jackson.JacksonSerializationProvider;
 import io.servicetalk.data.jackson.jersey.resources.SingleJsonResources;
 import io.servicetalk.http.router.jersey.AbstractJerseyStreamingHttpServiceTest;
 
@@ -23,11 +22,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
 import java.util.Set;
-import javax.annotation.Nullable;
 import javax.ws.rs.core.Application;
-import javax.ws.rs.ext.ContextResolver;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static io.servicetalk.data.jackson.jersey.ServiceTalkJacksonSerializerFeature.contextResolverFor;
 import static io.servicetalk.data.jackson.jersey.resources.SingleJsonResources.PATH;
 import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_JSON;
 import static io.servicetalk.http.api.HttpResponseStatuses.OK;
@@ -43,17 +41,7 @@ public class CustomJacksonSerializationProviderTest extends AbstractJerseyStream
 
         @Override
         public Set<Object> getSingletons() {
-            return singleton(new ContextResolver<JacksonSerializationProvider>() {
-                @Nullable
-                @Override
-                public JacksonSerializationProvider getContext(final Class<?> type) {
-                    if (!JacksonSerializationProvider.class.isAssignableFrom(type)) {
-                        return null;
-                    }
-
-                    return new JacksonSerializationProvider(new ObjectMapper().disable(FAIL_ON_UNKNOWN_PROPERTIES));
-                }
-            });
+            return singleton(contextResolverFor(new ObjectMapper().disable(FAIL_ON_UNKNOWN_PROPERTIES)));
         }
     }
 

--- a/servicetalk-data-jackson/src/main/java/io/servicetalk/data/jackson/JacksonSerializationProvider.java
+++ b/servicetalk-data-jackson/src/main/java/io/servicetalk/data/jackson/JacksonSerializationProvider.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 
 import static io.servicetalk.buffer.api.Buffer.asOutputStream;
 import static io.servicetalk.concurrent.internal.PlatformDependent.throwException;
+import static java.util.Objects.requireNonNull;
 
 /**
  * {@link SerializationProvider} implementation using jackson.
@@ -55,7 +56,7 @@ public final class JacksonSerializationProvider implements SerializationProvider
      * @param mapper {@link ObjectMapper} to use.
      */
     public JacksonSerializationProvider(final ObjectMapper mapper) {
-        this.mapper = mapper;
+        this.mapper = requireNonNull(mapper);
     }
 
     @Override


### PR DESCRIPTION
## Motivation

Currently users have to do the following to be able to provide a custom ObjectMapper to our JAX-RS serialization:
```java
    new ContextResolver<JacksonSerializationProvider>() {
                @Nullable
                @Override
                public JacksonSerializationProvider getContext(final Class<?> type) {
                    if (!JacksonSerializationProvider.class.isAssignableFrom(type)) {
                        return null;
                    }

                    return new JacksonSerializationProvider(customObjectMapper);
                }
            }
```
We can wrap this in a static helper exposed on `ServiceTalkJacksonSerializerFeature`.

## Modifications

Add `ServiceTalkJacksonSerializerFeature #contextResolverFor` methods that allow creating `ContextResolver<JacksonSerializationProvider>` for custom `ObjectMapper` and `JacksonSerializationProvider` instances.

## Result

Less boilerplate code to write.
