### PR TITLE
Completable#andThen renamed to Completable#concatWith

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -292,8 +292,8 @@ public abstract class Completable implements io.servicetalk.concurrent.Completab
      * @return A {@link Completable} that emits the terminal signal of {@code next} {@link Completable}, after this
      * {@link Completable} has terminated successfully.
      */
-    public final Completable andThen(Completable next) {
-        return new CompletableAndThenCompletable(this, next, executor);
+    public final Completable concatWith(Completable next) {
+        return new CompletableConcatWithCompletable(this, next, executor);
     }
 
     /**
@@ -314,8 +314,8 @@ public abstract class Completable implements io.servicetalk.concurrent.Completab
      * @return A {@link Single} that emits the result of {@code next} {@link Single}, after this {@link Completable}
      * has terminated successfully.
      */
-    public final <T> Single<T> andThen(Single<? extends T> next) {
-        return new CompletableAndThenSingle<>(this, next, executor);
+    public final <T> Single<T> concatWith(Single<? extends T> next) {
+        return new CompletableConcatWithSingle<>(this, next, executor);
     }
 
     /**
@@ -337,7 +337,7 @@ public abstract class Completable implements io.servicetalk.concurrent.Completab
      * @return A {@link Publisher} that emits all items emitted from {@code next} {@link Publisher}, after this
      * {@link Completable} has terminated successfully.
      */
-    public final <T> Publisher<T> andThen(Publisher<? extends T> next) {
+    public final <T> Publisher<T> concatWith(Publisher<? extends T> next) {
         return toSingle().flatMapPublisher(aVoid -> next);
     }
 
@@ -1045,7 +1045,7 @@ public abstract class Completable implements io.servicetalk.concurrent.Completab
      * <p>
      * No {@link org.reactivestreams.Subscriber#onNext(Object)} signals will be delivered to the returned
      * {@link Publisher}. Only terminal signals will be delivered. If you need more control you should consider using
-     * {@link #andThen(Publisher)}.
+     * {@link #concatWith(Publisher)}.
      * @param <T> The value type of the resulting {@link Publisher}.
      * @return A {@link Publisher} that mirrors the terminal signal from this {@link Completable}.
      */
@@ -1057,7 +1057,7 @@ public abstract class Completable implements io.servicetalk.concurrent.Completab
      * Converts this {@code Completable} to a {@link Single}.
      * <p>
      * The return value's {@link Single.Subscriber#onSuccess(Object)} value is undefined. If you need a specific value
-     * you can also use {@link #andThen(Single)} with a {@link Single#success(Object)}.
+     * you can also use {@link #concatWith(Single)} with a {@link Single#success(Object)}.
      * @param <T> The value type of the resulting {@link Single}.
      * @return A {@link Single} that mirrors the terminal signal from this {@link Completable}.
      */

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableConcatWithCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableConcatWithCompletable.java
@@ -25,13 +25,13 @@ import javax.annotation.Nullable;
 import static java.util.Objects.requireNonNull;
 
 /**
- * As returned by {@link Completable#andThen(Completable)}.
+ * As returned by {@link Completable#concatWith(Completable)}.
  */
-final class CompletableAndThenCompletable extends AbstractNoHandleSubscribeCompletable {
+final class CompletableConcatWithCompletable extends AbstractNoHandleSubscribeCompletable {
     private final Completable original;
     private final Completable next;
 
-    CompletableAndThenCompletable(Completable original, Completable next, Executor executor) {
+    CompletableConcatWithCompletable(Completable original, Completable next, Executor executor) {
         super(executor);
         this.original = original;
         this.next = requireNonNull(next);
@@ -56,12 +56,12 @@ final class CompletableAndThenCompletable extends AbstractNoHandleSubscribeCompl
         // Cancellable of the original Completable. So, we do not need to do anything special there.
         // In order to cover for this case ((2) above) we always offload the passed Subscriber here.
         Subscriber offloadSubscriber = offloader.offloadSubscriber(subscriber);
-        original.subscribe(new AndThenSubscriber(offloadSubscriber, next), offloader);
+        original.subscribe(new ConcatWithSubscriber(offloadSubscriber, next), offloader);
     }
 
-    private static final class AndThenSubscriber implements Subscriber {
-        private static final AtomicIntegerFieldUpdater<AndThenSubscriber> subscribedToNextUpdater =
-                AtomicIntegerFieldUpdater.newUpdater(AndThenSubscriber.class, "subscribedToNext");
+    private static final class ConcatWithSubscriber implements Subscriber {
+        private static final AtomicIntegerFieldUpdater<ConcatWithSubscriber> subscribedToNextUpdater =
+                AtomicIntegerFieldUpdater.newUpdater(ConcatWithSubscriber.class, "subscribedToNext");
         private final Subscriber target;
         private final Completable next;
         @Nullable
@@ -69,7 +69,7 @@ final class CompletableAndThenCompletable extends AbstractNoHandleSubscribeCompl
         @SuppressWarnings("unused")
         private volatile int subscribedToNext;
 
-        AndThenSubscriber(Subscriber target, Completable next) {
+        ConcatWithSubscriber(Subscriber target, Completable next) {
             this.target = target;
             this.next = next;
         }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableConcatWithSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableConcatWithSingle.java
@@ -24,15 +24,15 @@ import javax.annotation.Nullable;
 import static java.util.Objects.requireNonNull;
 
 /**
- * As returned by {@link Completable#andThen(Single)}.
+ * As returned by {@link Completable#concatWith(Single)}.
  *
  * @param <T> Type of result of this {@link Single}.
  */
-final class CompletableAndThenSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
+final class CompletableConcatWithSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
     private final Completable original;
     private final Single<? extends T> next;
 
-    CompletableAndThenSingle(Completable original, Single<? extends T> next, Executor executor) {
+    CompletableConcatWithSingle(Completable original, Single<? extends T> next, Executor executor) {
         super(executor);
         this.original = requireNonNull(original);
         this.next = requireNonNull(next);
@@ -58,16 +58,16 @@ final class CompletableAndThenSingle<T> extends AbstractNoHandleSubscribeSingle<
         // of the original Completable. So, we do not need to do anything special there.
         // In order to cover for this case ((2) above) we always offload the passed Subscriber here.
         Subscriber<? super T> offloadSubscriber = offloader.offloadSubscriber(subscriber);
-        original.subscribe(new AndThenSubscriber<>(offloadSubscriber, next), offloader);
+        original.subscribe(new ConcatWithSubscriber<>(offloadSubscriber, next), offloader);
     }
 
-    private static final class AndThenSubscriber<T> implements Subscriber<T>, Completable.Subscriber {
+    private static final class ConcatWithSubscriber<T> implements Subscriber<T>, Completable.Subscriber {
         private final Subscriber<? super T> target;
         private final Single<? extends T> next;
         @Nullable
         private volatile SequentialCancellable sequentialCancellable;
 
-        AndThenSubscriber(Subscriber<? super T> target, Single<? extends T> next) {
+        ConcatWithSubscriber(Subscriber<? super T> target, Single<? extends T> next) {
             this.target = target;
             this.next = next;
         }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultCompositeCloseable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultCompositeCloseable.java
@@ -124,12 +124,12 @@ final class DefaultCompositeCloseable implements CompositeCloseable {
     }
 
     private void concatCloseableDelayError(final AsyncCloseable closeable) {
-        closeAsync = closeAsync.andThen(closeable.closeAsync().onErrorResume(th -> {
+        closeAsync = closeAsync.concatWith(closeable.closeAsync().onErrorResume(th -> {
             //TODO: This should use concatDelayError when available.
             LOGGER.debug("Ignored failure to close {}.", closeable, th);
             return completed();
         }));
-        closeAsyncGracefully = closeAsyncGracefully.andThen(closeable.closeAsyncGracefully().onErrorResume(th -> {
+        closeAsyncGracefully = closeAsyncGracefully.concatWith(closeable.closeAsyncGracefully().onErrorResume(th -> {
             //TODO: This should use concatDelayError when available.
             LOGGER.debug("Ignored failure to close {}.", closeable, th);
             return completed();
@@ -141,11 +141,11 @@ final class DefaultCompositeCloseable implements CompositeCloseable {
             //TODO: This should use prependDelayError when available.
             LOGGER.debug("Ignored failure to close {}.", closeable, th);
             return completed();
-        }).andThen(closeAsync);
+        }).concatWith(closeAsync);
         closeAsyncGracefully = closeable.closeAsync().onErrorResume(th -> {
             //TODO: This should use prependDelayError when available.
             LOGGER.debug("Ignored failure to close {}.", closeable, th);
             return completed();
-        }).andThen(closeAsyncGracefully);
+        }).concatWith(closeAsyncGracefully);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -695,7 +695,7 @@ public abstract class Publisher<T> implements org.reactivestreams.Publisher<T> {
     public final Publisher<T> concatWith(Completable next) {
         // We can not use next.toPublisher() here as that returns Publisher<Void> which can not be concatenated with
         // Publisher<T>
-        return new ConcatPublisher<>(this, next.andThen(empty()), executor);
+        return new ConcatPublisher<>(this, next.concatWith(empty()), executor);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -397,7 +397,7 @@ public abstract class Single<T> implements io.servicetalk.concurrent.Single<T> {
      */
     public final Single<T> concatWith(Completable next) {
         // We cannot use next.toPublisher() as that returns Publisher<Void> which can not be concatenated with Single<T>
-        return concatWith(next.andThen(empty())).first();
+        return concatWith(next.concatWith(empty())).first();
     }
 
     /**

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/tck/CompletableConcatWithCompletableTckTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/tck/CompletableConcatWithCompletableTckTest.java
@@ -16,15 +16,14 @@
 package io.servicetalk.concurrent.api.tck;
 
 import io.servicetalk.concurrent.api.Completable;
-import io.servicetalk.concurrent.api.Single;
 
 import org.testng.annotations.Test;
 
 @Test
-public class CompletableAndThenSingleTckTest extends AbstractCompletableOperatorTckTest {
+public class CompletableConcatWithCompletableTckTest extends AbstractCompletableOperatorTckTest {
 
     @Override
     protected Completable composeCompletable(Completable completable) {
-        return completable.andThen(Single.success(1)).ignoreResult();
+        return completable.concatWith(Completable.completed());
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/tck/CompletableConcatWithPublisherTckTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/tck/CompletableConcatWithPublisherTckTest.java
@@ -17,13 +17,20 @@ package io.servicetalk.concurrent.api.tck;
 
 import io.servicetalk.concurrent.api.Completable;
 
+import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 @Test
-public class CompletableAndThenCompletableTckTest extends AbstractCompletableOperatorTckTest {
+public class CompletableConcatWithPublisherTckTest extends AbstractPublisherTckTest<Integer> {
 
     @Override
-    protected Completable composeCompletable(Completable completable) {
-        return completable.andThen(Completable.completed());
+    public Publisher<Integer> createPublisher(long elements) {
+        int numElements = TckUtils.requestNToInt(elements);
+        return Completable.completed().concatWith(TckUtils.newPublisher(numElements));
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return TckUtils.maxElementsFromPublisher();
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/tck/CompletableConcatWithSingleTckTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/tck/CompletableConcatWithSingleTckTest.java
@@ -16,21 +16,15 @@
 package io.servicetalk.concurrent.api.tck;
 
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Single;
 
-import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 @Test
-public class CompletableAndThenPublisherTckTest extends AbstractPublisherTckTest<Integer> {
+public class CompletableConcatWithSingleTckTest extends AbstractCompletableOperatorTckTest {
 
     @Override
-    public Publisher<Integer> createPublisher(long elements) {
-        int numElements = TckUtils.requestNToInt(elements);
-        return Completable.completed().andThen(TckUtils.newPublisher(numElements));
-    }
-
-    @Override
-    public long maxElementsFromPublisher() {
-        return TckUtils.maxElementsFromPublisher();
+    protected Completable composeCompletable(Completable completable) {
+        return completable.concatWith(Single.success(1)).ignoreResult();
     }
 }

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/backends/RecommendationBackend.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/backends/RecommendationBackend.java
@@ -93,7 +93,7 @@ final class RecommendationBackend {
                     // We use defer() here so that we do not eagerly create a Recommendation which will get emitted for
                     // every schedule. defer() helps us lazily create a new Recommendation object every time we the
                     // scheduler emits a tick.
-                    .andThen(defer(() -> success(newRecommendation())))
+                    .concatWith(defer(() -> success(newRecommendation())))
                     // Since schedule() only schedules a single tick, we repeat the ticks to generate infinite
                     // recommendations. This simulates a push based API which pushes new recommendations as and when
                     // they are available.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -46,7 +46,7 @@ abstract class AbstractStreamingHttpConnection<CC extends ConnectionContext> ext
         super(reqRespFactory);
         this.connection = requireNonNull(conn);
         this.executionContext = requireNonNull(executionContext);
-        maxConcurrencySetting = just(config.getMaxPipelinedRequests()).concatWith(onClosing.andThen(success(0)));
+        maxConcurrencySetting = just(config.getMaxPipelinedRequests()).concatWith(onClosing.concatWith(success(0)));
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NonPipelinedStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NonPipelinedStreamingHttpConnection.java
@@ -31,6 +31,6 @@ final class NonPipelinedStreamingHttpConnection extends AbstractStreamingHttpCon
 
     @Override
     protected Publisher<Object> writeAndRead(final Publisher<Object> requestStream) {
-        return connection.write(requestStream).andThen(connection.read());
+        return connection.write(requestStream).concatWith(connection.read());
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultHttpConnectionBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultHttpConnectionBuilderTest.java
@@ -67,7 +67,7 @@ public class DefaultHttpConnectionBuilderTest extends AbstractEchoServerBasedHtt
         public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
             // fanout - simulates followup request on response
             return delegate().request(request).flatMap(resp ->
-                    resp.payloadBody().ignoreElements().andThen(delegate().request(request)));
+                    resp.payloadBody().ignoreElements().concatWith(delegate().request(request)));
         }
 
         @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
@@ -116,7 +116,7 @@ public class HttpAuthConnectionFactoryClientTest {
                                 if (response.status().equals(OK)) {
                                     // In this test we have not enabled pipelining so we drain this response before
                                     // indicating the connection is usable.
-                                    return response.payloadBody().ignoreElements().andThen(success(cnx));
+                                    return response.payloadBody().ignoreElements().concatWith(success(cnx));
                                 }
                                 cnx.closeAsync().subscribe();
                                 return error(new IllegalStateException("failed auth"));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerContextFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerContextFilterTest.java
@@ -58,15 +58,15 @@ public class NettyHttpServerContextFilterTest extends AbstractNettyHttpServerTes
 
     enum FilterMode {
         ACCEPT_ALL(true, (executor, context) -> success(true)),
-        DELAY_ACCEPT_ALL(true, (executor, context) -> executor.timer(100, MILLISECONDS).andThen(success(true))),
+        DELAY_ACCEPT_ALL(true, (executor, context) -> executor.timer(100, MILLISECONDS).concatWith(success(true))),
         REJECT_ALL(false, (executor, context) -> success(false)),
         DELAY_REJECT_ALL(false, (executor, context) ->
-                executor.timer(100, MILLISECONDS).andThen(success(false))),
+                executor.timer(100, MILLISECONDS).concatWith(success(false))),
         THROW_EXCEPTION(false, (executor, context) -> {
             throw DELIBERATE_EXCEPTION;
         }),
         DELAY_SINGLE_ERROR(false, (executor, context) ->
-                executor.timer(100, MILLISECONDS).andThen(error(DELIBERATE_EXCEPTION))),
+                executor.timer(100, MILLISECONDS).concatWith(error(DELIBERATE_EXCEPTION))),
         SINGLE_ERROR(false, (executor, context) -> error(new DeliberateException())),
         ACCEPT_ALL_CONSTANT(true, (executor, context) -> success(true)) {
             @Override

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/EndpointEnhancingRequestFilter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/EndpointEnhancingRequestFilter.java
@@ -259,7 +259,7 @@ final class EndpointEnhancingRequestFilter implements ContainerRequestFilter {
 
         @Override
         protected Single<Response> handleSourceResponse(final Completable source, final ContainerResponse res) {
-            return source.andThen(defer(() -> success(noContent().build())));
+            return source.concatWith(defer(() -> success(noContent().build())));
         }
     }
 

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/resources/AbstractAsynchronousResources.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/resources/AbstractAsynchronousResources.java
@@ -80,7 +80,7 @@ public abstract class AbstractAsynchronousResources {
     @GET
     public Single<String> getStringSingle(final @QueryParam("fail") boolean fail) {
         return ctx.executionContext().executor().timer(10, MILLISECONDS)
-                .andThen(fail ? error(DELIBERATE_EXCEPTION) : success("DONE"));
+                .concatWith(fail ? error(DELIBERATE_EXCEPTION) : success("DONE"));
     }
 
     @Consumes(APPLICATION_JSON)
@@ -105,7 +105,7 @@ public abstract class AbstractAsynchronousResources {
     @GET
     public Single<Response> getResponseSingle(final @QueryParam("fail") boolean fail) {
         return ctx.executionContext().executor().timer(10, MILLISECONDS)
-                .andThen(fail ? error(DELIBERATE_EXCEPTION) : success(accepted("DONE").build()));
+                .concatWith(fail ? error(DELIBERATE_EXCEPTION) : success(accepted("DONE").build()));
     }
 
     @Produces(TEXT_PLAIN)
@@ -114,7 +114,7 @@ public abstract class AbstractAsynchronousResources {
     public Single<Response> getResponseSinglePublisherEntity(@QueryParam("i") final int i) {
         final BufferAllocator allocator = ctx.executionContext().bufferAllocator();
         return ctx.executionContext().executor().timer(10, MILLISECONDS)
-                .andThen(defer(() -> {
+                .concatWith(defer(() -> {
                     final String contentString = "GOT: " + i;
                     final Publisher<Buffer> responseContent = just(allocator.fromAscii(contentString));
 
@@ -132,7 +132,7 @@ public abstract class AbstractAsynchronousResources {
     @GET
     public Single<Map<String, Object>> getMapSingle(final @QueryParam("fail") boolean fail) {
         return ctx.executionContext().executor().timer(10, MILLISECONDS)
-                .andThen(fail ? error(DELIBERATE_EXCEPTION) : defer(() -> success(singletonMap("foo", "bar4"))));
+                .concatWith(fail ? error(DELIBERATE_EXCEPTION) : defer(() -> success(singletonMap("foo", "bar4"))));
     }
 
     @Produces(APPLICATION_JSON)
@@ -140,7 +140,7 @@ public abstract class AbstractAsynchronousResources {
     @GET
     public Single<TestPojo> getPojoSingle(final @QueryParam("fail") boolean fail) {
         return ctx.executionContext().executor().timer(10, MILLISECONDS)
-                .andThen(fail ? error(DELIBERATE_EXCEPTION) : defer(() -> {
+                .concatWith(fail ? error(DELIBERATE_EXCEPTION) : defer(() -> {
                     final TestPojo testPojo = new TestPojo();
                     testPojo.setaString("boo");
                     testPojo.setAnInt(456);
@@ -155,7 +155,7 @@ public abstract class AbstractAsynchronousResources {
     public Single<TestPojo> postJsonPojoInPojoOutSingle(@QueryParam("fail") final boolean fail,
                                                         final TestPojo testPojo) {
         return ctx.executionContext().executor().timer(10, MILLISECONDS)
-                .andThen(fail ? error(DELIBERATE_EXCEPTION) : defer(() -> {
+                .concatWith(fail ? error(DELIBERATE_EXCEPTION) : defer(() -> {
                     testPojo.setAnInt(testPojo.getAnInt() + 1);
                     testPojo.setaString(testPojo.getaString() + "x");
                     return success(testPojo);
@@ -169,7 +169,7 @@ public abstract class AbstractAsynchronousResources {
     public Single<Response> postJsonPojoInPojoOutResponseSingle(@QueryParam("fail") final boolean fail,
                                                                 final TestPojo testPojo) {
         return ctx.executionContext().executor().timer(10, MILLISECONDS)
-                .andThen(fail ? error(DELIBERATE_EXCEPTION) : defer(() -> {
+                .concatWith(fail ? error(DELIBERATE_EXCEPTION) : defer(() -> {
                     testPojo.setAnInt(testPojo.getAnInt() + 1);
                     testPojo.setaString(testPojo.getaString() + "x");
                     return success(accepted(testPojo).build());

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/resources/ExecutionStrategyResources.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/resources/ExecutionStrategyResources.java
@@ -312,7 +312,7 @@ public final class ExecutionStrategyResources {
 
             return content
                     .doOnNext(__ -> requireFromSameExecutorAs(resourceMethodThread))
-                    .ignoreElements().andThen(bufferSingle.toPublisher())
+                    .ignoreElements().concatWith(bufferSingle.toPublisher())
                     .doOnRequest(__ -> requireFromSameExecutorAs(resourceMethodThread));
         }
 

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/CommanderUtils.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/CommanderUtils.java
@@ -181,7 +181,7 @@ final class CommanderUtils {
                             return Completable.error(discardThrowable);
                         })
                         // If releaseAsync() completes successfully, emit the original error.
-                        .andThen(error(discardThrowable))
+                        .concatWith(error(discardThrowable))
                 ).concatWith(reservedCnx.releaseAsync()); // If discard succeeds, release the connection.
             }
             discardSingle.doAfterCancel(() -> handleCancel(reservedCnx, singles,
@@ -228,8 +228,8 @@ final class CommanderUtils {
                             return error(discardThrowable);
                         })
                         // If releaseAsync() completes successfully, emit the original error.
-                        .andThen(error(discardThrowable))
-                ).andThen(reservedCnx.releaseAsync()); // If exec succeeds, release the connection.
+                        .concatWith(error(discardThrowable))
+                ).concatWith(reservedCnx.releaseAsync()); // If exec succeeds, release the connection.
             }
             execCompletable.doAfterCancel(() -> handleCancel(reservedCnx, singles,
                     "Connection closed due to exec() cancellation."))

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/AbstractRedisConnection.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/AbstractRedisConnection.java
@@ -52,7 +52,7 @@ abstract class AbstractRedisConnection extends RedisConnection {
     private final Completable closeAsync = new Completable() {
         @Override
         protected void handleSubscribe(Subscriber subscriber) {
-            pinger.closeAsync().andThen(doClose()).subscribe(subscriber);
+            pinger.closeAsync().concatWith(doClose()).subscribe(subscriber);
         }
     };
     private final Executor pingTimerProvider;
@@ -88,7 +88,7 @@ abstract class AbstractRedisConnection extends RedisConnection {
             maxPendingRequests = maxPipelinedRequests;
         }
         maxConcurrencySetting = just(roConfig.getMaxPipelinedRequests())
-                .concatWith(onClosing.andThen(success(0)));
+                .concatWith(onClosing.concatWith(success(0)));
     }
 
     @Override

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/InternalSubscribedRedisConnection.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/InternalSubscribedRedisConnection.java
@@ -139,7 +139,7 @@ final class InternalSubscribedRedisConnection extends AbstractRedisConnection {
                 if (deferSubscribeTillConnect) {
                     response = concatDeferOnSubscribe(write, readStreamSplitter.registerNewCommand(command));
                 } else {
-                    response = write.andThen(readStreamSplitter.registerNewCommand(command));
+                    response = write.concatWith(readStreamSplitter.registerNewCommand(command));
                 }
                 // Unwrap PubSubChannelMessage if it wraps an SimpleString response
                 response.map(m -> m.getKeyType() == SimpleString ? m.getData() : m).subscribe(subscriber);
@@ -158,8 +158,8 @@ final class InternalSubscribedRedisConnection extends AbstractRedisConnection {
                 connection.executionContext().bufferAllocator()),
                 connection.executionContext().bufferAllocator()))).ignoreElements())
                 .onErrorResume(th -> matches(th, ClosedChannelException.class) ? completed() :
-                        connection.closeAsync().andThen(error(th)))
-                .andThen(connection.closeAsync());
+                        connection.closeAsync().concatWith(error(th)))
+                .concatWith(connection.closeAsync());
     }
 
     @Override

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/PipelinedRedisConnection.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/PipelinedRedisConnection.java
@@ -96,8 +96,8 @@ final class PipelinedRedisConnection extends AbstractRedisConnection {
                 connection.executionContext().bufferAllocator())), true, false)
                 .ignoreElements()
                 .onErrorResume(th -> matches(th, ClosedChannelException.class) ? completed() :
-                        connection.closeAsync().andThen(error(th)))
-                .andThen(connection.closeAsync());
+                        connection.closeAsync().concatWith(error(th)))
+                .concatWith(connection.closeAsync());
     }
 
     @Override

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/AbstractPartitionedRedisClientTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/AbstractPartitionedRedisClientTest.java
@@ -168,7 +168,7 @@ public abstract class AbstractPartitionedRedisClientTest {
             return;
         }
 
-        awaitIndefinitely(client.closeAsync().andThen(ioExecutor.closeAsync()));
+        awaitIndefinitely(client.closeAsync().concatWith(ioExecutor.closeAsync()));
     }
 
     public Function<Command, RedisPartitionAttributesBuilder> getPartitionAttributesBuilderFactory() {

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisAuthConnectionFactoryClientTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisAuthConnectionFactoryClientTest.java
@@ -62,7 +62,7 @@ public class RedisAuthConnectionFactoryClientTest {
     public void cleanup() throws Exception {
         if (client != null) {
             assert ioExecutor != null;
-            awaitIndefinitely(client.closeAsync().andThen(ioExecutor.closeAsync()));
+            awaitIndefinitely(client.closeAsync().concatWith(ioExecutor.closeAsync()));
         }
     }
 

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisAuthConnectionFactoryConnectionTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisAuthConnectionFactoryConnectionTest.java
@@ -65,10 +65,10 @@ public class RedisAuthConnectionFactoryConnectionTest {
             assert ioExecutor != null;
             awaitIndefinitely(connectionSingle
                     .flatMap(connection ->
-                            connection.closeAsync().onErrorResume(cause -> completed()).andThen(success(connection)))
+                            connection.closeAsync().onErrorResume(cause -> completed()).concatWith(success(connection)))
                     .ignoreResult()
                     .onErrorResume(cause -> completed())
-                    .andThen(ioExecutor.closeAsync()));
+                    .concatWith(ioExecutor.closeAsync()));
         }
     }
 

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpServerInitializerContextFilterTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpServerInitializerContextFilterTest.java
@@ -52,19 +52,19 @@ public class TcpServerInitializerContextFilterTest extends AbstractTcpServerTest
 
     enum FilterMode {
         ACCEPT_ALL(true, false, (executor, context) -> success(true)),
-        DELAY_ACCEPT_ALL(true, false, (executor, context) -> executor.timer(100, MILLISECONDS).andThen(success(true))),
+        DELAY_ACCEPT_ALL(true, false, (executor, context) -> executor.timer(100, MILLISECONDS).concatWith(success(true))),
         REJECT_ALL(false, false, (executor, context) -> success(false)),
         DELAY_REJECT_ALL(false, false, (executor, context) ->
-                executor.timer(100, MILLISECONDS).andThen(success(false))),
+                executor.timer(100, MILLISECONDS).concatWith(success(false))),
         THROW_EXCEPTION(false, false, (executor, context) -> {
             throw DELIBERATE_EXCEPTION;
         }),
         DELAY_SINGLE_ERROR(false, false, (executor, context) ->
-                executor.timer(100, MILLISECONDS).andThen(error(DELIBERATE_EXCEPTION))),
+                executor.timer(100, MILLISECONDS).concatWith(error(DELIBERATE_EXCEPTION))),
         SINGLE_ERROR(false, false, (executor, context) -> error(new DeliberateException())),
         INITIALIZER_THROW(false, true, (executor, context) -> success(true)),
         DELAY_INITIALIZER_THROW(false, true, (executor, context) ->
-                executor.timer(100, MILLISECONDS).andThen(success(true))),
+                executor.timer(100, MILLISECONDS).concatWith(success(true))),
         ACCEPT_ALL_CONSTANT(true, false, (executor, context) -> success(true)) {
             @Override
             ContextFilter getContextFilter(final Executor executor) {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyPipelinedConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyPipelinedConnection.java
@@ -155,7 +155,7 @@ public final class DefaultNettyPipelinedConnection<Req, Resp> implements NettyPi
                             "Unexpected reject from an unbounded pending requests queue."));
                 }
             }
-        }.andThen(
+        }.concatWith(
                 connection.read()
                         // Below is related to read stream: terminal predicate and responseQueue
                         // We should only trigger this on the read stream signals. Attaching them to the write+read


### PR DESCRIPTION
Motivation:
Our goal is to keep operator names consistent across our asynchronous sources. However Completable has an andThen method with Single/Publisher have a concatWith method for the same purpose.

Modifications:
- Rename Completable#andThen to Completable#concatWith

Result:
More consistent operator names across asynchronous sources.