### PR TITLE
`DefaultDnsServiceDiscoverer` prematurely decrements requested count

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscoverer.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscoverer.java
@@ -48,7 +48,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.client.internal.ServiceDiscovererUtils.calculateDifference;
@@ -57,9 +56,11 @@ import static io.servicetalk.concurrent.api.Publisher.error;
 import static io.servicetalk.concurrent.internal.EmptySubscription.EMPTY_SUBSCRIPTION;
 import static io.servicetalk.transport.netty.internal.BuilderUtils.datagramChannel;
 import static io.servicetalk.transport.netty.internal.EventLoopAwareNettyIoExecutors.toEventLoopAwareNettyIoExecutor;
+import static java.lang.System.nanoTime;
 import static java.nio.ByteBuffer.wrap;
 import static java.util.Comparator.comparing;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.function.Function.identity;
 
 /**
@@ -368,7 +369,7 @@ final class DefaultDnsServiceDiscoverer
                         if (ttlNanos < 0) {
                             doQuery();
                         } else {
-                            long durationNs = System.nanoTime() - resolveDoneNoScheduleTime;
+                            long durationNs = nanoTime() - resolveDoneNoScheduleTime;
                             if (durationNs > ttlNanos) {
                                 doQuery();
                             } else {
@@ -415,13 +416,13 @@ final class DefaultDnsServiceDiscoverer
                         List<ServiceDiscovererEvent<InetAddress>> events = calculateDifference(activeAddresses,
                                 addresses, INET_ADDRESS_COMPARATOR);
                         // TODO(scott): the TTL value should be derived from the cache.
-                        ttlNanos = TimeUnit.SECONDS.toNanos(2);
+                        ttlNanos = SECONDS.toNanos(2);
                         if (events != null) {
                             --pendingRequests;
                             if (pendingRequests > 0) {
                                 scheduleQuery(ttlNanos);
                             } else {
-                                resolveDoneNoScheduleTime = System.nanoTime();
+                                resolveDoneNoScheduleTime = nanoTime();
                                 cancellableForQuery = null;
                             }
                             activeAddresses = addresses;


### PR DESCRIPTION
__Motivation__

`DefaultDnsServiceDiscoverer` will eventually stop querying DNS if there is no change in the DNS entries.
It decrements `pendingRequests` count even if it did not emit any event (no change in DNS entries). This will make `pendingRequests` `0` after some polls.
Downstream `Subscriber` MAY not request more if no items were emitted. This means we will stop polling if the requested amount is finite.

__Modification__

Decrement `pendingRequests` only when we are emitting an event.

__Result__

Correct demand management and keep polling as long as there is demand.