### PR TITLE
Selective offloading

### DIFF
--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/GatewayServer.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/GatewayServer.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.data.jackson.JacksonSerializationProvider;
 import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpSerializationProvider;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpClientAdapter;
@@ -125,8 +126,9 @@ public final class GatewayServer {
                         // Apply a timeout filter for the client to guard against latent clients.
                         .appendClientFilter(from(client -> new StreamingHttpClientAdapter(client) {
                                     @Override
-                                    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-                                        return super.request(request).timeout(ofMillis(500),
+                                    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                                                 final StreamingHttpRequest request) {
+                                        return super.request(strategy, request).timeout(ofMillis(500),
                                                 client.executionContext().executor());
                                     }
                                 })

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClient.java
@@ -46,7 +46,23 @@ public abstract class BlockingHttpClient extends BlockingHttpRequester {
      * @throws Exception if a exception occurs during the reservation process.
      * @see StreamingHttpClient#reserveConnection(StreamingHttpRequest)
      */
-    public abstract ReservedBlockingHttpConnection reserveConnection(HttpRequest request) throws Exception;
+    public ReservedBlockingHttpConnection reserveConnection(HttpRequest request) throws Exception {
+        return reserveConnection(executionStrategy(), request);
+    }
+
+    /**
+     * Reserve a {@link ReservedBlockingHttpConnection} for handling the provided
+     * {@link HttpRequest} but <b>does not execute it</b>!
+     *
+     * @param strategy {@link HttpExecutionStrategy} to use.
+     * @param request Allows the underlying layers to know what {@link BlockingHttpConnection}s are valid to
+     * reserve. For example this may provide some insight into shard or other info.
+     * @return a {@link ReservedBlockingHttpConnection}.
+     * @throws Exception if a exception occurs during the reservation process.
+     * @see StreamingHttpClient#reserveConnection(HttpExecutionStrategy, StreamingHttpRequest)
+     */
+    public abstract ReservedBlockingHttpConnection reserveConnection(HttpExecutionStrategy strategy,
+                                                                     HttpRequest request) throws Exception;
 
     /**
      * Attempt a <a href="https://tools.ietf.org/html/rfc7230.html#section-6.7">protocol upgrade</a>.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClientToHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClientToHttpClient.java
@@ -38,9 +38,10 @@ final class BlockingHttpClientToHttpClient extends HttpClient {
     }
 
     @Override
-    public Single<? extends ReservedHttpConnection> reserveConnection(final HttpRequest request) {
+    public Single<? extends ReservedHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
+                                                                      final HttpRequest request) {
         return blockingToSingle(() -> new ReservedBlockingHttpConnectionToReservedHttpConnection(
-                client.reserveConnection(request)));
+                client.reserveConnection(strategy, request)));
     }
 
     @Override
@@ -49,8 +50,8 @@ final class BlockingHttpClientToHttpClient extends HttpClient {
     }
 
     @Override
-    public Single<HttpResponse> request(final HttpRequest request) {
-        return BlockingUtils.request(client, request);
+    public Single<HttpResponse> request(final HttpExecutionStrategy strategy, final HttpRequest request) {
+        return blockingToSingle(() -> client.request(strategy, request));
     }
 
     @Override
@@ -101,8 +102,8 @@ final class BlockingHttpClientToHttpClient extends HttpClient {
         }
 
         @Override
-        public Single<HttpResponse> request(final HttpRequest request) {
-            return BlockingUtils.request(connection, request);
+        public Single<HttpResponse> request(final HttpExecutionStrategy strategy, final HttpRequest request) {
+            return blockingToSingle(() -> connection.request(strategy, request));
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClientToStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClientToStreamingHttpClient.java
@@ -38,9 +38,10 @@ final class BlockingHttpClientToStreamingHttpClient extends StreamingHttpClient 
     }
 
     @Override
-    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final StreamingHttpRequest request) {
+    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
+                                                                               final StreamingHttpRequest request) {
         return request.toRequest().flatMap(req -> blockingToSingle(() ->
-                new BlockingReservedStreamingHttpConnectionToReserved(client.reserveConnection(req))));
+                new BlockingReservedStreamingHttpConnectionToReserved(client.reserveConnection(strategy, req))));
     }
 
     @Override
@@ -50,8 +51,10 @@ final class BlockingHttpClientToStreamingHttpClient extends StreamingHttpClient 
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-        return BlockingUtils.request(client, request);
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
+        return request.toRequest().flatMap(req -> blockingToSingle(() -> client.request(strategy, req))
+                .map(HttpResponse::toStreamingResponse));
     }
 
     @Override
@@ -102,8 +105,10 @@ final class BlockingHttpClientToStreamingHttpClient extends StreamingHttpClient 
         }
 
         @Override
-        public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-            return BlockingUtils.request(connection, request);
+        public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                     final StreamingHttpRequest request) {
+            return request.toRequest().flatMap(req -> blockingToSingle(() -> connection.request(strategy, req))
+                    .map(HttpResponse::toStreamingResponse));
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpConnectionToHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpConnectionToHttpConnection.java
@@ -25,6 +25,7 @@ import io.servicetalk.transport.api.ExecutionContext;
 import static io.servicetalk.concurrent.api.Completable.error;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.http.api.BlockingUtils.blockingToCompletable;
+import static io.servicetalk.http.api.BlockingUtils.blockingToSingle;
 import static java.util.Objects.requireNonNull;
 
 final class BlockingHttpConnectionToHttpConnection extends HttpConnection {
@@ -46,8 +47,8 @@ final class BlockingHttpConnectionToHttpConnection extends HttpConnection {
     }
 
     @Override
-    public Single<HttpResponse> request(final HttpRequest request) {
-        return BlockingUtils.request(connection, request);
+    public Single<HttpResponse> request(final HttpExecutionStrategy strategy, final HttpRequest request) {
+        return blockingToSingle(() -> connection.request(strategy, request));
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpConnectionToStreamingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpConnectionToStreamingHttpConnection.java
@@ -24,6 +24,7 @@ import io.servicetalk.transport.api.ExecutionContext;
 import static io.servicetalk.concurrent.api.Completable.error;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.http.api.BlockingUtils.blockingToCompletable;
+import static io.servicetalk.http.api.BlockingUtils.blockingToSingle;
 import static java.util.Objects.requireNonNull;
 
 final class BlockingHttpConnectionToStreamingHttpConnection extends StreamingHttpConnection {
@@ -45,8 +46,10 @@ final class BlockingHttpConnectionToStreamingHttpConnection extends StreamingHtt
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-        return BlockingUtils.request(connection, request);
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
+        return request.toRequest().flatMap(req -> blockingToSingle(() -> connection.request(strategy, req))
+                .map(HttpResponse::toStreamingResponse));
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpRequester.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.transport.api.ExecutionContext;
 
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -41,7 +42,19 @@ public abstract class BlockingHttpRequester implements HttpRequestFactory, AutoC
      * @return The response.
      * @throws Exception if an exception occurs during the request processing.
      */
-    public abstract HttpResponse request(HttpRequest request) throws Exception;
+    public HttpResponse request(HttpRequest request) throws Exception {
+        return request(executionStrategy(), request);
+    }
+
+    /**
+     * Send a {@code request} using the passed {@link HttpExecutionStrategy strategy}.
+     *
+     * @param strategy {@link HttpExecutionStrategy} to use.
+     * @param request the request to send.
+     * @return The response.
+     * @throws Exception if an exception occurs during the request processing.
+     */
+    public abstract HttpResponse request(HttpExecutionStrategy strategy, HttpRequest request) throws Exception;
 
     /**
      * Get the {@link ExecutionContext} used during construction of this object.
@@ -100,6 +113,15 @@ public abstract class BlockingHttpRequester implements HttpRequestFactory, AutoC
      */
     public final BlockingStreamingHttpRequester asBlockingStreamingRequester() {
         return asStreamingRequester().asBlockingStreamingRequester();
+    }
+
+    /**
+     * Returns the default {@link HttpExecutionStrategy} for this {@link BlockingHttpRequester}.
+     *
+     * @return Default {@link HttpExecutionStrategy} for this {@link BlockingHttpRequester}.
+     */
+    HttpExecutionStrategy executionStrategy() {
+        return defaultStrategy();
     }
 
     StreamingHttpRequester asStreamingRequesterInternal() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpRequesterToHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpRequesterToHttpRequester.java
@@ -21,6 +21,7 @@ import io.servicetalk.transport.api.ExecutionContext;
 
 import static io.servicetalk.concurrent.api.Completable.error;
 import static io.servicetalk.http.api.BlockingUtils.blockingToCompletable;
+import static io.servicetalk.http.api.BlockingUtils.blockingToSingle;
 import static java.util.Objects.requireNonNull;
 
 final class BlockingHttpRequesterToHttpRequester extends HttpRequester {
@@ -32,8 +33,8 @@ final class BlockingHttpRequesterToHttpRequester extends HttpRequester {
     }
 
     @Override
-    public Single<HttpResponse> request(final HttpRequest request) {
-        return BlockingUtils.request(requester, request);
+    public Single<HttpResponse> request(final HttpExecutionStrategy strategy, final HttpRequest request) {
+        return blockingToSingle(() -> requester.request(strategy, request));
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpRequesterToStreamingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpRequesterToStreamingHttpRequester.java
@@ -21,6 +21,7 @@ import io.servicetalk.transport.api.ExecutionContext;
 
 import static io.servicetalk.concurrent.api.Completable.error;
 import static io.servicetalk.http.api.BlockingUtils.blockingToCompletable;
+import static io.servicetalk.http.api.BlockingUtils.blockingToSingle;
 import static java.util.Objects.requireNonNull;
 
 final class BlockingHttpRequesterToStreamingHttpRequester extends StreamingHttpRequester {
@@ -32,8 +33,10 @@ final class BlockingHttpRequesterToStreamingHttpRequester extends StreamingHttpR
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-        return BlockingUtils.request(requester, request);
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
+        return request.toRequest().flatMap(req -> blockingToSingle(() -> requester.request(strategy, req))
+                .map(HttpResponse::toStreamingResponse));
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpService.java
@@ -15,6 +15,8 @@
  */
 package io.servicetalk.http.api;
 
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+
 /**
  * The equivalent of {@link HttpService} but with synchronous/blocking APIs instead of asynchronous APIs.
  */
@@ -64,6 +66,15 @@ public abstract class BlockingHttpService implements AutoCloseable, BlockingHttp
      */
     public final BlockingStreamingHttpService asBlockingStreamingService() {
         return asStreamingService().asBlockingStreamingService();
+    }
+
+    /**
+     * Returns the {@link HttpExecutionStrategy} for this {@link BlockingHttpService}.
+     *
+     * @return The {@link HttpExecutionStrategy} for this {@link BlockingHttpService}.
+     */
+    public HttpExecutionStrategy executionStrategy() {
+        return defaultStrategy();
     }
 
     StreamingHttpService asStreamingServiceInternal() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClient.java
@@ -55,8 +55,24 @@ public abstract class BlockingStreamingHttpClient extends BlockingStreamingHttpR
      * @throws Exception if a exception occurs during the reservation process.
      * @see StreamingHttpClient#reserveConnection(StreamingHttpRequest)
      */
+    public ReservedBlockingStreamingHttpConnection reserveConnection(BlockingStreamingHttpRequest request)
+            throws Exception {
+        return reserveConnection(executionStrategy(), request);
+    }
+
+    /**
+     * Reserve a {@link BlockingStreamingHttpConnection} for handling the provided {@link BlockingStreamingHttpRequest}
+     * but <b>does not execute it</b>!
+     *
+     * @param strategy {@link HttpExecutionStrategy} to use.
+     * @param request Allows the underlying layers to know what {@link BlockingStreamingHttpConnection}s are valid to
+     * reserve. For example this may provide some insight into shard or other info.
+     * @return a {@link ReservedStreamingHttpConnection}.
+     * @throws Exception if a exception occurs during the reservation process.
+     * @see StreamingHttpClient#reserveConnection(HttpExecutionStrategy, StreamingHttpRequest)
+     */
     public abstract ReservedBlockingStreamingHttpConnection reserveConnection(
-            BlockingStreamingHttpRequest request) throws Exception;
+            HttpExecutionStrategy strategy, BlockingStreamingHttpRequest request) throws Exception;
 
     /**
      * Attempt a <a href="https://tools.ietf.org/html/rfc7230.html#section-6.7">protocol upgrade</a>.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClientToStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClientToStreamingHttpClient.java
@@ -56,14 +56,17 @@ final class BlockingStreamingHttpClientToStreamingHttpClient extends StreamingHt
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-        return BlockingUtils.request(blockingClient, request);
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
+        return blockingToSingle(() -> blockingClient.request(strategy, request.toBlockingStreamingRequest())
+                .toStreamingResponse());
     }
 
     @Override
-    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final StreamingHttpRequest request) {
+    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
+                                                                               final StreamingHttpRequest request) {
         return blockingToSingle(() -> new BlockingToReservedStreamingHttpConnection(
-                    blockingClient.reserveConnection(request.toBlockingStreamingRequest())));
+                    blockingClient.reserveConnection(strategy, request.toBlockingStreamingRequest())));
     }
 
     @Override
@@ -121,8 +124,11 @@ final class BlockingStreamingHttpClientToStreamingHttpClient extends StreamingHt
         }
 
         @Override
-        public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-            return BlockingUtils.request(blockingReservedConnection, request);
+        public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                     final StreamingHttpRequest request) {
+            return blockingToSingle(() ->
+                    blockingReservedConnection.request(strategy, request.toBlockingStreamingRequest())
+                            .toStreamingResponse());
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpConnectionToStreamingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpConnectionToStreamingHttpConnection.java
@@ -24,6 +24,7 @@ import io.servicetalk.transport.api.ExecutionContext;
 import static io.servicetalk.concurrent.api.Completable.error;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.http.api.BlockingUtils.blockingToCompletable;
+import static io.servicetalk.http.api.BlockingUtils.blockingToSingle;
 import static java.util.Objects.requireNonNull;
 
 final class BlockingStreamingHttpConnectionToStreamingHttpConnection extends StreamingHttpConnection {
@@ -46,8 +47,10 @@ final class BlockingStreamingHttpConnectionToStreamingHttpConnection extends Str
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-        return BlockingUtils.request(blockingConnection, request);
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
+        return blockingToSingle(() -> blockingConnection.request(strategy, request.toBlockingStreamingRequest())
+                .toStreamingResponse());
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequester.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.transport.api.ExecutionContext;
 
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -41,7 +42,20 @@ public abstract class BlockingStreamingHttpRequester implements BlockingStreamin
      * @return The response.
      * @throws Exception if an exception occurs during the request processing.
      */
-    public abstract BlockingStreamingHttpResponse request(BlockingStreamingHttpRequest request) throws Exception;
+    public BlockingStreamingHttpResponse request(BlockingStreamingHttpRequest request) throws Exception {
+        return request(executionStrategy(), request);
+    }
+
+    /**
+     * Send a {@code request} using the passed {@link HttpExecutionStrategy strategy}.
+     *
+     * @param strategy {@link HttpExecutionStrategy} to use.
+     * @param request the request to send.
+     * @return The response.
+     * @throws Exception if an exception occurs during the request processing.
+     */
+    public abstract BlockingStreamingHttpResponse request(HttpExecutionStrategy strategy,
+                                                          BlockingStreamingHttpRequest request) throws Exception;
 
     /**
      * Get the {@link ExecutionContext} used during construction of this object.
@@ -100,6 +114,15 @@ public abstract class BlockingStreamingHttpRequester implements BlockingStreamin
      */
     public final BlockingHttpRequester asBlockingRequester() {
         return asStreamingRequester().asBlockingRequester();
+    }
+
+    /**
+     * Returns the default {@link HttpExecutionStrategy} for this {@link BlockingStreamingHttpRequester}.
+     *
+     * @return Default {@link HttpExecutionStrategy} for this {@link BlockingStreamingHttpRequester}.
+     */
+    HttpExecutionStrategy executionStrategy() {
+        return defaultStrategy();
     }
 
     StreamingHttpRequester asStreamingRequesterInternal() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequesterToStreamingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequesterToStreamingHttpRequester.java
@@ -21,6 +21,7 @@ import io.servicetalk.transport.api.ExecutionContext;
 
 import static io.servicetalk.concurrent.api.Completable.error;
 import static io.servicetalk.http.api.BlockingUtils.blockingToCompletable;
+import static io.servicetalk.http.api.BlockingUtils.blockingToSingle;
 import static java.util.Objects.requireNonNull;
 
 final class BlockingStreamingHttpRequesterToStreamingHttpRequester extends StreamingHttpRequester {
@@ -33,8 +34,10 @@ final class BlockingStreamingHttpRequesterToStreamingHttpRequester extends Strea
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-        return BlockingUtils.request(requester, request);
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
+        return blockingToSingle(() -> requester.request(strategy, request.toBlockingStreamingRequest())
+                .toStreamingResponse());
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpService.java
@@ -15,6 +15,10 @@
  */
 package io.servicetalk.http.api;
 
+import javax.annotation.Nullable;
+
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+
 /**
  * The equivalent of {@link StreamingHttpService} but with synchronous/blocking APIs instead of asynchronous APIs.
  */
@@ -64,6 +68,16 @@ public abstract class BlockingStreamingHttpService implements AutoCloseable, Blo
      */
     public final BlockingHttpService asBlockingService() {
         return asStreamingService().asBlockingService();
+    }
+
+    /**
+     * Returns the {@link HttpExecutionStrategy} for this {@link BlockingStreamingHttpService}.
+     *
+     * @return The {@link HttpExecutionStrategy} for this {@link BlockingStreamingHttpService}.
+     */
+    @Nullable
+    public HttpExecutionStrategy executionStrategy() {
+        return defaultStrategy();
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpExecutionStrategy.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+
+/**
+ * Default implementation for {@link HttpExecutionStrategy}.
+ */
+final class DefaultHttpExecutionStrategy implements HttpExecutionStrategy {
+
+    static final byte OFFLOAD_RECEIVE_META = 2;
+    static final byte OFFLOAD_RECEIVE_DATA = 4;
+    static final byte OFFLOAD_SEND = 8;
+    @Nullable
+    private final Executor executor;
+    private final byte offloads;
+
+    DefaultHttpExecutionStrategy(@Nullable final Executor executor, final byte offloads) {
+        this.executor = executor;
+        this.offloads = offloads;
+    }
+
+    @Nullable
+    @Override
+    public Executor executor() {
+        return executor;
+    }
+
+    @Override
+    public Single<StreamingHttpResponse> invokeClient(final Executor fallback, final StreamingHttpRequest request,
+                                                      final Function<Publisher<Object>, Single<StreamingHttpResponse>> client) {
+        final Executor e = executor(fallback);
+        Publisher<Object> flatReq = flatten(request, request.payloadBodyAndTrailers());
+        if (offloaded(OFFLOAD_SEND)) {
+            flatReq = flatReq.subscribeOn(e);
+        }
+        Single<StreamingHttpResponse> resp = client.apply(flatReq);
+        if (offloaded(OFFLOAD_RECEIVE_META)) {
+            resp = resp.publishOn(e);
+        }
+        if (offloaded(OFFLOAD_RECEIVE_DATA)) {
+            resp = resp.map(response -> response.transformPayloadBody(payload -> payload.publishOn(e)));
+        }
+        return resp;
+    }
+
+    @Override
+    public Publisher<Object> invokeService(
+            final Executor fallback, StreamingHttpRequest request,
+            final Function<StreamingHttpRequest, Single<StreamingHttpResponse>> service,
+            final BiFunction<Throwable, Executor, Single<StreamingHttpResponse>> errorHandler) {
+        final Executor e = executor(fallback);
+        if (offloaded(OFFLOAD_RECEIVE_DATA)) {
+            request = request.transformPayloadBody(payload -> payload.publishOn(e));
+        }
+        Single<StreamingHttpResponse> responseSingle;
+        if (offloaded(OFFLOAD_RECEIVE_META)) {
+            final StreamingHttpRequest r = request;
+            responseSingle = e.submit(() -> service.apply(r.transformPayloadBody(bdy -> bdy.publishOn(e))))
+                    // exec.submit() returns a Single<Single<response>>, so flatten the nested Single.
+                    .flatMap(identity());
+        } else {
+            responseSingle = service.apply(request);
+        }
+        Publisher<Object> resp = responseSingle.onErrorResume(t -> errorHandler.apply(t, e))
+                .flatMapPublisher(response -> flatten(response, response.payloadBodyAndTrailers()));
+        if (offloaded(OFFLOAD_SEND)) {
+            resp = resp.subscribeOn(e);
+        }
+        return resp;
+    }
+
+    @Override
+    public StreamingHttpService wrap(final Executor fallback, final StreamingHttpService service) {
+        if (offloads == 0) {
+            // no offloading
+            return service;
+        }
+        final Executor e = executor(fallback);
+        return new StreamingHttpService() {
+            @Override
+            public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
+                                                        StreamingHttpRequest request,
+                                                        final StreamingHttpResponseFactory responseFactory) {
+                if (offloaded(OFFLOAD_RECEIVE_DATA)) {
+                    request = request.transformPayloadBody(p -> p.publishOn(e));
+                }
+                Single<StreamingHttpResponse> resp;
+                if (offloaded(OFFLOAD_RECEIVE_META)) {
+                    final StreamingHttpRequest r = request;
+                    resp = e.submit(() -> service.handle(ctx, r, responseFactory))
+                            // exec.submit() returns a Single<Single<response>>, so flatten the nested Single.
+                            .flatMap(identity());
+                } else {
+                    resp = service.handle(ctx, request, responseFactory);
+                }
+                return offloaded(OFFLOAD_SEND) ?
+                        resp.map(r -> r.transformPayloadBody(p -> p.subscribeOn(e))).subscribeOn(e) : resp;
+            }
+        };
+    }
+
+    @Override
+    public StreamingHttpClient wrap(final Executor fallback, final StreamingHttpClient client) {
+        if (offloads == 0) {
+            // no offloading
+            return client;
+        }
+        return new StreamingHttpClientAdapter(client) {
+            @Override
+            public Single<? extends ReservedStreamingHttpConnection> reserveConnection(
+                    final StreamingHttpRequest request) {
+                return reserveConnection(DefaultHttpExecutionStrategy.this, request);
+            }
+
+            @Override
+            public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+                return request(DefaultHttpExecutionStrategy.this, request);
+            }
+        };
+    }
+
+    @Override
+    public <T> Single<T> offloadSend(final Executor fallback, final Single<T> original) {
+        return offloaded(OFFLOAD_SEND) ? original.subscribeOn(executor(fallback)) : original;
+    }
+
+    @Override
+    public <T> Single<T> offloadReceive(final Executor fallback, final Single<T> original) {
+        return offloaded(OFFLOAD_SEND) ? original.publishOn(executor(fallback)) : original;
+    }
+
+    @Override
+    public <T> Publisher<T> offloadSend(final Executor fallback, final Publisher<T> original) {
+        return offloaded(OFFLOAD_SEND) ? original.subscribeOn(executor(fallback)) : original;
+    }
+
+    @Override
+    public <T> Publisher<T> offloadReceive(final Executor fallback, final Publisher<T> original) {
+        return offloaded(OFFLOAD_SEND) ? original.publishOn(executor(fallback)) : original;
+    }
+
+    private Executor executor(final Executor fallback) {
+        requireNonNull(fallback);
+        return executor == null ? fallback : executor;
+    }
+
+    private boolean offloaded(byte flag) {
+        return (offloads & flag) == flag;
+    }
+
+    private static Publisher<Object> flatten(HttpMetaData metaData, Publisher<Object> payload) {
+        return (Publisher.<Object>just(metaData)).concatWith(payload);
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpClientGroup.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpClientGroup.java
@@ -60,7 +60,8 @@ final class DefaultStreamingHttpClientGroup<UnresolvedAddress> extends Streaming
     // Placeholder should not leak outside of the scope of existing class
     private static final StreamingHttpClient PLACEHOLDER_CLIENT = new StreamingHttpClient(NOOP_REQ_RESP_FACTORY) {
         @Override
-        public Single<ReservedStreamingHttpConnection> reserveConnection(final StreamingHttpRequest request) {
+        public Single<ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
+                                                                         final StreamingHttpRequest request) {
             return Single.error(new UnsupportedOperationException(PLACEHOLDER_EXCEPTION_MSG));
         }
 
@@ -76,7 +77,8 @@ final class DefaultStreamingHttpClientGroup<UnresolvedAddress> extends Streaming
         }
 
         @Override
-        public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+        public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                     final StreamingHttpRequest request) {
             return Single.error(new UnsupportedOperationException(PLACEHOLDER_EXCEPTION_MSG));
         }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClient.java
@@ -48,7 +48,20 @@ public abstract class HttpClient extends HttpRequester {
      * For example this may provide some insight into shard or other info.
      * @return a {@link Single} that provides the {@link ReservedHttpConnection} upon completion.
      */
-    public abstract Single<? extends ReservedHttpConnection> reserveConnection(HttpRequest request);
+    public Single<? extends ReservedHttpConnection> reserveConnection(HttpRequest request) {
+        return reserveConnection(executionStrategy(), request);
+    }
+
+    /**
+     * Reserve a {@link HttpConnection} for handling the provided {@link HttpRequest} but <b>does not execute it</b>!
+     *
+     * @param strategy {@link HttpExecutionStrategy} to use.
+     * @param request Allows the underlying layers to know what {@link HttpConnection}s are valid to reserve.
+     * For example this may provide some insight into shard or other info.
+     * @return a {@link Single} that provides the {@link ReservedHttpConnection} upon completion.
+     */
+    public abstract Single<? extends ReservedHttpConnection> reserveConnection(HttpExecutionStrategy strategy,
+                                                                               HttpRequest request);
 
     /**
      * Attempt a <a href="https://tools.ietf.org/html/rfc7230.html#section-6.7">protocol upgrade</a>.
@@ -101,7 +114,7 @@ public abstract class HttpClient extends HttpRequester {
 
     /**
      * A special type of {@link HttpConnection} for the exclusive use of the caller of
-     * {@link #reserveConnection(HttpRequest)}.
+     * {@link #reserveConnection(HttpRequest)} and {@link #reserveConnection(HttpExecutionStrategy, HttpRequest)}.
      * @see ReservedStreamingHttpConnection
      */
     public abstract static class ReservedHttpConnection extends HttpConnection {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientAdapter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientAdapter.java
@@ -44,8 +44,9 @@ public abstract class HttpClientAdapter extends HttpClient {
     }
 
     @Override
-    public Single<? extends ReservedHttpConnection> reserveConnection(final HttpRequest request) {
-        return delegate.reserveConnection(request);
+    public Single<? extends ReservedHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
+                                                                      final HttpRequest request) {
+        return delegate.reserveConnection(strategy, request);
     }
 
     @Override
@@ -54,8 +55,8 @@ public abstract class HttpClientAdapter extends HttpClient {
     }
 
     @Override
-    public Single<? extends HttpResponse> request(final HttpRequest request) {
-        return delegate.request(request);
+    public Single<? extends HttpResponse> request(final HttpExecutionStrategy strategy, final HttpRequest request) {
+        return delegate.request(strategy, request);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
@@ -22,7 +22,6 @@ import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.LoadBalancerFactory;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
-import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.IoExecutor;
 
@@ -46,12 +45,12 @@ public interface HttpClientBuilder<U, R> {
     HttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
 
     /**
-     * Sets the {@link Executor} for all clients created from this {@link HttpClientBuilder}.
+     * Sets the {@link HttpExecutionStrategy} for all clients created from this {@link HttpClientBuilder}.
      *
-     * @param executor {@link Executor} to use.
+     * @param strategy {@link HttpExecutionStrategy} to use.
      * @return {@code this}.
      */
-    HttpClientBuilder<U, R> executor(Executor executor);
+    HttpClientBuilder<U, R> executionStrategy(HttpExecutionStrategy strategy);
 
     /**
      * Sets the {@link BufferAllocator} for all clients created from this {@link HttpClientBuilder}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientGroupToHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientGroupToHttpRequester.java
@@ -41,12 +41,13 @@ final class HttpClientGroupToHttpRequester<UnresolvedAddress> extends HttpReques
     }
 
     @Override
-    public Single<HttpResponse> request(final HttpRequest request) {
+    public Single<HttpResponse> request(final HttpExecutionStrategy strategy, final HttpRequest request) {
         return new Single<HttpResponse>() {
             @Override
             protected void handleSubscribe(final Subscriber<? super HttpResponse> subscriber) {
                 final Single<? extends HttpResponse> response;
                 try {
+                    //TODO: Add strategy to group
                     response = clientGroup.request(requestToGroupKeyFunc.apply(request), request);
                 } catch (final Throwable t) {
                     subscriber.onSubscribe(IGNORE_CANCEL);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientToBlockingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientToBlockingHttpClient.java
@@ -33,9 +33,10 @@ final class HttpClientToBlockingHttpClient extends BlockingHttpClient {
     }
 
     @Override
-    public ReservedBlockingHttpConnection reserveConnection(final HttpRequest request) throws Exception {
+    public ReservedBlockingHttpConnection reserveConnection(final HttpExecutionStrategy strategy,
+                                                            final HttpRequest request) throws Exception {
         return new ReservedHttpConnectionToReservedBlockingHttpConnection(
-                blockingInvocation(client.reserveConnection(request)));
+                blockingInvocation(client.reserveConnection(strategy, request)));
     }
 
     @Override
@@ -46,8 +47,8 @@ final class HttpClientToBlockingHttpClient extends BlockingHttpClient {
     }
 
     @Override
-    public HttpResponse request(final HttpRequest request) throws Exception {
-        return BlockingUtils.request(client, request);
+    public HttpResponse request(final HttpExecutionStrategy strategy, final HttpRequest request) throws Exception {
+        return blockingInvocation(client.request(strategy, request));
     }
 
     @Override
@@ -93,8 +94,8 @@ final class HttpClientToBlockingHttpClient extends BlockingHttpClient {
         }
 
         @Override
-        public HttpResponse request(final HttpRequest request) throws Exception {
-            return BlockingUtils.request(connection, request);
+        public HttpResponse request(final HttpExecutionStrategy strategy, final HttpRequest request) throws Exception {
+            return blockingInvocation(connection.request(strategy, request));
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientToStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientToStreamingHttpClient.java
@@ -53,8 +53,9 @@ final class HttpClientToStreamingHttpClient extends StreamingHttpClient {
     }
 
     @Override
-    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final StreamingHttpRequest request) {
-        return request.toRequest().flatMap(client::reserveConnection)
+    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
+                                                                               final StreamingHttpRequest request) {
+        return request.toRequest().flatMap(r -> client.reserveConnection(strategy, r))
                 .map(ReservedHttpConnectionToReservedStreamingHttpConnection::new);
     }
 
@@ -65,8 +66,9 @@ final class HttpClientToStreamingHttpClient extends StreamingHttpClient {
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-        return request.toRequest().flatMap(client::request).map(HttpResponse::toStreamingResponse);
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
+        return request.toRequest().flatMap(r -> client.request(strategy, r)).map(HttpResponse::toStreamingResponse);
     }
 
     @Override
@@ -119,8 +121,10 @@ final class HttpClientToStreamingHttpClient extends StreamingHttpClient {
         }
 
         @Override
-        public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-            return request.toRequest().flatMap(reservedConnection::request).map(HttpResponse::toStreamingResponse);
+        public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                     final StreamingHttpRequest request) {
+            return request.toRequest().flatMap(r -> reservedConnection.request(strategy, r))
+                    .map(HttpResponse::toStreamingResponse);
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnectionAdapter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnectionAdapter.java
@@ -57,8 +57,8 @@ public abstract class HttpConnectionAdapter extends HttpConnection {
     }
 
     @Override
-    public Single<? extends HttpResponse> request(final HttpRequest request) {
-        return delegate.request(request);
+    public Single<? extends HttpResponse> request(final HttpExecutionStrategy strategy, final HttpRequest request) {
+        return delegate.request(strategy, request);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnectionToBlockingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnectionToBlockingHttpConnection.java
@@ -43,8 +43,8 @@ final class HttpConnectionToBlockingHttpConnection extends BlockingHttpConnectio
     }
 
     @Override
-    public HttpResponse request(final HttpRequest request)throws Exception {
-        return BlockingUtils.request(connection, request);
+    public HttpResponse request(final HttpExecutionStrategy strategy, final HttpRequest request)throws Exception {
+        return blockingInvocation(connection.request(strategy, request));
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnectionToStreamingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnectionToStreamingHttpConnection.java
@@ -42,8 +42,10 @@ final class HttpConnectionToStreamingHttpConnection extends StreamingHttpConnect
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-        return request.toRequest().flatMap(connection::request).map(HttpResponse::toStreamingResponse);
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
+        return request.toRequest().flatMap(r -> connection.request(strategy, r))
+                .map(HttpResponse::toStreamingResponse);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.concurrent.api.Executor;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEIVE_DATA;
+import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEIVE_META;
+import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_SEND;
+
+/**
+ * A factory to create different {@link HttpExecutionStrategy}.
+ */
+public final class HttpExecutionStrategies {
+
+    private HttpExecutionStrategies() {
+        // No instances.
+    }
+
+    /**
+     * The default {@link HttpExecutionStrategy}.
+     *
+     * @return Default {@link HttpExecutionStrategy}.
+     */
+    public static HttpExecutionStrategy defaultStrategy() {
+        return Builder.DEFAULT;
+    }
+
+    /**
+     * The default {@link HttpExecutionStrategy} using the passed {@link Executor}.
+     *
+     * @param executor {@link Executor} to use.
+     * @return Default {@link HttpExecutionStrategy}.
+     */
+    public static HttpExecutionStrategy defaultStrategy(Executor executor) {
+        return customStrategyBuilder().executor(executor).build();
+    }
+
+    /**
+     * A {@link HttpExecutionStrategy} that disables all offloads.
+     *
+     * @return {@link HttpExecutionStrategy} that disables all offloads.
+     */
+    public static HttpExecutionStrategy noOffloadsStrategy() {
+        return Builder.NO_OFFLOADS;
+    }
+
+    /**
+     * A {@link HttpExecutionStrategy} that disables all offloads.
+     *
+     * @return {@link HttpExecutionStrategy} that disables all offloads.
+     */
+    public static Builder customStrategyBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder to build an {@link HttpExecutionStrategy}.
+     */
+    public static final class Builder {
+
+        static final HttpExecutionStrategy DEFAULT = new Builder().offloadAll().build();
+        static final HttpExecutionStrategy NO_OFFLOADS = new Builder().noOffload().build();
+
+        @Nullable
+        private Executor executor;
+        // offload everything by default
+        private byte offloads = OFFLOAD_RECEIVE_DATA | OFFLOAD_RECEIVE_META | OFFLOAD_SEND;
+
+        private Builder() {
+        }
+
+        /**
+         * Enables offloading for receiving of metadata.
+         *
+         * @return {@code this}.
+         */
+        public Builder offloadReceiveMetadata() {
+            return updateOffload(OFFLOAD_RECEIVE_META);
+        }
+
+        /**
+         * Enables offloading for receiving of data.
+         *
+         * @return {@code this}.
+         */
+        public Builder offloadReceiveData() {
+            return updateOffload(OFFLOAD_RECEIVE_DATA);
+        }
+
+        /**
+         * Enables offloading for sending.
+         *
+         * @return {@code this}.
+         */
+        public Builder offloadSend() {
+            return updateOffload(OFFLOAD_SEND);
+        }
+
+        /**
+         * Enable all offloads.
+         *
+         * @return {@code this}.
+         */
+        public Builder offloadAll() {
+            return offloadReceiveMetadata().offloadReceiveData().offloadSend();
+        }
+
+        /**
+         * Disable all offloads.
+         *
+         * @return {@code this}.
+         */
+        public Builder noOffload() {
+            offloads = 0;
+            return this;
+        }
+
+        /**
+         * Specify an {@link Executor} to use.
+         *
+         * @param executor {@link Executor} to use.
+         * @return {@code this}.
+         */
+        public Builder executor(Executor executor) {
+            this.executor = executor;
+            return this;
+        }
+
+        /**
+         * Builds a new {@link HttpExecutionStrategy}.
+         *
+         * @return New {@link HttpExecutionStrategy}.
+         */
+        public HttpExecutionStrategy build() {
+            return new DefaultHttpExecutionStrategy(executor, offloads);
+        }
+
+        @Nonnull
+        private Builder updateOffload(byte flag) {
+            offloads |= flag;
+            return this;
+        }
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategy.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.transport.api.ExecutionStrategy;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * An execution strategy for HTTP client and servers.
+ */
+public interface HttpExecutionStrategy extends ExecutionStrategy {
+
+    /**
+     * Invokes the passed {@link Function} and applies the necessary offloading of request and response for a client.
+     *
+     * @param fallback {@link Executor} to use as a fallback if this {@link HttpExecutionStrategy} does not define an
+     * {@link Executor}.
+     * @param request {@link StreamingHttpRequest} for which the offloading is to be applied.
+     * @param client A {@link Function} that given flattened stream of {@link HttpRequestMetaData}, payload and
+     * trailers, for the passed {@link StreamingHttpRequest} returns a {@link Single}.
+     * @return {@link Single} which is offloaded as required.
+     */
+    Single<StreamingHttpResponse> invokeClient(Executor fallback, StreamingHttpRequest request,
+                                               Function<Publisher<Object>, Single<StreamingHttpResponse>> client);
+
+    /**
+     * Invokes the passed {@link Function} and applies the necessary offloading of request and response for a server.
+     *
+     * @param fallback {@link Executor} to use as a fallback if this {@link HttpExecutionStrategy} does not define an
+     * {@link Executor}.
+     * @param request {@link StreamingHttpRequest} for which the offloading is to be applied.
+     * @param service A {@link Function} that executes a {@link StreamingHttpRequest} and returns a
+     * {@link Single}
+     * @param errorHandler In case there is an error on calling the passed {@code service} or if the returned
+     * {@link Single} from the {@code service} terminates with an error. This {@link BiFunction} will be called to
+     * generate an error response.
+     * @return A flattened {@link Publisher} containing {@link HttpRequestMetaData}, payload and trailers
+     * for the {@link StreamingHttpResponse} returned by the passed {@code service}.
+     */
+    Publisher<Object> invokeService(Executor fallback, StreamingHttpRequest request,
+                                    Function<StreamingHttpRequest, Single<StreamingHttpResponse>> service,
+                                    BiFunction<Throwable, Executor, Single<StreamingHttpResponse>> errorHandler);
+
+    /**
+     * Wraps the passed {@link StreamingHttpService} to apply this {@link HttpExecutionStrategy}.
+     *
+     * @param fallback {@link Executor} to use as a fallback if this {@link HttpExecutionStrategy} does not define an
+     * {@link Executor}.
+     * @param service {@link StreamingHttpService} to wrap.
+     * @return Wrapped {@link StreamingHttpService}.
+     */
+    StreamingHttpService wrap(Executor fallback, StreamingHttpService service);
+
+    /**
+     * Wraps the passed {@link StreamingHttpClient} to apply this {@link HttpExecutionStrategy}.
+     *
+     * @param fallback {@link Executor} to use as a fallback if this {@link HttpExecutionStrategy} does not define an
+     * {@link Executor}.
+     * @param client {@link StreamingHttpClient} to wrap.
+     * @return Wrapped {@link StreamingHttpClient}.
+     */
+    StreamingHttpClient wrap(Executor fallback, StreamingHttpClient client);
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequester.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ExecutionContext;
 
 import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -43,7 +44,18 @@ public abstract class HttpRequester implements HttpRequestFactory, ListenableAsy
      * @param request the request to send.
      * @return The response.
      */
-    public abstract Single<? extends HttpResponse> request(HttpRequest request);
+    public Single<? extends HttpResponse> request(HttpRequest request) {
+        return request(executionStrategy(), request);
+    }
+
+    /**
+     * Send a {@code request} using the specified {@link HttpExecutionStrategy strategy}.
+     *
+     * @param strategy {@link HttpExecutionStrategy} to use for executing the request.
+     * @param request the request to send.
+     * @return The response.
+     */
+    public abstract Single<? extends HttpResponse> request(HttpExecutionStrategy strategy, HttpRequest request);
 
     /**
      * Get the {@link ExecutionContext} used during construction of this object.
@@ -98,6 +110,15 @@ public abstract class HttpRequester implements HttpRequestFactory, ListenableAsy
     @Override
     public final void close() {
         awaitTermination(closeAsyncGracefully().toFuture());
+    }
+
+    /**
+     * Returns the default {@link HttpExecutionStrategy} for this {@link HttpRequester}.
+     *
+     * @return Default {@link HttpExecutionStrategy} for this {@link HttpRequester}.
+     */
+    HttpExecutionStrategy executionStrategy() {
+        return defaultStrategy();
     }
 
     StreamingHttpRequester asStreamingRequesterInternal() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequesterAdapter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequesterAdapter.java
@@ -44,8 +44,8 @@ public abstract class HttpRequesterAdapter extends HttpRequester {
     }
 
     @Override
-    public Single<? extends HttpResponse> request(final HttpRequest request) {
-        return delegate.request(request);
+    public Single<? extends HttpResponse> request(final HttpExecutionStrategy strategy, final HttpRequest request) {
+        return delegate.request(strategy, request);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequesterToBlockingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequesterToBlockingHttpRequester.java
@@ -30,8 +30,8 @@ final class HttpRequesterToBlockingHttpRequester extends BlockingHttpRequester {
     }
 
     @Override
-    public HttpResponse request(final HttpRequest request) throws Exception {
-        return BlockingUtils.request(requester, request);
+    public HttpResponse request(final HttpExecutionStrategy strategy, final HttpRequest request) throws Exception {
+        return blockingInvocation(requester.request(strategy, request));
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequesterToStreamingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequesterToStreamingHttpRequester.java
@@ -30,8 +30,10 @@ final class HttpRequesterToStreamingHttpRequester extends StreamingHttpRequester
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-        return request.toRequest().flatMap(requester::request).map(HttpResponse::toStreamingResponse);
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
+        return request.toRequest().flatMap(r -> requester.request(strategy, r))
+                .map(HttpResponse::toStreamingResponse);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -16,7 +16,6 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.BufferAllocator;
-import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ContextFilter;
 import io.servicetalk.transport.api.IoExecutor;
@@ -207,14 +206,6 @@ public interface HttpServerBuilder {
      * @return {@code this}.
      */
     HttpServerBuilder ioExecutor(IoExecutor ioExecutor);
-
-    /**
-     * Sets the {@link Executor} to be used by this server.
-     *
-     * @param executor {@link Executor} to use.
-     * @return {@code this}.
-     */
-    HttpServerBuilder executor(Executor executor);
 
     /**
      * Sets the {@link BufferAllocator} to be used by this server.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpService.java
@@ -18,6 +18,8 @@ package io.servicetalk.http.api;
 import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
 
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+
 /**
  * Same as {@link StreamingHttpService} but that accepts {@link HttpRequest} and returns {@link HttpResponse}.
  */
@@ -63,6 +65,15 @@ public abstract class HttpService implements HttpRequestHandler, AsyncCloseable 
      */
     public final BlockingHttpService asBlockingService() {
         return asBlockingServiceInternal();
+    }
+
+    /**
+     * Returns the {@link HttpExecutionStrategy}.
+     *
+     * @return The {@link HttpExecutionStrategy} for this {@link HttpService}.
+     */
+    public HttpExecutionStrategy executionStrategy() {
+        return defaultStrategy();
     }
 
     StreamingHttpService asStreamingServiceInternal() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/LoadBalancerReadyStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/LoadBalancerReadyStreamingHttpClient.java
@@ -29,8 +29,9 @@ import static io.servicetalk.concurrent.api.Completable.error;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A {@link StreamingHttpClient} filter that will account for transient failures introduced by a {@link LoadBalancer} not being
- * ready for {@link #request(StreamingHttpRequest)} and retry/delay requests until the {@link LoadBalancer} is ready.
+ * A {@link StreamingHttpClient} filter that will account for transient failures introduced by a {@link LoadBalancer}
+ * not being ready for {@link #request(StreamingHttpRequest)} and retry/delay requests until the {@link LoadBalancer}
+ * is ready.
  */
 public final class LoadBalancerReadyStreamingHttpClient extends StreamingHttpClient {
     private final LoadBalancerReadySubscriber loadBalancerReadySubscriber;
@@ -59,8 +60,9 @@ public final class LoadBalancerReadyStreamingHttpClient extends StreamingHttpCli
     }
 
     @Override
-    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final StreamingHttpRequest request) {
-        return next.reserveConnection(request).retryWhen(retryWhenFunction());
+    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
+                                                                               final StreamingHttpRequest request) {
+        return next.reserveConnection(strategy, request).retryWhen(retryWhenFunction());
     }
 
     @Override
@@ -69,8 +71,9 @@ public final class LoadBalancerReadyStreamingHttpClient extends StreamingHttpCli
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-        return next.request(request).retryWhen(retryWhenFunction());
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
+        return next.request(strategy, request).retryWhen(retryWhenFunction());
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -20,7 +20,6 @@ import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.LoadBalancerFactory;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
-import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.SslConfig;
@@ -44,7 +43,7 @@ public interface MultiAddressHttpClientBuilder<U, R> extends HttpClientBuilder<U
     MultiAddressHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
 
     @Override
-    MultiAddressHttpClientBuilder<U, R> executor(Executor executor);
+    MultiAddressHttpClientBuilder<U, R> executionStrategy(HttpExecutionStrategy strategy);
 
     @Override
     MultiAddressHttpClientBuilder<U, R> bufferAllocator(BufferAllocator allocator);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ReservedFromStreamingHttpConnectionAdapter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ReservedFromStreamingHttpConnectionAdapter.java
@@ -57,8 +57,8 @@ public abstract class ReservedFromStreamingHttpConnectionAdapter extends Reserve
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-        return delegate.request(request);
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy, final StreamingHttpRequest request) {
+        return delegate.request(strategy, request);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -21,7 +21,6 @@ import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.LoadBalancerFactory;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
-import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.SslConfig;
@@ -45,7 +44,7 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
     SingleAddressHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
 
     @Override
-    SingleAddressHttpClientBuilder<U, R> executor(Executor executor);
+    SingleAddressHttpClientBuilder<U, R> executionStrategy(HttpExecutionStrategy strategy);
 
     @Override
     SingleAddressHttpClientBuilder<U, R> bufferAllocator(BufferAllocator allocator);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClient.java
@@ -56,7 +56,21 @@ public abstract class StreamingHttpClient extends StreamingHttpRequester {
      * For example this may provide some insight into shard or other info.
      * @return a {@link ReservedStreamingHttpConnection}.
      */
-    public abstract Single<? extends ReservedStreamingHttpConnection> reserveConnection(StreamingHttpRequest request);
+    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(StreamingHttpRequest request) {
+        return reserveConnection(executionStrategy(), request);
+    }
+
+    /**
+     * Reserve a {@link StreamingHttpConnection} for handling the provided {@link StreamingHttpRequest} but <b>does not
+     * execute it</b>!
+     *
+     * @param strategy {@link HttpExecutionStrategy} to use.
+     * @param request Allows the underlying layers to know what {@link StreamingHttpConnection}s are valid to reserve.
+     * For example this may provide some insight into shard or other info.
+     * @return a {@link ReservedStreamingHttpConnection}.
+     */
+    public abstract Single<? extends ReservedStreamingHttpConnection> reserveConnection(HttpExecutionStrategy strategy,
+                                                                                        StreamingHttpRequest request);
 
     /**
      * Attempt a <a href="https://tools.ietf.org/html/rfc7230.html#section-6.7">protocol upgrade</a>.
@@ -118,7 +132,8 @@ public abstract class StreamingHttpClient extends StreamingHttpRequester {
 
     /**
      * A special type of {@link StreamingHttpConnection} for the exclusive use of the caller of
-     * {@link #reserveConnection(StreamingHttpRequest)}.
+     * {@link #reserveConnection(StreamingHttpRequest)} and
+     * {@link #reserveConnection(HttpExecutionStrategy, StreamingHttpRequest)}.
      */
     public abstract static class ReservedStreamingHttpConnection extends StreamingHttpConnection {
         /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientAdapter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientAdapter.java
@@ -44,8 +44,9 @@ public abstract class StreamingHttpClientAdapter extends StreamingHttpClient {
     }
 
     @Override
-    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final StreamingHttpRequest request) {
-        return delegate.reserveConnection(request);
+    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
+                                                                               final StreamingHttpRequest request) {
+        return delegate.reserveConnection(strategy, request);
     }
 
     @Override
@@ -54,8 +55,9 @@ public abstract class StreamingHttpClientAdapter extends StreamingHttpClient {
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-        return delegate.request(request);
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
+        return delegate.request(strategy, request);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientGroupToStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientGroupToStreamingHttpClient.java
@@ -41,12 +41,14 @@ final class StreamingHttpClientGroupToStreamingHttpClient<UnresolvedAddress> ext
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
         return new Single<StreamingHttpResponse>() {
             @Override
             protected void handleSubscribe(final Subscriber<? super StreamingHttpResponse> subscriber) {
                 final Single<? extends StreamingHttpResponse> response;
                 try {
+                    // TODO: Add strategy to group
                     response = clientGroup.request(requestToGroupKeyFunc.apply(request), request);
                 } catch (final Throwable t) {
                     subscriber.onSubscribe(IGNORE_CANCEL);
@@ -59,7 +61,8 @@ final class StreamingHttpClientGroupToStreamingHttpClient<UnresolvedAddress> ext
     }
 
     @Override
-    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final StreamingHttpRequest request) {
+    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
+                                                                               final StreamingHttpRequest request) {
         return new Single<ReservedStreamingHttpConnection>() {
             @Override
             protected void handleSubscribe(final Subscriber<? super ReservedStreamingHttpConnection> subscriber) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingHttpClient.java
@@ -36,8 +36,9 @@ final class StreamingHttpClientToBlockingHttpClient extends BlockingHttpClient {
     }
 
     @Override
-    public ReservedBlockingHttpConnection reserveConnection(final HttpRequest request) throws Exception {
-        return blockingInvocation(client.reserveConnection(request.toStreamingRequest())
+    public ReservedBlockingHttpConnection reserveConnection(final HttpExecutionStrategy strategy,
+                                                            final HttpRequest request) throws Exception {
+        return blockingInvocation(client.reserveConnection(strategy, request.toStreamingRequest())
                 .map(ReservedStreamingHttpConnectionToBlocking::new));
     }
 
@@ -47,8 +48,9 @@ final class StreamingHttpClientToBlockingHttpClient extends BlockingHttpClient {
     }
 
     @Override
-    public HttpResponse request(final HttpRequest request) throws Exception {
-        return BlockingUtils.request(client, request);
+    public HttpResponse request(final HttpExecutionStrategy strategy, final HttpRequest request) throws Exception {
+        return blockingInvocation(client.request(strategy, request.toStreamingRequest())
+                .flatMap(StreamingHttpResponse::toResponse));
     }
 
     @Override
@@ -94,8 +96,9 @@ final class StreamingHttpClientToBlockingHttpClient extends BlockingHttpClient {
         }
 
         @Override
-        public HttpResponse request(final HttpRequest request) throws Exception {
-            return BlockingUtils.request(connection, request);
+        public HttpResponse request(final HttpExecutionStrategy strategy, final HttpRequest request) throws Exception {
+            return blockingInvocation(connection.request(request.toStreamingRequest())
+                    .flatMap(StreamingHttpResponse::toResponse));
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingStreamingHttpClient.java
@@ -55,8 +55,9 @@ final class StreamingHttpClientToBlockingStreamingHttpClient extends BlockingStr
     }
 
     @Override
-    public BlockingStreamingHttpResponse request(final BlockingStreamingHttpRequest request) throws Exception {
-        return BlockingUtils.request(client, request);
+    public BlockingStreamingHttpResponse request(final HttpExecutionStrategy strategy,
+                                                 final BlockingStreamingHttpRequest request) throws Exception {
+        return blockingInvocation(client.request(strategy, request.toStreamingRequest())).toBlockingStreamingResponse();
     }
 
     @Override
@@ -65,12 +66,13 @@ final class StreamingHttpClientToBlockingStreamingHttpClient extends BlockingStr
     }
 
     @Override
-    public ReservedBlockingStreamingHttpConnection reserveConnection(final BlockingStreamingHttpRequest request)
+    public ReservedBlockingStreamingHttpConnection reserveConnection(final HttpExecutionStrategy strategy,
+                                                                     final BlockingStreamingHttpRequest request)
             throws Exception {
         // It is assumed that users will always apply timeouts at the StreamingHttpService layer (e.g. via filter).
         // So we don't apply any explicit timeout here and just wait forever.
         return new ReservedStreamingHttpConnectionToBlockingStreaming(
-                blockingInvocation(client.reserveConnection(request.toStreamingRequest())));
+                blockingInvocation(client.reserveConnection(strategy, request.toStreamingRequest())));
     }
 
     @Override
@@ -122,8 +124,10 @@ final class StreamingHttpClientToBlockingStreamingHttpClient extends BlockingStr
         }
 
         @Override
-        public BlockingStreamingHttpResponse request(final BlockingStreamingHttpRequest request) throws Exception {
-            return BlockingUtils.request(connection, request);
+        public BlockingStreamingHttpResponse request(final HttpExecutionStrategy strategy,
+                                                     final BlockingStreamingHttpRequest request) throws Exception {
+            return blockingInvocation(connection.request(strategy, request.toStreamingRequest()))
+                    .toBlockingStreamingResponse();
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToHttpClient.java
@@ -43,8 +43,9 @@ final class StreamingHttpClientToHttpClient extends HttpClient {
     }
 
     @Override
-    public Single<? extends ReservedHttpConnection> reserveConnection(final HttpRequest request) {
-        return client.reserveConnection(request.toStreamingRequest())
+    public Single<? extends ReservedHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
+                                                                      final HttpRequest request) {
+        return client.reserveConnection(strategy, request.toStreamingRequest())
                 .map(ReservedStreamingHttpConnectionToReservedHttpConnection::new);
     }
 
@@ -60,8 +61,8 @@ final class StreamingHttpClientToHttpClient extends HttpClient {
     }
 
     @Override
-    public Single<? extends HttpResponse> request(final HttpRequest request) {
-        return client.request(request.toStreamingRequest()).flatMap(StreamingHttpResponse::toResponse);
+    public Single<? extends HttpResponse> request(final HttpExecutionStrategy strategy, final HttpRequest request) {
+        return client.request(strategy, request.toStreamingRequest()).flatMap(StreamingHttpResponse::toResponse);
     }
 
     @Override
@@ -114,8 +115,8 @@ final class StreamingHttpClientToHttpClient extends HttpClient {
         }
 
         @Override
-        public Single<? extends HttpResponse> request(final HttpRequest request) {
-            return reservedConnection.request(request.toStreamingRequest())
+        public Single<? extends HttpResponse> request(final HttpExecutionStrategy strategy, final HttpRequest request) {
+            return reservedConnection.request(strategy, request.toStreamingRequest())
                     .flatMap(StreamingHttpResponse::toResponse);
         }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionAdapter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionAdapter.java
@@ -56,8 +56,9 @@ public abstract class StreamingHttpConnectionAdapter extends StreamingHttpConnec
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-        return delegate.request(request);
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
+        return delegate.request(strategy, request);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToBlockingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToBlockingHttpConnection.java
@@ -42,8 +42,9 @@ final class StreamingHttpConnectionToBlockingHttpConnection extends BlockingHttp
     }
 
     @Override
-    public HttpResponse request(final HttpRequest request) throws Exception {
-        return BlockingUtils.request(connection, request);
+    public HttpResponse request(final HttpExecutionStrategy strategy, final HttpRequest request) throws Exception {
+        return blockingInvocation(connection.request(strategy, request.toStreamingRequest())
+                .flatMap(StreamingHttpResponse::toResponse));
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToBlockingStreamingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToBlockingStreamingHttpConnection.java
@@ -44,8 +44,10 @@ final class StreamingHttpConnectionToBlockingStreamingHttpConnection extends Blo
     }
 
     @Override
-    public BlockingStreamingHttpResponse request(final BlockingStreamingHttpRequest request) throws Exception {
-        return BlockingUtils.request(connection, request);
+    public BlockingStreamingHttpResponse request(final HttpExecutionStrategy strategy,
+                                                 final BlockingStreamingHttpRequest request) throws Exception {
+        return blockingInvocation(connection.request(strategy, request.toStreamingRequest()))
+                .toBlockingStreamingResponse();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToHttpConnection.java
@@ -42,8 +42,8 @@ final class StreamingHttpConnectionToHttpConnection extends HttpConnection {
     }
 
     @Override
-    public Single<? extends HttpResponse> request(final HttpRequest request) {
-        return connection.request(request.toStreamingRequest()).flatMap(StreamingHttpResponse::toResponse);
+    public Single<? extends HttpResponse> request(final HttpExecutionStrategy strategy, final HttpRequest request) {
+        return connection.request(strategy, request.toStreamingRequest()).flatMap(StreamingHttpResponse::toResponse);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequester.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ExecutionContext;
 
 import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -32,6 +33,7 @@ public abstract class StreamingHttpRequester implements
 
     /**
      * Create a new instance.
+     *
      * @param reqRespFactory The {@link StreamingHttpRequestResponseFactory} used to
      * {@link #newRequest(HttpRequestMethod, String) create new requests} and {@link #httpResponseFactory()}.
      */
@@ -41,19 +43,36 @@ public abstract class StreamingHttpRequester implements
 
     /**
      * Send a {@code request}.
+     *
      * @param request the request to send.
      * @return The response.
      */
-    public abstract Single<StreamingHttpResponse> request(StreamingHttpRequest request);
+    public Single<StreamingHttpResponse> request(StreamingHttpRequest request) {
+        return request(executionStrategy(), request);
+    }
+
+    /**
+     * Send a {@code request} using the specified {@link HttpExecutionStrategy strategy}.
+     *
+     * @param strategy {@link HttpExecutionStrategy} to use for executing the request.
+     * @param request the request to send.
+     * @return The response.
+     */
+    public abstract Single<StreamingHttpResponse> request(HttpExecutionStrategy strategy, StreamingHttpRequest request);
 
     /**
      * Get the {@link ExecutionContext} used during construction of this object.
      * <p>
      * Note that the {@link ExecutionContext#ioExecutor()} will not necessarily be associated with a specific thread
      * unless that was how this object was built.
+     *
      * @return the {@link ExecutionContext} used during construction of this object.
      */
     public abstract ExecutionContext executionContext();
+
+    HttpExecutionStrategy executionStrategy() {
+        return defaultStrategy();
+    }
 
     @Override
     public final StreamingHttpRequest newRequest(HttpRequestMethod method, String requestTarget) {
@@ -62,6 +81,7 @@ public abstract class StreamingHttpRequester implements
 
     /**
      * Get a {@link StreamingHttpResponseFactory}.
+     *
      * @return a {@link StreamingHttpResponseFactory}.
      */
     public final StreamingHttpResponseFactory httpResponseFactory() {
@@ -73,6 +93,7 @@ public abstract class StreamingHttpRequester implements
      * <p>
      * This API is provided for convenience for a more familiar sequential programming model. It is recommended that
      * filters are implemented using the {@link StreamingHttpRequester} asynchronous API for maximum portability.
+     *
      * @return a {@link BlockingStreamingHttpRequester} representation of this {@link StreamingHttpRequester}.
      */
     public final BlockingStreamingHttpRequester asBlockingStreamingRequester() {
@@ -84,6 +105,7 @@ public abstract class StreamingHttpRequester implements
      * <p>
      * This API is provided for convenience. It is recommended that
      * filters are implemented using the {@link StreamingHttpRequester} asynchronous API for maximum portability.
+     *
      * @return a {@link HttpRequester} representation of this {@link StreamingHttpRequester}.
      */
     public final HttpRequester asRequester() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequesterAdapter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequesterAdapter.java
@@ -44,8 +44,9 @@ public abstract class StreamingHttpRequesterAdapter extends StreamingHttpRequest
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-        return delegate.request(request);
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
+        return delegate.request(strategy, request);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequesterToBlockingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequesterToBlockingHttpRequester.java
@@ -30,8 +30,9 @@ final class StreamingHttpRequesterToBlockingHttpRequester extends BlockingHttpRe
     }
 
     @Override
-    public HttpResponse request(final HttpRequest request) throws Exception {
-        return BlockingUtils.request(requester, request);
+    public HttpResponse request(final HttpExecutionStrategy strategy, final HttpRequest request) throws Exception {
+        return blockingInvocation(requester.request(strategy, request.toStreamingRequest())
+                .flatMap(StreamingHttpResponse::toResponse));
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequesterToBlockingStreamingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequesterToBlockingStreamingHttpRequester.java
@@ -31,8 +31,10 @@ final class StreamingHttpRequesterToBlockingStreamingHttpRequester extends Block
     }
 
     @Override
-    public BlockingStreamingHttpResponse request(final BlockingStreamingHttpRequest request) throws Exception {
-        return BlockingUtils.request(requester, request);
+    public BlockingStreamingHttpResponse request(final HttpExecutionStrategy strategy,
+                                                 final BlockingStreamingHttpRequest request) throws Exception {
+        return blockingInvocation(requester.request(strategy, request.toStreamingRequest()))
+                .toBlockingStreamingResponse();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequesterToHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequesterToHttpRequester.java
@@ -30,8 +30,8 @@ final class StreamingHttpRequesterToHttpRequester extends HttpRequester {
     }
 
     @Override
-    public Single<? extends HttpResponse> request(final HttpRequest request) {
-        return requester.request(request.toStreamingRequest()).flatMap(StreamingHttpResponse::toResponse);
+    public Single<? extends HttpResponse> request(final HttpExecutionStrategy strategy, final HttpRequest request) {
+        return requester.request(strategy, request.toStreamingRequest()).flatMap(StreamingHttpResponse::toResponse);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpService.java
@@ -18,10 +18,14 @@ package io.servicetalk.http.api;
 import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
 
+import static io.servicetalk.concurrent.api.Completable.completed;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+
 /**
  * A service contract for the HTTP protocol.
  */
 public abstract class StreamingHttpService implements AsyncCloseable, StreamingHttpRequestHandler {
+
     /**
      * Closes this {@link StreamingHttpService} asynchronously.
      *
@@ -29,7 +33,7 @@ public abstract class StreamingHttpService implements AsyncCloseable, StreamingH
      */
     @Override
     public Completable closeAsync() {
-        return Completable.completed();
+        return completed();
     }
 
     @Override
@@ -66,6 +70,15 @@ public abstract class StreamingHttpService implements AsyncCloseable, StreamingH
      */
     public final BlockingHttpService asBlockingService() {
         return asBlockingServiceInternal();
+    }
+
+    /**
+     * Returns the {@link HttpExecutionStrategy} for this {@link StreamingHttpService}.
+     *
+     * @return The {@link HttpExecutionStrategy} for this {@link StreamingHttpService}.
+     */
+    public HttpExecutionStrategy executionStrategy() {
+        return defaultStrategy();
     }
 
     HttpService asServiceInternal() {

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpClientTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpClientTest.java
@@ -21,7 +21,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ExecutionContext;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import static io.servicetalk.concurrent.api.Single.error;
 import static java.util.Objects.requireNonNull;
@@ -31,16 +31,18 @@ public class BlockingStreamingHttpClientTest extends AbstractBlockingStreamingHt
     @Override
     protected <T extends StreamingHttpRequester & TestHttpRequester> T newAsyncRequester(
             StreamingHttpRequestResponseFactory factory,
-            final ExecutionContext ctx, final Function<StreamingHttpRequest, Single<StreamingHttpResponse>> doRequest) {
+            final ExecutionContext ctx,
+            final BiFunction<HttpExecutionStrategy, StreamingHttpRequest, Single<StreamingHttpResponse>> doRequest) {
         return (T) new TestStreamingHttpClient(factory, ctx) {
             @Override
-            public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-                return doRequest.apply(request);
+            public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                         final StreamingHttpRequest request) {
+                return doRequest.apply(strategy, request);
             }
 
             @Override
             public Single<? extends ReservedStreamingHttpConnection> reserveConnection(
-                    final StreamingHttpRequest request) {
+                    final HttpExecutionStrategy strategy, final StreamingHttpRequest request) {
                 return error(new UnsupportedOperationException());
             }
 
@@ -55,18 +57,19 @@ public class BlockingStreamingHttpClientTest extends AbstractBlockingStreamingHt
     @SuppressWarnings("unchecked")
     @Override
     protected <T extends BlockingStreamingHttpRequester & TestHttpRequester> T newBlockingRequester(
-            BlockingStreamingHttpRequestResponseFactory factory,
+            final BlockingStreamingHttpRequestResponseFactory factory,
             final ExecutionContext ctx,
-            final Function<BlockingStreamingHttpRequest, BlockingStreamingHttpResponse> doRequest) {
+            final BiFunction<HttpExecutionStrategy, BlockingStreamingHttpRequest, BlockingStreamingHttpResponse> doRequest) {
         return (T) new TestBlockingStreamingHttpClient(factory, ctx) {
             @Override
-            public BlockingStreamingHttpResponse request(final BlockingStreamingHttpRequest request) {
-                return doRequest.apply(request);
+            public BlockingStreamingHttpResponse request(final HttpExecutionStrategy strategy,
+                                                         final BlockingStreamingHttpRequest request) {
+                return doRequest.apply(strategy, request);
             }
 
             @Override
             public ReservedBlockingStreamingHttpConnection reserveConnection(
-                    final BlockingStreamingHttpRequest request) {
+                    final HttpExecutionStrategy strategy, final BlockingStreamingHttpRequest request) {
                 throw new UnsupportedOperationException();
             }
 

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpConnectionTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpConnectionTest.java
@@ -24,7 +24,7 @@ import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ExecutionContext;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -35,11 +35,13 @@ public class BlockingStreamingHttpConnectionTest extends AbstractBlockingStreami
     @Override
     protected <T extends StreamingHttpRequester & TestHttpRequester> T newAsyncRequester(
             StreamingHttpRequestResponseFactory factory,
-            final ExecutionContext ctx, final Function<StreamingHttpRequest, Single<StreamingHttpResponse>> doRequest) {
+            final ExecutionContext ctx,
+            final BiFunction<HttpExecutionStrategy, StreamingHttpRequest, Single<StreamingHttpResponse>> doRequest) {
         return (T) new TestStreamingHttpConnection(factory, ctx) {
             @Override
-            public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-                return doRequest.apply(request);
+            public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                         final StreamingHttpRequest request) {
+                return doRequest.apply(strategy, request);
             }
         };
     }
@@ -49,11 +51,12 @@ public class BlockingStreamingHttpConnectionTest extends AbstractBlockingStreami
     protected <T extends BlockingStreamingHttpRequester & TestHttpRequester> T newBlockingRequester(
             BlockingStreamingHttpRequestResponseFactory factory,
             final ExecutionContext ctx,
-            final Function<BlockingStreamingHttpRequest, BlockingStreamingHttpResponse> doRequest) {
+            final BiFunction<HttpExecutionStrategy, BlockingStreamingHttpRequest, BlockingStreamingHttpResponse> doRequest) {
         return (T) new TestBlockingStreamingHttpConnection(factory, ctx) {
             @Override
-            public BlockingStreamingHttpResponse request(final BlockingStreamingHttpRequest request) {
-                return doRequest.apply(request);
+            public BlockingStreamingHttpResponse request(final HttpExecutionStrategy strategy,
+                                                         final BlockingStreamingHttpRequest request) {
+                return doRequest.apply(strategy, request);
             }
         };
     }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/LoadBalancerReadyHttpClientTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/LoadBalancerReadyHttpClientTest.java
@@ -66,12 +66,13 @@ public class LoadBalancerReadyHttpClientTest {
 
     private StreamingHttpClient client = new TestStreamingHttpClient(reqRespFactory, mockExecutionCtx) {
         @Override
-        public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+        public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                     final StreamingHttpRequest request) {
             return defer(new DeferredSuccessSupplier<>(newOkResponse()));
         }
 
         @Override
-        public Single<? extends ReservedStreamingHttpConnection> reserveConnection(
+        public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
                 final StreamingHttpRequest request) {
             return defer(new DeferredSuccessSupplier<>(mockReservedConnection));
         }

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpClient.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpClient.java
@@ -41,7 +41,8 @@ public class TestStreamingHttpClient extends StreamingHttpClient {
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
         return error(new UnsupportedOperationException());
     }
 
@@ -51,7 +52,8 @@ public class TestStreamingHttpClient extends StreamingHttpClient {
     }
 
     @Override
-    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final StreamingHttpRequest request) {
+    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
+                                                                               final StreamingHttpRequest request) {
         return error(new UnsupportedOperationException());
     }
 

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpConnection.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpConnection.java
@@ -46,7 +46,8 @@ public class TestStreamingHttpConnection extends StreamingHttpConnection {
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
         return error(new UnsupportedOperationException());
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -25,7 +25,6 @@ import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.CompositeCloseable;
-import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.ClientGroupFilterFunction;
@@ -33,6 +32,7 @@ import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.HttpClientBuilder;
 import io.servicetalk.http.api.HttpClientGroupFilterFactory;
 import io.servicetalk.http.api.HttpConnectionFilterFactory;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpHeadersFactory;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpScheme;
@@ -266,13 +266,15 @@ final class DefaultMultiAddressUrlHttpClientBuilder
         }
 
         @Override
-        public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-            return httpClient.request(request);
+        public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                     final StreamingHttpRequest request) {
+            return httpClient.request(strategy, request);
         }
 
         @Override
-        public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final StreamingHttpRequest request) {
-            return httpClient.reserveConnection(request);
+        public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
+                                                                                   final StreamingHttpRequest request) {
+            return httpClient.reserveConnection(strategy, request);
         }
 
         @Override
@@ -309,8 +311,9 @@ final class DefaultMultiAddressUrlHttpClientBuilder
     }
 
     @Override
-    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> executor(final Executor executor) {
-        builderTemplate.executor(executor);
+    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> executionStrategy(
+            final HttpExecutionStrategy strategy) {
+        builderTemplate.executionStrategy(strategy);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultStreamingHttpClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultStreamingHttpClient.java
@@ -18,6 +18,7 @@ package io.servicetalk.http.netty;
 import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
@@ -38,20 +39,24 @@ final class DefaultStreamingHttpClient extends StreamingHttpClient {
 
     // TODO Proto specific LB after upgrade and worry about SSL
     private final ExecutionContext executionContext;
+    private final HttpExecutionStrategy executionStrategy;
     private final LoadBalancer<LoadBalancedStreamingHttpConnection> loadBalancer;
 
     @SuppressWarnings("unchecked")
-    DefaultStreamingHttpClient(final ExecutionContext executionContext,
+    DefaultStreamingHttpClient(final ExecutionContext executionContext, final HttpExecutionStrategy executionStrategy,
                                final LoadBalancer<LoadBalancedStreamingHttpConnection> loadBalancer,
                                final StreamingHttpRequestResponseFactory reqRespFactory) {
         super(reqRespFactory);
         this.executionContext = requireNonNull(executionContext);
+        this.executionStrategy = executionStrategy;
         this.loadBalancer = requireNonNull(loadBalancer);
     }
 
     @Override
-    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final StreamingHttpRequest request) {
-        return loadBalancer.selectConnection(SELECTOR_FOR_RESERVE);
+    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
+                                                                               final StreamingHttpRequest request) {
+        return strategy.offloadReceive(executionContext.executor(),
+                loadBalancer.selectConnection(SELECTOR_FOR_RESERVE));
     }
 
     @Override
@@ -61,13 +66,19 @@ final class DefaultStreamingHttpClient extends StreamingHttpClient {
 
     @Override
     public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+        return request(executionStrategy, request);
+    }
+
+    @Override
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
         // We have to do the incrementing/decrementing in the Client instead of LoadBalancedStreamingHttpConnection
         // because it is possible that someone can use the ConnectionFactory exported by this Client before the
         // LoadBalancer takes ownership of it (e.g. connection initialization) and in that case they will not be
         // following the LoadBalancer API which this Client depends upon to ensure the concurrent request count state is
         // correct.
         return loadBalancer.selectConnection(SELECTOR_FOR_REQUEST)
-                .flatMap(c -> c.request(request).liftSynchronous(new ConcurrencyControlSingleOperator(c)));
+                .flatMap(c -> c.request(strategy, request).liftSynchronous(new ConcurrencyControlSingleOperator(c)));
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HostHeaderHttpConnectionFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HostHeaderHttpConnectionFilter.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpHeaderNames;
 import io.servicetalk.http.api.StreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpConnectionAdapter;
@@ -70,10 +71,11 @@ final class HostHeaderHttpConnectionFilter extends StreamingHttpConnectionAdapte
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
         if (request.version() == HTTP_1_1 && !request.headers().contains(HOST)) {
             request.headers().set(HOST, fallbackHost);
         }
-        return delegate().request(request);
+        return delegate().request(strategy, request);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedStreamingHttpConnection.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
@@ -38,14 +39,14 @@ final class PipelinedStreamingHttpConnection extends AbstractStreamingHttpConnec
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(StreamingHttpRequest request) {
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy, StreamingHttpRequest request) {
         HttpProtocolVersion version = request.version();
         if (version != HTTP_1_1 && (version.majorVersion() != HTTP_1_1.majorVersion()
                 || version.minorVersion() != HTTP_1_1.minorVersion())) {
             return Single.error(new IllegalArgumentException(
                     "Pipelining unsupported in protocol version: " + request.version()));
         }
-        return super.request(request);
+        return super.request(strategy, request);
     }
 
     @SuppressWarnings("unchecked")

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/SpliceFlatStreamToMetaSingle.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/SpliceFlatStreamToMetaSingle.java
@@ -28,7 +28,6 @@ import org.reactivestreams.Subscription;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -68,20 +67,6 @@ final class SpliceFlatStreamToMetaSingle<Data, MetaData, Payload> extends Single
     @Override
     protected void handleSubscribe(Subscriber<? super Data> dataSubscriber) {
         original.subscribe(new SplicingSubscriber<>(this, dataSubscriber));
-    }
-
-    /**
-     * Operator to flatten a {@link Data}&lt;{@link Payload}&gt; into a {@link Publisher}&lt;{@link Object}&gt;.
-     *
-     * @param data object containing a {@link Publisher}&lt;{@link Payload}&gt;
-     * @param unpack function to unpack the {@link Publisher}&lt;{@link Payload}&gt; from the container
-     * @param <Data> type of container, eg. {@link StreamingHttpResponse}&lt;{@link Buffer}&gt;
-     * @param <Payload> type of payload inside the {@link Data}, eg. {@link Buffer}
-     * @return a flattened {@link Publisher}&lt;{@link Object}&gt;
-     */
-    @SuppressWarnings("unchecked")
-    static <Data, Payload> Publisher<Object> flatten(Data data, Function<Data, Publisher<Payload>> unpack) {
-        return ((Publisher) Publisher.just(data)).concatWith(unpack.apply(data));
     }
 
     /* Visible for testing */

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractEchoServerBasedHttpRequesterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractEchoServerBasedHttpRequesterTest.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpHeaderNames;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpServiceContext;
@@ -42,6 +43,7 @@ import static io.servicetalk.concurrent.api.Publisher.just;
 import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponentialBackoff;
 import static io.servicetalk.concurrent.internal.Await.awaitIndefinitely;
 import static io.servicetalk.concurrent.internal.Await.awaitIndefinitelyNonNull;
+import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.http.api.HttpRequestMethods.GET;
 import static io.servicetalk.transport.netty.internal.ExecutionContextRule.immediate;
@@ -64,7 +66,6 @@ public abstract class AbstractEchoServerBasedHttpRequesterTest {
     public static void startServer() throws Exception {
         serverContext = HttpServers.forPort(0)
                 .ioExecutor(CTX.ioExecutor())
-                .executor(CTX.executor())
                 .listenStreamingAndAwait(new EchoServiceStreaming());
     }
 
@@ -88,6 +89,11 @@ public abstract class AbstractEchoServerBasedHttpRequesterTest {
             HttpHeaders headers = resp.headers();
             request.headers().forEach(entry -> headers.set("test-req-header-" + entry.getKey(), entry.getValue()));
             return Single.success(resp);
+        }
+
+        @Override
+        public HttpExecutionStrategy executionStrategy() {
+            return noOffloadsStrategy();
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -63,6 +63,7 @@ import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
 import static io.servicetalk.concurrent.internal.Await.await;
 import static io.servicetalk.concurrent.internal.Await.awaitIndefinitely;
 import static io.servicetalk.concurrent.internal.Await.awaitIndefinitelyNonNull;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.transport.api.ContextFilter.ACCEPT_ALL;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.parseBoolean;
@@ -130,7 +131,7 @@ public abstract class AbstractNettyHttpServerTest {
     @Before
     public void startServer() throws Exception {
         final InetSocketAddress bindAddress = new InetSocketAddress(LOOPBACK_ADDRESS, 0);
-        setService(new TestServiceStreaming(publisherSupplier));
+        setService(new TestServiceStreaming(publisherSupplier, defaultStrategy(serverExecutor)));
 
         // A small SNDBUF is needed to test that the server defers closing the connection until writes are complete.
         // However, if it is too small, tests that expect certain chunks of data will see those chunks broken up
@@ -144,7 +145,7 @@ public abstract class AbstractNettyHttpServerTest {
                     .build();
             serverBuilder.sslConfig(sslConfig);
         }
-        serverContext = awaitIndefinitelyNonNull(serverBuilder.ioExecutor(serverIoExecutor).executor(serverExecutor)
+        serverContext = awaitIndefinitelyNonNull(serverBuilder.ioExecutor(serverIoExecutor)
                 .contextFilter(contextFilter)
                 .listenStreaming(service)
                 .doBeforeSuccess(ctx -> LOGGER.debug("Server started on {}.", ctx.listenAddress()))

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultHttpConnectionBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultHttpConnectionBuilderTest.java
@@ -18,6 +18,7 @@ package io.servicetalk.http.netty;
 import io.servicetalk.client.api.ConnectionFactory;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.StreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpConnectionAdapter;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -64,9 +65,10 @@ public class DefaultHttpConnectionBuilderTest extends AbstractEchoServerBasedHtt
         }
 
         @Override
-        public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+        public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                     final StreamingHttpRequest request) {
             // fanout - simulates followup request on response
-            return delegate().request(request).flatMap(resp ->
+            return delegate().request(strategy, request).flatMap(resp ->
                     resp.payloadBody().ignoreElements().andThen(delegate().request(request)));
         }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
@@ -33,6 +33,7 @@ import org.junit.rules.Timeout;
 import java.net.InetSocketAddress;
 
 import static io.servicetalk.concurrent.internal.Await.awaitIndefinitely;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.transport.netty.internal.ExecutionContextRule.immediate;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
@@ -51,7 +52,7 @@ public class DefaultMultiAddressUrlHttpClientBuilderTest {
     public void buildWithDefaults() throws Exception {
         StreamingHttpRequester newRequester = HttpClients.forMultiAddressUrl()
                 .ioExecutor(CTX.ioExecutor())
-                .executor(CTX.executor())
+                .executionStrategy(defaultStrategy(CTX.executor()))
                 .buildStreaming();
         assertNotNull(newRequester);
         awaitIndefinitely(newRequester.closeAsync());
@@ -61,7 +62,7 @@ public class DefaultMultiAddressUrlHttpClientBuilderTest {
     public void buildAggregatedWithDefaults() throws Exception {
         HttpRequester newAggregatedRequester = HttpClients.forMultiAddressUrl()
                 .ioExecutor(CTX.ioExecutor())
-                .executor(CTX.executor())
+                .executionStrategy(defaultStrategy(CTX.executor()))
                 .build();
         assertNotNull(newAggregatedRequester);
         awaitIndefinitely(newAggregatedRequester.closeAsync());
@@ -71,7 +72,7 @@ public class DefaultMultiAddressUrlHttpClientBuilderTest {
     public void buildBlockingWithDefaults() throws Exception {
         BlockingStreamingHttpRequester newBlockingRequester = HttpClients.forMultiAddressUrl()
                 .ioExecutor(CTX.ioExecutor())
-                .executor(CTX.executor())
+                .executionStrategy(defaultStrategy(CTX.executor()))
                 .buildBlockingStreaming();
         assertNotNull(newBlockingRequester);
         newBlockingRequester.close();
@@ -81,7 +82,7 @@ public class DefaultMultiAddressUrlHttpClientBuilderTest {
     public void buildBlockingAggregatedWithDefaults() throws Exception {
         BlockingHttpRequester newBlockingAggregatedRequester = HttpClients.forMultiAddressUrl()
                 .ioExecutor(CTX.ioExecutor())
-                .executor(CTX.executor())
+                .executionStrategy(defaultStrategy(CTX.executor()))
                 .buildBlocking();
         assertNotNull(newBlockingAggregatedRequester);
         newBlockingAggregatedRequester.close();
@@ -95,7 +96,7 @@ public class DefaultMultiAddressUrlHttpClientBuilderTest {
         StreamingHttpRequester newRequester = HttpClients.forMultiAddressUrl()
                 .serviceDiscoverer(mockedServiceDiscoverer)
                 .ioExecutor(CTX.ioExecutor())
-                .executor(CTX.executor())
+                .executionStrategy(defaultStrategy(CTX.executor()))
                 .buildStreaming();
         awaitIndefinitely(newRequester.closeAsync());
         verify(mockedServiceDiscoverer, never()).closeAsync();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOverrideTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOverrideTest.java
@@ -23,6 +23,7 @@ import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.PublisherRule;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpClient.ReservedStreamingHttpConnection;
@@ -52,6 +53,7 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.success;
+import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
 import static io.servicetalk.transport.netty.internal.ExecutionContextRule.immediate;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -74,14 +76,13 @@ public class FlushStrategyOverrideTest {
         service = new FlushingService();
         serverCtx = HttpServers.forPort(0)
                 .ioExecutor(ctx.ioExecutor())
-                .executor(ctx.executor())
                 .listenStreaming(service)
                 .toFuture().get();
         InetSocketAddress serverAddr = (InetSocketAddress) serverCtx.listenAddress();
         client = forSingleAddress(new NoopSD(serverAddr), serverAddr)
                 .disableHostHeaderFallback()
                 .ioExecutor(ctx.ioExecutor())
-                .executor(ctx.executor())
+                .executionStrategy(noOffloadsStrategy())
                 .buildStreaming();
         conn = client.reserveConnection(client.get("/")).toFuture().get();
     }
@@ -122,7 +123,7 @@ public class FlushStrategyOverrideTest {
 
         Collection<Object> chunks = clientResp.get();
         assertThat("Unexpected items received.", chunks, hasSize(4 /*3 chunks + last chunk*/));
-        clientStrategy.verifyWriteCancelled(); // Single.flatMapPublisher sends a cancel when switching to Publisher.
+
         c.cancel(); // revert to flush on each.
 
         // No more custom strategies.
@@ -157,6 +158,11 @@ public class FlushStrategyOverrideTest {
 
         MockFlushStrategy getLastUsedStrategy() throws InterruptedException {
             return flushStrategies.take();
+        }
+
+        @Override
+        public HttpExecutionStrategy executionStrategy() {
+            return noOffloadsStrategy();
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientBuilderTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutionException;
 import javax.annotation.Nonnull;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
+import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
@@ -78,7 +79,7 @@ public class HttpClientBuilderTest extends AbstractEchoServerBasedHttpRequesterT
                 .appendConnectionFactoryFilter(factoryFilter(factory1))
                 .appendConnectionFactoryFilter(factoryFilter(factory2))
                 .ioExecutor(CTX.ioExecutor())
-                .executor(CTX.executor())
+                .executionStrategy(noOffloadsStrategy())
                 .buildStreaming();
         makeRequestValidateResponseAndClose(requester);
 
@@ -115,7 +116,7 @@ public class HttpClientBuilderTest extends AbstractEchoServerBasedHttpRequesterT
         StreamingHttpClient requester = HttpClients.forSingleAddress("localhost", port)
                 .serviceDiscoverer(disco)
                 .ioExecutor(CTX.ioExecutor())
-                .executor(CTX.executor())
+                .executionStrategy(noOffloadsStrategy())
                 .buildStreaming();
         makeRequestValidateResponseAndClose(requester);
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionConcurrentRequestsFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionConcurrentRequestsFilterTest.java
@@ -25,6 +25,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.http.api.DefaultHttpHeadersFactory;
 import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.StreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
@@ -81,12 +82,13 @@ public class HttpConnectionConcurrentRequestsFilterTest {
             }
 
             @Override
-            public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+            public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                         final StreamingHttpRequest request) {
                 switch (reqCount.incrementAndGet()) {
                     case 1: return success(reqRespFactory.ok().payloadBody(response1Publisher.getPublisher()));
                     case 2: return success(reqRespFactory.ok().payloadBody(response2Publisher.getPublisher()));
                     case 3: return success(reqRespFactory.ok().payloadBody(response3Publisher.getPublisher()));
-                    default: return super.request(request);
+                    default: return super.request(strategy, request);
                 }
             }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionEmptyPayloadTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionEmptyPayloadTest.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.api.AsyncCloseables;
 import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -40,6 +41,7 @@ import static io.servicetalk.concurrent.api.Publisher.just;
 import static io.servicetalk.concurrent.api.Single.success;
 import static io.servicetalk.concurrent.internal.Await.awaitIndefinitely;
 import static io.servicetalk.concurrent.internal.Await.awaitIndefinitelyNonNull;
+import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpRequestMethods.HEAD;
 import static io.servicetalk.http.api.HttpResponseStatuses.OK;
@@ -63,7 +65,6 @@ public class HttpConnectionEmptyPayloadTest {
             ThreadLocalRandom.current().nextBytes(expectedPayload);
             ServerContext serverContext = closeable.merge(HttpServers.forPort(0)
                     .ioExecutor(executionContextRule.ioExecutor())
-                    .executor(executionContextRule.executor())
                     .listenStreamingAndAwait(
                             new StreamingHttpService() {
                                 @Override
@@ -76,6 +77,11 @@ public class HttpConnectionEmptyPayloadTest {
                                                     .newBuffer(expectedContentLength).writeBytes(expectedPayload)));
                                     resp.addHeader(CONTENT_LENGTH, String.valueOf(expectedContentLength));
                                     return success(resp);
+                                }
+
+                                @Override
+                                public HttpExecutionStrategy executionStrategy() {
+                                    return noOffloadsStrategy();
                                 }
                             }));
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionTest.java
@@ -49,6 +49,7 @@ import org.mockito.ArgumentCaptor;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
 import static io.servicetalk.http.api.HttpRequestMethods.GET;
 import static io.servicetalk.http.netty.DefaultHttpServiceContext.newInstance;
 import static io.servicetalk.http.netty.NettyHttpServerConnection.newConnection;
@@ -93,6 +94,7 @@ public class NettyHttpServerConnectionTest {
         DefaultHttpServiceContext serviceContext = newInstance(ctx, DefaultHttpHeadersFactory.INSTANCE);
 
         httpService = mock(StreamingHttpService.class);
+        when(httpService.executionStrategy()).thenReturn(noOffloadsStrategy());
         responseSingle = new TestSingle<>();
         when(httpService.handle(any(), any(), any())).thenReturn(responseSingle);
         originalStrategy = new MockFlushStrategy();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SpliceFlatStreamToMetaSingleTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SpliceFlatStreamToMetaSingleTest.java
@@ -25,7 +25,6 @@ import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 
@@ -33,8 +32,6 @@ import static io.servicetalk.concurrent.api.DeliberateException.DELIBERATE_EXCEP
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Publisher.just;
 import static io.servicetalk.concurrent.internal.Await.awaitIndefinitely;
-import static io.servicetalk.http.netty.SpliceFlatStreamToMetaSingle.flatten;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -61,13 +58,6 @@ public class SpliceFlatStreamToMetaSingleTest {
 
     @Rule
     public final MockedSingleListenerRule<Data> dataSubscriber = new MockedSingleListenerRule<>();
-
-    @Test
-    public void flattenShouldBreakDownGroupWithEmbeddedPayloadIntoFlatHeterogeneousPublisherOfObject()
-            throws ExecutionException, InterruptedException {
-        List<Object> flattened = awaitIndefinitely(flatten(data, Data::getPayload));
-        assertThat(flattened, contains(data, one, two, last));
-    }
 
     @Test
     public void streamWithHeaderAndPayloadShouldProduceDataWithEmbeddedPayload() {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TestServiceStreaming.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TestServiceStreaming.java
@@ -19,6 +19,7 @@ import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
@@ -55,11 +56,14 @@ final class TestServiceStreaming extends StreamingHttpService {
     static final String SVC_ERROR_BEFORE_READ = "/errorBeforeRead";
     static final String SVC_ERROR_DURING_READ = "/errorDuringRead";
     private final Function<StreamingHttpRequest, Publisher<Buffer>> publisherSupplier;
+    private final HttpExecutionStrategy strategy;
 
     private int counter;
 
-    TestServiceStreaming(final Function<StreamingHttpRequest, Publisher<Buffer>> publisherSupplier) {
+    TestServiceStreaming(final Function<StreamingHttpRequest, Publisher<Buffer>> publisherSupplier,
+                         final HttpExecutionStrategy strategy) {
         this.publisherSupplier = publisherSupplier;
+        this.strategy = strategy;
     }
 
     @Override
@@ -105,6 +109,11 @@ final class TestServiceStreaming extends StreamingHttpService {
                 response = newNotFoundResponse(req, factory);
         }
         return Single.success(response);
+    }
+
+    @Override
+    public HttpExecutionStrategy executionStrategy() {
+        return strategy;
     }
 
     private StreamingHttpResponse newEchoResponse(final StreamingHttpRequest req,

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/HttpJerseyRouterBuilder.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/HttpJerseyRouterBuilder.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.router.jersey;
 
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.transport.api.ConnectionContext;
@@ -26,6 +27,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import javax.ws.rs.core.Application;
 
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.utils.HttpRequestUriUtils.getBaseRequestUri;
 import static java.util.Objects.requireNonNull;
 
@@ -42,6 +44,7 @@ public final class HttpJerseyRouterBuilder {
     private BiFunction<ConnectionContext, StreamingHttpRequest, String> baseUriFunction =
             (ctx, req) -> getBaseRequestUri(ctx, req, false);
     private Function<String, Executor> executorFactory = __ -> null;
+    private HttpExecutionStrategy strategy = defaultStrategy();
 
     /**
      * Set the hint for the capacity of the intermediary queue that stores items when adapting {@link Publisher}s
@@ -50,7 +53,7 @@ public final class HttpJerseyRouterBuilder {
      * @param publisherInputStreamQueueCapacity the capacity hint.
      * @return this
      */
-    public HttpJerseyRouterBuilder setPublisherInputStreamQueueCapacity(final int publisherInputStreamQueueCapacity) {
+    public HttpJerseyRouterBuilder publisherInputStreamQueueCapacity(final int publisherInputStreamQueueCapacity) {
         if (publisherInputStreamQueueCapacity <= 0) {
             throw new IllegalArgumentException("Invalid queue capacity: " + publisherInputStreamQueueCapacity
                     + " (expected > 0).");
@@ -68,10 +71,21 @@ public final class HttpJerseyRouterBuilder {
      * @return this
      * @see <a href="https://tools.ietf.org/html/rfc3986#section-3">URI Syntax Components</a>
      */
-    public HttpJerseyRouterBuilder setBaseUriFunction(
+    public HttpJerseyRouterBuilder baseUriFunction(
             final BiFunction<ConnectionContext, StreamingHttpRequest, String> baseUriFunction) {
 
         this.baseUriFunction = requireNonNull(baseUriFunction);
+        return this;
+    }
+
+    /**
+     * Set the {@link HttpExecutionStrategy} for this router.
+     *
+     * @param strategy {@link HttpExecutionStrategy} to use.
+     * @return this
+     */
+    public HttpJerseyRouterBuilder executionStrategy(HttpExecutionStrategy strategy) {
+        this.strategy = strategy;
         return this;
     }
 
@@ -97,7 +111,7 @@ public final class HttpJerseyRouterBuilder {
      */
     public StreamingHttpService build(final Application application) {
         return new DefaultJerseyStreamingHttpRouter(application, publisherInputStreamQueueCapacity, baseUriFunction,
-                executorFactory);
+                executorFactory, strategy);
     }
 
     /**
@@ -108,6 +122,6 @@ public final class HttpJerseyRouterBuilder {
      */
     public StreamingHttpService build(final Class<? extends Application> applicationClass) {
         return new DefaultJerseyStreamingHttpRouter(applicationClass, publisherInputStreamQueueCapacity,
-                baseUriFunction, executorFactory);
+                baseUriFunction, executorFactory, strategy);
     }
 }

--- a/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/InOrderRouter.java
+++ b/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/InOrderRouter.java
@@ -64,7 +64,9 @@ final class InOrderRouter extends StreamingHttpService {
                                                 final StreamingHttpResponseFactory factory) {
         for (final PredicateServicePair pair : predicateServicePairs) {
             if (pair.getPredicate().test(ctx, request)) {
-                return pair.getService().handle(ctx, request, factory);
+                StreamingHttpService service = pair.getService();
+                return service.executionStrategy().wrap(ctx.executionContext().executor(), service)
+                        .handle(ctx, request, factory);
             }
         }
         return fallbackService.handle(ctx, request, factory);

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/BaseHttpPredicateRouterBuilderTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/BaseHttpPredicateRouterBuilderTest.java
@@ -35,7 +35,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
@@ -45,6 +44,7 @@ import java.util.Spliterator;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Executors.immediate;
+import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
 import static io.servicetalk.http.api.HttpProtocolVersions.HTTP_1_1;
 import static java.util.Arrays.asList;
 import static org.mockito.ArgumentMatchers.any;
@@ -83,13 +83,17 @@ public abstract class BaseHttpPredicateRouterBuilderTest {
         when(executionCtx.executor()).thenReturn(immediate());
         when(request.version()).thenReturn(HTTP_1_1);
         when(request.headers()).thenReturn(headers);
-        when(factory.newResponse(any(HttpResponseStatus.class))).thenAnswer(new Answer<StreamingHttpResponse>() {
-            @Override
-            public StreamingHttpResponse answer(final InvocationOnMock invocation) throws Throwable {
-                HttpResponseStatus status = invocation.getArgument(0);
-                return reqRespFactory.newResponse(status);
-            }
+        when(factory.newResponse(any(HttpResponseStatus.class))).thenAnswer((Answer<StreamingHttpResponse>) invocation -> {
+            HttpResponseStatus status = invocation.getArgument(0);
+            return reqRespFactory.newResponse(status);
         });
+
+        when(serviceA.executionStrategy()).thenReturn(noOffloadsStrategy());
+        when(serviceB.executionStrategy()).thenReturn(noOffloadsStrategy());
+        when(serviceC.executionStrategy()).thenReturn(noOffloadsStrategy());
+        when(serviceD.executionStrategy()).thenReturn(noOffloadsStrategy());
+        when(serviceE.executionStrategy()).thenReturn(noOffloadsStrategy());
+        when(fallbackService.executionStrategy()).thenReturn(noOffloadsStrategy());
 
         when(serviceA.handle(eq(ctx), eq(request), any())).thenReturn(responseA);
         when(serviceB.handle(eq(ctx), eq(request), any())).thenReturn(responseB);

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RetryingHttpClientFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RetryingHttpClientFilter.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.api.BiIntFunction;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.StreamingHttpClient;
@@ -57,17 +58,19 @@ public final class RetryingHttpClientFilter extends StreamingHttpClientAdapter {
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy executionStrategy,
+                                                 final StreamingHttpRequest request) {
         if (isRetryable.test(request)) {
-            return delegate().request(request).retryWhen(strategy);
+            return delegate().request(executionStrategy, request).retryWhen(strategy);
         }
         return delegate().request(request);
     }
 
     @Override
-    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final StreamingHttpRequest request) {
+    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(
+            final HttpExecutionStrategy executionStrategy, final StreamingHttpRequest request) {
         if (isRetryable.test(request)) {
-            return delegate().reserveConnection(request).retryWhen(strategy);
+            return delegate().reserveConnection(executionStrategy, request).retryWhen(strategy);
         }
         return delegate().reserveConnection(request);
     }

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpConnectionFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpConnectionFilter.java
@@ -16,6 +16,7 @@
 package io.servicetalk.opentracing.http;
 
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.StreamingHttpConnection;
@@ -76,7 +77,8 @@ public class TracingHttpConnectionFilter extends StreamingHttpConnectionAdapter 
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                 final StreamingHttpRequest request) {
         return new Single<StreamingHttpResponse>() {
             @Override
             protected void handleSubscribe(final Subscriber<? super StreamingHttpResponse> subscriber) {
@@ -94,7 +96,7 @@ public class TracingHttpConnectionFilter extends StreamingHttpConnectionAdapter 
 
                     childScope = spanBuilder.startActive(true);
                     tracer.inject(childScope.span().context(), formatter, request.headers());
-                    responseSingle = requireNonNull(delegate().request(request));
+                    responseSingle = requireNonNull(delegate().request(strategy, request));
                 } catch (Throwable cause) {
                     subscriber.onSubscribe(IGNORE_CANCEL);
                     subscriber.onError(cause);

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultRedisExecutionStrategy.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/DefaultRedisExecutionStrategy.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.redis.api;
+
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+
+import java.util.function.Function;
+import javax.annotation.Nullable;
+
+/**
+ * Default implementation for {@link RedisExecutionStrategy}.
+ */
+final class DefaultRedisExecutionStrategy implements RedisExecutionStrategy {
+
+    static final byte OFFLOAD_RECEIVE = 2;
+    static final byte OFFLOAD_SEND = 4;
+    @Nullable
+    private final Executor executor;
+    private final byte offloads;
+
+    DefaultRedisExecutionStrategy(@Nullable final Executor executor, final byte offloads) {
+        this.executor = executor;
+        this.offloads = offloads;
+    }
+
+    @Nullable
+    @Override
+    public Executor executor() {
+        return executor;
+    }
+
+    @Override
+    public <T> Single<T> offloadSend(final Executor fallback, final Single<T> original) {
+        return offloaded(OFFLOAD_SEND) ? original.subscribeOn(executor(fallback)) : original;
+    }
+
+    @Override
+    public <T> Single<T> offloadReceive(final Executor fallback, final Single<T> original) {
+        return offloaded(OFFLOAD_SEND) ? original.publishOn(executor(fallback)) : original;
+    }
+
+    @Override
+    public <T> Publisher<T> offloadSend(final Executor fallback, final Publisher<T> original) {
+        return offloaded(OFFLOAD_SEND) ? original.subscribeOn(executor(fallback)) : original;
+    }
+
+    @Override
+    public <T> Publisher<T> offloadReceive(final Executor fallback, final Publisher<T> original) {
+        return offloaded(OFFLOAD_SEND) ? original.publishOn(executor(fallback)) : original;
+    }
+
+    @Override
+    public Publisher<RedisData> offloadClient(final Executor fallback, RedisRequest request,
+                                              final Function<RedisRequest, Publisher<RedisData>> client) {
+        Executor e = this.executor == null ? fallback : this.executor;
+        request = offloaded(OFFLOAD_SEND) ? request.transformContent(c -> c.subscribeOn(e)) : request;
+        return offloaded(OFFLOAD_RECEIVE) ? client.apply(request).publishOn(e) : client.apply(request);
+    }
+
+    private Executor executor(final Executor fallback) {
+        return executor == null ? fallback : executor;
+    }
+
+    private boolean offloaded(byte flag) {
+        return (offloads & flag) == flag;
+    }
+}

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/LoadBalancerReadyRedisClient.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/LoadBalancerReadyRedisClient.java
@@ -59,13 +59,14 @@ public final class LoadBalancerReadyRedisClient extends RedisClient {
     }
 
     @Override
-    public Single<? extends ReservedRedisConnection> reserveConnection(Command command) {
-        return next.reserveConnection(command).retryWhen(retryWhenFunction());
+    public Single<? extends ReservedRedisConnection> reserveConnection(RedisExecutionStrategy strategy,
+                                                                       Command command) {
+        return next.reserveConnection(strategy, command).retryWhen(retryWhenFunction());
     }
 
     @Override
-    public Publisher<RedisData> request(final RedisRequest request) {
-        return next.request(request).retryWhen(retryWhenFunction());
+    public Publisher<RedisData> request(final RedisExecutionStrategy strategy, final RedisRequest request) {
+        return next.request(strategy, request).retryWhen(retryWhenFunction());
     }
 
     @Override

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisClient.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisClient.java
@@ -35,7 +35,23 @@ public abstract class RedisClient extends RedisRequester {
      * request/response based commands.
      * @return a {@link ReservedRedisConnection}.
      */
-    public abstract Single<? extends ReservedRedisConnection> reserveConnection(Command command);
+    public Single<? extends ReservedRedisConnection> reserveConnection(Command command) {
+        return reserveConnection(executionStrategy(), command);
+    }
+
+    /**
+     * Reserve a {@link RedisConnection} for exclusive use. Caller is responsible for invoking
+     * {@link ReservedRedisConnection#releaseAsync()} after done using the return value.
+     *
+     * @param strategy {@link RedisExecutionStrategy} to use.
+     * @param command A command representing how the returned {@link ReservedRedisConnection} will be used. It is
+     * possible that this {@link RedisClient} will return different types of {@link ReservedRedisConnection} depending
+     * on usage. For example {@link Command#SUBSCRIBE} and {@link Command#MONITOR} may be treated differently than other
+     * request/response based commands.
+     * @return a {@link ReservedRedisConnection}.
+     */
+    public abstract Single<? extends ReservedRedisConnection> reserveConnection(RedisExecutionStrategy strategy,
+                                                                                Command command);
 
     /**
      * A {@link RedisConnection} that is reserved for exclusive use until {@link #releaseAsync() released}.

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisExecutionStrategies.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisExecutionStrategies.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.redis.api;
+
+import io.servicetalk.concurrent.api.Executor;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.redis.api.DefaultRedisExecutionStrategy.OFFLOAD_RECEIVE;
+import static io.servicetalk.redis.api.DefaultRedisExecutionStrategy.OFFLOAD_SEND;
+
+/**
+ * A factory to create different {@link RedisExecutionStrategy}.
+ */
+public final class RedisExecutionStrategies {
+
+    private RedisExecutionStrategies() {
+        // No instances.
+    }
+
+    /**
+     * The default {@link RedisExecutionStrategy}.
+     *
+     * @return Default {@link RedisExecutionStrategy}.
+     */
+    public static RedisExecutionStrategy defaultStrategy() {
+        return Builder.DEFAULT;
+    }
+
+    /**
+     * The default {@link RedisExecutionStrategy} using the passed {@link Executor}.
+     *
+     * @param executor {@link Executor} to use.
+     * @return Default {@link RedisExecutionStrategy}.
+     */
+    public static RedisExecutionStrategy defaultStrategy(Executor executor) {
+        return customStrategyBuilder().executor(executor).build();
+    }
+
+    /**
+     * A {@link RedisExecutionStrategy} that disables all offloads.
+     *
+     * @return {@link RedisExecutionStrategy} that disables all offloads.
+     */
+    public static RedisExecutionStrategy noOffloadsStrategy() {
+        return Builder.NO_OFFLOADS;
+    }
+
+    /**
+     * A {@link RedisExecutionStrategy} that disables all offloads.
+     *
+     * @return {@link RedisExecutionStrategy} that disables all offloads.
+     */
+    public static Builder customStrategyBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder to build an {@link RedisExecutionStrategy}.
+     */
+    public static final class Builder {
+
+        static final RedisExecutionStrategy DEFAULT = new Builder().offloadAll().build();
+        static final RedisExecutionStrategy NO_OFFLOADS = new Builder().noOffload().build();
+
+        @Nullable
+        private Executor executor;
+        // offload everything by default
+        private byte offloads = OFFLOAD_RECEIVE | OFFLOAD_SEND;
+
+        private Builder() {
+        }
+
+        /**
+         * Enables offloading for receiving.
+         *
+         * @return {@code this}.
+         */
+        public Builder offloadReceive() {
+            return updateOffload(OFFLOAD_RECEIVE);
+        }
+
+        /**
+         * Enables offloading for sending.
+         *
+         * @return {@code this}.
+         */
+        public Builder offloadSend() {
+            return updateOffload(OFFLOAD_SEND);
+        }
+
+        /**
+         * Enable all offloads.
+         *
+         * @return {@code this}.
+         */
+        public Builder offloadAll() {
+            return offloadReceive().offloadSend();
+        }
+
+        /**
+         * Disable all offloads.
+         *
+         * @return {@code this}.
+         */
+        public Builder noOffload() {
+            offloads = 0;
+            return this;
+        }
+
+        /**
+         * Specify an {@link Executor} to use.
+         *
+         * @param executor {@link Executor} to use.
+         * @return {@code this}.
+         */
+        public Builder executor(Executor executor) {
+            this.executor = executor;
+            return this;
+        }
+
+        /**
+         * Builds a new {@link RedisExecutionStrategy}.
+         *
+         * @return New {@link RedisExecutionStrategy}.
+         */
+        public RedisExecutionStrategy build() {
+            return new DefaultRedisExecutionStrategy(executor, offloads);
+        }
+
+        @Nonnull
+        private Builder updateOffload(byte flag) {
+            offloads |= flag;
+            return this;
+        }
+    }
+}

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisExecutionStrategy.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisExecutionStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.redis.api;
+
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.transport.api.ExecutionStrategy;
+
+import java.util.function.Function;
+
+/**
+ * An {@link ExecutionStrategy} for redis.
+ */
+public interface RedisExecutionStrategy extends ExecutionStrategy {
+
+    /**
+     * Invokes the passed {@link Function} and applies the necessary offloading of request and response for a client.
+     *
+     * @param fallback {@link Executor} to use as a fallback if this {@link RedisExecutionStrategy} does not define an
+     * {@link Executor}.
+     * @param request {@link RedisRequest} for which the offloading is to be applied.
+     * @param client A {@link Function} that given a {@link RedisRequest} returns a {@link Publisher} of
+     * {@link RedisData}.
+     * @return {@link Publisher} which is offloaded as required.
+     */
+    Publisher<RedisData> offloadClient(Executor fallback, RedisRequest request,
+                                       Function<RedisRequest, Publisher<RedisData>> client);
+}

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisRequesterUtils.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisRequesterUtils.java
@@ -55,17 +55,20 @@ final class RedisRequesterUtils {
     }
 
     static final class ToStringSingle<R> extends Single<R> {
+        private final RedisExecutionStrategy strategy;
         private final RedisRequester requester;
         private final RedisRequest request;
 
-        ToStringSingle(final RedisRequester requester, final RedisRequest request) {
+        ToStringSingle(final RedisExecutionStrategy strategy, final RedisRequester requester,
+                       final RedisRequest request) {
+            this.strategy = strategy;
             this.requester = requester;
             this.request = request;
         }
 
         @Override
         protected void handleSubscribe(final Subscriber<? super R> subscriber) {
-            requester.request(request).subscribe(new AggregatingSubscriber<R>(subscriber) {
+            requester.request(strategy, request).subscribe(new AggregatingSubscriber<R>(subscriber) {
                 @Nullable
                 private CharSequence lastMessage;
                 @Nullable
@@ -137,17 +140,20 @@ final class RedisRequesterUtils {
     }
 
     static final class ToBufferSingle<R> extends Single<R> {
+        private final RedisExecutionStrategy strategy;
         private final RedisRequester requester;
         private final RedisRequest request;
 
-        ToBufferSingle(final RedisRequester requester, final RedisRequest request) {
+        ToBufferSingle(final RedisExecutionStrategy strategy, final RedisRequester requester,
+                       final RedisRequest request) {
+            this.strategy = strategy;
             this.requester = requester;
             this.request = request;
         }
 
         @Override
         protected void handleSubscribe(final Subscriber<? super R> subscriber) {
-            requester.request(request).subscribe(new AggregatingSubscriber<R>(subscriber) {
+            requester.request(strategy, request).subscribe(new AggregatingSubscriber<R>(subscriber) {
                 @Nullable
                 private Buffer aggregator;
                 @Nullable
@@ -214,17 +220,20 @@ final class RedisRequesterUtils {
     }
 
     static final class ToLongSingle<R> extends Single<R> {
+        private final RedisExecutionStrategy strategy;
         private final RedisRequester requester;
         private final RedisRequest request;
 
-        ToLongSingle(final RedisRequester requester, final RedisRequest request) {
+        ToLongSingle(final RedisExecutionStrategy strategy, final RedisRequester requester,
+                     final RedisRequest request) {
+            this.strategy = strategy;
             this.requester = requester;
             this.request = request;
         }
 
         @Override
         protected void handleSubscribe(final Subscriber<? super R> subscriber) {
-            requester.request(request).subscribe(new AggregatingSubscriber<R>(subscriber) {
+            requester.request(strategy, request).subscribe(new AggregatingSubscriber<R>(subscriber) {
                 @Nullable
                 private Long answer;
                 @Nullable
@@ -269,11 +278,14 @@ final class RedisRequesterUtils {
     }
 
     static final class ToListSingle<R> extends Single<R> {
+        private final RedisExecutionStrategy strategy;
         private final boolean coerceBuffersToCharSequences;
         private final RedisRequester requester;
         private final RedisRequest request;
 
-        ToListSingle(final RedisRequester requester, final RedisRequest request, final boolean coerceBuffersToCharSequences) {
+        ToListSingle(final RedisExecutionStrategy strategy, final RedisRequester requester, final RedisRequest request,
+                     final boolean coerceBuffersToCharSequences) {
+            this.strategy = strategy;
             this.coerceBuffersToCharSequences = coerceBuffersToCharSequences;
             this.requester = requester;
             this.request = request;
@@ -281,7 +293,7 @@ final class RedisRequesterUtils {
 
         @Override
         protected void handleSubscribe(final Subscriber<? super R> subscriber) {
-            requester.request(request).subscribe(new AggregatingSubscriber<R>(subscriber) {
+            requester.request(strategy, request).subscribe(new AggregatingSubscriber<R>(subscriber) {
                 @Nullable
                 private RedisServerException redisError;
                 @Nullable

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/StandAloneReservedRedisConnection.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/StandAloneReservedRedisConnection.java
@@ -61,8 +61,8 @@ final class StandAloneReservedRedisConnection extends RedisClient.ReservedRedisC
     }
 
     @Override
-    public Publisher<RedisData> request(RedisRequest request) {
-        return delegate.request(request);
+    public Publisher<RedisData> request(RedisExecutionStrategy strategy, RedisRequest request) {
+        return delegate.request(strategy, request);
     }
 
     @Override

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/DefaultPartitionedRedisClientBuilder.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/DefaultPartitionedRedisClientBuilder.java
@@ -42,6 +42,7 @@ import io.servicetalk.redis.api.RedisClientFilterFactory;
 import io.servicetalk.redis.api.RedisConnection;
 import io.servicetalk.redis.api.RedisConnectionFilterFactory;
 import io.servicetalk.redis.api.RedisData;
+import io.servicetalk.redis.api.RedisExecutionStrategy;
 import io.servicetalk.redis.api.RedisPartitionAttributesBuilder;
 import io.servicetalk.redis.api.RedisProtocolSupport.Command;
 import io.servicetalk.redis.api.RedisRequest;
@@ -495,12 +496,13 @@ final class DefaultPartitionedRedisClientBuilder<U, R> implements PartitionedRed
         }
 
         @Override
-        public Single<? extends ReservedRedisConnection> reserveConnection(Command command) {
+        public Single<? extends ReservedRedisConnection> reserveConnection(RedisExecutionStrategy strategy,
+                                                                           Command command) {
             return Single.error(new IllegalStateException("Partition is closed."));
         }
 
         @Override
-        public Publisher<RedisData> request(RedisRequest request) {
+        public Publisher<RedisData> request(RedisExecutionStrategy strategy, RedisRequest request) {
             return error(new IllegalStateException("Partition is closed."));
         }
 

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/LoadBalancedRedisConnection.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/LoadBalancedRedisConnection.java
@@ -21,6 +21,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.redis.api.RedisClient.ReservedRedisConnection;
 import io.servicetalk.redis.api.RedisConnection;
 import io.servicetalk.redis.api.RedisData;
+import io.servicetalk.redis.api.RedisExecutionStrategy;
 import io.servicetalk.redis.api.RedisRequest;
 import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ExecutionContext;
@@ -44,8 +45,8 @@ final class LoadBalancedRedisConnection extends ReservedRedisConnection
     }
 
     @Override
-    public Publisher<RedisData> request(RedisRequest request) {
-        return delegate.request(request);
+    public Publisher<RedisData> request(RedisExecutionStrategy strategy, RedisRequest request) {
+        return delegate.request(strategy, request);
     }
 
     @Override

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/RedisIdleConnectionReaper.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/RedisIdleConnectionReaper.java
@@ -22,6 +22,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.internal.SequentialCancellable;
 import io.servicetalk.redis.api.RedisConnection;
 import io.servicetalk.redis.api.RedisData;
+import io.servicetalk.redis.api.RedisExecutionStrategy;
 import io.servicetalk.redis.api.RedisRequest;
 import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ExecutionContext;
@@ -155,8 +156,8 @@ final class RedisIdleConnectionReaper implements UnaryOperator<RedisConnection> 
         }
 
         @Override
-        public Publisher<RedisData> request(final RedisRequest request) {
-            return delegate.request(request)
+        public Publisher<RedisData> request(final RedisExecutionStrategy strategy, final RedisRequest request) {
+            return delegate.request(strategy, request)
                     .doBeforeSubscribe(__ -> onRequestStarted())
                     .doBeforeFinally(this::onRequestFinished);
         }
@@ -167,8 +168,9 @@ final class RedisIdleConnectionReaper implements UnaryOperator<RedisConnection> 
         }
 
         @Override
-        public <R> Single<R> request(final RedisRequest request, final Class<R> responseType) {
-            return delegate.request(request, responseType)
+        public <R> Single<R> request(final RedisExecutionStrategy strategy, final RedisRequest request,
+                                     final Class<R> responseType) {
+            return delegate.request(strategy, request, responseType)
                     .doBeforeSubscribe(__ -> onRequestStarted())
                     .doBeforeFinally(this::onRequestFinished);
         }

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/RedisSubscribedConcurrencyLimitingFilter.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/RedisSubscribedConcurrencyLimitingFilter.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.redis.api.RedisConnection;
 import io.servicetalk.redis.api.RedisData;
+import io.servicetalk.redis.api.RedisExecutionStrategy;
 import io.servicetalk.redis.api.RedisRequest;
 import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ExecutionContext;
@@ -51,8 +52,8 @@ final class RedisSubscribedConcurrencyLimitingFilter extends RedisConnection {
     }
 
     @Override
-    public Publisher<RedisData> request(RedisRequest request) {
-        return limiter.tryRequest() ? next.request(request) :
+    public Publisher<RedisData> request(RedisExecutionStrategy strategy, RedisRequest request) {
+        return limiter.tryRequest() ? next.request(strategy, request) :
                 Publisher.error(new IllegalStateException("Connection in invalid state for requests: " + this));
     }
 

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/LoadBalancedRedisConnectionTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/LoadBalancedRedisConnectionTest.java
@@ -45,7 +45,7 @@ public class LoadBalancedRedisConnectionTest {
         when(delegate.onClose()).thenReturn(never());
         when(delegate.closeAsync()).thenReturn(completed());
         when(delegate.settingStream(any(SettingKey.class))).thenReturn(maxRequestsPublisher);
-        when(delegate.request(any(RedisRequest.class))).thenReturn(just(PONG));
+        when(delegate.request(any(), any(RedisRequest.class))).thenReturn(just(PONG));
         LoadBalancedRedisConnection connection = new LoadBalancedRedisConnection(delegate,
                 ReservableRequestConcurrencyControllers.newController(just(1), never(), 1));
         assertTrue(connection.tryRequest());

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisClientTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisClientTest.java
@@ -30,6 +30,7 @@ import io.servicetalk.redis.api.RedisData.BulkStringSize;
 import io.servicetalk.redis.api.RedisData.CompleteBulkString;
 import io.servicetalk.redis.api.RedisData.LastBulkStringChunk;
 import io.servicetalk.redis.api.RedisData.RequestRedisData;
+import io.servicetalk.redis.api.RedisExecutionStrategy;
 import io.servicetalk.redis.api.RedisProtocolSupport.Command;
 import io.servicetalk.redis.api.RedisRequest;
 import io.servicetalk.redis.api.RedisServerException;
@@ -242,14 +243,15 @@ public class RedisClientTest extends BaseRedisClientTest {
         final AtomicBoolean closeCalled = new AtomicBoolean();
         RedisClient filteredClient = new RedisClient() {
             @Override
-            public Single<? extends ReservedRedisConnection> reserveConnection(Command command) {
-                return delegate.reserveConnection(command);
+            public Single<? extends ReservedRedisConnection> reserveConnection(RedisExecutionStrategy strategy,
+                                                                               Command command) {
+                return delegate.reserveConnection(strategy, command);
             }
 
             @Override
-            public Publisher<RedisData> request(RedisRequest request) {
+            public Publisher<RedisData> request(final RedisExecutionStrategy strategy, final RedisRequest request) {
                 requestCalled.set(true);
-                return delegate.request(request);
+                return delegate.request(strategy, request);
             }
 
             @Override

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisConnectionTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisConnectionTest.java
@@ -25,6 +25,7 @@ import io.servicetalk.redis.api.RedisConnection;
 import io.servicetalk.redis.api.RedisData;
 import io.servicetalk.redis.api.RedisData.ArraySize;
 import io.servicetalk.redis.api.RedisData.CompleteBulkString;
+import io.servicetalk.redis.api.RedisExecutionStrategy;
 import io.servicetalk.redis.api.RedisRequest;
 import io.servicetalk.redis.api.RedisServerException;
 import io.servicetalk.transport.api.ConnectionContext;
@@ -335,9 +336,9 @@ public class RedisConnectionTest extends BaseRedisClientTest {
         }
 
         @Override
-        public Publisher<RedisData> request(RedisRequest request) {
+        public Publisher<RedisData> request(RedisExecutionStrategy strategy, RedisRequest request) {
             requestCalled.set(true);
-            return delegate.request(request);
+            return delegate.request(strategy, request);
         }
 
         @Override

--- a/servicetalk-redis-utils/src/main/java/io/servicetalk/redis/utils/DelegatingRedisClient.java
+++ b/servicetalk-redis-utils/src/main/java/io/servicetalk/redis/utils/DelegatingRedisClient.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.redis.api.RedisClient;
 import io.servicetalk.redis.api.RedisData;
+import io.servicetalk.redis.api.RedisExecutionStrategy;
 import io.servicetalk.redis.api.RedisProtocolSupport.Command;
 import io.servicetalk.redis.api.RedisRequest;
 import io.servicetalk.transport.api.ExecutionContext;
@@ -43,8 +44,9 @@ public abstract class DelegatingRedisClient extends RedisClient {
     }
 
     @Override
-    public Single<? extends ReservedRedisConnection> reserveConnection(Command command) {
-        return wrapped.reserveConnection(command);
+    public Single<? extends ReservedRedisConnection> reserveConnection(RedisExecutionStrategy strategy,
+                                                                       Command command) {
+        return wrapped.reserveConnection(strategy, command);
     }
 
     @Override
@@ -53,13 +55,14 @@ public abstract class DelegatingRedisClient extends RedisClient {
     }
 
     @Override
-    public Publisher<RedisData> request(final RedisRequest request) {
-        return wrapped.request(request);
+    public Publisher<RedisData> request(final RedisExecutionStrategy strategy, final RedisRequest request) {
+        return wrapped.request(strategy, request);
     }
 
     @Override
-    public <R> Single<R> request(final RedisRequest request, final Class<R> responseType) {
-        return wrapped.request(request, responseType);
+    public <R> Single<R> request(final RedisExecutionStrategy strategy, final RedisRequest request,
+                                 final Class<R> responseType) {
+        return wrapped.request(strategy, request, responseType);
     }
 
     @Override

--- a/servicetalk-redis-utils/src/main/java/io/servicetalk/redis/utils/RetryingRedisClient.java
+++ b/servicetalk-redis-utils/src/main/java/io/servicetalk/redis/utils/RetryingRedisClient.java
@@ -24,6 +24,7 @@ import io.servicetalk.concurrent.api.RetryStrategies;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.redis.api.RedisClient;
 import io.servicetalk.redis.api.RedisData;
+import io.servicetalk.redis.api.RedisExecutionStrategy;
 import io.servicetalk.redis.api.RedisProtocolSupport.Command;
 import io.servicetalk.redis.api.RedisRequest;
 
@@ -58,27 +59,29 @@ public final class RetryingRedisClient extends DelegatingRedisClient {
     }
 
     @Override
-    public Publisher<RedisData> request(final RedisRequest request) {
+    public Publisher<RedisData> request(final RedisExecutionStrategy executionStrategy, final RedisRequest request) {
         if (!isRetryable.test(request.command())) {
-            return super.request(request);
+            return super.request(executionStrategy, request);
         }
-        return super.request(request).retryWhen(strategy);
+        return super.request(executionStrategy, request).retryWhen(strategy);
     }
 
     @Override
-    public <R> Single<R> request(final RedisRequest request, final Class<R> responseType) {
+    public <R> Single<R> request(final RedisExecutionStrategy executionStrategy, final RedisRequest request,
+                                 final Class<R> responseType) {
         if (!isRetryable.test(request.command())) {
-            return super.request(request, responseType);
+            return super.request(executionStrategy, request, responseType);
         }
-        return super.request(request, responseType).retryWhen(strategy);
+        return super.request(executionStrategy, request, responseType).retryWhen(strategy);
     }
 
     @Override
-    public Single<? extends ReservedRedisConnection> reserveConnection(Command command) {
+    public Single<? extends ReservedRedisConnection> reserveConnection(RedisExecutionStrategy executionStrategy,
+                                                                       Command command) {
         if (!isRetryable.test(command)) {
-            return super.reserveConnection(command);
+            return super.reserveConnection(executionStrategy, command);
         }
-        return super.reserveConnection(command).retryWhen(strategy);
+        return super.reserveConnection(executionStrategy, command).retryWhen(strategy);
     }
 
     /**

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionStrategy.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionStrategy.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.api;
+
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+
+import javax.annotation.Nullable;
+
+/**
+ * An execution strategy for all transports.
+ */
+public interface ExecutionStrategy {
+
+    /**
+     * Offloads the {@code original} {@link Single} for sending data on the transport.
+     *
+     * @param fallback {@link Executor} to use as a fallback if this {@link ExecutionStrategy} does not define an
+     * {@link Executor}.
+     * @param original {@link Single} to offload.
+     * @param <T> Type of result of the {@code original} {@link Single}.
+     * @return Offloaded {@link Single}.
+     */
+    <T> Single<T> offloadSend(Executor fallback, Single<T> original);
+
+    /**
+     * Offloads the {@code original} {@link Single} for receiving data from the transport.
+     *
+     * @param fallback {@link Executor} to use as a fallback if this {@link ExecutionStrategy} does not define an
+     * {@link Executor}.
+     * @param original {@link Single} to offload.
+     * @param <T> Type of result of the {@code original} {@link Single}.
+     * @return Offloaded {@link Single}.
+     */
+    <T> Single<T> offloadReceive(Executor fallback, Single<T> original);
+
+    /**
+     * Offloads the {@code original} {@link Publisher} for sending data on the transport.
+     *
+     * @param fallback {@link Executor} to use as a fallback if this {@link ExecutionStrategy} does not define an
+     * {@link Executor}.
+     * @param original {@link Publisher} to offload.
+     * @param <T> Type of items emitted from the {@code original} {@link Publisher}.
+     * @return Offloaded {@link Publisher}.
+     */
+    <T> Publisher<T> offloadSend(Executor fallback, Publisher<T> original);
+
+    /**
+     * Offloads the {@code original} {@link Publisher} for receiving data from the transport.
+     *
+     * @param fallback {@link Executor} to use as a fallback if this {@link ExecutionStrategy} does not define an
+     * {@link Executor}.
+     * @param original {@link Publisher} to offload.
+     * @param <T> Type of items emitted from the {@code original} {@link Publisher}.
+     * @return Offloaded {@link Publisher}.
+     */
+    <T> Publisher<T> offloadReceive(Executor fallback, Publisher<T> original);
+
+    /**
+     * Returns the {@link Executor}, if any for this {@link ExecutionStrategy}.
+     *
+     * @return {@link Executor} for this {@link ExecutionStrategy}. {@code null} if none specified.
+     */
+    @Nullable
+    Executor executor();
+}


### PR DESCRIPTION
__Motivation__

Today there is only one way to influence offloading done by client/server by specifying or omitting an `Executor` for that client/server.
This works well for homogeneous clients/server where there is just one execution model: either offload or not. However, in reality client/servers may need offloading for some execution paths but others can be asynchronous.
We should offer a way to override the offloading strategy per request/route, for which we should do the following:

- One should be able to specify the offloading strategy while making request to a client.
- One should be able to specify a different offloading strategy per route on a server. Since, we need the strategy to even call the `Service`, this strategy should be provided before we call the `Service`.
- Our predicate router should be able to handle different routes with different offloading strategies.

__Modification__

Introduce the concept of `ExecutionStrategy` in place of `Executor` which can be specified at the following places:

- While making requests to the clients.
- By implementing a method `executionStrategy()` on a service.

`ExecutionStrategy` influences the following aspects of offloading:

- Which `Executor` should be used for offloading.
- Whether sending of data (request for client, response for server) should be offloaded.
- Whether receiving of data (response for client, request for server) should be offloaded.
- Whether calling the service should be offloaded.
- For HTTP: Whether invoking the `Single` returned by the client should be offloaded.

Static factories are provided per protocol to get a suitable strategy for use.

__Result__

Flexibility of offloading per request.