### PR TITLE
Ignore flaky BlockingBufferRedisCommanderTest.pubSubMultipleSubscribes

### DIFF
--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BlockingBufferRedisCommanderTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BlockingBufferRedisCommanderTest.java
@@ -62,6 +62,8 @@ import static io.servicetalk.redis.api.RedisProtocolSupport.IntegerType.U04;
 import static io.servicetalk.redis.api.RedisProtocolSupport.IntegerType.U08;
 import static io.servicetalk.redis.api.RedisProtocolSupport.SetCondition.NX;
 import static io.servicetalk.redis.api.RedisProtocolSupport.SetExpire.EX;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.parseBoolean;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -354,6 +356,7 @@ public class BlockingBufferRedisCommanderTest extends BaseRedisClientTest {
 
     @Test
     public void pubSubMultipleSubscribes() throws Exception {
+        assumeThat("Ignored flaky test", parseBoolean(System.getenv("CI")), is(FALSE));
         final BlockingPubSubBufferRedisConnection pubSubClient1 = commandClient.subscribe(key("channel-1"));
         BlockingIterable<PubSubRedisMessage> messages1 = pubSubClient1.getMessages();
         BlockingIterator<PubSubRedisMessage> iterator1 = messages1.iterator();


### PR DESCRIPTION
Motivation:

This test periodically fails on CI with timeout exception and breaks PRB.

Modifications:

- Ignore `BlockingBufferRedisCommanderTest.pubSubMultipleSubscribes` on CI;

Result:

Minus one flaky test.

---
This PR ignores test from issue #104. 