### PR TITLE
RetryingHttpClientFilter default retry count to 1

### DIFF
--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RetryingHttpClientFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RetryingHttpClientFilter.java
@@ -87,7 +87,7 @@ public final class RetryingHttpClientFilter extends StreamingHttpClientAdapter {
 
         private final StreamingHttpClient delegate;
         private Executor executor;
-        private int retryCount = 2;
+        private int retryCount = 1;
         private boolean jitter;
         private boolean exponential;
         @Nullable


### PR DESCRIPTION
Motivation:
A default retry count of 2 maybe too much for some users, but it is safe to assume that users want at least 1 retry if they use RetryingHttpClientFilter.

Modifications:
- The default value changed from 2 to 1

Result:
Less aggressive retrying by default.