### PR TITLE
Stop asserting no response in CancellationTest#testCancelResponseSingle (fixes #108)

### DIFF
--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/CancellationTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/CancellationTest.java
@@ -201,7 +201,7 @@ public class CancellationTest {
 
         jerseyRouter.handle(ctx, req, HTTP_REQ_RES_FACTORY)
                 .doBeforeError(errorRef::set)
-                .doBeforeCancel(cancelledLatch::countDown)
+                .doAfterCancel(cancelledLatch::countDown)
                 .ignoreResult().subscribe().cancel();
 
         cancelledLatch.await();


### PR DESCRIPTION
__Motivation__

Fix flakiness of `CancellationTest#testCancelResponseSingle`, as reported in: https://github.com/servicetalk/servicetalk/issues/108

__Modification__

Do not assert that no response was delivered in case of cancellation, as one may have been delivered.

__Result__

`CancellationTest#testCancelResponseSingle` passes reliably.