### PR TITLE
Ignore flaky `pubSubMultipleSubscribes()` tests

### DIFF
--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BlockingRedisCommanderTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BlockingRedisCommanderTest.java
@@ -60,6 +60,8 @@ import static io.servicetalk.redis.api.RedisProtocolSupport.IntegerType.U04;
 import static io.servicetalk.redis.api.RedisProtocolSupport.IntegerType.U08;
 import static io.servicetalk.redis.api.RedisProtocolSupport.SetCondition.NX;
 import static io.servicetalk.redis.api.RedisProtocolSupport.SetExpire.EX;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.parseBoolean;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -344,6 +346,7 @@ public class BlockingRedisCommanderTest extends BaseRedisClientTest {
 
     @Test
     public void pubSubMultipleSubscribes() throws Exception {
+        assumeThat("Ignored flaky test", parseBoolean(System.getenv("CI")), is(FALSE));
         final BlockingPubSubRedisConnection pubSubClient1 = commandClient.subscribe(key("channel-1"));
         BlockingIterable<PubSubRedisMessage> messages1 = pubSubClient1.getMessages();
         BlockingIterator<PubSubRedisMessage> iterator1 = messages1.iterator();

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BufferRedisCommanderTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BufferRedisCommanderTest.java
@@ -61,6 +61,8 @@ import static io.servicetalk.redis.api.RedisProtocolSupport.IntegerType.U04;
 import static io.servicetalk.redis.api.RedisProtocolSupport.IntegerType.U08;
 import static io.servicetalk.redis.api.RedisProtocolSupport.SetCondition.NX;
 import static io.servicetalk.redis.api.RedisProtocolSupport.SetExpire.EX;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.parseBoolean;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -425,6 +427,7 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
 
     @Test
     public void pubSubMultipleSubscribes() throws Exception {
+        assumeThat("Ignored flaky test", parseBoolean(System.getenv("CI")), is(FALSE));
         final PubSubBufferRedisConnection pubSubClient1 = awaitIndefinitely(commandClient.subscribe(key("channel-1")));
         final AccumulatingSubscriber<PubSubRedisMessage> subscriber1 = new AccumulatingSubscriber<>();
         subscriber1.subscribe(pubSubClient1.getMessages());

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisCommanderTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisCommanderTest.java
@@ -61,6 +61,8 @@ import static io.servicetalk.redis.api.RedisProtocolSupport.IntegerType.U04;
 import static io.servicetalk.redis.api.RedisProtocolSupport.IntegerType.U08;
 import static io.servicetalk.redis.api.RedisProtocolSupport.SetCondition.NX;
 import static io.servicetalk.redis.api.RedisProtocolSupport.SetExpire.EX;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.parseBoolean;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -424,6 +426,7 @@ public class RedisCommanderTest extends BaseRedisClientTest {
 
     @Test
     public void pubSubMultipleSubscribes() throws Exception {
+        assumeThat("Ignored flaky test", parseBoolean(System.getenv("CI")), is(FALSE));
         final PubSubRedisConnection pubSubClient1 = awaitIndefinitely(commandClient.subscribe(key("channel-1")));
         final AccumulatingSubscriber<PubSubRedisMessage> subscriber1 = new AccumulatingSubscriber<>();
 

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/SubscribedRedisClientTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/SubscribedRedisClientTest.java
@@ -67,6 +67,8 @@ import static io.servicetalk.redis.netty.SubscribedChannelReadStream.PubSubChann
 import static io.servicetalk.redis.netty.SubscribedChannelReadStream.PubSubChannelMessage.KeyType.Pattern;
 import static io.servicetalk.redis.netty.SubscribedChannelReadStream.PubSubChannelMessage.KeyType.Ping;
 import static io.servicetalk.redis.netty.SubscribedChannelReadStream.PubSubChannelMessage.MessageType.DATA;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.parseBoolean;
 import static java.lang.Thread.currentThread;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.emptyCollectionOf;
@@ -77,6 +79,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
 
 public class SubscribedRedisClientTest extends BaseRedisClientTest {
     static final class AccumulatingSubscriber<T> implements Subscriber<T> {
@@ -237,6 +240,7 @@ public class SubscribedRedisClientTest extends BaseRedisClientTest {
 
     @Test
     public void pubSubMultipleSubscribes() throws Exception {
+        assumeThat("Ignored flaky test", parseBoolean(System.getenv("CI")), is(FALSE));
         final RedisRequest subscribeRequest = newRequest(SUBSCRIBE, new CompleteBulkString(buf("test-channel-3")));
 
         final ReservedRedisConnection cnx = awaitIndefinitely(getEnv().client.reserveConnection(SUBSCRIBE));


### PR DESCRIPTION
__Motivation__

`pubSubMultipleSubscribes()` tests exists in various classes for different commanders.
These tests are known to be flaky and have a tracking issue https://github.com/servicetalk/servicetalk/issues/104

__Modification__

Ignore these tests on CI

__Result__

Less flaky tests.