### PR TITLE
HTTP FormUrlEncoder followup

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FormUrlEncodedHttpSerializer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FormUrlEncodedHttpSerializer.java
@@ -32,16 +32,15 @@ import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
-import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED;
+import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED_UTF8;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * An {@link HttpSerializer} that serializes a key-values {@link Map} to an urlencoded form.
  */
 final class FormUrlEncodedHttpSerializer implements HttpSerializer<Map<String, List<String>>> {
-
     static final FormUrlEncodedHttpSerializer UTF8 = new FormUrlEncodedHttpSerializer(UTF_8,
-            headers -> headers.set(CONTENT_TYPE, APPLICATION_X_WWW_FORM_URLENCODED + "; charset=UTF-8"));
+            headers -> headers.set(CONTENT_TYPE, APPLICATION_X_WWW_FORM_URLENCODED_UTF8));
 
     private final Charset charset;
     private final Consumer<HttpHeaders> addContentType;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderValues.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderValues.java
@@ -31,6 +31,12 @@ public final class HttpHeaderValues {
      */
     public static final CharSequence APPLICATION_X_WWW_FORM_URLENCODED =
             newAsciiString("application/x-www-form-urlencoded");
+
+    /**
+     * {@code "application/x-www-form-urlencoded; charset=UTF-8"}
+     */
+    public static final CharSequence APPLICATION_X_WWW_FORM_URLENCODED_UTF8 =
+            newAsciiString(APPLICATION_X_WWW_FORM_URLENCODED + "; charset=UTF-8");
     /**
      * {@code "base64"}
      */

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpSerializationProviders.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpSerializationProviders.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
+import static io.servicetalk.http.api.CharSequences.newAsciiString;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
 import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_JSON;
 import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED;
@@ -65,7 +66,8 @@ public final class HttpSerializationProviders {
      * href="https://url.spec.whatwg.org/#application/x-www-form-urlencoded">x-www-form-urlencoded specification</a>
      */
     public static HttpSerializer<Map<String, List<String>>> formUrlEncodedSerializer(Charset charset) {
-        final String contentType = APPLICATION_X_WWW_FORM_URLENCODED + "; charset=" + charset.name();
+        final CharSequence contentType = newAsciiString(APPLICATION_X_WWW_FORM_URLENCODED + "; charset=" +
+                charset.name());
         return formUrlEncodedSerializer(charset, headers -> headers.set(CONTENT_TYPE, contentType));
     }
 
@@ -94,22 +96,39 @@ public final class HttpSerializationProviders {
      * href="https://url.spec.whatwg.org/#application/x-www-form-urlencoded">x-www-form-urlencoded specification</a>
      */
     public static HttpDeserializer<Map<String, List<String>>> formUrlEncodedDeserializer() {
-        return FormUrlEncodedHttpDeserializer.UTF_8;
+        return FormUrlEncodedHttpDeserializer.UTF8;
     }
 
     /**
      * Creates an {@link HttpDeserializer} that can deserialize key-values {@link Map}s
      * with {@link StandardCharsets#UTF_8} from urlencoded forms.
      *
-     * @param checkContentType A {@link Predicate} that validates the passed {@link HttpHeaders} as expected for the
+     * @param charset {@link Charset} for the key-value {@link Map} that will be deserialized.
      * deserialized payload. If the validation fails, then deserialization will fail with {@link SerializationException}
      * @return {@link HttpDeserializer} that could deserialize a key-value {@link Map}.
      * @see <a
      * href="https://url.spec.whatwg.org/#application/x-www-form-urlencoded">x-www-form-urlencoded specification</a>
      */
+    public static HttpDeserializer<Map<String, List<String>>> formUrlEncodedDeserializer(Charset charset) {
+        final CharSequence contentType = newAsciiString(APPLICATION_X_WWW_FORM_URLENCODED + "; charset=" +
+                charset.name());
+        return formUrlEncodedDeserializer(charset, headers -> headers.contains(CONTENT_TYPE, contentType));
+    }
+
+    /**
+     * Creates an {@link HttpDeserializer} that can deserialize key-values {@link Map}s
+     * with {@link StandardCharsets#UTF_8} from urlencoded forms.
+     *
+     * @param charset {@link Charset} for the key-value {@link Map} that will be deserialized.
+     * @param checkContentType Checks the {@link HttpHeaders} to see if a compatible encoding is found.
+     * deserialized payload. If the validation fails, then deserialization will fail with {@link SerializationException}
+     * @return {@link HttpDeserializer} that could deserialize a key-value {@link Map}.
+     * @see <a href="https://url.spec.whatwg.org/#application/x-www-form-urlencoded">x-www-form-urlencoded
+    specification</a>
+     */
     public static HttpDeserializer<Map<String, List<String>>> formUrlEncodedDeserializer(
-            Predicate<HttpHeaders> checkContentType) {
-        return new FormUrlEncodedHttpDeserializer(checkContentType);
+            Charset charset, Predicate<HttpHeaders> checkContentType) {
+        return new FormUrlEncodedHttpDeserializer(charset, checkContentType);
     }
 
     /**
@@ -129,7 +148,7 @@ public final class HttpSerializationProviders {
      * @return {@link HttpSerializer} that could serialize from {@link String}.
      */
     public static HttpSerializer<String> textSerializer(Charset charset) {
-        final String contentType = TEXT_PLAIN + "; charset=" + charset.name();
+        final CharSequence contentType = newAsciiString(TEXT_PLAIN + "; charset=" + charset.name());
         return textSerializer(charset, headers -> headers.set(CONTENT_TYPE, contentType));
     }
 
@@ -162,7 +181,7 @@ public final class HttpSerializationProviders {
      * @return {@link HttpDeserializer} that could deserialize {@link String}.
      */
     public static HttpDeserializer<String> textDeserializer(Charset charset) {
-        final String contentType = TEXT_PLAIN + "; charset=" + charset.name();
+        final CharSequence contentType = newAsciiString(TEXT_PLAIN + "; charset=" + charset.name());
         return textDeserializer(charset, headers -> headers.contains(CONTENT_TYPE, contentType));
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpUri.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpUri.java
@@ -38,10 +38,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * get wrong. {@link HttpUri} attempts to address these issues.
  */
 final class HttpUri {
-    /**
-     * Default character set (UTF-8)
-     */
-    public static final Charset DEFAULT_CHARSET = UTF_8;
     private static final String SPACE = " ";
 
     static final int DEFAULT_PORT_HTTP = 80;
@@ -304,7 +300,7 @@ final class HttpUri {
     String getPath() {
         if (path == null) {
             final String raw = getRawPath();
-            path = decodeComponent(raw, 0, raw.length(), true);
+            path = decodeComponent(raw, 0, raw.length(), true, UTF_8);
         }
         return path;
     }
@@ -388,7 +384,8 @@ final class HttpUri {
         return uri;
     }
 
-    static String decodeComponent(final String s, final int from, final int toExcluded, final boolean isPath) {
+    static String decodeComponent(final String s, final int from, final int toExcluded, final boolean isPath,
+                                  final Charset charset) {
         final int len = toExcluded - from;
         if (len <= 0) {
             return "";
@@ -405,7 +402,7 @@ final class HttpUri {
             return s.substring(from, toExcluded);
         }
 
-        final CharsetDecoder decoder = DEFAULT_CHARSET.newDecoder()
+        final CharsetDecoder decoder = charset.newDecoder()
                 .onMalformedInput(REPLACE).onUnmappableCharacter(REPLACE);
 
         // Each encoded byte takes 3 characters (e.g. "%20")

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/FormUrlEncodedHttpDeserializerTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/FormUrlEncodedHttpDeserializerTest.java
@@ -45,7 +45,7 @@ public class FormUrlEncodedHttpDeserializerTest {
 
     @Test
     public void formParametersAreDeserialized() {
-        final FormUrlEncodedHttpDeserializer deserializer = FormUrlEncodedHttpDeserializer.UTF_8;
+        final FormUrlEncodedHttpDeserializer deserializer = FormUrlEncodedHttpDeserializer.UTF8;
 
         final HttpHeaders headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders();
         headers.set(CONTENT_TYPE, "application/x-www-form-urlencoded; charset=UTF-8");
@@ -67,7 +67,7 @@ public class FormUrlEncodedHttpDeserializerTest {
 
     @Test
     public void deserializeEmptyBuffer() {
-        final FormUrlEncodedHttpDeserializer deserializer = FormUrlEncodedHttpDeserializer.UTF_8;
+        final FormUrlEncodedHttpDeserializer deserializer = FormUrlEncodedHttpDeserializer.UTF8;
 
         final HttpHeaders headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders();
         headers.set(CONTENT_TYPE, "application/x-www-form-urlencoded; charset=UTF-8");
@@ -79,7 +79,7 @@ public class FormUrlEncodedHttpDeserializerTest {
 
     @Test
     public void invalidContentTypeThrows() {
-        final FormUrlEncodedHttpDeserializer deserializer = FormUrlEncodedHttpDeserializer.UTF_8;
+        final FormUrlEncodedHttpDeserializer deserializer = FormUrlEncodedHttpDeserializer.UTF8;
 
         final HttpHeaders headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders();
         headers.set(CONTENT_TYPE, "invalid/content/type");
@@ -91,7 +91,7 @@ public class FormUrlEncodedHttpDeserializerTest {
 
     @Test
     public void iterableCloseIsPropagated() throws Exception {
-        final FormUrlEncodedHttpDeserializer deserializer = FormUrlEncodedHttpDeserializer.UTF_8;
+        final FormUrlEncodedHttpDeserializer deserializer = FormUrlEncodedHttpDeserializer.UTF8;
         final HttpHeaders headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders();
         headers.set(CONTENT_TYPE, "application/x-www-form-urlencoded; charset=UTF-8");
 

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/FormUrlEncodedHttpSerializerTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/FormUrlEncodedHttpSerializerTest.java
@@ -52,9 +52,8 @@ public class FormUrlEncodedHttpSerializerTest {
         assertEquals("Unexpected serialized content.",
                 "emptyParam=&escape%26this%3D=and%26this%25&param2=foo&param2=bar",
                 serialized.toString(UTF_8));
-        assertEquals("Unexpected content type.", "" +
-                        "application/x-www-form-urlencoded; charset=UTF-8",
-                headers.get(CONTENT_TYPE));
+        assertTrue("Unexpected content type.",
+                headers.contains(CONTENT_TYPE, "application/x-www-form-urlencoded; charset=UTF-8"));
     }
 
     @Test
@@ -67,9 +66,8 @@ public class FormUrlEncodedHttpSerializerTest {
         final Buffer serialized = serializer.serialize(headers, formParameters, DEFAULT_ALLOCATOR);
 
         assertEquals("Unexpected buffer length.", 0, serialized.readableBytes());
-        assertEquals("Unexpected content type.",
-                "application/x-www-form-urlencoded; charset=UTF-8",
-                headers.get(CONTENT_TYPE));
+        assertTrue("Unexpected content type.",
+                headers.contains(CONTENT_TYPE, "application/x-www-form-urlencoded; charset=UTF-8"));
     }
 
     @Test
@@ -111,8 +109,7 @@ public class FormUrlEncodedHttpSerializerTest {
         serialized.iterator().close();
 
         assertTrue(isClosed.get());
-        assertEquals("Unexpected content type.",
-                "application/x-www-form-urlencoded; charset=UTF-8",
-                headers.get(CONTENT_TYPE));
+        assertTrue("Unexpected content type.",
+                headers.contains(CONTENT_TYPE, "application/x-www-form-urlencoded; charset=UTF-8"));
     }
 }


### PR DESCRIPTION
Motivation:
The HTTP FormUrlEncoder related classes have a few areas for improvement related to Buffer empty, consistency, and avoiding String concatenation.

Modifications:
- FormUrlEncodedHttpDeserializer checks buffer.capacity() == 0 when IIUC it should be buffer.readableBytes() == 0
- FormUrlEncodedHttpDeserializer doesn't have a consistent construction pattern to FormUrlEncodedHttpSerializer. It can take a Charset in order to provide feature parity
- HttpSerializationProviders does some string concatenation on each verification operation, when it could be done once per HttpSerializationProvider creation

Result:
Improved HTTP FormUrlEncoder.