### PR TITLE
Further reducing scope of uncaught exceptions in sources

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -22,6 +22,8 @@ import io.servicetalk.concurrent.internal.SignalOffloader;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -66,6 +68,8 @@ import static java.util.Objects.requireNonNull;
  * @see org.reactivestreams.Publisher
  */
 public abstract class Publisher<T> implements org.reactivestreams.Publisher<T> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Publisher.class);
+
     private final Executor executor;
 
     static {
@@ -2223,7 +2227,7 @@ public abstract class Publisher<T> implements org.reactivestreams.Publisher<T> {
      * @param signalOffloader {@link SignalOffloader} to use for this {@link Subscriber}.
      */
     final void subscribe(Subscriber<? super T> subscriber, SignalOffloader signalOffloader) {
-        getPublisherPlugin().handleSubscribe(requireNonNull(subscriber), signalOffloader, this::safeHandleSubscribe);
+        getPublisherPlugin().handleSubscribe(requireNonNull(subscriber), signalOffloader, this::handleSubscribe);
     }
 
     /**
@@ -2240,13 +2244,24 @@ public abstract class Publisher<T> implements org.reactivestreams.Publisher<T> {
      */
     void handleSubscribe(Subscriber<? super T> subscriber, SignalOffloader signalOffloader) {
         Subscriber<? super T> offloaded = signalOffloader.offloadSubscriber(subscriber);
-        signalOffloader.offloadSubscribe(offloaded, this::handleSubscribe);
+        signalOffloader.offloadSubscribe(offloaded, this::safeHandleSubscribe);
     }
 
-    private void safeHandleSubscribe(Subscriber<? super T> subscriber, SignalOffloader signalOffloader) {
+    private void safeHandleSubscribe(Subscriber<? super T> subscriber) {
         try {
-            handleSubscribe(subscriber, signalOffloader);
+            handleSubscribe(subscriber);
         } catch (Throwable t) {
+            LOGGER.warn("Unexpected exception from subscribe(), assuming no interaction with the Subscriber.", t);
+            // At this point we are unsure if any signal was sent to the Subscriber and if it is safe to invoke the
+            // Subscriber without violating specifications. However, not propagating the error to the Subscriber will
+            // result in hard to debug scenarios where no further signals may be sent to the Subscriber and hence it
+            // will be hard to distinguish between a "hung" source and a wrongly implemented source that violates the
+            // specifications and throw from subscribe() (Rule 1.9).
+            //
+            // By doing the following we may violate the rules:
+            // 1) Rule 2.12: onSubscribe() MUST be called at most once.
+            // 2) Rule 1.7: Once a terminal state has been signaled (onError, onComplete) it is REQUIRED that no
+            // further signals occur.
             subscriber.onSubscribe(EMPTY_SUBSCRIPTION);
             subscriber.onError(t);
         }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -18,6 +18,9 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.internal.SignalOffloader;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
@@ -48,6 +51,8 @@ import static java.util.Objects.requireNonNull;
  * @param <T> Type of the result of the single.
  */
 public abstract class Single<T> implements io.servicetalk.concurrent.Single<T> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Single.class);
+
     private final Executor executor;
 
     static {
@@ -1159,7 +1164,7 @@ public abstract class Single<T> implements io.servicetalk.concurrent.Single<T> {
      * @param signalOffloader {@link SignalOffloader} to use for this {@link Subscriber}.
      */
     final void subscribe(Subscriber<? super T> subscriber, SignalOffloader signalOffloader) {
-        getSinglePlugin().handleSubscribe(requireNonNull(subscriber), signalOffloader, this::safeHandleSubscribe);
+        getSinglePlugin().handleSubscribe(requireNonNull(subscriber), signalOffloader, this::handleSubscribe);
     }
 
     /**
@@ -1177,13 +1182,24 @@ public abstract class Single<T> implements io.servicetalk.concurrent.Single<T> {
      */
     void handleSubscribe(Subscriber<? super T> subscriber, SignalOffloader signalOffloader) {
         Subscriber<? super T> offloaded = signalOffloader.offloadSubscriber(subscriber);
-        signalOffloader.offloadSubscribe(offloaded, this::handleSubscribe);
+        signalOffloader.offloadSubscribe(offloaded, this::safeHandleSubscribe);
     }
 
-    private void safeHandleSubscribe(Subscriber<? super T> subscriber, SignalOffloader signalOffloader) {
+    private void safeHandleSubscribe(Subscriber<? super T> subscriber) {
         try {
-            handleSubscribe(subscriber, signalOffloader);
+            handleSubscribe(subscriber);
         } catch (Throwable t) {
+            LOGGER.warn("Unexpected exception from subscribe(), assuming no interaction with the Subscriber.", t);
+            // At this point we are unsure if any signal was sent to the Subscriber and if it is safe to invoke the
+            // Subscriber without violating specifications. However, not propagating the error to the Subscriber will
+            // result in hard to debug scenarios where no further signals may be sent to the Subscriber and hence it
+            // will be hard to distinguish between a "hung" source and a wrongly implemented source that violates the
+            // specifications and throw from subscribe() (Rule 1.9).
+            //
+            // By doing the following we may violate the rules:
+            // 1) Rule 2.12: onSubscribe() MUST be called at most once.
+            // 2) Rule 1.7: Once a terminal state has been signaled (onError, onComplete) it is REQUIRED that no
+            // further signals occur.
             subscriber.onSubscribe(IGNORE_CANCEL);
             subscriber.onError(t);
         }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/DefaultSignalOffloaderSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/DefaultSignalOffloaderSingleTest.java
@@ -30,6 +30,7 @@ import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
@@ -39,6 +40,7 @@ import static io.servicetalk.concurrent.internal.NoopRunnable.NOOP_RUNNABLE;
 import static io.servicetalk.concurrent.internal.ThrowingRunnable.THROWING_RUNNABLE;
 import static java.lang.Thread.currentThread;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -153,6 +155,20 @@ public class DefaultSignalOffloaderSingleTest {
         state.awaitTermination();
         expected.expect(IllegalStateException.class);
         state.offloader.offloadSubscriber(state.subscriber);
+    }
+
+    @Test
+    public void executorRejectsForHandleSubscribe() {
+        DefaultSignalOffloader offloader = new DefaultSignalOffloader(task -> {
+            throw new RejectedExecutionException();
+        });
+        offloader.offloadSubscribe(state.subscriber, __ -> {
+        });
+        verify(state.subscriber).onSubscribe(any(Cancellable.class));
+        ArgumentCaptor<Throwable> errorCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(state.subscriber).onError(errorCaptor.capture());
+        assertThat("Unexpected error received by the subscriber.", errorCaptor.getValue(),
+                instanceOf(RejectedExecutionException.class));
     }
 
     private static final class OffloaderRule extends ExternalResource {


### PR DESCRIPTION
__Motivation__

All asynchronous sources currently have a rather coarse catch-all block to protect against:

- `handleSubscribe` offloading fails
- Sources implement `handleSubscribe` and throws.

We can assume that offloader will not throw and instead correctly signal the `Subscriber`.
This will further reduce the scope and if an exception is thrown there, it will never be expected.

__Modification__

- `DefaultSignalOffloader` now signals error to the `Subscriber` when it is sure that the `Subscriber` has not been signalled.
- Reduce scope of catch-all just to the call to the abstract `handleSubscribe`

__Result__

Reduced catch-all which most definetly signifies a badly written source (throwing from `subscribe()`)