### PR TITLE
Allow for override with `immediate()`

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnCompletables.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnCompletables.java
@@ -17,7 +17,6 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.internal.SignalOffloader;
 
-import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.MergedExecutors.mergeAndOffloadPublish;
 import static io.servicetalk.concurrent.api.MergedExecutors.mergeAndOffloadSubscribe;
 
@@ -32,33 +31,27 @@ final class PublishAndSubscribeOnCompletables {
     }
 
     static Completable publishAndSubscribeOn(Completable original, Executor executor) {
-        return original.getExecutor() == executor || executor == immediate() ?
-                original : new PublishAndSubscribeOn(executor, original);
+        return original.getExecutor() == executor ? original : new PublishAndSubscribeOn(executor, original);
     }
 
     static Completable publishAndSubscribeOnOverride(Completable original, Executor executor) {
-        return original.getExecutor() == executor || executor == immediate() ?
-                original : new PublishAndSubscribeOnOverride(original, executor);
+        return original.getExecutor() == executor ? original : new PublishAndSubscribeOnOverride(original, executor);
     }
 
     static Completable publishOn(Completable original, Executor executor) {
-        return original.getExecutor() == executor || executor == immediate() ?
-                original : new PublishOn(executor, original);
+        return original.getExecutor() == executor ? original : new PublishOn(executor, original);
     }
 
     static Completable publishOnOverride(Completable original, Executor executor) {
-        return original.getExecutor() == executor || executor == immediate() ?
-                original : new PublishOnOverride(original, executor);
+        return original.getExecutor() == executor ? original : new PublishOnOverride(original, executor);
     }
 
     static Completable subscribeOn(Completable original, Executor executor) {
-        return original.getExecutor() == executor || executor == immediate() ?
-                original : new SubscribeOn(executor, original);
+        return original.getExecutor() == executor ? original : new SubscribeOn(executor, original);
     }
 
     static Completable subscribeOnOverride(Completable original, Executor executor) {
-        return original.getExecutor() == executor || executor == immediate() ?
-                original : new SubscribeOnOverride(original, executor);
+        return original.getExecutor() == executor ? original : new SubscribeOnOverride(original, executor);
     }
 
     private static final class PublishAndSubscribeOn extends AbstractNoHandleSubscribeCompletable {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnPublishers.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnPublishers.java
@@ -19,7 +19,6 @@ import io.servicetalk.concurrent.internal.SignalOffloader;
 
 import org.reactivestreams.Subscriber;
 
-import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.MergedExecutors.mergeAndOffloadPublish;
 import static io.servicetalk.concurrent.api.MergedExecutors.mergeAndOffloadSubscribe;
 
@@ -34,33 +33,27 @@ final class PublishAndSubscribeOnPublishers {
     }
 
     static <T> Publisher<T> publishAndSubscribeOn(Publisher<T> original, Executor executor) {
-        return original.getExecutor() == executor || executor == immediate() ?
-                original : new PublishAndSubscribeOn<>(executor, original);
+        return original.getExecutor() == executor ? original : new PublishAndSubscribeOn<>(executor, original);
     }
 
     static <T> Publisher<T> publishAndSubscribeOnOverride(Publisher<T> original, Executor executor) {
-        return original.getExecutor() == executor || executor == immediate() ?
-                original : new PublishAndSubscribeOnOverride<>(original, executor);
+        return original.getExecutor() == executor ? original : new PublishAndSubscribeOnOverride<>(original, executor);
     }
 
     static <T> Publisher<T> publishOn(Publisher<T> original, Executor executor) {
-        return original.getExecutor() == executor || executor == immediate() ?
-                original : new PublishOn<>(executor, original);
+        return original.getExecutor() == executor ? original : new PublishOn<>(executor, original);
     }
 
     static <T> Publisher<T> publishOnOverride(Publisher<T> original, Executor executor) {
-        return original.getExecutor() == executor || executor == immediate() ?
-                original : new PublishOnOverride<>(original, executor);
+        return original.getExecutor() == executor ? original : new PublishOnOverride<>(original, executor);
     }
 
     static <T> Publisher<T> subscribeOn(Publisher<T> original, Executor executor) {
-        return original.getExecutor() == executor || executor == immediate() ?
-                original : new SubscribeOn<>(executor, original);
+        return original.getExecutor() == executor ? original : new SubscribeOn<>(executor, original);
     }
 
     static <T> Publisher<T> subscribeOnOverride(Publisher<T> original, Executor executor) {
-        return original.getExecutor() == executor || executor == immediate() ?
-                original : new SubscribeOnOverride<>(original, executor);
+        return original.getExecutor() == executor ? original : new SubscribeOnOverride<>(original, executor);
     }
 
     private static final class PublishAndSubscribeOn<T> extends AbstractNoHandleSubscribePublisher<T> {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnSingles.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnSingles.java
@@ -17,7 +17,6 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.internal.SignalOffloader;
 
-import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.MergedExecutors.mergeAndOffloadPublish;
 import static io.servicetalk.concurrent.api.MergedExecutors.mergeAndOffloadSubscribe;
 
@@ -32,33 +31,27 @@ final class PublishAndSubscribeOnSingles {
     }
 
     static <T> Single<T> publishAndSubscribeOn(Single<T> original, Executor executor) {
-        return original.getExecutor() == executor || executor == immediate() ?
-                original : new PublishAndSubscribeOn<>(executor, original);
+        return original.getExecutor() == executor ? original : new PublishAndSubscribeOn<>(executor, original);
     }
 
     static <T> Single<T> publishAndSubscribeOnOverride(Single<T> original, Executor executor) {
-        return original.getExecutor() == executor || executor == immediate() ?
-                original : new PublishAndSubscribeOnOverride<>(original, executor);
+        return original.getExecutor() == executor ? original : new PublishAndSubscribeOnOverride<>(original, executor);
     }
 
     static <T> Single<T> publishOn(Single<T> original, Executor executor) {
-        return original.getExecutor() == executor || executor == immediate() ?
-                original : new PublishOn<>(executor, original);
+        return original.getExecutor() == executor ? original : new PublishOn<>(executor, original);
     }
 
     static <T> Single<T> publishOnOverride(Single<T> original, Executor executor) {
-        return original.getExecutor() == executor || executor == immediate() ?
-                original : new PublishOnOverride<>(original, executor);
+        return original.getExecutor() == executor ? original : new PublishOnOverride<>(original, executor);
     }
 
     static <T> Single<T> subscribeOn(Single<T> original, Executor executor) {
-        return original.getExecutor() == executor || executor == immediate() ?
-                original : new SubscribeOn<>(executor, original);
+        return original.getExecutor() == executor ? original : new SubscribeOn<>(executor, original);
     }
 
     static <T> Single<T> subscribeOnOverride(Single<T> original, Executor executor) {
-        return original.getExecutor() == executor || executor == immediate() ?
-                original : new SubscribeOnOverride<>(original, executor);
+        return original.getExecutor() == executor ? original : new SubscribeOnOverride<>(original, executor);
     }
 
     private static final class PublishAndSubscribeOn<T> extends AbstractNoHandleSubscribeSingle<T> {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractPublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractPublishAndSubscribeOnTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api.completable;
+
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.CompletableWithExecutor;
+import io.servicetalk.concurrent.api.ExecutorRule;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+
+import org.junit.Rule;
+import org.junit.rules.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Function;
+
+import static io.servicetalk.concurrent.api.Completable.completed;
+import static io.servicetalk.concurrent.api.Completable.never;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+
+public abstract class AbstractPublishAndSubscribeOnTest {
+    static final int ORIGINAL_SUBSCRIBER_THREAD = 0;
+    static final int OFFLOADED_SUBSCRIBER_THREAD = 1;
+
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+    @Rule
+    public final ExecutorRule originalSourceExecutorRule = new ExecutorRule();
+
+    protected Thread[] setupAndSubscribe(Function<Completable, Completable> offloadingFunction)
+            throws InterruptedException {
+        CountDownLatch allDone = new CountDownLatch(1);
+        Thread[] capturedThreads = new Thread[2];
+
+        Completable original = new CompletableWithExecutor(originalSourceExecutorRule.getExecutor(), completed())
+                .doAfterComplete(() -> capturedThreads[0] = Thread.currentThread());
+
+        Completable offloaded = offloadingFunction.apply(original);
+
+        offloaded.doAfterFinally(allDone::countDown)
+                .doBeforeComplete(() -> capturedThreads[1] = Thread.currentThread())
+                .subscribe();
+        allDone.await();
+
+        verifyCapturedThreads(capturedThreads);
+        return capturedThreads;
+    }
+
+    protected Thread[] setupForCancelAndSubscribe(Function<Completable, Completable> offloadingFunction)
+            throws InterruptedException {
+        CountDownLatch allDone = new CountDownLatch(1);
+        Thread[] capturedThreads = new Thread[2];
+
+        Completable original = new CompletableWithExecutor(originalSourceExecutorRule.getExecutor(), never())
+                .doAfterCancel(() -> {
+                    capturedThreads[0] = Thread.currentThread();
+                    allDone.countDown();
+                });
+
+        Completable offloaded = offloadingFunction.apply(original);
+
+        offloaded.doBeforeCancel(() -> capturedThreads[1] = Thread.currentThread())
+                .subscribe().cancel();
+        allDone.await();
+
+        verifyCapturedThreads(capturedThreads);
+        return capturedThreads;
+    }
+
+    private void verifyCapturedThreads(final Thread[] capturedThreads) {
+        for (int i = 0; i < capturedThreads.length; i++) {
+            final Thread capturedThread = capturedThreads[i];
+            assertThat("Unexpected captured thread at index: " + i, capturedThread, notNullValue());
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/PublishAndSubscribeOnDisableOffloadTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/PublishAndSubscribeOnDisableOffloadTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api.completable;
+
+import org.junit.Test;
+
+import static io.servicetalk.concurrent.api.Executors.immediate;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class PublishAndSubscribeOnDisableOffloadTest extends AbstractPublishAndSubscribeOnTest {
+
+    @Test
+    public void testPublishOnDisable() throws InterruptedException {
+        Thread[] capturedThreads = setupAndSubscribe(c -> c.publishOnOverride(immediate()));
+        assertThat("Unexpected threads for original and offloaded source.",
+                capturedThreads[ORIGINAL_SUBSCRIBER_THREAD], is(capturedThreads[OFFLOADED_SUBSCRIBER_THREAD]));
+    }
+
+    @Test
+    public void testSubscribeOnDisable() throws InterruptedException {
+        Thread[] capturedThreads = setupAndSubscribe(c -> c.subscribeOnOverride(immediate()));
+        assertThat("Unexpected threads for original and offloaded source.",
+                capturedThreads[ORIGINAL_SUBSCRIBER_THREAD], is(capturedThreads[OFFLOADED_SUBSCRIBER_THREAD]));
+    }
+
+    @Test
+    public void testPublishAndSubscribeOnDisable() throws InterruptedException {
+        Thread[] capturedThreads = setupAndSubscribe(c -> c.publishAndSubscribeOnOverride(immediate()));
+        assertThat("Unexpected threads for original and offloaded source.",
+                capturedThreads[ORIGINAL_SUBSCRIBER_THREAD], is(capturedThreads[OFFLOADED_SUBSCRIBER_THREAD]));
+    }
+
+    @Test
+    public void testPublishAndSubscribeOnDisableWithCancel() throws InterruptedException {
+        Thread[] capturedThreads = setupForCancelAndSubscribe(c -> c.publishAndSubscribeOnOverride(immediate()));
+        assertThat("Unexpected threads for original and offloaded source.",
+                capturedThreads[ORIGINAL_SUBSCRIBER_THREAD], is(capturedThreads[OFFLOADED_SUBSCRIBER_THREAD]));
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractPublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractPublishAndSubscribeOnTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api.publisher;
+
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.ExecutorRule;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.PublisherWithExecutor;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+
+import org.junit.Rule;
+import org.junit.rules.Timeout;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.function.BiFunction;
+
+import static io.servicetalk.concurrent.api.Publisher.just;
+import static java.lang.Long.MAX_VALUE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.Matchers.notNullValue;
+
+public abstract class AbstractPublishAndSubscribeOnTest {
+
+    protected static final int ORIGINAL_SUBSCRIBER_THREAD = 0;
+    protected static final int ORIGINAL_SUBSCRIPTION_THREAD = 1;
+    protected static final int OFFLOADED_SUBSCRIBER_THREAD = 2;
+    protected static final int OFFLOADED_SUBSCRIPTION_THREAD = 3;
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+    @Rule
+    public final ExecutorRule originalSourceExecutorRule = new ExecutorRule();
+
+    protected Thread[] setupAndSubscribe(BiFunction<Publisher<String>, Executor, Publisher<String>> offloadingFunction,
+                                         Executor executor)
+            throws InterruptedException {
+        CountDownLatch allDone = new CountDownLatch(1);
+        Thread[] capturedThreads = new Thread[4];
+
+        Publisher<String> original = new PublisherWithExecutor<>(originalSourceExecutorRule.getExecutor(),
+                just("Hello"))
+                .doBeforeNext(__ -> capturedThreads[ORIGINAL_SUBSCRIBER_THREAD] = Thread.currentThread())
+                .doBeforeRequest(__ -> capturedThreads[ORIGINAL_SUBSCRIPTION_THREAD] = Thread.currentThread());
+
+        Publisher<String> offloaded = offloadingFunction.apply(original, executor);
+
+        offloaded.doBeforeNext(__ -> capturedThreads[OFFLOADED_SUBSCRIBER_THREAD] = Thread.currentThread())
+                .doBeforeRequest(__ -> capturedThreads[OFFLOADED_SUBSCRIPTION_THREAD] = Thread.currentThread())
+                .doAfterFinally(allDone::countDown)
+                .subscribe(new Subscriber<String>() {
+                    @Override
+                    public void onSubscribe(final Subscription s) {
+                        // Do not request from the caller thread to make sure synchronous request-onNext does not
+                        // pollute thread capturing of subscription.
+                        executor.execute(() -> s.request(MAX_VALUE));
+                    }
+
+                    @Override
+                    public void onNext(final String s) {
+                        // noop
+                    }
+
+                    @Override
+                    public void onError(final Throwable t) {
+                        // noop
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        // noop
+                    }
+                });
+        allDone.await();
+
+        assertThat("All threads were not captured.", capturedThreads, hasItemInArray(notNullValue()));
+
+        return capturedThreads;
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublishAndSubscribeOnDisableOffloadTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublishAndSubscribeOnDisableOffloadTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api.publisher;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+import org.junit.Test;
+
+import static io.servicetalk.concurrent.api.Executors.immediate;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class PublishAndSubscribeOnDisableOffloadTest extends AbstractPublishAndSubscribeOnTest {
+
+    @Test
+    public void testPublishOnDisable() throws InterruptedException {
+        Thread[] capturedThreads = setupAndSubscribe(Publisher::publishOnOverride, immediate());
+
+        assertThat("Unexpected threads for original and offloaded source.",
+                capturedThreads[ORIGINAL_SUBSCRIBER_THREAD], is(capturedThreads[OFFLOADED_SUBSCRIBER_THREAD]));
+    }
+
+    @Test
+    public void testSubscribeOnDisable() throws InterruptedException {
+        Thread[] capturedThreads = setupAndSubscribe(Publisher::subscribeOnOverride, immediate());
+
+        assertThat("Unexpected threads for subscription and subscriber for offloaded source.",
+                capturedThreads[OFFLOADED_SUBSCRIBER_THREAD], is(capturedThreads[OFFLOADED_SUBSCRIPTION_THREAD]));
+    }
+
+    @Test
+    public void testPublishAndSubscribeOnDisable() throws InterruptedException {
+        Thread[] capturedThreads = setupAndSubscribe(Publisher::publishAndSubscribeOnOverride, immediate());
+
+        assertThat("Unexpected threads for subscription and subscriber for offloaded source.",
+                capturedThreads[OFFLOADED_SUBSCRIBER_THREAD], is(capturedThreads[OFFLOADED_SUBSCRIPTION_THREAD]));
+
+        assertThat("Unexpected threads for original and offloaded source.",
+                capturedThreads[ORIGINAL_SUBSCRIBER_THREAD], is(capturedThreads[OFFLOADED_SUBSCRIBER_THREAD]));
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublishAndSubscribeOnTest.java
@@ -15,46 +15,24 @@
  */
 package io.servicetalk.concurrent.api.publisher;
 
-import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ExecutorRule;
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.api.PublisherWithExecutor;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.function.BiFunction;
-
-import static io.servicetalk.concurrent.api.Publisher.just;
-import static java.lang.Long.MAX_VALUE;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItemInArray;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
 
-public class PublishAndSubscribeOnTest {
+public class PublishAndSubscribeOnTest extends AbstractPublishAndSubscribeOnTest {
 
-    private static final int ORIGINAL_SUBSCRIBER_THREAD = 0;
-    private static final int ORIGINAL_SUBSCRIPTION_THREAD = 1;
-    private static final int OFFLOADED_SUBSCRIBER_THREAD = 2;
-    private static final int OFFLOADED_SUBSCRIPTION_THREAD = 3;
-
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
     @Rule
     public final ExecutorRule executorRule = new ExecutorRule();
-    @Rule
-    public final ExecutorRule originalSourceExecutorRule = new ExecutorRule();
 
     @Test
     public void testPublishOnNoOverride() throws InterruptedException {
-        Thread[] capturedThreads = setupAndSubscribe(Publisher::publishOn);
+        Thread[] capturedThreads = setupAndSubscribe(Publisher::publishOn, executorRule.getExecutor());
 
         assertThat("Unexpected threads for subscription and subscriber for original source.",
                 capturedThreads[ORIGINAL_SUBSCRIBER_THREAD], is(capturedThreads[ORIGINAL_SUBSCRIPTION_THREAD]));
@@ -66,7 +44,7 @@ public class PublishAndSubscribeOnTest {
 
     @Test
     public void testPublishOnOverride() throws InterruptedException {
-        Thread[] capturedThreads = setupAndSubscribe(Publisher::publishOnOverride);
+        Thread[] capturedThreads = setupAndSubscribe(Publisher::publishOnOverride, executorRule.getExecutor());
 
         assertThat("Unexpected threads for subscription and subscriber for original source.",
                 capturedThreads[ORIGINAL_SUBSCRIBER_THREAD], not(capturedThreads[ORIGINAL_SUBSCRIPTION_THREAD]));
@@ -78,7 +56,7 @@ public class PublishAndSubscribeOnTest {
 
     @Test
     public void testSubscribeOnNoOverride() throws InterruptedException {
-        Thread[] capturedThreads = setupAndSubscribe(Publisher::subscribeOn);
+        Thread[] capturedThreads = setupAndSubscribe(Publisher::subscribeOn, executorRule.getExecutor());
 
         assertThat("Unexpected threads for subscription and subscriber for original source.",
                 capturedThreads[ORIGINAL_SUBSCRIBER_THREAD], is(capturedThreads[ORIGINAL_SUBSCRIPTION_THREAD]));
@@ -90,7 +68,7 @@ public class PublishAndSubscribeOnTest {
 
     @Test
     public void testSubscribeOnOverride() throws InterruptedException {
-        Thread[] capturedThreads = setupAndSubscribe(Publisher::subscribeOnOverride);
+        Thread[] capturedThreads = setupAndSubscribe(Publisher::subscribeOnOverride, executorRule.getExecutor());
 
         assertThat("Unexpected threads for subscription and subscriber for original source.",
                 capturedThreads[ORIGINAL_SUBSCRIBER_THREAD], not(capturedThreads[ORIGINAL_SUBSCRIPTION_THREAD]));
@@ -102,7 +80,7 @@ public class PublishAndSubscribeOnTest {
 
     @Test
     public void testNoOverride() throws InterruptedException {
-        Thread[] capturedThreads = setupAndSubscribe(Publisher::publishAndSubscribeOn);
+        Thread[] capturedThreads = setupAndSubscribe(Publisher::publishAndSubscribeOn, executorRule.getExecutor());
 
         assertThat("Unexpected threads for subscription and subscriber for original source.",
                 capturedThreads[ORIGINAL_SUBSCRIBER_THREAD], is(capturedThreads[ORIGINAL_SUBSCRIPTION_THREAD]));
@@ -114,7 +92,8 @@ public class PublishAndSubscribeOnTest {
 
     @Test
     public void testOverride() throws InterruptedException {
-        Thread[] capturedThreads = setupAndSubscribe(Publisher::publishAndSubscribeOnOverride);
+        Thread[] capturedThreads = setupAndSubscribe(Publisher::publishAndSubscribeOnOverride,
+                executorRule.getExecutor());
 
         assertThat("Unexpected threads for subscription and subscriber for original source.",
                 capturedThreads[ORIGINAL_SUBSCRIBER_THREAD], is(capturedThreads[ORIGINAL_SUBSCRIPTION_THREAD]));
@@ -122,51 +101,5 @@ public class PublishAndSubscribeOnTest {
                 capturedThreads[OFFLOADED_SUBSCRIBER_THREAD], is(capturedThreads[OFFLOADED_SUBSCRIPTION_THREAD]));
         assertThat("Unexpected threads for original and offloaded source.",
                 capturedThreads[ORIGINAL_SUBSCRIPTION_THREAD], is(capturedThreads[OFFLOADED_SUBSCRIPTION_THREAD]));
-    }
-
-    private Thread[] setupAndSubscribe(BiFunction<Publisher<String>, Executor, Publisher<String>> offloadingFunction)
-            throws InterruptedException {
-        CountDownLatch allDone = new CountDownLatch(1);
-        Thread[] capturedThreads = new Thread[4];
-
-        Publisher<String> original = new PublisherWithExecutor<>(originalSourceExecutorRule.getExecutor(),
-                just("Hello"))
-                .doBeforeNext(__ -> capturedThreads[ORIGINAL_SUBSCRIBER_THREAD] = Thread.currentThread())
-                .doBeforeRequest(__ -> capturedThreads[ORIGINAL_SUBSCRIPTION_THREAD] = Thread.currentThread());
-
-        final Executor executor = executorRule.getExecutor();
-        Publisher<String> offloaded = offloadingFunction.apply(original, executor);
-
-        offloaded.doBeforeNext(__ -> capturedThreads[OFFLOADED_SUBSCRIBER_THREAD] = Thread.currentThread())
-                .doBeforeRequest(__ -> capturedThreads[OFFLOADED_SUBSCRIPTION_THREAD] = Thread.currentThread())
-                .doAfterFinally(allDone::countDown)
-                .subscribe(new Subscriber<String>() {
-                    @Override
-                    public void onSubscribe(final Subscription s) {
-                        // Do not request from the caller thread to make sure synchronous request-onNext does not
-                        // pollute thread capturing of subscription.
-                        executorRule.getExecutor().execute(() -> s.request(MAX_VALUE));
-                    }
-
-                    @Override
-                    public void onNext(final String s) {
-                        // noop
-                    }
-
-                    @Override
-                    public void onError(final Throwable t) {
-                        // noop
-                    }
-
-                    @Override
-                    public void onComplete() {
-                        // noop
-                    }
-                });
-        allDone.await();
-
-        assertThat("All threads were not captured.", capturedThreads, hasItemInArray(notNullValue()));
-
-        return capturedThreads;
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractPublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractPublishAndSubscribeOnTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api.single;
+
+import io.servicetalk.concurrent.api.ExecutorRule;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.api.SingleWithExecutor;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+
+import org.junit.Rule;
+import org.junit.rules.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Function;
+
+import static io.servicetalk.concurrent.api.Single.success;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+
+public abstract class AbstractPublishAndSubscribeOnTest {
+
+    static final int ORIGINAL_SUBSCRIBER_THREAD = 0;
+    static final int OFFLOADED_SUBSCRIBER_THREAD = 1;
+
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+    @Rule
+    public final ExecutorRule originalSourceExecutorRule = new ExecutorRule();
+
+    protected Thread[] setupAndSubscribe(Function<Single<String>, Single<String>> offloadingFunction)
+            throws InterruptedException {
+        CountDownLatch allDone = new CountDownLatch(1);
+        Thread[] capturedThreads = new Thread[2];
+
+        Single<String> original = new SingleWithExecutor<>(originalSourceExecutorRule.getExecutor(), success("Hello"))
+                .doBeforeSuccess(__ -> capturedThreads[ORIGINAL_SUBSCRIBER_THREAD] = Thread.currentThread());
+
+        Single<String> offloaded = offloadingFunction.apply(original);
+
+        offloaded.doAfterFinally(allDone::countDown)
+                .doBeforeSuccess(__ -> capturedThreads[OFFLOADED_SUBSCRIBER_THREAD] = Thread.currentThread())
+                .subscribe(val -> { });
+        allDone.await();
+
+        verifyCapturedThreads(capturedThreads);
+        return capturedThreads;
+    }
+
+    protected Thread[] setupForCancelAndSubscribe(Function<Single<String>, Single<String>> offloadingFunction)
+            throws InterruptedException {
+        CountDownLatch allDone = new CountDownLatch(1);
+        Thread[] capturedThreads = new Thread[2];
+
+        Single<String> original = new SingleWithExecutor<>(originalSourceExecutorRule.getExecutor(),
+                Single.<String>never())
+                .doAfterCancel(() -> {
+                    capturedThreads[ORIGINAL_SUBSCRIBER_THREAD] = Thread.currentThread();
+                    allDone.countDown();
+                });
+
+        Single<String> offloaded = offloadingFunction.apply(original);
+
+        offloaded.doBeforeCancel(() -> capturedThreads[OFFLOADED_SUBSCRIBER_THREAD] = Thread.currentThread())
+                .subscribe(val -> { }).cancel();
+        allDone.await();
+
+        verifyCapturedThreads(capturedThreads);
+        return capturedThreads;
+    }
+
+    private void verifyCapturedThreads(final Thread[] capturedThreads) {
+        for (int i = 0; i < capturedThreads.length; i++) {
+            final Thread capturedThread = capturedThreads[i];
+            assertThat("Unexpected captured thread at index: " + i, capturedThread, notNullValue());
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/PublishAndSubscribeOnDisableOffloadTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/PublishAndSubscribeOnDisableOffloadTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api.single;
+
+import org.junit.Test;
+
+import static io.servicetalk.concurrent.api.Executors.immediate;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class PublishAndSubscribeOnDisableOffloadTest extends AbstractPublishAndSubscribeOnTest {
+
+    @Test
+    public void testPublishOnDisable() throws InterruptedException {
+        Thread[] capturedThreads = setupAndSubscribe(c -> c.publishOnOverride(immediate()));
+        assertThat("Unexpected threads for original and offloaded source.",
+                capturedThreads[ORIGINAL_SUBSCRIBER_THREAD], is(capturedThreads[OFFLOADED_SUBSCRIBER_THREAD]));
+    }
+
+    @Test
+    public void testSubscribeOnDisable() throws InterruptedException {
+        Thread[] capturedThreads = setupAndSubscribe(c -> c.subscribeOnOverride(immediate()));
+        assertThat("Unexpected threads for original and offloaded source.",
+                capturedThreads[ORIGINAL_SUBSCRIBER_THREAD], is(capturedThreads[OFFLOADED_SUBSCRIBER_THREAD]));
+    }
+
+    @Test
+    public void testPublishAndSubscribeOnDisable() throws InterruptedException {
+        Thread[] capturedThreads = setupAndSubscribe(c -> c.publishAndSubscribeOnOverride(immediate()));
+        assertThat("Unexpected threads for original and offloaded source.",
+                capturedThreads[ORIGINAL_SUBSCRIBER_THREAD], is(capturedThreads[OFFLOADED_SUBSCRIBER_THREAD]));
+    }
+
+    @Test
+    public void testPublishAndSubscribeOnDisableWithCancel() throws InterruptedException {
+        Thread[] capturedThreads = setupForCancelAndSubscribe(c -> c.publishAndSubscribeOnOverride(immediate()));
+        assertThat("Unexpected threads for original and offloaded source.",
+                capturedThreads[ORIGINAL_SUBSCRIBER_THREAD], is(capturedThreads[OFFLOADED_SUBSCRIBER_THREAD]));
+    }
+}


### PR DESCRIPTION
__Motivation__

It should be possible to provide an `immediate()` `Executor` in any of the offloading operators to override existing offloading.

__Modification__

We were ignoring the override if the provided `Executor` was `immediate()`. Changed code to not ignore and added tests.

__Result__

Override with `immediate()` now possible.