### PR TITLE
Update to log4j 2.11.1

### DIFF
--- a/servicetalk-bom-internal/gradle.properties
+++ b/servicetalk-bom-internal/gradle.properties
@@ -20,7 +20,7 @@ version=0.9.0-SNAPSHOT
 nettyVersion=4.1.31.Final
 jsr305Version=3.0.2
 
-log4jVersion=2.11.0
+log4jVersion=2.11.1
 slf4jVersion=1.7.25
 
 junitVersion=4.12


### PR DESCRIPTION
## Motivation

We've faced issues with ST and Log4j async logging that are solved in `2.11.1` [1]

[1] http://logging.apache.org/log4j/2.x/changes-report.html#a2.11.1