### PR TITLE
Rename `ActiveConnectionsLimitingFactory` for consistency

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LimitingActiveConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LimitingActiveConnectionFactoryFilter.java
@@ -34,14 +34,14 @@ import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
  * @param <ResolvedAddress> The type of a resolved address that can be used for connecting.
  * @param <C> The type of connections created by this factory.
  */
-public final class ActiveConnectionsLimitingFactory<ResolvedAddress, C extends ListenableAsyncCloseable>
-        implements ConnectionFactory<ResolvedAddress, C> {
+public final class LimitingActiveConnectionFactoryFilter<ResolvedAddress, C extends ListenableAsyncCloseable>
+  implements ConnectionFactory<ResolvedAddress, C> {
 
     private final ConnectionFactory<ResolvedAddress, C> original;
     private final ConnectionLimiter<ResolvedAddress> limiter;
 
-    private ActiveConnectionsLimitingFactory(final ConnectionFactory<ResolvedAddress, C> original,
-                                             final ConnectionLimiter<ResolvedAddress> limiter) {
+    private LimitingActiveConnectionFactoryFilter(final ConnectionFactory<ResolvedAddress, C> original,
+                                                  final ConnectionLimiter<ResolvedAddress> limiter) {
         this.original = original;
         this.limiter = limiter;
     }
@@ -98,11 +98,11 @@ public final class ActiveConnectionsLimitingFactory<ResolvedAddress, C extends L
      */
     public static <A, C extends ListenableAsyncCloseable> ConnectionFactory<A, C> withLimiter(
             ConnectionFactory<A, C> original, ConnectionLimiter<A> limiter) {
-        return new ActiveConnectionsLimitingFactory<>(original, limiter);
+        return new LimitingActiveConnectionFactoryFilter<>(original, limiter);
     }
 
     /**
-     * A contract to limit number of connections created by {@link ActiveConnectionsLimitingFactory}.
+     * A contract to limit number of connections created by {@link LimitingActiveConnectionFactoryFilter}.
      * <p>
      * The following rules apply:
      * <ul>

--- a/servicetalk-client-api/src/test/java/io/servicetalk/client/api/LimitingActiveConnectionFactoryFilterTest.java
+++ b/servicetalk-client-api/src/test/java/io/servicetalk/client/api/LimitingActiveConnectionFactoryFilterTest.java
@@ -29,7 +29,7 @@ import org.junit.rules.ExpectedException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import static io.servicetalk.client.api.ActiveConnectionsLimitingFactory.withMaxConnections;
+import static io.servicetalk.client.api.LimitingActiveConnectionFactoryFilter.withMaxConnections;
 import static io.servicetalk.concurrent.api.Single.never;
 import static io.servicetalk.concurrent.api.Single.success;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -39,8 +39,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ActiveConnectionsLimitingFactoryTest {
-
+public class LimitingActiveConnectionFactoryFilterTest {
     @Rule
     public final ServiceTalkTestTimeout timeout = new ServiceTalkTestTimeout();
     @Rule


### PR DESCRIPTION
__Motivation__

The naming pattern used in other filters is `{filterName}{filterType}`. We should be consistent in the `ActiveConnectionsLimitingFactory` naming.

__Modifications__

Rename `ActiveConnectionsLimitingFactory` to `LimitingActiveConnectionFactoryFilter`.

__Result__

`LimitingActiveConnectionFactoryFilter` naming is consistent with the rest of the filters.