### PR TITLE
Fix generics on mget/hmget.

### DIFF
--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingBufferRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingBufferRedisCommander.java
@@ -1544,11 +1544,10 @@ public abstract class BlockingBufferRedisCommander implements AutoCloseable {
      * @param key the key
      * @param field the field
      * @return a {@link List} result
-     * @param <T> the type of elements
      * @throws Exception if an exception occurs during the request processing.
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> List<T> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field) throws Exception;
+    public abstract List<Buffer> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field) throws Exception;
 
     /**
      * Get the values of all the given hash fields.
@@ -1557,12 +1556,11 @@ public abstract class BlockingBufferRedisCommander implements AutoCloseable {
      * @param field1 the field1
      * @param field2 the field2
      * @return a {@link List} result
-     * @param <T> the type of elements
      * @throws Exception if an exception occurs during the request processing.
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> List<T> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field1,
-                                      Buffer field2) throws Exception;
+    public abstract List<Buffer> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field1,
+                                       Buffer field2) throws Exception;
 
     /**
      * Get the values of all the given hash fields.
@@ -1572,12 +1570,11 @@ public abstract class BlockingBufferRedisCommander implements AutoCloseable {
      * @param field2 the field2
      * @param field3 the field3
      * @return a {@link List} result
-     * @param <T> the type of elements
      * @throws Exception if an exception occurs during the request processing.
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> List<T> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field1, Buffer field2,
-                                      Buffer field3) throws Exception;
+    public abstract List<Buffer> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field1, Buffer field2,
+                                       Buffer field3) throws Exception;
 
     /**
      * Get the values of all the given hash fields.
@@ -1585,11 +1582,11 @@ public abstract class BlockingBufferRedisCommander implements AutoCloseable {
      * @param key the key
      * @param fields the fields
      * @return a {@link List} result
-     * @param <T> the type of elements
      * @throws Exception if an exception occurs during the request processing.
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> List<T> hmget(@RedisProtocolSupport.Key Buffer key, Collection<Buffer> fields) throws Exception;
+    public abstract List<Buffer> hmget(@RedisProtocolSupport.Key Buffer key,
+                                       Collection<Buffer> fields) throws Exception;
 
     /**
      * Set multiple hash fields to multiple values.
@@ -2027,11 +2024,10 @@ public abstract class BlockingBufferRedisCommander implements AutoCloseable {
      *
      * @param key the key
      * @return a {@link List} result
-     * @param <T> the type of elements
      * @throws Exception if an exception occurs during the request processing.
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> List<T> mget(@RedisProtocolSupport.Key Buffer key) throws Exception;
+    public abstract List<Buffer> mget(@RedisProtocolSupport.Key Buffer key) throws Exception;
 
     /**
      * Get the values of all the given keys.
@@ -2039,12 +2035,11 @@ public abstract class BlockingBufferRedisCommander implements AutoCloseable {
      * @param key1 the key1
      * @param key2 the key2
      * @return a {@link List} result
-     * @param <T> the type of elements
      * @throws Exception if an exception occurs during the request processing.
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> List<T> mget(@RedisProtocolSupport.Key Buffer key1,
-                                     @RedisProtocolSupport.Key Buffer key2) throws Exception;
+    public abstract List<Buffer> mget(@RedisProtocolSupport.Key Buffer key1,
+                                      @RedisProtocolSupport.Key Buffer key2) throws Exception;
 
     /**
      * Get the values of all the given keys.
@@ -2053,23 +2048,21 @@ public abstract class BlockingBufferRedisCommander implements AutoCloseable {
      * @param key2 the key2
      * @param key3 the key3
      * @return a {@link List} result
-     * @param <T> the type of elements
      * @throws Exception if an exception occurs during the request processing.
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> List<T> mget(@RedisProtocolSupport.Key Buffer key1, @RedisProtocolSupport.Key Buffer key2,
-                                     @RedisProtocolSupport.Key Buffer key3) throws Exception;
+    public abstract List<Buffer> mget(@RedisProtocolSupport.Key Buffer key1, @RedisProtocolSupport.Key Buffer key2,
+                                      @RedisProtocolSupport.Key Buffer key3) throws Exception;
 
     /**
      * Get the values of all the given keys.
      *
      * @param keys the keys
      * @return a {@link List} result
-     * @param <T> the type of elements
      * @throws Exception if an exception occurs during the request processing.
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> List<T> mget(@RedisProtocolSupport.Key Collection<Buffer> keys) throws Exception;
+    public abstract List<Buffer> mget(@RedisProtocolSupport.Key Collection<Buffer> keys) throws Exception;
 
     /**
      * Listen for all requests received by the server in real time.
@@ -3509,7 +3502,7 @@ public abstract class BlockingBufferRedisCommander implements AutoCloseable {
      * @throws Exception if an exception occurs during the request processing.
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.SRANDMEMBER)
-    public abstract List<String> srandmember(@RedisProtocolSupport.Key Buffer key, long count) throws Exception;
+    public abstract List<Buffer> srandmember(@RedisProtocolSupport.Key Buffer key, long count) throws Exception;
 
     /**
      * Remove one or more members from a set.

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingBufferRedisCommanderToBufferRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingBufferRedisCommanderToBufferRedisCommander.java
@@ -731,24 +731,24 @@ final class BlockingBufferRedisCommanderToBufferRedisCommander extends BufferRed
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
+    public Single<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         return blockingToSingle(() -> blockingCommander.hmget(key, field));
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
-                                     final Buffer field2) {
+    public Single<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
+                                      final Buffer field2) {
         return blockingToSingle(() -> blockingCommander.hmget(key, field1, field2));
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
-                                     final Buffer field2, final Buffer field3) {
+    public Single<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
+                                      final Buffer field2, final Buffer field3) {
         return blockingToSingle(() -> blockingCommander.hmget(key, field1, field2, field3));
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
+    public Single<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
         return blockingToSingle(() -> blockingCommander.hmget(key, fields));
     }
 
@@ -944,25 +944,25 @@ final class BlockingBufferRedisCommanderToBufferRedisCommander extends BufferRed
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Buffer key) {
+    public Single<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key) {
         return blockingToSingle(() -> blockingCommander.mget(key));
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Buffer key1,
-                                    @RedisProtocolSupport.Key final Buffer key2) {
+    public Single<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key1,
+                                     @RedisProtocolSupport.Key final Buffer key2) {
         return blockingToSingle(() -> blockingCommander.mget(key1, key2));
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Buffer key1,
-                                    @RedisProtocolSupport.Key final Buffer key2,
-                                    @RedisProtocolSupport.Key final Buffer key3) {
+    public Single<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key1,
+                                     @RedisProtocolSupport.Key final Buffer key2,
+                                     @RedisProtocolSupport.Key final Buffer key3) {
         return blockingToSingle(() -> blockingCommander.mget(key1, key2, key3));
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
+    public Single<List<Buffer>> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         return blockingToSingle(() -> blockingCommander.mget(keys));
     }
 
@@ -1637,7 +1637,7 @@ final class BlockingBufferRedisCommanderToBufferRedisCommander extends BufferRed
     }
 
     @Override
-    public Single<List<String>> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) {
+    public Single<List<Buffer>> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) {
         return blockingToSingle(() -> blockingCommander.srandmember(key, count));
     }
 

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingPartitionedBufferRedisCommanderToPartitionedBufferRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingPartitionedBufferRedisCommanderToPartitionedBufferRedisCommander.java
@@ -732,24 +732,24 @@ final class BlockingPartitionedBufferRedisCommanderToPartitionedBufferRedisComma
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
+    public Single<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         return blockingToSingle(() -> partitionedRedisClient.hmget(key, field));
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
-                                     final Buffer field2) {
+    public Single<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
+                                      final Buffer field2) {
         return blockingToSingle(() -> partitionedRedisClient.hmget(key, field1, field2));
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
-                                     final Buffer field2, final Buffer field3) {
+    public Single<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
+                                      final Buffer field2, final Buffer field3) {
         return blockingToSingle(() -> partitionedRedisClient.hmget(key, field1, field2, field3));
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
+    public Single<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
         return blockingToSingle(() -> partitionedRedisClient.hmget(key, fields));
     }
 
@@ -946,25 +946,25 @@ final class BlockingPartitionedBufferRedisCommanderToPartitionedBufferRedisComma
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Buffer key) {
+    public Single<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key) {
         return blockingToSingle(() -> partitionedRedisClient.mget(key));
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Buffer key1,
-                                    @RedisProtocolSupport.Key final Buffer key2) {
+    public Single<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key1,
+                                     @RedisProtocolSupport.Key final Buffer key2) {
         return blockingToSingle(() -> partitionedRedisClient.mget(key1, key2));
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Buffer key1,
-                                    @RedisProtocolSupport.Key final Buffer key2,
-                                    @RedisProtocolSupport.Key final Buffer key3) {
+    public Single<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key1,
+                                     @RedisProtocolSupport.Key final Buffer key2,
+                                     @RedisProtocolSupport.Key final Buffer key3) {
         return blockingToSingle(() -> partitionedRedisClient.mget(key1, key2, key3));
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
+    public Single<List<Buffer>> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         return blockingToSingle(() -> partitionedRedisClient.mget(keys));
     }
 
@@ -1640,7 +1640,7 @@ final class BlockingPartitionedBufferRedisCommanderToPartitionedBufferRedisComma
     }
 
     @Override
-    public Single<List<String>> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) {
+    public Single<List<Buffer>> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) {
         return blockingToSingle(() -> partitionedRedisClient.srandmember(key, count));
     }
 

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingPartitionedRedisCommanderToPartitionedRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingPartitionedRedisCommanderToPartitionedRedisCommander.java
@@ -744,25 +744,25 @@ final class BlockingPartitionedRedisCommanderToPartitionedRedisCommander extends
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
+    public Single<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         return blockingToSingle(() -> partitionedRedisClient.hmget(key, field));
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
-                                     final CharSequence field2) {
+    public Single<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
+                                      final CharSequence field2) {
         return blockingToSingle(() -> partitionedRedisClient.hmget(key, field1, field2));
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
-                                     final CharSequence field2, final CharSequence field3) {
+    public Single<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
+                                      final CharSequence field2, final CharSequence field3) {
         return blockingToSingle(() -> partitionedRedisClient.hmget(key, field1, field2, field3));
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key,
-                                     final Collection<? extends CharSequence> fields) {
+    public Single<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key,
+                                      final Collection<? extends CharSequence> fields) {
         return blockingToSingle(() -> partitionedRedisClient.hmget(key, fields));
     }
 
@@ -970,25 +970,25 @@ final class BlockingPartitionedRedisCommanderToPartitionedRedisCommander extends
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key) {
+    public Single<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key) {
         return blockingToSingle(() -> partitionedRedisClient.mget(key));
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key1,
-                                    @RedisProtocolSupport.Key final CharSequence key2) {
+    public Single<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key1,
+                                     @RedisProtocolSupport.Key final CharSequence key2) {
         return blockingToSingle(() -> partitionedRedisClient.mget(key1, key2));
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key1,
-                                    @RedisProtocolSupport.Key final CharSequence key2,
-                                    @RedisProtocolSupport.Key final CharSequence key3) {
+    public Single<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key1,
+                                     @RedisProtocolSupport.Key final CharSequence key2,
+                                     @RedisProtocolSupport.Key final CharSequence key3) {
         return blockingToSingle(() -> partitionedRedisClient.mget(key1, key2, key3));
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
+    public Single<List<String>> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         return blockingToSingle(() -> partitionedRedisClient.mget(keys));
     }
 

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingRedisCommander.java
@@ -1558,11 +1558,10 @@ public abstract class BlockingRedisCommander implements AutoCloseable {
      * @param key the key
      * @param field the field
      * @return a {@link List} result
-     * @param <T> the type of elements
      * @throws Exception if an exception occurs during the request processing.
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> List<T> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field) throws Exception;
+    public abstract List<String> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field) throws Exception;
 
     /**
      * Get the values of all the given hash fields.
@@ -1571,12 +1570,11 @@ public abstract class BlockingRedisCommander implements AutoCloseable {
      * @param field1 the field1
      * @param field2 the field2
      * @return a {@link List} result
-     * @param <T> the type of elements
      * @throws Exception if an exception occurs during the request processing.
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> List<T> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field1,
-                                      CharSequence field2) throws Exception;
+    public abstract List<String> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field1,
+                                       CharSequence field2) throws Exception;
 
     /**
      * Get the values of all the given hash fields.
@@ -1586,12 +1584,11 @@ public abstract class BlockingRedisCommander implements AutoCloseable {
      * @param field2 the field2
      * @param field3 the field3
      * @return a {@link List} result
-     * @param <T> the type of elements
      * @throws Exception if an exception occurs during the request processing.
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> List<T> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field1,
-                                      CharSequence field2, CharSequence field3) throws Exception;
+    public abstract List<String> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field1,
+                                       CharSequence field2, CharSequence field3) throws Exception;
 
     /**
      * Get the values of all the given hash fields.
@@ -1599,12 +1596,11 @@ public abstract class BlockingRedisCommander implements AutoCloseable {
      * @param key the key
      * @param fields the fields
      * @return a {@link List} result
-     * @param <T> the type of elements
      * @throws Exception if an exception occurs during the request processing.
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> List<T> hmget(@RedisProtocolSupport.Key CharSequence key,
-                                      Collection<? extends CharSequence> fields) throws Exception;
+    public abstract List<String> hmget(@RedisProtocolSupport.Key CharSequence key,
+                                       Collection<? extends CharSequence> fields) throws Exception;
 
     /**
      * Set multiple hash fields to multiple values.
@@ -2051,11 +2047,10 @@ public abstract class BlockingRedisCommander implements AutoCloseable {
      *
      * @param key the key
      * @return a {@link List} result
-     * @param <T> the type of elements
      * @throws Exception if an exception occurs during the request processing.
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> List<T> mget(@RedisProtocolSupport.Key CharSequence key) throws Exception;
+    public abstract List<String> mget(@RedisProtocolSupport.Key CharSequence key) throws Exception;
 
     /**
      * Get the values of all the given keys.
@@ -2063,12 +2058,11 @@ public abstract class BlockingRedisCommander implements AutoCloseable {
      * @param key1 the key1
      * @param key2 the key2
      * @return a {@link List} result
-     * @param <T> the type of elements
      * @throws Exception if an exception occurs during the request processing.
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> List<T> mget(@RedisProtocolSupport.Key CharSequence key1,
-                                     @RedisProtocolSupport.Key CharSequence key2) throws Exception;
+    public abstract List<String> mget(@RedisProtocolSupport.Key CharSequence key1,
+                                      @RedisProtocolSupport.Key CharSequence key2) throws Exception;
 
     /**
      * Get the values of all the given keys.
@@ -2077,24 +2071,22 @@ public abstract class BlockingRedisCommander implements AutoCloseable {
      * @param key2 the key2
      * @param key3 the key3
      * @return a {@link List} result
-     * @param <T> the type of elements
      * @throws Exception if an exception occurs during the request processing.
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> List<T> mget(@RedisProtocolSupport.Key CharSequence key1,
-                                     @RedisProtocolSupport.Key CharSequence key2,
-                                     @RedisProtocolSupport.Key CharSequence key3) throws Exception;
+    public abstract List<String> mget(@RedisProtocolSupport.Key CharSequence key1,
+                                      @RedisProtocolSupport.Key CharSequence key2,
+                                      @RedisProtocolSupport.Key CharSequence key3) throws Exception;
 
     /**
      * Get the values of all the given keys.
      *
      * @param keys the keys
      * @return a {@link List} result
-     * @param <T> the type of elements
      * @throws Exception if an exception occurs during the request processing.
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> List<T> mget(@RedisProtocolSupport.Key Collection<? extends CharSequence> keys) throws Exception;
+    public abstract List<String> mget(@RedisProtocolSupport.Key Collection<? extends CharSequence> keys) throws Exception;
 
     /**
      * Listen for all requests received by the server in real time.

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingRedisCommanderToRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingRedisCommanderToRedisCommander.java
@@ -744,25 +744,25 @@ final class BlockingRedisCommanderToRedisCommander extends RedisCommander {
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
+    public Single<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         return blockingToSingle(() -> blockingCommander.hmget(key, field));
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
-                                     final CharSequence field2) {
+    public Single<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
+                                      final CharSequence field2) {
         return blockingToSingle(() -> blockingCommander.hmget(key, field1, field2));
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
-                                     final CharSequence field2, final CharSequence field3) {
+    public Single<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
+                                      final CharSequence field2, final CharSequence field3) {
         return blockingToSingle(() -> blockingCommander.hmget(key, field1, field2, field3));
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key,
-                                     final Collection<? extends CharSequence> fields) {
+    public Single<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key,
+                                      final Collection<? extends CharSequence> fields) {
         return blockingToSingle(() -> blockingCommander.hmget(key, fields));
     }
 
@@ -969,25 +969,25 @@ final class BlockingRedisCommanderToRedisCommander extends RedisCommander {
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key) {
+    public Single<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key) {
         return blockingToSingle(() -> blockingCommander.mget(key));
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key1,
-                                    @RedisProtocolSupport.Key final CharSequence key2) {
+    public Single<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key1,
+                                     @RedisProtocolSupport.Key final CharSequence key2) {
         return blockingToSingle(() -> blockingCommander.mget(key1, key2));
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key1,
-                                    @RedisProtocolSupport.Key final CharSequence key2,
-                                    @RedisProtocolSupport.Key final CharSequence key3) {
+    public Single<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key1,
+                                     @RedisProtocolSupport.Key final CharSequence key2,
+                                     @RedisProtocolSupport.Key final CharSequence key3) {
         return blockingToSingle(() -> blockingCommander.mget(key1, key2, key3));
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
+    public Single<List<String>> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         return blockingToSingle(() -> blockingCommander.mget(keys));
     }
 

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingTransactedBufferRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingTransactedBufferRedisCommander.java
@@ -1433,10 +1433,9 @@ public abstract class BlockingTransactedBufferRedisCommander implements AutoClos
      * @param key the key
      * @param field the field
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Future<List<T>> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field);
+    public abstract Future<List<Buffer>> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field);
 
     /**
      * Get the values of all the given hash fields.
@@ -1445,10 +1444,9 @@ public abstract class BlockingTransactedBufferRedisCommander implements AutoClos
      * @param field1 the field1
      * @param field2 the field2
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Future<List<T>> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field1, Buffer field2);
+    public abstract Future<List<Buffer>> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field1, Buffer field2);
 
     /**
      * Get the values of all the given hash fields.
@@ -1458,11 +1456,10 @@ public abstract class BlockingTransactedBufferRedisCommander implements AutoClos
      * @param field2 the field2
      * @param field3 the field3
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Future<List<T>> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field1, Buffer field2,
-                                              Buffer field3);
+    public abstract Future<List<Buffer>> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field1, Buffer field2,
+                                               Buffer field3);
 
     /**
      * Get the values of all the given hash fields.
@@ -1470,10 +1467,9 @@ public abstract class BlockingTransactedBufferRedisCommander implements AutoClos
      * @param key the key
      * @param fields the fields
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Future<List<T>> hmget(@RedisProtocolSupport.Key Buffer key, Collection<Buffer> fields);
+    public abstract Future<List<Buffer>> hmget(@RedisProtocolSupport.Key Buffer key, Collection<Buffer> fields);
 
     /**
      * Set multiple hash fields to multiple values.
@@ -1874,10 +1870,9 @@ public abstract class BlockingTransactedBufferRedisCommander implements AutoClos
      *
      * @param key the key
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Future<List<T>> mget(@RedisProtocolSupport.Key Buffer key);
+    public abstract Future<List<Buffer>> mget(@RedisProtocolSupport.Key Buffer key);
 
     /**
      * Get the values of all the given keys.
@@ -1885,11 +1880,10 @@ public abstract class BlockingTransactedBufferRedisCommander implements AutoClos
      * @param key1 the key1
      * @param key2 the key2
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Future<List<T>> mget(@RedisProtocolSupport.Key Buffer key1,
-                                             @RedisProtocolSupport.Key Buffer key2);
+    public abstract Future<List<Buffer>> mget(@RedisProtocolSupport.Key Buffer key1,
+                                              @RedisProtocolSupport.Key Buffer key2);
 
     /**
      * Get the values of all the given keys.
@@ -1898,22 +1892,20 @@ public abstract class BlockingTransactedBufferRedisCommander implements AutoClos
      * @param key2 the key2
      * @param key3 the key3
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Future<List<T>> mget(@RedisProtocolSupport.Key Buffer key1,
-                                             @RedisProtocolSupport.Key Buffer key2,
-                                             @RedisProtocolSupport.Key Buffer key3);
+    public abstract Future<List<Buffer>> mget(@RedisProtocolSupport.Key Buffer key1,
+                                              @RedisProtocolSupport.Key Buffer key2,
+                                              @RedisProtocolSupport.Key Buffer key3);
 
     /**
      * Get the values of all the given keys.
      *
      * @param keys the keys
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Future<List<T>> mget(@RedisProtocolSupport.Key Collection<Buffer> keys);
+    public abstract Future<List<Buffer>> mget(@RedisProtocolSupport.Key Collection<Buffer> keys);
 
     /**
      * Move a key to another database.
@@ -3206,7 +3198,7 @@ public abstract class BlockingTransactedBufferRedisCommander implements AutoClos
      * @return a {@link Future} result
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.SRANDMEMBER)
-    public abstract Future<List<String>> srandmember(@RedisProtocolSupport.Key Buffer key, long count);
+    public abstract Future<List<Buffer>> srandmember(@RedisProtocolSupport.Key Buffer key, long count);
 
     /**
      * Remove one or more members from a set.

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingTransactedBufferRedisCommanderToTransactedBufferRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingTransactedBufferRedisCommanderToTransactedBufferRedisCommander.java
@@ -740,24 +740,24 @@ final class BlockingTransactedBufferRedisCommanderToTransactedBufferRedisCommand
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
+    public Future<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         return reservedCnx.hmget(key, field);
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
-                                     final Buffer field2) {
+    public Future<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
+                                      final Buffer field2) {
         return reservedCnx.hmget(key, field1, field2);
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
-                                     final Buffer field2, final Buffer field3) {
+    public Future<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
+                                      final Buffer field2, final Buffer field3) {
         return reservedCnx.hmget(key, field1, field2, field3);
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
+    public Future<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
         return reservedCnx.hmget(key, fields);
     }
 
@@ -953,25 +953,25 @@ final class BlockingTransactedBufferRedisCommanderToTransactedBufferRedisCommand
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final Buffer key) {
+    public Future<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key) {
         return reservedCnx.mget(key);
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final Buffer key1,
-                                    @RedisProtocolSupport.Key final Buffer key2) {
+    public Future<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key1,
+                                     @RedisProtocolSupport.Key final Buffer key2) {
         return reservedCnx.mget(key1, key2);
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final Buffer key1,
-                                    @RedisProtocolSupport.Key final Buffer key2,
-                                    @RedisProtocolSupport.Key final Buffer key3) {
+    public Future<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key1,
+                                     @RedisProtocolSupport.Key final Buffer key2,
+                                     @RedisProtocolSupport.Key final Buffer key3) {
         return reservedCnx.mget(key1, key2, key3);
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
+    public Future<List<Buffer>> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         return reservedCnx.mget(keys);
     }
 
@@ -1627,7 +1627,7 @@ final class BlockingTransactedBufferRedisCommanderToTransactedBufferRedisCommand
     }
 
     @Override
-    public Future<List<String>> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) {
+    public Future<List<Buffer>> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) {
         return reservedCnx.srandmember(key, count);
     }
 

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingTransactedRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingTransactedRedisCommander.java
@@ -1453,10 +1453,9 @@ public abstract class BlockingTransactedRedisCommander implements AutoCloseable 
      * @param key the key
      * @param field the field
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Future<List<T>> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field);
+    public abstract Future<List<String>> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field);
 
     /**
      * Get the values of all the given hash fields.
@@ -1465,11 +1464,10 @@ public abstract class BlockingTransactedRedisCommander implements AutoCloseable 
      * @param field1 the field1
      * @param field2 the field2
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Future<List<T>> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field1,
-                                              CharSequence field2);
+    public abstract Future<List<String>> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field1,
+                                               CharSequence field2);
 
     /**
      * Get the values of all the given hash fields.
@@ -1479,11 +1477,10 @@ public abstract class BlockingTransactedRedisCommander implements AutoCloseable 
      * @param field2 the field2
      * @param field3 the field3
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Future<List<T>> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field1,
-                                              CharSequence field2, CharSequence field3);
+    public abstract Future<List<String>> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field1,
+                                               CharSequence field2, CharSequence field3);
 
     /**
      * Get the values of all the given hash fields.
@@ -1491,11 +1488,10 @@ public abstract class BlockingTransactedRedisCommander implements AutoCloseable 
      * @param key the key
      * @param fields the fields
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Future<List<T>> hmget(@RedisProtocolSupport.Key CharSequence key,
-                                              Collection<? extends CharSequence> fields);
+    public abstract Future<List<String>> hmget(@RedisProtocolSupport.Key CharSequence key,
+                                               Collection<? extends CharSequence> fields);
 
     /**
      * Set multiple hash fields to multiple values.
@@ -1902,10 +1898,9 @@ public abstract class BlockingTransactedRedisCommander implements AutoCloseable 
      *
      * @param key the key
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Future<List<T>> mget(@RedisProtocolSupport.Key CharSequence key);
+    public abstract Future<List<String>> mget(@RedisProtocolSupport.Key CharSequence key);
 
     /**
      * Get the values of all the given keys.
@@ -1913,11 +1908,10 @@ public abstract class BlockingTransactedRedisCommander implements AutoCloseable 
      * @param key1 the key1
      * @param key2 the key2
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Future<List<T>> mget(@RedisProtocolSupport.Key CharSequence key1,
-                                             @RedisProtocolSupport.Key CharSequence key2);
+    public abstract Future<List<String>> mget(@RedisProtocolSupport.Key CharSequence key1,
+                                              @RedisProtocolSupport.Key CharSequence key2);
 
     /**
      * Get the values of all the given keys.
@@ -1926,22 +1920,20 @@ public abstract class BlockingTransactedRedisCommander implements AutoCloseable 
      * @param key2 the key2
      * @param key3 the key3
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Future<List<T>> mget(@RedisProtocolSupport.Key CharSequence key1,
-                                             @RedisProtocolSupport.Key CharSequence key2,
-                                             @RedisProtocolSupport.Key CharSequence key3);
+    public abstract Future<List<String>> mget(@RedisProtocolSupport.Key CharSequence key1,
+                                              @RedisProtocolSupport.Key CharSequence key2,
+                                              @RedisProtocolSupport.Key CharSequence key3);
 
     /**
      * Get the values of all the given keys.
      *
      * @param keys the keys
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Future<List<T>> mget(@RedisProtocolSupport.Key Collection<? extends CharSequence> keys);
+    public abstract Future<List<String>> mget(@RedisProtocolSupport.Key Collection<? extends CharSequence> keys);
 
     /**
      * Move a key to another database.

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingTransactedRedisCommanderToTransactedRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingTransactedRedisCommanderToTransactedRedisCommander.java
@@ -752,25 +752,25 @@ final class BlockingTransactedRedisCommanderToTransactedRedisCommander extends T
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
+    public Future<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         return reservedCnx.hmget(key, field);
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
-                                     final CharSequence field2) {
+    public Future<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
+                                      final CharSequence field2) {
         return reservedCnx.hmget(key, field1, field2);
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
-                                     final CharSequence field2, final CharSequence field3) {
+    public Future<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
+                                      final CharSequence field2, final CharSequence field3) {
         return reservedCnx.hmget(key, field1, field2, field3);
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key,
-                                     final Collection<? extends CharSequence> fields) {
+    public Future<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key,
+                                      final Collection<? extends CharSequence> fields) {
         return reservedCnx.hmget(key, fields);
     }
 
@@ -977,25 +977,25 @@ final class BlockingTransactedRedisCommanderToTransactedRedisCommander extends T
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key) {
+    public Future<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key) {
         return reservedCnx.mget(key);
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key1,
-                                    @RedisProtocolSupport.Key final CharSequence key2) {
+    public Future<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key1,
+                                     @RedisProtocolSupport.Key final CharSequence key2) {
         return reservedCnx.mget(key1, key2);
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key1,
-                                    @RedisProtocolSupport.Key final CharSequence key2,
-                                    @RedisProtocolSupport.Key final CharSequence key3) {
+    public Future<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key1,
+                                     @RedisProtocolSupport.Key final CharSequence key2,
+                                     @RedisProtocolSupport.Key final CharSequence key3) {
         return reservedCnx.mget(key1, key2, key3);
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
+    public Future<List<String>> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         return reservedCnx.mget(keys);
     }
 

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BufferRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BufferRedisCommander.java
@@ -1424,10 +1424,9 @@ public abstract class BufferRedisCommander implements AsyncCloseable {
      * @param key the key
      * @param field the field
      * @return a {@link Single} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Single<List<T>> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field);
+    public abstract Single<List<Buffer>> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field);
 
     /**
      * Get the values of all the given hash fields.
@@ -1436,10 +1435,9 @@ public abstract class BufferRedisCommander implements AsyncCloseable {
      * @param field1 the field1
      * @param field2 the field2
      * @return a {@link Single} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Single<List<T>> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field1, Buffer field2);
+    public abstract Single<List<Buffer>> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field1, Buffer field2);
 
     /**
      * Get the values of all the given hash fields.
@@ -1449,11 +1447,10 @@ public abstract class BufferRedisCommander implements AsyncCloseable {
      * @param field2 the field2
      * @param field3 the field3
      * @return a {@link Single} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Single<List<T>> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field1, Buffer field2,
-                                              Buffer field3);
+    public abstract Single<List<Buffer>> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field1, Buffer field2,
+                                               Buffer field3);
 
     /**
      * Get the values of all the given hash fields.
@@ -1461,10 +1458,9 @@ public abstract class BufferRedisCommander implements AsyncCloseable {
      * @param key the key
      * @param fields the fields
      * @return a {@link Single} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Single<List<T>> hmget(@RedisProtocolSupport.Key Buffer key, Collection<Buffer> fields);
+    public abstract Single<List<Buffer>> hmget(@RedisProtocolSupport.Key Buffer key, Collection<Buffer> fields);
 
     /**
      * Set multiple hash fields to multiple values.
@@ -1865,10 +1861,9 @@ public abstract class BufferRedisCommander implements AsyncCloseable {
      *
      * @param key the key
      * @return a {@link Single} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Single<List<T>> mget(@RedisProtocolSupport.Key Buffer key);
+    public abstract Single<List<Buffer>> mget(@RedisProtocolSupport.Key Buffer key);
 
     /**
      * Get the values of all the given keys.
@@ -1876,11 +1871,10 @@ public abstract class BufferRedisCommander implements AsyncCloseable {
      * @param key1 the key1
      * @param key2 the key2
      * @return a {@link Single} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Single<List<T>> mget(@RedisProtocolSupport.Key Buffer key1,
-                                             @RedisProtocolSupport.Key Buffer key2);
+    public abstract Single<List<Buffer>> mget(@RedisProtocolSupport.Key Buffer key1,
+                                              @RedisProtocolSupport.Key Buffer key2);
 
     /**
      * Get the values of all the given keys.
@@ -1889,22 +1883,20 @@ public abstract class BufferRedisCommander implements AsyncCloseable {
      * @param key2 the key2
      * @param key3 the key3
      * @return a {@link Single} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Single<List<T>> mget(@RedisProtocolSupport.Key Buffer key1,
-                                             @RedisProtocolSupport.Key Buffer key2,
-                                             @RedisProtocolSupport.Key Buffer key3);
+    public abstract Single<List<Buffer>> mget(@RedisProtocolSupport.Key Buffer key1,
+                                              @RedisProtocolSupport.Key Buffer key2,
+                                              @RedisProtocolSupport.Key Buffer key3);
 
     /**
      * Get the values of all the given keys.
      *
      * @param keys the keys
      * @return a {@link Single} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Single<List<T>> mget(@RedisProtocolSupport.Key Collection<Buffer> keys);
+    public abstract Single<List<Buffer>> mget(@RedisProtocolSupport.Key Collection<Buffer> keys);
 
     /**
      * Listen for all requests received by the server in real time.
@@ -3223,7 +3215,7 @@ public abstract class BufferRedisCommander implements AsyncCloseable {
      * @return a {@link Single} result
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.SRANDMEMBER)
-    public abstract Single<List<String>> srandmember(@RedisProtocolSupport.Key Buffer key, long count);
+    public abstract Single<List<Buffer>> srandmember(@RedisProtocolSupport.Key Buffer key, long count);
 
     /**
      * Remove one or more members from a set.

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BufferRedisCommanderToBlockingBufferRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BufferRedisCommanderToBlockingBufferRedisCommander.java
@@ -728,25 +728,25 @@ final class BufferRedisCommanderToBlockingBufferRedisCommander extends BlockingB
     }
 
     @Override
-    public <T> List<T> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) throws Exception {
+    public List<Buffer> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) throws Exception {
         return blockingInvocation(commander.hmget(key, field));
     }
 
     @Override
-    public <T> List<T> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
-                             final Buffer field2) throws Exception {
+    public List<Buffer> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
+                              final Buffer field2) throws Exception {
         return blockingInvocation(commander.hmget(key, field1, field2));
     }
 
     @Override
-    public <T> List<T> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1, final Buffer field2,
-                             final Buffer field3) throws Exception {
+    public List<Buffer> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1, final Buffer field2,
+                              final Buffer field3) throws Exception {
         return blockingInvocation(commander.hmget(key, field1, field2, field3));
     }
 
     @Override
-    public <T> List<T> hmget(@RedisProtocolSupport.Key final Buffer key,
-                             final Collection<Buffer> fields) throws Exception {
+    public List<Buffer> hmget(@RedisProtocolSupport.Key final Buffer key,
+                              final Collection<Buffer> fields) throws Exception {
         return blockingInvocation(commander.hmget(key, fields));
     }
 
@@ -952,24 +952,24 @@ final class BufferRedisCommanderToBlockingBufferRedisCommander extends BlockingB
     }
 
     @Override
-    public <T> List<T> mget(@RedisProtocolSupport.Key final Buffer key) throws Exception {
+    public List<Buffer> mget(@RedisProtocolSupport.Key final Buffer key) throws Exception {
         return blockingInvocation(commander.mget(key));
     }
 
     @Override
-    public <T> List<T> mget(@RedisProtocolSupport.Key final Buffer key1,
-                            @RedisProtocolSupport.Key final Buffer key2) throws Exception {
+    public List<Buffer> mget(@RedisProtocolSupport.Key final Buffer key1,
+                             @RedisProtocolSupport.Key final Buffer key2) throws Exception {
         return blockingInvocation(commander.mget(key1, key2));
     }
 
     @Override
-    public <T> List<T> mget(@RedisProtocolSupport.Key final Buffer key1, @RedisProtocolSupport.Key final Buffer key2,
-                            @RedisProtocolSupport.Key final Buffer key3) throws Exception {
+    public List<Buffer> mget(@RedisProtocolSupport.Key final Buffer key1, @RedisProtocolSupport.Key final Buffer key2,
+                             @RedisProtocolSupport.Key final Buffer key3) throws Exception {
         return blockingInvocation(commander.mget(key1, key2, key3));
     }
 
     @Override
-    public <T> List<T> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) throws Exception {
+    public List<Buffer> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) throws Exception {
         return blockingInvocation(commander.mget(keys));
     }
 
@@ -1645,7 +1645,7 @@ final class BufferRedisCommanderToBlockingBufferRedisCommander extends BlockingB
     }
 
     @Override
-    public List<String> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) throws Exception {
+    public List<Buffer> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) throws Exception {
         return blockingInvocation(commander.srandmember(key, count));
     }
 

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultBufferRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultBufferRedisCommander.java
@@ -2114,7 +2114,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
+    public Single<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         requireNonNull(key);
         requireNonNull(field);
         final BufferAllocator allocator = requester.executionContext().bufferAllocator();
@@ -2124,13 +2124,13 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         addRequestArgument(key, cb, allocator);
         addRequestArgument(field, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.HMGET, cb);
-        final Single<List<T>> result = (Single) requester.request(request, List.class);
+        final Single<List<Buffer>> result = (Single) requester.request(request, List.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
-                                     final Buffer field2) {
+    public Single<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
+                                      final Buffer field2) {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
@@ -2142,13 +2142,13 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         addRequestArgument(field1, cb, allocator);
         addRequestArgument(field2, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.HMGET, cb);
-        final Single<List<T>> result = (Single) requester.request(request, List.class);
+        final Single<List<Buffer>> result = (Single) requester.request(request, List.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
-                                     final Buffer field2, final Buffer field3) {
+    public Single<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
+                                      final Buffer field2, final Buffer field3) {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
@@ -2162,12 +2162,12 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         addRequestArgument(field2, cb, allocator);
         addRequestArgument(field3, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.HMGET, cb);
-        final Single<List<T>> result = (Single) requester.request(request, List.class);
+        final Single<List<Buffer>> result = (Single) requester.request(request, List.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
+    public Single<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
         requireNonNull(key);
         requireNonNull(fields);
         final BufferAllocator allocator = requester.executionContext().bufferAllocator();
@@ -2178,7 +2178,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         addRequestArgument(key, cb, allocator);
         addRequestBufferArguments(fields, null, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.HMGET, cb);
-        final Single<List<T>> result = (Single) requester.request(request, List.class);
+        final Single<List<Buffer>> result = (Single) requester.request(request, List.class);
         return result;
     }
 
@@ -2764,7 +2764,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Buffer key) {
+    public Single<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
         final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
@@ -2772,13 +2772,13 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
         addRequestArgument(key, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.MGET, cb);
-        final Single<List<T>> result = (Single) requester.request(request, List.class);
+        final Single<List<Buffer>> result = (Single) requester.request(request, List.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Buffer key1,
-                                    @RedisProtocolSupport.Key final Buffer key2) {
+    public Single<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key1,
+                                     @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
         final BufferAllocator allocator = requester.executionContext().bufferAllocator();
@@ -2788,14 +2788,14 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         addRequestArgument(key1, cb, allocator);
         addRequestArgument(key2, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.MGET, cb);
-        final Single<List<T>> result = (Single) requester.request(request, List.class);
+        final Single<List<Buffer>> result = (Single) requester.request(request, List.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Buffer key1,
-                                    @RedisProtocolSupport.Key final Buffer key2,
-                                    @RedisProtocolSupport.Key final Buffer key3) {
+    public Single<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key1,
+                                     @RedisProtocolSupport.Key final Buffer key2,
+                                     @RedisProtocolSupport.Key final Buffer key3) {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
@@ -2807,12 +2807,12 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         addRequestArgument(key2, cb, allocator);
         addRequestArgument(key3, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.MGET, cb);
-        final Single<List<T>> result = (Single) requester.request(request, List.class);
+        final Single<List<Buffer>> result = (Single) requester.request(request, List.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
+    public Single<List<Buffer>> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
         final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
@@ -2821,7 +2821,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
         addRequestBufferArguments(keys, null, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.MGET, cb);
-        final Single<List<T>> result = (Single) requester.request(request, List.class);
+        final Single<List<Buffer>> result = (Single) requester.request(request, List.class);
         return result;
     }
 
@@ -4873,7 +4873,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
     }
 
     @Override
-    public Single<List<String>> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) {
+    public Single<List<Buffer>> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) {
         requireNonNull(key);
         final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
@@ -4882,7 +4882,7 @@ final class DefaultBufferRedisCommander extends BufferRedisCommander {
         addRequestArgument(key, cb, allocator);
         addRequestArgument(count, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.SRANDMEMBER, cb);
-        final Single<List<String>> result = (Single) requester.request(request, List.class);
+        final Single<List<Buffer>> result = (Single) requester.request(request, List.class);
         return result;
     }
 

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultPartitionedBufferRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultPartitionedBufferRedisCommander.java
@@ -2580,7 +2580,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
+    public Single<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         requireNonNull(key);
         requireNonNull(field);
         final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
@@ -2593,14 +2593,14 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         final RedisPartitionAttributesBuilder partitionAttributesBuilder = partitionAttributesBuilderFunction
                     .apply(RedisProtocolSupport.Command.HMGET);
         partitionAttributesBuilder.addKey(key);
-        final Single<List<T>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
+        final Single<List<Buffer>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
                     request, List.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
-                                     final Buffer field2) {
+    public Single<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
+                                      final Buffer field2) {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
@@ -2615,14 +2615,14 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         final RedisPartitionAttributesBuilder partitionAttributesBuilder = partitionAttributesBuilderFunction
                     .apply(RedisProtocolSupport.Command.HMGET);
         partitionAttributesBuilder.addKey(key);
-        final Single<List<T>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
+        final Single<List<Buffer>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
                     request, List.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
-                                     final Buffer field2, final Buffer field3) {
+    public Single<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
+                                      final Buffer field2, final Buffer field3) {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
@@ -2639,13 +2639,13 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         final RedisPartitionAttributesBuilder partitionAttributesBuilder = partitionAttributesBuilderFunction
                     .apply(RedisProtocolSupport.Command.HMGET);
         partitionAttributesBuilder.addKey(key);
-        final Single<List<T>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
+        final Single<List<Buffer>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
                     request, List.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
+    public Single<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
         requireNonNull(key);
         requireNonNull(fields);
         final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
@@ -2659,7 +2659,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         final RedisPartitionAttributesBuilder partitionAttributesBuilder = partitionAttributesBuilderFunction
                     .apply(RedisProtocolSupport.Command.HMGET);
         partitionAttributesBuilder.addKey(key);
-        final Single<List<T>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
+        final Single<List<Buffer>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
                     request, List.class);
         return result;
     }
@@ -3385,7 +3385,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Buffer key) {
+    public Single<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
         final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
@@ -3396,14 +3396,14 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         final RedisPartitionAttributesBuilder partitionAttributesBuilder = partitionAttributesBuilderFunction
                     .apply(RedisProtocolSupport.Command.MGET);
         partitionAttributesBuilder.addKey(key);
-        final Single<List<T>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
+        final Single<List<Buffer>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
                     request, List.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Buffer key1,
-                                    @RedisProtocolSupport.Key final Buffer key2) {
+    public Single<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key1,
+                                     @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
         final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
@@ -3417,15 +3417,15 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
                     .apply(RedisProtocolSupport.Command.MGET);
         partitionAttributesBuilder.addKey(key1);
         partitionAttributesBuilder.addKey(key2);
-        final Single<List<T>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
+        final Single<List<Buffer>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
                     request, List.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Buffer key1,
-                                    @RedisProtocolSupport.Key final Buffer key2,
-                                    @RedisProtocolSupport.Key final Buffer key3) {
+    public Single<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key1,
+                                     @RedisProtocolSupport.Key final Buffer key2,
+                                     @RedisProtocolSupport.Key final Buffer key3) {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
@@ -3442,13 +3442,13 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         partitionAttributesBuilder.addKey(key1);
         partitionAttributesBuilder.addKey(key2);
         partitionAttributesBuilder.addKey(key3);
-        final Single<List<T>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
+        final Single<List<Buffer>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
                     request, List.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
+    public Single<List<Buffer>> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
         final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
@@ -3460,7 +3460,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         final RedisPartitionAttributesBuilder partitionAttributesBuilder = partitionAttributesBuilderFunction
                     .apply(RedisProtocolSupport.Command.MGET);
         addBufferKeysToAttributeBuilder(keys, partitionAttributesBuilder);
-        final Single<List<T>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
+        final Single<List<Buffer>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
                     request, List.class);
         return result;
     }
@@ -6022,7 +6022,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
     }
 
     @Override
-    public Single<List<String>> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) {
+    public Single<List<Buffer>> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) {
         requireNonNull(key);
         final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
@@ -6034,7 +6034,7 @@ final class DefaultPartitionedBufferRedisCommander extends BufferRedisCommander 
         final RedisPartitionAttributesBuilder partitionAttributesBuilder = partitionAttributesBuilderFunction
                     .apply(RedisProtocolSupport.Command.SRANDMEMBER);
         partitionAttributesBuilder.addKey(key);
-        final Single<List<String>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
+        final Single<List<Buffer>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
                     request, List.class);
         return result;
     }

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultPartitionedRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultPartitionedRedisCommander.java
@@ -2594,7 +2594,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
+    public Single<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         requireNonNull(key);
         requireNonNull(field);
         final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
@@ -2607,14 +2607,14 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         final RedisPartitionAttributesBuilder partitionAttributesBuilder = partitionAttributesBuilderFunction
                     .apply(RedisProtocolSupport.Command.HMGET);
         partitionAttributesBuilder.addKey(key);
-        final Single<List<T>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
+        final Single<List<String>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
                     request, RedisUtils.ListWithBuffersCoercedToCharSequences.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
-                                     final CharSequence field2) {
+    public Single<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
+                                      final CharSequence field2) {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
@@ -2629,14 +2629,14 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         final RedisPartitionAttributesBuilder partitionAttributesBuilder = partitionAttributesBuilderFunction
                     .apply(RedisProtocolSupport.Command.HMGET);
         partitionAttributesBuilder.addKey(key);
-        final Single<List<T>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
+        final Single<List<String>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
                     request, RedisUtils.ListWithBuffersCoercedToCharSequences.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
-                                     final CharSequence field2, final CharSequence field3) {
+    public Single<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
+                                      final CharSequence field2, final CharSequence field3) {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
@@ -2653,14 +2653,14 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         final RedisPartitionAttributesBuilder partitionAttributesBuilder = partitionAttributesBuilderFunction
                     .apply(RedisProtocolSupport.Command.HMGET);
         partitionAttributesBuilder.addKey(key);
-        final Single<List<T>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
+        final Single<List<String>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
                     request, RedisUtils.ListWithBuffersCoercedToCharSequences.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key,
-                                     final Collection<? extends CharSequence> fields) {
+    public Single<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key,
+                                      final Collection<? extends CharSequence> fields) {
         requireNonNull(key);
         requireNonNull(fields);
         final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
@@ -2674,7 +2674,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         final RedisPartitionAttributesBuilder partitionAttributesBuilder = partitionAttributesBuilderFunction
                     .apply(RedisProtocolSupport.Command.HMGET);
         partitionAttributesBuilder.addKey(key);
-        final Single<List<T>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
+        final Single<List<String>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
                     request, RedisUtils.ListWithBuffersCoercedToCharSequences.class);
         return result;
     }
@@ -3411,7 +3411,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key) {
+    public Single<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
         final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
@@ -3422,14 +3422,14 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         final RedisPartitionAttributesBuilder partitionAttributesBuilder = partitionAttributesBuilderFunction
                     .apply(RedisProtocolSupport.Command.MGET);
         partitionAttributesBuilder.addKey(key);
-        final Single<List<T>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
+        final Single<List<String>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
                     request, RedisUtils.ListWithBuffersCoercedToCharSequences.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key1,
-                                    @RedisProtocolSupport.Key final CharSequence key2) {
+    public Single<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key1,
+                                     @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
         final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
@@ -3443,15 +3443,15 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
                     .apply(RedisProtocolSupport.Command.MGET);
         partitionAttributesBuilder.addKey(key1);
         partitionAttributesBuilder.addKey(key2);
-        final Single<List<T>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
+        final Single<List<String>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
                     request, RedisUtils.ListWithBuffersCoercedToCharSequences.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key1,
-                                    @RedisProtocolSupport.Key final CharSequence key2,
-                                    @RedisProtocolSupport.Key final CharSequence key3) {
+    public Single<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key1,
+                                     @RedisProtocolSupport.Key final CharSequence key2,
+                                     @RedisProtocolSupport.Key final CharSequence key3) {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
@@ -3468,13 +3468,13 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         partitionAttributesBuilder.addKey(key1);
         partitionAttributesBuilder.addKey(key2);
         partitionAttributesBuilder.addKey(key3);
-        final Single<List<T>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
+        final Single<List<String>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
                     request, RedisUtils.ListWithBuffersCoercedToCharSequences.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
+    public Single<List<String>> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
         final BufferAllocator allocator = partitionedRedisClient.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
@@ -3486,7 +3486,7 @@ final class DefaultPartitionedRedisCommander extends RedisCommander {
         final RedisPartitionAttributesBuilder partitionAttributesBuilder = partitionAttributesBuilderFunction
                     .apply(RedisProtocolSupport.Command.MGET);
         addCharSequenceKeysToAttributeBuilder(keys, partitionAttributesBuilder);
-        final Single<List<T>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
+        final Single<List<String>> result = (Single) partitionedRedisClient.request(partitionAttributesBuilder.build(),
                     request, RedisUtils.ListWithBuffersCoercedToCharSequences.class);
         return result;
     }

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultRedisCommander.java
@@ -2158,7 +2158,7 @@ final class DefaultRedisCommander extends RedisCommander {
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
+    public Single<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         requireNonNull(key);
         requireNonNull(field);
         final BufferAllocator allocator = requester.executionContext().bufferAllocator();
@@ -2168,14 +2168,14 @@ final class DefaultRedisCommander extends RedisCommander {
         addRequestArgument(key, cb, allocator);
         addRequestArgument(field, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.HMGET, cb);
-        final Single<List<T>> result = (Single) requester.request(request,
+        final Single<List<String>> result = (Single) requester.request(request,
                     RedisUtils.ListWithBuffersCoercedToCharSequences.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
-                                     final CharSequence field2) {
+    public Single<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
+                                      final CharSequence field2) {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
@@ -2187,14 +2187,14 @@ final class DefaultRedisCommander extends RedisCommander {
         addRequestArgument(field1, cb, allocator);
         addRequestArgument(field2, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.HMGET, cb);
-        final Single<List<T>> result = (Single) requester.request(request,
+        final Single<List<String>> result = (Single) requester.request(request,
                     RedisUtils.ListWithBuffersCoercedToCharSequences.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
-                                     final CharSequence field2, final CharSequence field3) {
+    public Single<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
+                                      final CharSequence field2, final CharSequence field3) {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
@@ -2208,14 +2208,14 @@ final class DefaultRedisCommander extends RedisCommander {
         addRequestArgument(field2, cb, allocator);
         addRequestArgument(field3, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.HMGET, cb);
-        final Single<List<T>> result = (Single) requester.request(request,
+        final Single<List<String>> result = (Single) requester.request(request,
                     RedisUtils.ListWithBuffersCoercedToCharSequences.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key,
-                                     final Collection<? extends CharSequence> fields) {
+    public Single<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key,
+                                      final Collection<? extends CharSequence> fields) {
         requireNonNull(key);
         requireNonNull(fields);
         final BufferAllocator allocator = requester.executionContext().bufferAllocator();
@@ -2226,7 +2226,7 @@ final class DefaultRedisCommander extends RedisCommander {
         addRequestArgument(key, cb, allocator);
         addRequestCharSequenceArguments(fields, null, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.HMGET, cb);
-        final Single<List<T>> result = (Single) requester.request(request,
+        final Single<List<String>> result = (Single) requester.request(request,
                     RedisUtils.ListWithBuffersCoercedToCharSequences.class);
         return result;
     }
@@ -2831,7 +2831,7 @@ final class DefaultRedisCommander extends RedisCommander {
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key) {
+    public Single<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
         final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
@@ -2839,14 +2839,14 @@ final class DefaultRedisCommander extends RedisCommander {
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
         addRequestArgument(key, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.MGET, cb);
-        final Single<List<T>> result = (Single) requester.request(request,
+        final Single<List<String>> result = (Single) requester.request(request,
                     RedisUtils.ListWithBuffersCoercedToCharSequences.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key1,
-                                    @RedisProtocolSupport.Key final CharSequence key2) {
+    public Single<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key1,
+                                     @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
         final BufferAllocator allocator = requester.executionContext().bufferAllocator();
@@ -2856,15 +2856,15 @@ final class DefaultRedisCommander extends RedisCommander {
         addRequestArgument(key1, cb, allocator);
         addRequestArgument(key2, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.MGET, cb);
-        final Single<List<T>> result = (Single) requester.request(request,
+        final Single<List<String>> result = (Single) requester.request(request,
                     RedisUtils.ListWithBuffersCoercedToCharSequences.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key1,
-                                    @RedisProtocolSupport.Key final CharSequence key2,
-                                    @RedisProtocolSupport.Key final CharSequence key3) {
+    public Single<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key1,
+                                     @RedisProtocolSupport.Key final CharSequence key2,
+                                     @RedisProtocolSupport.Key final CharSequence key3) {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
@@ -2876,13 +2876,13 @@ final class DefaultRedisCommander extends RedisCommander {
         addRequestArgument(key2, cb, allocator);
         addRequestArgument(key3, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.MGET, cb);
-        final Single<List<T>> result = (Single) requester.request(request,
+        final Single<List<String>> result = (Single) requester.request(request,
                     RedisUtils.ListWithBuffersCoercedToCharSequences.class);
         return result;
     }
 
     @Override
-    public <T> Single<List<T>> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
+    public Single<List<String>> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
         final BufferAllocator allocator = requester.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
@@ -2891,7 +2891,7 @@ final class DefaultRedisCommander extends RedisCommander {
         final CompositeBuffer cb = newRequestCompositeBuffer(len, RedisProtocolSupport.Command.MGET, allocator);
         addRequestCharSequenceArguments(keys, null, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.MGET, cb);
-        final Single<List<T>> result = (Single) requester.request(request,
+        final Single<List<String>> result = (Single) requester.request(request,
                     RedisUtils.ListWithBuffersCoercedToCharSequences.class);
         return result;
     }

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultTransactedBufferRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultTransactedBufferRedisCommander.java
@@ -2273,7 +2273,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
+    public Future<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         requireNonNull(key);
         requireNonNull(field);
         final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
@@ -2284,13 +2284,13 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         addRequestArgument(field, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.HMGET, cb);
         final Single<String> queued = reservedCnx.request(request, String.class);
-        Future<List<T>> result = enqueueForExecute(state, singles, queued);
+        Future<List<Buffer>> result = enqueueForExecute(state, singles, queued);
         return result;
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
-                                     final Buffer field2) {
+    public Future<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
+                                      final Buffer field2) {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
@@ -2303,13 +2303,13 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         addRequestArgument(field2, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.HMGET, cb);
         final Single<String> queued = reservedCnx.request(request, String.class);
-        Future<List<T>> result = enqueueForExecute(state, singles, queued);
+        Future<List<Buffer>> result = enqueueForExecute(state, singles, queued);
         return result;
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
-                                     final Buffer field2, final Buffer field3) {
+    public Future<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
+                                      final Buffer field2, final Buffer field3) {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
@@ -2324,12 +2324,12 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         addRequestArgument(field3, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.HMGET, cb);
         final Single<String> queued = reservedCnx.request(request, String.class);
-        Future<List<T>> result = enqueueForExecute(state, singles, queued);
+        Future<List<Buffer>> result = enqueueForExecute(state, singles, queued);
         return result;
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
+    public Future<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
         requireNonNull(key);
         requireNonNull(fields);
         final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
@@ -2341,7 +2341,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         addRequestBufferArguments(fields, null, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.HMGET, cb);
         final Single<String> queued = reservedCnx.request(request, String.class);
-        Future<List<T>> result = enqueueForExecute(state, singles, queued);
+        Future<List<Buffer>> result = enqueueForExecute(state, singles, queued);
         return result;
     }
 
@@ -2963,7 +2963,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final Buffer key) {
+    public Future<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key) {
         requireNonNull(key);
         final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
@@ -2972,13 +2972,13 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         addRequestArgument(key, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.MGET, cb);
         final Single<String> queued = reservedCnx.request(request, String.class);
-        Future<List<T>> result = enqueueForExecute(state, singles, queued);
+        Future<List<Buffer>> result = enqueueForExecute(state, singles, queued);
         return result;
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final Buffer key1,
-                                    @RedisProtocolSupport.Key final Buffer key2) {
+    public Future<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key1,
+                                     @RedisProtocolSupport.Key final Buffer key2) {
         requireNonNull(key1);
         requireNonNull(key2);
         final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
@@ -2989,14 +2989,14 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         addRequestArgument(key2, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.MGET, cb);
         final Single<String> queued = reservedCnx.request(request, String.class);
-        Future<List<T>> result = enqueueForExecute(state, singles, queued);
+        Future<List<Buffer>> result = enqueueForExecute(state, singles, queued);
         return result;
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final Buffer key1,
-                                    @RedisProtocolSupport.Key final Buffer key2,
-                                    @RedisProtocolSupport.Key final Buffer key3) {
+    public Future<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key1,
+                                     @RedisProtocolSupport.Key final Buffer key2,
+                                     @RedisProtocolSupport.Key final Buffer key3) {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
@@ -3009,12 +3009,12 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         addRequestArgument(key3, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.MGET, cb);
         final Single<String> queued = reservedCnx.request(request, String.class);
-        Future<List<T>> result = enqueueForExecute(state, singles, queued);
+        Future<List<Buffer>> result = enqueueForExecute(state, singles, queued);
         return result;
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
+    public Future<List<Buffer>> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         requireNonNull(keys);
         final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
@@ -3024,7 +3024,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         addRequestBufferArguments(keys, null, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.MGET, cb);
         final Single<String> queued = reservedCnx.request(request, String.class);
-        Future<List<T>> result = enqueueForExecute(state, singles, queued);
+        Future<List<Buffer>> result = enqueueForExecute(state, singles, queued);
         return result;
     }
 
@@ -5158,7 +5158,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
     }
 
     @Override
-    public Future<List<String>> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) {
+    public Future<List<Buffer>> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) {
         requireNonNull(key);
         final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
@@ -5168,7 +5168,7 @@ final class DefaultTransactedBufferRedisCommander extends TransactedBufferRedisC
         addRequestArgument(count, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.SRANDMEMBER, cb);
         final Single<String> queued = reservedCnx.request(request, String.class);
-        Future<List<String>> result = enqueueForExecute(state, singles, queued);
+        Future<List<Buffer>> result = enqueueForExecute(state, singles, queued);
         return result;
     }
 

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultTransactedRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultTransactedRedisCommander.java
@@ -2288,7 +2288,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
+    public Future<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         requireNonNull(key);
         requireNonNull(field);
         final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
@@ -2299,13 +2299,13 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         addRequestArgument(field, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.HMGET, cb);
         final Single<String> queued = reservedCnx.request(request, String.class);
-        Future<List<T>> result = enqueueForExecute(state, singles, queued);
+        Future<List<String>> result = enqueueForExecute(state, singles, queued);
         return result;
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
-                                     final CharSequence field2) {
+    public Future<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
+                                      final CharSequence field2) {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
@@ -2318,13 +2318,13 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         addRequestArgument(field2, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.HMGET, cb);
         final Single<String> queued = reservedCnx.request(request, String.class);
-        Future<List<T>> result = enqueueForExecute(state, singles, queued);
+        Future<List<String>> result = enqueueForExecute(state, singles, queued);
         return result;
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
-                                     final CharSequence field2, final CharSequence field3) {
+    public Future<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
+                                      final CharSequence field2, final CharSequence field3) {
         requireNonNull(key);
         requireNonNull(field1);
         requireNonNull(field2);
@@ -2339,13 +2339,13 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         addRequestArgument(field3, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.HMGET, cb);
         final Single<String> queued = reservedCnx.request(request, String.class);
-        Future<List<T>> result = enqueueForExecute(state, singles, queued);
+        Future<List<String>> result = enqueueForExecute(state, singles, queued);
         return result;
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key,
-                                     final Collection<? extends CharSequence> fields) {
+    public Future<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key,
+                                      final Collection<? extends CharSequence> fields) {
         requireNonNull(key);
         requireNonNull(fields);
         final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
@@ -2357,7 +2357,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         addRequestCharSequenceArguments(fields, null, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.HMGET, cb);
         final Single<String> queued = reservedCnx.request(request, String.class);
-        Future<List<T>> result = enqueueForExecute(state, singles, queued);
+        Future<List<String>> result = enqueueForExecute(state, singles, queued);
         return result;
     }
 
@@ -2990,7 +2990,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key) {
+    public Future<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key) {
         requireNonNull(key);
         final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
@@ -2999,13 +2999,13 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         addRequestArgument(key, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.MGET, cb);
         final Single<String> queued = reservedCnx.request(request, String.class);
-        Future<List<T>> result = enqueueForExecute(state, singles, queued);
+        Future<List<String>> result = enqueueForExecute(state, singles, queued);
         return result;
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key1,
-                                    @RedisProtocolSupport.Key final CharSequence key2) {
+    public Future<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key1,
+                                     @RedisProtocolSupport.Key final CharSequence key2) {
         requireNonNull(key1);
         requireNonNull(key2);
         final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
@@ -3016,14 +3016,14 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         addRequestArgument(key2, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.MGET, cb);
         final Single<String> queued = reservedCnx.request(request, String.class);
-        Future<List<T>> result = enqueueForExecute(state, singles, queued);
+        Future<List<String>> result = enqueueForExecute(state, singles, queued);
         return result;
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key1,
-                                    @RedisProtocolSupport.Key final CharSequence key2,
-                                    @RedisProtocolSupport.Key final CharSequence key3) {
+    public Future<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key1,
+                                     @RedisProtocolSupport.Key final CharSequence key2,
+                                     @RedisProtocolSupport.Key final CharSequence key3) {
         requireNonNull(key1);
         requireNonNull(key2);
         requireNonNull(key3);
@@ -3036,12 +3036,12 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         addRequestArgument(key3, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.MGET, cb);
         final Single<String> queued = reservedCnx.request(request, String.class);
-        Future<List<T>> result = enqueueForExecute(state, singles, queued);
+        Future<List<String>> result = enqueueForExecute(state, singles, queued);
         return result;
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
+    public Future<List<String>> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         requireNonNull(keys);
         final BufferAllocator allocator = reservedCnx.executionContext().bufferAllocator();
         // Compute the number of request arguments, accounting for nullable ones
@@ -3051,7 +3051,7 @@ final class DefaultTransactedRedisCommander extends TransactedRedisCommander {
         addRequestCharSequenceArguments(keys, null, cb, allocator);
         final RedisRequest request = newRequest(RedisProtocolSupport.Command.MGET, cb);
         final Single<String> queued = reservedCnx.request(request, String.class);
-        Future<List<T>> result = enqueueForExecute(state, singles, queued);
+        Future<List<String>> result = enqueueForExecute(state, singles, queued);
         return result;
     }
 

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/PartitionedBufferRedisCommanderToBlockingPartitionedBufferRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/PartitionedBufferRedisCommanderToBlockingPartitionedBufferRedisCommander.java
@@ -728,25 +728,25 @@ final class PartitionedBufferRedisCommanderToBlockingPartitionedBufferRedisComma
     }
 
     @Override
-    public <T> List<T> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) throws Exception {
+    public List<Buffer> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) throws Exception {
         return blockingInvocation(commander.hmget(key, field));
     }
 
     @Override
-    public <T> List<T> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
-                             final Buffer field2) throws Exception {
+    public List<Buffer> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
+                              final Buffer field2) throws Exception {
         return blockingInvocation(commander.hmget(key, field1, field2));
     }
 
     @Override
-    public <T> List<T> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1, final Buffer field2,
-                             final Buffer field3) throws Exception {
+    public List<Buffer> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1, final Buffer field2,
+                              final Buffer field3) throws Exception {
         return blockingInvocation(commander.hmget(key, field1, field2, field3));
     }
 
     @Override
-    public <T> List<T> hmget(@RedisProtocolSupport.Key final Buffer key,
-                             final Collection<Buffer> fields) throws Exception {
+    public List<Buffer> hmget(@RedisProtocolSupport.Key final Buffer key,
+                              final Collection<Buffer> fields) throws Exception {
         return blockingInvocation(commander.hmget(key, fields));
     }
 
@@ -952,24 +952,24 @@ final class PartitionedBufferRedisCommanderToBlockingPartitionedBufferRedisComma
     }
 
     @Override
-    public <T> List<T> mget(@RedisProtocolSupport.Key final Buffer key) throws Exception {
+    public List<Buffer> mget(@RedisProtocolSupport.Key final Buffer key) throws Exception {
         return blockingInvocation(commander.mget(key));
     }
 
     @Override
-    public <T> List<T> mget(@RedisProtocolSupport.Key final Buffer key1,
-                            @RedisProtocolSupport.Key final Buffer key2) throws Exception {
+    public List<Buffer> mget(@RedisProtocolSupport.Key final Buffer key1,
+                             @RedisProtocolSupport.Key final Buffer key2) throws Exception {
         return blockingInvocation(commander.mget(key1, key2));
     }
 
     @Override
-    public <T> List<T> mget(@RedisProtocolSupport.Key final Buffer key1, @RedisProtocolSupport.Key final Buffer key2,
-                            @RedisProtocolSupport.Key final Buffer key3) throws Exception {
+    public List<Buffer> mget(@RedisProtocolSupport.Key final Buffer key1, @RedisProtocolSupport.Key final Buffer key2,
+                             @RedisProtocolSupport.Key final Buffer key3) throws Exception {
         return blockingInvocation(commander.mget(key1, key2, key3));
     }
 
     @Override
-    public <T> List<T> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) throws Exception {
+    public List<Buffer> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) throws Exception {
         return blockingInvocation(commander.mget(keys));
     }
 
@@ -1645,7 +1645,7 @@ final class PartitionedBufferRedisCommanderToBlockingPartitionedBufferRedisComma
     }
 
     @Override
-    public List<String> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) throws Exception {
+    public List<Buffer> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) throws Exception {
         return blockingInvocation(commander.srandmember(key, count));
     }
 

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/PartitionedRedisCommanderToBlockingPartitionedRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/PartitionedRedisCommanderToBlockingPartitionedRedisCommander.java
@@ -737,26 +737,26 @@ final class PartitionedRedisCommanderToBlockingPartitionedRedisCommander extends
     }
 
     @Override
-    public <T> List<T> hmget(@RedisProtocolSupport.Key final CharSequence key,
-                             final CharSequence field) throws Exception {
+    public List<String> hmget(@RedisProtocolSupport.Key final CharSequence key,
+                              final CharSequence field) throws Exception {
         return blockingInvocation(commander.hmget(key, field));
     }
 
     @Override
-    public <T> List<T> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
-                             final CharSequence field2) throws Exception {
+    public List<String> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
+                              final CharSequence field2) throws Exception {
         return blockingInvocation(commander.hmget(key, field1, field2));
     }
 
     @Override
-    public <T> List<T> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
-                             final CharSequence field2, final CharSequence field3) throws Exception {
+    public List<String> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
+                              final CharSequence field2, final CharSequence field3) throws Exception {
         return blockingInvocation(commander.hmget(key, field1, field2, field3));
     }
 
     @Override
-    public <T> List<T> hmget(@RedisProtocolSupport.Key final CharSequence key,
-                             final Collection<? extends CharSequence> fields) throws Exception {
+    public List<String> hmget(@RedisProtocolSupport.Key final CharSequence key,
+                              final Collection<? extends CharSequence> fields) throws Exception {
         return blockingInvocation(commander.hmget(key, fields));
     }
 
@@ -965,25 +965,25 @@ final class PartitionedRedisCommanderToBlockingPartitionedRedisCommander extends
     }
 
     @Override
-    public <T> List<T> mget(@RedisProtocolSupport.Key final CharSequence key) throws Exception {
+    public List<String> mget(@RedisProtocolSupport.Key final CharSequence key) throws Exception {
         return blockingInvocation(commander.mget(key));
     }
 
     @Override
-    public <T> List<T> mget(@RedisProtocolSupport.Key final CharSequence key1,
-                            @RedisProtocolSupport.Key final CharSequence key2) throws Exception {
+    public List<String> mget(@RedisProtocolSupport.Key final CharSequence key1,
+                             @RedisProtocolSupport.Key final CharSequence key2) throws Exception {
         return blockingInvocation(commander.mget(key1, key2));
     }
 
     @Override
-    public <T> List<T> mget(@RedisProtocolSupport.Key final CharSequence key1,
-                            @RedisProtocolSupport.Key final CharSequence key2,
-                            @RedisProtocolSupport.Key final CharSequence key3) throws Exception {
+    public List<String> mget(@RedisProtocolSupport.Key final CharSequence key1,
+                             @RedisProtocolSupport.Key final CharSequence key2,
+                             @RedisProtocolSupport.Key final CharSequence key3) throws Exception {
         return blockingInvocation(commander.mget(key1, key2, key3));
     }
 
     @Override
-    public <T> List<T> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) throws Exception {
+    public List<String> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) throws Exception {
         return blockingInvocation(commander.mget(keys));
     }
 

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisCommander.java
@@ -1445,10 +1445,9 @@ public abstract class RedisCommander implements AsyncCloseable {
      * @param key the key
      * @param field the field
      * @return a {@link Single} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Single<List<T>> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field);
+    public abstract Single<List<String>> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field);
 
     /**
      * Get the values of all the given hash fields.
@@ -1457,11 +1456,10 @@ public abstract class RedisCommander implements AsyncCloseable {
      * @param field1 the field1
      * @param field2 the field2
      * @return a {@link Single} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Single<List<T>> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field1,
-                                              CharSequence field2);
+    public abstract Single<List<String>> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field1,
+                                               CharSequence field2);
 
     /**
      * Get the values of all the given hash fields.
@@ -1471,11 +1469,10 @@ public abstract class RedisCommander implements AsyncCloseable {
      * @param field2 the field2
      * @param field3 the field3
      * @return a {@link Single} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Single<List<T>> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field1,
-                                              CharSequence field2, CharSequence field3);
+    public abstract Single<List<String>> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field1,
+                                               CharSequence field2, CharSequence field3);
 
     /**
      * Get the values of all the given hash fields.
@@ -1483,11 +1480,10 @@ public abstract class RedisCommander implements AsyncCloseable {
      * @param key the key
      * @param fields the fields
      * @return a {@link Single} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Single<List<T>> hmget(@RedisProtocolSupport.Key CharSequence key,
-                                              Collection<? extends CharSequence> fields);
+    public abstract Single<List<String>> hmget(@RedisProtocolSupport.Key CharSequence key,
+                                               Collection<? extends CharSequence> fields);
 
     /**
      * Set multiple hash fields to multiple values.
@@ -1894,10 +1890,9 @@ public abstract class RedisCommander implements AsyncCloseable {
      *
      * @param key the key
      * @return a {@link Single} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Single<List<T>> mget(@RedisProtocolSupport.Key CharSequence key);
+    public abstract Single<List<String>> mget(@RedisProtocolSupport.Key CharSequence key);
 
     /**
      * Get the values of all the given keys.
@@ -1905,11 +1900,10 @@ public abstract class RedisCommander implements AsyncCloseable {
      * @param key1 the key1
      * @param key2 the key2
      * @return a {@link Single} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Single<List<T>> mget(@RedisProtocolSupport.Key CharSequence key1,
-                                             @RedisProtocolSupport.Key CharSequence key2);
+    public abstract Single<List<String>> mget(@RedisProtocolSupport.Key CharSequence key1,
+                                              @RedisProtocolSupport.Key CharSequence key2);
 
     /**
      * Get the values of all the given keys.
@@ -1918,22 +1912,20 @@ public abstract class RedisCommander implements AsyncCloseable {
      * @param key2 the key2
      * @param key3 the key3
      * @return a {@link Single} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Single<List<T>> mget(@RedisProtocolSupport.Key CharSequence key1,
-                                             @RedisProtocolSupport.Key CharSequence key2,
-                                             @RedisProtocolSupport.Key CharSequence key3);
+    public abstract Single<List<String>> mget(@RedisProtocolSupport.Key CharSequence key1,
+                                              @RedisProtocolSupport.Key CharSequence key2,
+                                              @RedisProtocolSupport.Key CharSequence key3);
 
     /**
      * Get the values of all the given keys.
      *
      * @param keys the keys
      * @return a {@link Single} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Single<List<T>> mget(@RedisProtocolSupport.Key Collection<? extends CharSequence> keys);
+    public abstract Single<List<String>> mget(@RedisProtocolSupport.Key Collection<? extends CharSequence> keys);
 
     /**
      * Listen for all requests received by the server in real time.

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisCommanderToBlockingRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisCommanderToBlockingRedisCommander.java
@@ -737,26 +737,26 @@ final class RedisCommanderToBlockingRedisCommander extends BlockingRedisCommande
     }
 
     @Override
-    public <T> List<T> hmget(@RedisProtocolSupport.Key final CharSequence key,
-                             final CharSequence field) throws Exception {
+    public List<String> hmget(@RedisProtocolSupport.Key final CharSequence key,
+                              final CharSequence field) throws Exception {
         return blockingInvocation(commander.hmget(key, field));
     }
 
     @Override
-    public <T> List<T> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
-                             final CharSequence field2) throws Exception {
+    public List<String> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
+                              final CharSequence field2) throws Exception {
         return blockingInvocation(commander.hmget(key, field1, field2));
     }
 
     @Override
-    public <T> List<T> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
-                             final CharSequence field2, final CharSequence field3) throws Exception {
+    public List<String> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
+                              final CharSequence field2, final CharSequence field3) throws Exception {
         return blockingInvocation(commander.hmget(key, field1, field2, field3));
     }
 
     @Override
-    public <T> List<T> hmget(@RedisProtocolSupport.Key final CharSequence key,
-                             final Collection<? extends CharSequence> fields) throws Exception {
+    public List<String> hmget(@RedisProtocolSupport.Key final CharSequence key,
+                              final Collection<? extends CharSequence> fields) throws Exception {
         return blockingInvocation(commander.hmget(key, fields));
     }
 
@@ -965,25 +965,25 @@ final class RedisCommanderToBlockingRedisCommander extends BlockingRedisCommande
     }
 
     @Override
-    public <T> List<T> mget(@RedisProtocolSupport.Key final CharSequence key) throws Exception {
+    public List<String> mget(@RedisProtocolSupport.Key final CharSequence key) throws Exception {
         return blockingInvocation(commander.mget(key));
     }
 
     @Override
-    public <T> List<T> mget(@RedisProtocolSupport.Key final CharSequence key1,
-                            @RedisProtocolSupport.Key final CharSequence key2) throws Exception {
+    public List<String> mget(@RedisProtocolSupport.Key final CharSequence key1,
+                             @RedisProtocolSupport.Key final CharSequence key2) throws Exception {
         return blockingInvocation(commander.mget(key1, key2));
     }
 
     @Override
-    public <T> List<T> mget(@RedisProtocolSupport.Key final CharSequence key1,
-                            @RedisProtocolSupport.Key final CharSequence key2,
-                            @RedisProtocolSupport.Key final CharSequence key3) throws Exception {
+    public List<String> mget(@RedisProtocolSupport.Key final CharSequence key1,
+                             @RedisProtocolSupport.Key final CharSequence key2,
+                             @RedisProtocolSupport.Key final CharSequence key3) throws Exception {
         return blockingInvocation(commander.mget(key1, key2, key3));
     }
 
     @Override
-    public <T> List<T> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) throws Exception {
+    public List<String> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) throws Exception {
         return blockingInvocation(commander.mget(keys));
     }
 

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/TransactedBufferRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/TransactedBufferRedisCommander.java
@@ -1445,10 +1445,9 @@ public abstract class TransactedBufferRedisCommander implements AsyncCloseable {
      * @param key the key
      * @param field the field
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Future<List<T>> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field);
+    public abstract Future<List<Buffer>> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field);
 
     /**
      * Get the values of all the given hash fields.
@@ -1457,10 +1456,9 @@ public abstract class TransactedBufferRedisCommander implements AsyncCloseable {
      * @param field1 the field1
      * @param field2 the field2
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Future<List<T>> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field1, Buffer field2);
+    public abstract Future<List<Buffer>> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field1, Buffer field2);
 
     /**
      * Get the values of all the given hash fields.
@@ -1470,11 +1468,10 @@ public abstract class TransactedBufferRedisCommander implements AsyncCloseable {
      * @param field2 the field2
      * @param field3 the field3
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Future<List<T>> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field1, Buffer field2,
-                                              Buffer field3);
+    public abstract Future<List<Buffer>> hmget(@RedisProtocolSupport.Key Buffer key, Buffer field1, Buffer field2,
+                                               Buffer field3);
 
     /**
      * Get the values of all the given hash fields.
@@ -1482,10 +1479,9 @@ public abstract class TransactedBufferRedisCommander implements AsyncCloseable {
      * @param key the key
      * @param fields the fields
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Future<List<T>> hmget(@RedisProtocolSupport.Key Buffer key, Collection<Buffer> fields);
+    public abstract Future<List<Buffer>> hmget(@RedisProtocolSupport.Key Buffer key, Collection<Buffer> fields);
 
     /**
      * Set multiple hash fields to multiple values.
@@ -1886,10 +1882,9 @@ public abstract class TransactedBufferRedisCommander implements AsyncCloseable {
      *
      * @param key the key
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Future<List<T>> mget(@RedisProtocolSupport.Key Buffer key);
+    public abstract Future<List<Buffer>> mget(@RedisProtocolSupport.Key Buffer key);
 
     /**
      * Get the values of all the given keys.
@@ -1897,11 +1892,10 @@ public abstract class TransactedBufferRedisCommander implements AsyncCloseable {
      * @param key1 the key1
      * @param key2 the key2
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Future<List<T>> mget(@RedisProtocolSupport.Key Buffer key1,
-                                             @RedisProtocolSupport.Key Buffer key2);
+    public abstract Future<List<Buffer>> mget(@RedisProtocolSupport.Key Buffer key1,
+                                              @RedisProtocolSupport.Key Buffer key2);
 
     /**
      * Get the values of all the given keys.
@@ -1910,22 +1904,20 @@ public abstract class TransactedBufferRedisCommander implements AsyncCloseable {
      * @param key2 the key2
      * @param key3 the key3
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Future<List<T>> mget(@RedisProtocolSupport.Key Buffer key1,
-                                             @RedisProtocolSupport.Key Buffer key2,
-                                             @RedisProtocolSupport.Key Buffer key3);
+    public abstract Future<List<Buffer>> mget(@RedisProtocolSupport.Key Buffer key1,
+                                              @RedisProtocolSupport.Key Buffer key2,
+                                              @RedisProtocolSupport.Key Buffer key3);
 
     /**
      * Get the values of all the given keys.
      *
      * @param keys the keys
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Future<List<T>> mget(@RedisProtocolSupport.Key Collection<Buffer> keys);
+    public abstract Future<List<Buffer>> mget(@RedisProtocolSupport.Key Collection<Buffer> keys);
 
     /**
      * Move a key to another database.
@@ -3218,7 +3210,7 @@ public abstract class TransactedBufferRedisCommander implements AsyncCloseable {
      * @return a {@link Future} result
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.SRANDMEMBER)
-    public abstract Future<List<String>> srandmember(@RedisProtocolSupport.Key Buffer key, long count);
+    public abstract Future<List<Buffer>> srandmember(@RedisProtocolSupport.Key Buffer key, long count);
 
     /**
      * Remove one or more members from a set.

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/TransactedBufferRedisCommanderToBlockingTransactedBufferRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/TransactedBufferRedisCommanderToBlockingTransactedBufferRedisCommander.java
@@ -732,24 +732,24 @@ final class TransactedBufferRedisCommanderToBlockingTransactedBufferRedisCommand
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
+    public Future<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field) {
         return commander.hmget(key, field);
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
-                                     final Buffer field2) {
+    public Future<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
+                                      final Buffer field2) {
         return commander.hmget(key, field1, field2);
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
-                                     final Buffer field2, final Buffer field3) {
+    public Future<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Buffer field1,
+                                      final Buffer field2, final Buffer field3) {
         return commander.hmget(key, field1, field2, field3);
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
+    public Future<List<Buffer>> hmget(@RedisProtocolSupport.Key final Buffer key, final Collection<Buffer> fields) {
         return commander.hmget(key, fields);
     }
 
@@ -945,25 +945,25 @@ final class TransactedBufferRedisCommanderToBlockingTransactedBufferRedisCommand
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final Buffer key) {
+    public Future<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key) {
         return commander.mget(key);
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final Buffer key1,
-                                    @RedisProtocolSupport.Key final Buffer key2) {
+    public Future<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key1,
+                                     @RedisProtocolSupport.Key final Buffer key2) {
         return commander.mget(key1, key2);
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final Buffer key1,
-                                    @RedisProtocolSupport.Key final Buffer key2,
-                                    @RedisProtocolSupport.Key final Buffer key3) {
+    public Future<List<Buffer>> mget(@RedisProtocolSupport.Key final Buffer key1,
+                                     @RedisProtocolSupport.Key final Buffer key2,
+                                     @RedisProtocolSupport.Key final Buffer key3) {
         return commander.mget(key1, key2, key3);
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
+    public Future<List<Buffer>> mget(@RedisProtocolSupport.Key final Collection<Buffer> keys) {
         return commander.mget(keys);
     }
 
@@ -1619,7 +1619,7 @@ final class TransactedBufferRedisCommanderToBlockingTransactedBufferRedisCommand
     }
 
     @Override
-    public Future<List<String>> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) {
+    public Future<List<Buffer>> srandmember(@RedisProtocolSupport.Key final Buffer key, final long count) {
         return commander.srandmember(key, count);
     }
 

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/TransactedRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/TransactedRedisCommander.java
@@ -1466,10 +1466,9 @@ public abstract class TransactedRedisCommander implements AsyncCloseable {
      * @param key the key
      * @param field the field
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Future<List<T>> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field);
+    public abstract Future<List<String>> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field);
 
     /**
      * Get the values of all the given hash fields.
@@ -1478,11 +1477,10 @@ public abstract class TransactedRedisCommander implements AsyncCloseable {
      * @param field1 the field1
      * @param field2 the field2
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Future<List<T>> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field1,
-                                              CharSequence field2);
+    public abstract Future<List<String>> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field1,
+                                               CharSequence field2);
 
     /**
      * Get the values of all the given hash fields.
@@ -1492,11 +1490,10 @@ public abstract class TransactedRedisCommander implements AsyncCloseable {
      * @param field2 the field2
      * @param field3 the field3
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Future<List<T>> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field1,
-                                              CharSequence field2, CharSequence field3);
+    public abstract Future<List<String>> hmget(@RedisProtocolSupport.Key CharSequence key, CharSequence field1,
+                                               CharSequence field2, CharSequence field3);
 
     /**
      * Get the values of all the given hash fields.
@@ -1504,11 +1501,10 @@ public abstract class TransactedRedisCommander implements AsyncCloseable {
      * @param key the key
      * @param fields the fields
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.HMGET)
-    public abstract <T> Future<List<T>> hmget(@RedisProtocolSupport.Key CharSequence key,
-                                              Collection<? extends CharSequence> fields);
+    public abstract Future<List<String>> hmget(@RedisProtocolSupport.Key CharSequence key,
+                                               Collection<? extends CharSequence> fields);
 
     /**
      * Set multiple hash fields to multiple values.
@@ -1915,10 +1911,9 @@ public abstract class TransactedRedisCommander implements AsyncCloseable {
      *
      * @param key the key
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Future<List<T>> mget(@RedisProtocolSupport.Key CharSequence key);
+    public abstract Future<List<String>> mget(@RedisProtocolSupport.Key CharSequence key);
 
     /**
      * Get the values of all the given keys.
@@ -1926,11 +1921,10 @@ public abstract class TransactedRedisCommander implements AsyncCloseable {
      * @param key1 the key1
      * @param key2 the key2
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Future<List<T>> mget(@RedisProtocolSupport.Key CharSequence key1,
-                                             @RedisProtocolSupport.Key CharSequence key2);
+    public abstract Future<List<String>> mget(@RedisProtocolSupport.Key CharSequence key1,
+                                              @RedisProtocolSupport.Key CharSequence key2);
 
     /**
      * Get the values of all the given keys.
@@ -1939,22 +1933,20 @@ public abstract class TransactedRedisCommander implements AsyncCloseable {
      * @param key2 the key2
      * @param key3 the key3
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Future<List<T>> mget(@RedisProtocolSupport.Key CharSequence key1,
-                                             @RedisProtocolSupport.Key CharSequence key2,
-                                             @RedisProtocolSupport.Key CharSequence key3);
+    public abstract Future<List<String>> mget(@RedisProtocolSupport.Key CharSequence key1,
+                                              @RedisProtocolSupport.Key CharSequence key2,
+                                              @RedisProtocolSupport.Key CharSequence key3);
 
     /**
      * Get the values of all the given keys.
      *
      * @param keys the keys
      * @return a {@link Future} result
-     * @param <T> the type of elements
      */
     @RedisProtocolSupport.Cmd(RedisProtocolSupport.Command.MGET)
-    public abstract <T> Future<List<T>> mget(@RedisProtocolSupport.Key Collection<? extends CharSequence> keys);
+    public abstract Future<List<String>> mget(@RedisProtocolSupport.Key Collection<? extends CharSequence> keys);
 
     /**
      * Move a key to another database.

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/TransactedRedisCommanderToBlockingTransactedRedisCommander.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/TransactedRedisCommanderToBlockingTransactedRedisCommander.java
@@ -743,25 +743,25 @@ final class TransactedRedisCommanderToBlockingTransactedRedisCommander extends B
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
+    public Future<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field) {
         return commander.hmget(key, field);
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
-                                     final CharSequence field2) {
+    public Future<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
+                                      final CharSequence field2) {
         return commander.hmget(key, field1, field2);
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
-                                     final CharSequence field2, final CharSequence field3) {
+    public Future<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key, final CharSequence field1,
+                                      final CharSequence field2, final CharSequence field3) {
         return commander.hmget(key, field1, field2, field3);
     }
 
     @Override
-    public <T> Future<List<T>> hmget(@RedisProtocolSupport.Key final CharSequence key,
-                                     final Collection<? extends CharSequence> fields) {
+    public Future<List<String>> hmget(@RedisProtocolSupport.Key final CharSequence key,
+                                      final Collection<? extends CharSequence> fields) {
         return commander.hmget(key, fields);
     }
 
@@ -968,25 +968,25 @@ final class TransactedRedisCommanderToBlockingTransactedRedisCommander extends B
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key) {
+    public Future<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key) {
         return commander.mget(key);
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key1,
-                                    @RedisProtocolSupport.Key final CharSequence key2) {
+    public Future<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key1,
+                                     @RedisProtocolSupport.Key final CharSequence key2) {
         return commander.mget(key1, key2);
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final CharSequence key1,
-                                    @RedisProtocolSupport.Key final CharSequence key2,
-                                    @RedisProtocolSupport.Key final CharSequence key3) {
+    public Future<List<String>> mget(@RedisProtocolSupport.Key final CharSequence key1,
+                                     @RedisProtocolSupport.Key final CharSequence key2,
+                                     @RedisProtocolSupport.Key final CharSequence key3) {
         return commander.mget(key1, key2, key3);
     }
 
     @Override
-    public <T> Future<List<T>> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
+    public Future<List<String>> mget(@RedisProtocolSupport.Key final Collection<? extends CharSequence> keys) {
         return commander.mget(keys);
     }
 

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/PartitionedRedisClientTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/PartitionedRedisClientTest.java
@@ -168,7 +168,7 @@ public class PartitionedRedisClientTest extends AbstractPartitionedRedisClientTe
 
         sendHost1ServiceDiscoveryEvent(false);
 
-        Single<List<Object>> mgetCommand = commander.mget("key1", "key3", "key5")
+        Single<List<String>> mgetCommand = commander.mget("key1", "key3", "key5")
                 .retry((i, t) -> {
                     if (i > 1 || !(t instanceof UnknownPartitionException)) {
                         return false;


### PR DESCRIPTION
Motivation:

Redis documents mget/hmget as returning lists of strings. Our methods return
types should reflect that. Returning List<T> as it does now allows for
class cast exceptions at runtime.

Modifications:

- Rerun codegen:
  - Override mget/hmget to return "bulk" string arrays.
  - Modify "bulk" string arrays to honour the buffer mode.
  - Change override for pubsub channels to use simple string, not bulk,
    so that it continues to return String, not Buffer.

Results:

mget/hmget now return List<String>, avoiding the runtime class cast exception.
As a pleasant side effect of these changes, srandmember now returns Buffer
in the buffer commander.