### PR TITLE
Improve behavior for `DoBeforeSubscribe` in presence of exceptions

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DoAfterSubscriberCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DoAfterSubscriberCompletable.java
@@ -46,17 +46,8 @@ final class DoAfterSubscriberCompletable extends AbstractSynchronousCompletableO
 
         @Override
         public void onSubscribe(final Cancellable cancellable) {
-            try {
-                original.onSubscribe(cancellable);
-            } catch (final Throwable cause) {
-                try {
-                    subscriber.onSubscribe(cancellable);
-                } catch (final Throwable err) {
-                    err.addSuppressed(cause);
-                    throw err;
-                }
-                throw cause;
-            }
+            original.onSubscribe(cancellable);
+            // If this throws we expect the source to bail on this Subscriber.
             subscriber.onSubscribe(cancellable);
         }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DoAfterSubscriberPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DoAfterSubscriberPublisher.java
@@ -46,17 +46,8 @@ final class DoAfterSubscriberPublisher<T> extends AbstractSynchronousPublisherOp
 
         @Override
         public void onSubscribe(Subscription s) {
-            try {
-                original.onSubscribe(s);
-            } catch (Throwable cause) {
-                try {
-                    subscriber.onSubscribe(s);
-                } catch (Throwable err) {
-                    err.addSuppressed(cause);
-                    throw err;
-                }
-                throw cause;
-            }
+            original.onSubscribe(s);
+            // If this throws we expect the source to bail on this Subscriber.
             subscriber.onSubscribe(s);
         }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DoAfterSubscriberSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DoAfterSubscriberSingle.java
@@ -45,17 +45,8 @@ final class DoAfterSubscriberSingle<T> extends AbstractSynchronousSingleOperator
 
         @Override
         public void onSubscribe(Cancellable cancellable) {
-            try {
-                original.onSubscribe(cancellable);
-            } catch (Throwable cause) {
-                try {
-                    subscriber.onSubscribe(cancellable);
-                } catch (Throwable err) {
-                    err.addSuppressed(cause);
-                    throw err;
-                }
-                throw cause;
-            }
+            original.onSubscribe(cancellable);
+            // If this throws we expect the source to bail on this Subscriber.
             subscriber.onSubscribe(cancellable);
         }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DoBeforeSubscriberCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DoBeforeSubscriberCompletable.java
@@ -46,17 +46,8 @@ final class DoBeforeSubscriberCompletable extends AbstractSynchronousCompletable
 
         @Override
         public void onSubscribe(Cancellable cancellable) {
-            try {
-                subscriber.onSubscribe(cancellable);
-            } catch (Throwable cause) {
-                try {
-                    original.onSubscribe(cancellable);
-                } catch (Throwable err) {
-                    cause.addSuppressed(err);
-                    throw cause;
-                }
-                throw cause;
-            }
+            // If this throws we expect the source to bail on this Subscriber.
+            subscriber.onSubscribe(cancellable);
             original.onSubscribe(cancellable);
         }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DoBeforeSubscriberPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DoBeforeSubscriberPublisher.java
@@ -46,17 +46,8 @@ final class DoBeforeSubscriberPublisher<T> extends AbstractSynchronousPublisherO
 
         @Override
         public void onSubscribe(Subscription s) {
-            try {
-                subscriber.onSubscribe(s);
-            } catch (Throwable cause) {
-                try {
-                    original.onSubscribe(s);
-                } catch (Throwable err) {
-                    cause.addSuppressed(err);
-                    throw cause;
-                }
-                throw cause;
-            }
+            // If this throws we expect the source to bail on this Subscriber.
+            subscriber.onSubscribe(s);
             original.onSubscribe(s);
         }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DoBeforeSubscriberSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DoBeforeSubscriberSingle.java
@@ -46,17 +46,8 @@ final class DoBeforeSubscriberSingle<T> extends AbstractSynchronousSingleOperato
 
         @Override
         public void onSubscribe(Cancellable cancellable) {
-            try {
-                subscriber.onSubscribe(cancellable);
-            } catch (Throwable cause) {
-                try {
-                    original.onSubscribe(cancellable);
-                } catch (Throwable err) {
-                    err.addSuppressed(cause);
-                    throw err;
-                }
-                throw cause;
-            }
+            // If this throws we expect the source to bail on this Subscriber.
+            subscriber.onSubscribe(cancellable);
             original.onSubscribe(cancellable);
         }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractDoSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractDoSubscribeTest.java
@@ -26,7 +26,6 @@ import org.junit.rules.ExpectedException;
 
 import java.util.function.Consumer;
 
-import static io.servicetalk.concurrent.api.DeliberateException.DELIBERATE_EXCEPTION;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -51,13 +50,6 @@ public abstract class AbstractDoSubscribeTest {
     public void testOnSubscribe() {
         listener.listen(doSubscribe(Completable.completed(), doOnListen)).verifyCompletion();
         verify(doOnListen).accept(any(Cancellable.class));
-    }
-
-    @Test
-    public void testCallbackThrowsError() {
-        listener.listen(doSubscribe(Completable.completed(), __ -> {
-            throw DELIBERATE_EXCEPTION;
-        }));
     }
 
     protected abstract Completable doSubscribe(Completable completable, Consumer<Cancellable> consumer);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/DoAfterSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/DoAfterSubscribeTest.java
@@ -18,9 +18,20 @@ package io.servicetalk.concurrent.api.completable;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.Completable;
 
+import org.junit.Test;
+
 import java.util.function.Consumer;
 
+import static io.servicetalk.concurrent.api.DeliberateException.DELIBERATE_EXCEPTION;
+
 public class DoAfterSubscribeTest extends AbstractDoSubscribeTest {
+
+    @Test
+    public void testCallbackThrowsError() {
+        listener.listen(doSubscribe(Completable.completed(), __ -> {
+            throw DELIBERATE_EXCEPTION;
+        })).verifyNoEmissions();
+    }
 
     @Override
     protected Completable doSubscribe(Completable completable, Consumer<Cancellable> consumer) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractDoSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractDoSubscribeTest.java
@@ -26,7 +26,6 @@ import org.reactivestreams.Subscription;
 
 import java.util.function.Consumer;
 
-import static io.servicetalk.concurrent.api.DeliberateException.DELIBERATE_EXCEPTION;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -51,14 +50,6 @@ public abstract class AbstractDoSubscribeTest {
     public void testOnSubscribe() {
         rule.subscribe(doSubscribe(Publisher.just("Hello"), doOnSubscribe)).verifySuccess("Hello");
         verify(doOnSubscribe).accept(any());
-    }
-
-    @Test
-    public void testCallbackThrowsError() {
-        Publisher<String> src = doSubscribe(Publisher.just("Hello"), s -> {
-            throw DELIBERATE_EXCEPTION;
-        });
-        rule.subscribe(src).request(1).verifySuccess("Hello");
     }
 
     protected abstract <T> Publisher<T> doSubscribe(Publisher<T> publisher, Consumer<Subscription> consumer);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/DoAfterSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/DoAfterSubscribeTest.java
@@ -17,11 +17,22 @@ package io.servicetalk.concurrent.api.publisher;
 
 import io.servicetalk.concurrent.api.Publisher;
 
+import org.junit.Test;
 import org.reactivestreams.Subscription;
 
 import java.util.function.Consumer;
 
+import static io.servicetalk.concurrent.api.DeliberateException.DELIBERATE_EXCEPTION;
+
 public class DoAfterSubscribeTest extends AbstractDoSubscribeTest {
+
+    @Test
+    public void testCallbackThrowsError() {
+        Publisher<String> src = doSubscribe(Publisher.just("Hello"), s -> {
+            throw DELIBERATE_EXCEPTION;
+        });
+        rule.subscribe(src).verifyNoEmissions();
+    }
 
     @Override
     protected <T> Publisher<T> doSubscribe(Publisher<T> publisher, Consumer<Subscription> consumer) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublishAndSubscribeOnTest.java
@@ -131,14 +131,14 @@ public class PublishAndSubscribeOnTest {
 
         Publisher<String> original = new PublisherWithExecutor<>(originalSourceExecutorRule.getExecutor(),
                 just("Hello"))
-                .doBeforeNext($ -> capturedThreads[ORIGINAL_SUBSCRIBER_THREAD] = Thread.currentThread())
-                .doBeforeRequest($ -> capturedThreads[ORIGINAL_SUBSCRIPTION_THREAD] = Thread.currentThread());
+                .doBeforeNext(__ -> capturedThreads[ORIGINAL_SUBSCRIBER_THREAD] = Thread.currentThread())
+                .doBeforeRequest(__ -> capturedThreads[ORIGINAL_SUBSCRIPTION_THREAD] = Thread.currentThread());
 
         final Executor executor = executorRule.getExecutor();
         Publisher<String> offloaded = offloadingFunction.apply(original, executor);
 
-        offloaded.doBeforeNext($ -> capturedThreads[OFFLOADED_SUBSCRIBER_THREAD] = Thread.currentThread())
-                .doBeforeRequest($ -> capturedThreads[OFFLOADED_SUBSCRIPTION_THREAD] = Thread.currentThread())
+        offloaded.doBeforeNext(__ -> capturedThreads[OFFLOADED_SUBSCRIBER_THREAD] = Thread.currentThread())
+                .doBeforeRequest(__ -> capturedThreads[OFFLOADED_SUBSCRIPTION_THREAD] = Thread.currentThread())
                 .doAfterFinally(allDone::countDown)
                 .subscribe(new Subscriber<String>() {
                     @Override

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractDoSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractDoSubscribeTest.java
@@ -26,7 +26,6 @@ import org.junit.rules.ExpectedException;
 
 import java.util.function.Consumer;
 
-import static io.servicetalk.concurrent.api.DeliberateException.DELIBERATE_EXCEPTION;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -51,13 +50,6 @@ public abstract class AbstractDoSubscribeTest {
     public void testSubscribe() {
         listener.listen(doSubscribe(Single.success("Hello"), doOnListen)).verifySuccess("Hello");
         verify(doOnListen).accept(any(Cancellable.class));
-    }
-
-    @Test
-    public void testCallbackThrowsError() {
-        listener.listen(doSubscribe(Single.success("Hello"), $ -> {
-            throw DELIBERATE_EXCEPTION;
-        }));
     }
 
     protected abstract <T> Single<T> doSubscribe(Single<T> single, Consumer<Cancellable> consumer);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/DoAfterSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/DoAfterSubscribeTest.java
@@ -18,9 +18,21 @@ package io.servicetalk.concurrent.api.single;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.Single;
 
+import org.junit.Test;
+
 import java.util.function.Consumer;
 
+import static io.servicetalk.concurrent.api.DeliberateException.DELIBERATE_EXCEPTION;
+
 public class DoAfterSubscribeTest extends AbstractDoSubscribeTest {
+
+    @Test
+    public void testCallbackThrowsError() {
+        listener.listen(doSubscribe(Single.success("Hello"), __ -> {
+            throw DELIBERATE_EXCEPTION;
+        })).verifyNoEmissions();
+    }
+
     @Override
     protected <T> Single<T> doSubscribe(Single<T> single, Consumer<Cancellable> consumer) {
         return single.doAfterSubscribe(consumer);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/DoBeforeSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/DoBeforeSubscribeTest.java
@@ -16,11 +16,45 @@
 package io.servicetalk.concurrent.api.single;
 
 import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.Single.Subscriber;
 import io.servicetalk.concurrent.api.Single;
 
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Consumer;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.DeliberateException.DELIBERATE_EXCEPTION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 
 public class DoBeforeSubscribeTest extends AbstractDoSubscribeTest {
+    @Test
+    public void testCallbackThrowsError() {
+        List<AssertionError> failures = new ArrayList<>();
+        doSubscribe(Single.success("Hello"), s -> {
+            throw DELIBERATE_EXCEPTION;
+        }).subscribe(new Subscriber<String>() {
+            @Override
+            public void onSubscribe(final Cancellable c) {
+                failures.add(new AssertionError("onSubscribe invoked unexpectedly."));
+            }
+
+            @Override
+            public void onError(final Throwable t) {
+                failures.add(new AssertionError("onError invoked unexpectedly.", t));
+            }
+
+            @Override
+            public void onSuccess(@Nullable String val) {
+                failures.add(new AssertionError("onSuccess invoked unexpectedly with value: " + val));
+            }
+        });
+        assertThat("Unexpected errors: " + failures, failures, hasSize(0));
+    }
+
     @Override
     protected <T> Single<T> doSubscribe(Single<T> single, Consumer<Cancellable> consumer) {
         return single.doBeforeSubscribe(consumer);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/PublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/PublishAndSubscribeOnTest.java
@@ -109,12 +109,12 @@ public class PublishAndSubscribeOnTest {
         Thread[] capturedThreads = new Thread[2];
 
         Single<String> original = new SingleWithExecutor<>(originalSourceExecutorRule.getExecutor(), success("Hello"))
-                .doBeforeSuccess($ -> capturedThreads[0] = Thread.currentThread());
+                .doBeforeSuccess(__ -> capturedThreads[0] = Thread.currentThread());
 
         Single<String> offloaded = offloadingFunction.apply(original, executorRule.getExecutor());
 
         offloaded.doAfterFinally(allDone::countDown)
-                .doBeforeSuccess($ -> capturedThreads[1] = Thread.currentThread())
+                .doBeforeSuccess(__ -> capturedThreads[1] = Thread.currentThread())
                 .subscribe(val -> { });
         allDone.await();
 

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -339,7 +339,7 @@ public class RoundRobinLoadBalancerTest {
     public void connectionFactoryErrorPropagation() throws Exception {
         thrown.expect(instanceOf(ExecutionException.class));
         thrown.expectCause(instanceOf(DeliberateException.class));
-        connectionFactory = new DelegatingConnectionFactory($ -> error(DELIBERATE_EXCEPTION));
+        connectionFactory = new DelegatingConnectionFactory(__ -> error(DELIBERATE_EXCEPTION));
         lb = newTestLoadBalancer(connectionFactory);
         sendServiceDiscoveryEvents(upEvent("address-1"));
         awaitIndefinitely(lb.selectConnection(identity()));
@@ -398,7 +398,7 @@ public class RoundRobinLoadBalancerTest {
     private TestLoadBalancedConnection newConnection(final String address) {
         final TestLoadBalancedConnection cnx = mock(TestLoadBalancedConnection.class);
         final CompletableProcessor closeCompletable = new CompletableProcessor();
-        when(cnx.closeAsync()).thenAnswer($ -> {
+        when(cnx.closeAsync()).thenAnswer(__ -> {
             closeCompletable.onComplete();
             return closeCompletable;
         });

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/DefaultPartitionedRedisClientBuilder.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/DefaultPartitionedRedisClientBuilder.java
@@ -369,14 +369,14 @@ final class DefaultPartitionedRedisClientBuilder<U, R> implements PartitionedRed
         public Completable closeAsync() {
             // Cancel doesn't provide any status and is assumed to complete immediately so we just cancel when subscribe
             // is called.
-            return partitionMap.closeAsync().doBeforeSubscribe($ -> sequentialCancellable.cancel());
+            return partitionMap.closeAsync().doBeforeSubscribe(__ -> sequentialCancellable.cancel());
         }
 
         @Override
         public Completable closeAsyncGracefully() {
             // Cancel doesn't provide any status and is assumed to complete immediately so we just cancel when subscribe
             // is called.
-            return partitionMap.closeAsyncGracefully().doBeforeSubscribe($ -> sequentialCancellable.cancel());
+            return partitionMap.closeAsyncGracefully().doBeforeSubscribe(__ -> sequentialCancellable.cancel());
         }
     }
 

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/RedisIdleConnectionReaper.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/RedisIdleConnectionReaper.java
@@ -157,7 +157,7 @@ final class RedisIdleConnectionReaper implements UnaryOperator<RedisConnection> 
         @Override
         public Publisher<RedisData> request(final RedisRequest request) {
             return delegate.request(request)
-                    .doBeforeSubscribe($ -> onRequestStarted())
+                    .doBeforeSubscribe(__ -> onRequestStarted())
                     .doBeforeFinally(this::onRequestFinished);
         }
 
@@ -169,7 +169,7 @@ final class RedisIdleConnectionReaper implements UnaryOperator<RedisConnection> 
         @Override
         public <R> Single<R> request(final RedisRequest request, final Class<R> responseType) {
             return delegate.request(request, responseType)
-                    .doBeforeSubscribe($ -> onRequestStarted())
+                    .doBeforeSubscribe(__ -> onRequestStarted())
                     .doBeforeFinally(this::onRequestFinished);
         }
 

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BufferRedisCommanderTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BufferRedisCommanderTest.java
@@ -414,7 +414,7 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
 
         assertThat(subscriber
                 .subscribe(commandClient.monitor()
-                        .doAfterNext($ -> awaitIndefinitelyUnchecked(commandClient.ping().ignoreResult()))
+                        .doAfterNext(__ -> awaitIndefinitelyUnchecked(commandClient.ping().ignoreResult()))
                         .doAfterCancel(cancelled::countDown))
                 .request(2)
                 .awaitUntilAtLeastNReceived(2, DEFAULT_TIMEOUT_SECONDS, SECONDS), is(true));

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/InternalSubscribedRedisConnectionTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/InternalSubscribedRedisConnectionTest.java
@@ -133,7 +133,7 @@ public class InternalSubscribedRedisConnectionTest {
                         .fromUtf8(channelToSubscribe)));
 
         Publisher<RedisData> subscriptionRequest = connection.request(subReq)
-                .doAfterSubscribe($ -> latch.countDown());
+                .doAfterSubscribe(__ -> latch.countDown());
 
         LinkedBlockingQueue<Object> notifications = new LinkedBlockingQueue<>();
         Subscription subscription = subscribeToResponse(subscriptionRequest, notifications);

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisCommanderTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisCommanderTest.java
@@ -413,7 +413,7 @@ public class RedisCommanderTest extends BaseRedisClientTest {
 
         assertThat(subscriber
                 .subscribe(commandClient.monitor()
-                        .doAfterNext($ -> awaitIndefinitelyUnchecked(commandClient.ping().ignoreResult()))
+                        .doAfterNext(__ -> awaitIndefinitelyUnchecked(commandClient.ping().ignoreResult()))
                         .doAfterCancel(cancelled::countDown))
                 .request(2)
                 .awaitUntilAtLeastNReceived(2, DEFAULT_TIMEOUT_SECONDS, SECONDS), is(true));

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/SubscribedRedisClientTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/SubscribedRedisClientTest.java
@@ -248,7 +248,7 @@ public class SubscribedRedisClientTest extends BaseRedisClientTest {
 
         CountDownLatch latch = new CountDownLatch(1);
 
-        final Publisher<RedisData> messages1 = cnx.request(subscribeRequest).doAfterSubscribe($ -> latch.countDown());
+        final Publisher<RedisData> messages1 = cnx.request(subscribeRequest).doAfterSubscribe(__ -> latch.countDown());
 
         final AccumulatingSubscriber<RedisData> messages1Subscriber = new AccumulatingSubscriber<RedisData>()
                 .subscribe(messages1);
@@ -367,7 +367,7 @@ public class SubscribedRedisClientTest extends BaseRedisClientTest {
 
         CountDownLatch latch = new CountDownLatch(1);
         cnx.request(subscribeRequest)
-                .doAfterSubscribe($ -> latch.countDown())
+                .doAfterSubscribe(__ -> latch.countDown())
                 .map(msg -> (PatternPubSubRedisMessage) msg)
                 .groupBy(ChannelPubSubRedisMessage::getChannel, 32)
                 .forEach(grp -> {

--- a/servicetalk-serialization-api/src/test/java/io/servicetalk/serialization/api/BlockingIterableMock.java
+++ b/servicetalk-serialization-api/src/test/java/io/servicetalk/serialization/api/BlockingIterableMock.java
@@ -35,12 +35,12 @@ final class BlockingIterableMock<T> {
     BlockingIterableMock(Iterable<T> source) {
         iterable = mock(BlockingIterable.class);
         iterator = mock(BlockingIterator.class);
-        when(iterable.iterator()).then($ -> {
+        when(iterable.iterator()).then(__ -> {
             final Iterator<T> srcIterator = source.iterator();
-            when(iterator.hasNext()).then($$ -> srcIterator.hasNext());
-            when(iterator.hasNext(anyLong(), any(TimeUnit.class))).then($$ -> srcIterator.hasNext());
-            when(iterator.next()).then($$ -> srcIterator.next());
-            when(iterator.next(anyLong(), any(TimeUnit.class))).then($$ -> srcIterator.next());
+            when(iterator.hasNext()).then($__ -> srcIterator.hasNext());
+            when(iterator.hasNext(anyLong(), any(TimeUnit.class))).then($__ -> srcIterator.hasNext());
+            when(iterator.next()).then($__ -> srcIterator.next());
+            when(iterator.next(anyLong(), any(TimeUnit.class))).then($__ -> srcIterator.next());
             return iterator;
         });
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
@@ -105,7 +105,7 @@ class RequestResponseCloseHandler extends CloseHandler {
     /**
      * Feed back events to {@link DefaultNettyConnection} bypassing the pipeline.
      */
-    private Consumer<CloseEvent> eventHandler = $ -> { };
+    private Consumer<CloseEvent> eventHandler = __ -> { };
 
     RequestResponseCloseHandler(final boolean client) {
         isClient = client;

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandlerTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandlerTest.java
@@ -302,28 +302,28 @@ public class RequestResponseCloseHandlerTest {
             when(loop.inEventLoop()).thenReturn(true);
             when(scc.isAllowHalfClosure()).thenReturn(true);
 
-            when(channel.isOutputShutdown()).then($ -> outputShutdown.get());
-            when(channel.isInputShutdown()).then($ -> inputShutdown.get());
-            when(channel.isOpen()).then($ -> !closed.get());
+            when(channel.isOutputShutdown()).then(__ -> outputShutdown.get());
+            when(channel.isInputShutdown()).then(__ -> inputShutdown.get());
+            when(channel.isOpen()).then(__ -> !closed.get());
             ChannelFuture future = mock(ChannelFuture.class);
-            when(channel.shutdownInput()).then($ -> {
+            when(channel.shutdownInput()).then(__ -> {
                 inputShutdown.set(true);
                 LOGGER.debug("channel.shutdownInput()");
                 h.channelClosedInbound(ctx); // OutputShutDownEvent observed from transport
                 return future;
             });
-            when(channel.shutdownOutput()).then($ -> {
+            when(channel.shutdownOutput()).then(__ -> {
                 outputShutdown.set(true);
                 LOGGER.debug("channel.shutdownOutput()");
                 h.channelClosedOutbound(ctx); // InputShutDownReadComplete observed from transport
                 return future;
             });
-            when(channel.close()).then($ -> {
+            when(channel.close()).then(__ -> {
                 closed.set(true);
                 LOGGER.debug("channel.close()");
                 return future;
             });
-            when(scc.setSoLinger(0)).then($ -> {
+            when(scc.setSoLinger(0)).then(__ -> {
                 LOGGER.debug("channel.config().setSoLinger(0)");
                 if (inputShutdown.get() && outputShutdown.get()) {
                     fail("mock => setsockopt() failed - output already shutdown!");


### PR DESCRIPTION
__Motivation__

`do[Before/After]Subscribe()` behavior is not ideal for the following scenarios:

- `doBefore` tries to send the `onSubscribe()` even if the callback failed. It also throws from `onSubscribe`. Since we are throwing from `onSubscribe()` we expect the source to bail on the `Subscriber` so we should reduce the exposure of the `Subscription`/`Cancellable.
- `doAfter` call the callback even if the original `Subscriber` threw from `onSubscribe()`. We do not need to do anything here since the original `Subscriber` has violated specifications.

__Modification__

Do not do any exception handling in `do[Before/After]Subscribe()` and let the original source decide how to handle these exceptions.

Also removed usage of `$` as the variable name in callback when they are ignored.

__Result__

Reduced complexity and less expsoure of `Subscription`/`Cancellable` in presence of spec violations.