### PR TITLE
Clarified Javadoc of HTTP request/response payload mutators

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
@@ -35,13 +35,13 @@ import java.util.function.UnaryOperator;
  */
 public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     /**
-     * Get the underlying payload as a {@link Publisher} of {@link Buffer}s.
+     * Gets the underlying payload as a {@link Publisher} of {@link Buffer}s.
      * @return The {@link Publisher} of {@link Buffer} representation of the underlying payload body.
      */
     BlockingIterable<Buffer> payloadBody();
 
     /**
-     * Get the underlying payload as a {@link InputStream}.
+     * Gets the underlying payload as a {@link InputStream}.
      * @return The {@link InputStream} representation of the underlying payload body.
      */
     default InputStream payloadBodyInputStream() {
@@ -49,7 +49,7 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     }
 
     /**
-     * Get and deserialize the payload body.
+     * Gets and deserializes the payload body.
      * @param deserializer The function that deserializes the underlying {@link BlockingIterable}.
      * @param <T> The resulting type of the deserialization operation.
      * @return The results of the deserialization operation.
@@ -59,7 +59,7 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     }
 
     /**
-     * Return a {@link BlockingStreamingHttpRequest} with its underlying payload set to {@code payloadBody}.
+     * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload set to {@code payloadBody}.
      * <p>
      * A best effort will be made to apply back pressure to the existing {@link Iterable} payload body. If this
      * default policy is not sufficient you can use {@link #transformPayloadBody(UnaryOperator)} for more fine grain
@@ -73,7 +73,7 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     BlockingStreamingHttpRequest payloadBody(Iterable<Buffer> payloadBody);
 
     /**
-     * Return a {@link BlockingStreamingHttpRequest} with its underlying payload set to {@code payloadBody}.
+     * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload set to {@code payloadBody}.
      * <p>
      * A best effort will be made to apply back pressure to the existing {@link CloseableIterable} payload body. If this
      * default policy is not sufficient you can use {@link #transformPayloadBody(UnaryOperator)} for more fine grain
@@ -87,7 +87,7 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     BlockingStreamingHttpRequest payloadBody(CloseableIterable<Buffer> payloadBody);
 
     /**
-     * Return a {@link BlockingStreamingHttpRequest} with its underlying payload set to the result of serialization.
+     * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload set to the result of serialization.
      * <p>
      * A best effort will be made to apply back pressure to the existing {@link Iterable} payload body. If this
      * default policy is not sufficient you can use {@link #transformPayloadBody(Function, HttpSerializer)} for more
@@ -103,7 +103,7 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     <T> BlockingStreamingHttpRequest payloadBody(Iterable<T> payloadBody, HttpSerializer<T> serializer);
 
     /**
-     * Return a {@link BlockingStreamingHttpRequest} with its underlying payload set to the result of serialization.
+     * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload set to the result of serialization.
      * <p>
      * A best effort will be made to apply back pressure to the existing {@link CloseableIterable} payload body. If this
      * default policy is not sufficient you can use {@link #transformPayloadBody(Function, HttpSerializer)} for more
@@ -119,7 +119,7 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     <T> BlockingStreamingHttpRequest payloadBody(CloseableIterable<T> payloadBody, HttpSerializer<T> serializer);
 
     /**
-     * Return a {@link BlockingStreamingHttpRequest} with its underlying payload transformed to the result of
+     * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload transformed to the result of
      * serialization.
      * @param transformer A {@link Function} which take as a parameter the existing payload body
      * {@link BlockingIterable} and returns the new payload body {@link BlockingIterable} prior to serialization. It is
@@ -133,7 +133,7 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
             Function<BlockingIterable<Buffer>, BlockingIterable<T>> transformer, HttpSerializer<T> serializer);
 
     /**
-     * Return a {@link BlockingStreamingHttpRequest} with its underlying payload transformed to the result of
+     * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload transformed to the result of
      * serialization.
      * @param transformer A {@link Function} which take as a parameter the existing payload body
      * {@link BlockingIterable} and returns the new payload body {@link BlockingIterable} prior to serialization. It is
@@ -152,7 +152,7 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     }
 
     /**
-     * Return a {@link BlockingStreamingHttpRequest} with its underlying payload transformed to {@link Buffer}s.
+     * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload transformed to {@link Buffer}s.
      * @param transformer A {@link Function} which take as a parameter the existing payload body
      * {@link BlockingIterable} and returns the new payload body {@link BlockingIterable}. It is assumed the existing
      * payload body {@link BlockingIterable} will be transformed/consumed or else no more requests may be processed.
@@ -161,7 +161,7 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     BlockingStreamingHttpRequest transformPayloadBody(UnaryOperator<BlockingIterable<Buffer>> transformer);
 
     /**
-     * Return a {@link BlockingStreamingHttpRequest} with its underlying payload transformed. Note that the raw objects
+     * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload transformed. Note that the raw objects
      * of the underlying {@link Iterable} may be exposed. The object types are not guaranteed to be homogeneous.
      * @param transformer Responsible for transforming the payload body.
      * @return A {@link BlockingStreamingHttpRequest} with the new payload body.
@@ -169,7 +169,7 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     BlockingStreamingHttpRequest transformRawPayloadBody(UnaryOperator<BlockingIterable<?>> transformer);
 
     /**
-     * Return a {@link BlockingStreamingHttpRequest} with its underlying payload transformed to {@link Buffer}s,
+     * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload transformed to {@link Buffer}s,
      * with access to the trailers.
      * @param stateSupplier Create a new state {@link Object} that will be provided to the {@code transformer} on each
      * invocation. The state will be persistent for each {@link Subscriber} of the underlying payload body.
@@ -184,7 +184,7 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
                                                BiFunction<T, HttpHeaders, HttpHeaders> trailersTransformer);
 
     /**
-     * Return a {@link BlockingStreamingHttpRequest} with its underlying payload transformed to {@link Object}s,
+     * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload transformed to {@link Object}s,
      * with access to the trailers.
      * @param stateSupplier Create a new state {@link Object} that will be provided to the {@code transformer} on each
      * invocation. The state will be persistent for each {@link Subscriber} of the underlying payload body.
@@ -199,14 +199,14 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
                                                   BiFunction<T, HttpHeaders, HttpHeaders> trailersTransformer);
 
     /**
-     * Translate this {@link BlockingStreamingHttpRequest} to a {@link HttpRequest}.
+     * Translates this {@link BlockingStreamingHttpRequest} to a {@link HttpRequest}.
      * @return a {@link Single} that completes with a {@link HttpRequest} representation of this
      * {@link BlockingStreamingHttpRequest}.
      */
     Single<? extends HttpRequest> toRequest();
 
     /**
-     * Translate this {@link BlockingStreamingHttpRequest} to a {@link StreamingHttpRequest}.
+     * Translates this {@link BlockingStreamingHttpRequest} to a {@link StreamingHttpRequest}.
      * @return a {@link StreamingHttpRequest} representation of this {@link BlockingStreamingHttpRequest}.
      */
     StreamingHttpRequest toStreamingRequest();

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
@@ -35,13 +35,13 @@ import java.util.function.UnaryOperator;
  */
 public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
     /**
-     * Get the underlying payload as a {@link Publisher} of {@link Buffer}s.
+     * Gets the underlying payload as a {@link Publisher} of {@link Buffer}s.
      * @return The {@link Publisher} of {@link Buffer} representation of the underlying payload body.
      */
     BlockingIterable<Buffer> payloadBody();
 
     /**
-     * Get the underlying payload as a {@link InputStream}.
+     * Gets the underlying payload as a {@link InputStream}.
      * @return The {@link InputStream} representation of the underlying payload body.
      */
     default InputStream payloadBodyInputStream() {
@@ -49,7 +49,7 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
     }
 
     /**
-     * Get and deserialize the payload body.
+     * Gets and deserializes the payload body.
      * @param deserializer The function that deserializes the underlying {@link BlockingIterable}.
      * @param <T> The resulting type of the deserialization operation.
      * @return The results of the deserialization operation.
@@ -59,7 +59,7 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
     }
 
     /**
-     * Return a {@link BlockingStreamingHttpResponse} with its underlying payload set to {@code payloadBody}.
+     * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload set to {@code payloadBody}.
      * <p>
      * A best effort will be made to apply back pressure to the existing {@link Iterable} payload body. If this
      * default policy is not sufficient you can use {@link #transformPayloadBody(UnaryOperator)} for more fine grain
@@ -73,7 +73,7 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
     BlockingStreamingHttpResponse payloadBody(Iterable<Buffer> payloadBody);
 
     /**
-     * Return a {@link BlockingStreamingHttpResponse} with its underlying payload set to {@code payloadBody}.
+     * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload set to {@code payloadBody}.
      * <p>
      * A best effort will be made to apply back pressure to the existing {@link CloseableIterable} payload body. If this
      * default policy is not sufficient you can use {@link #transformPayloadBody(UnaryOperator)} for more fine grain
@@ -87,7 +87,7 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
     BlockingStreamingHttpResponse payloadBody(CloseableIterable<Buffer> payloadBody);
 
     /**
-     * Return a {@link BlockingStreamingHttpResponse} with its underlying payload set to the result of serialization.
+     * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload set to the result of serialization.
      * <p>
      * A best effort will be made to apply back pressure to the existing {@link Iterable} payload body. If this
      * default policy is not sufficient you can use {@link #transformPayloadBody(Function, HttpSerializer)} for more
@@ -103,7 +103,7 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
     <T> BlockingStreamingHttpResponse payloadBody(Iterable<T> payloadBody, HttpSerializer<T> serializer);
 
     /**
-     * Return a {@link BlockingStreamingHttpResponse} with its underlying payload set to the result of serialization.
+     * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload set to the result of serialization.
      * <p>
      * A best effort will be made to apply back pressure to the existing {@link CloseableIterable} payload body. If this
      * default policy is not sufficient you can use {@link #transformPayloadBody(Function, HttpSerializer)} for more
@@ -119,7 +119,7 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
     <T> BlockingStreamingHttpResponse payloadBody(CloseableIterable<T> payloadBody, HttpSerializer<T> serializer);
 
     /**
-     * Return a {@link BlockingStreamingHttpResponse} with its underlying payload transformed to the result of
+     * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload transformed to the result of
      * serialization.
      * @param transformer A {@link Function} which take as a parameter the existing payload body
      * {@link BlockingIterable} and returns the new payload body {@link BlockingIterable} prior to serialization. It is
@@ -133,7 +133,7 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
             Function<BlockingIterable<Buffer>, BlockingIterable<T>> transformer, HttpSerializer<T> serializer);
 
     /**
-     * Return a {@link BlockingStreamingHttpResponse} with its underlying payload transformed to the result of
+     * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload transformed to the result of
      * serialization.
      * @param transformer A {@link Function} which take as a parameter the existing payload body
      * {@link BlockingIterable} and returns the new payload body {@link BlockingIterable} prior to serialization. It is
@@ -152,7 +152,7 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
     }
 
     /**
-     * Return a {@link BlockingStreamingHttpResponse} with its underlying payload transformed to {@link Buffer}s.
+     * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload transformed to {@link Buffer}s.
      * @param transformer A {@link Function} which take as a parameter the existing payload body
      * {@link BlockingIterable} and returns the new payload body {@link BlockingIterable}. It is assumed the existing
      * payload body {@link BlockingIterable} will be transformed/consumed or else no more responses may be processed.
@@ -161,7 +161,7 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
     BlockingStreamingHttpResponse transformPayloadBody(UnaryOperator<BlockingIterable<Buffer>> transformer);
 
     /**
-     * Return a {@link BlockingStreamingHttpResponse} with its underlying payload transformed.
+     * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload transformed.
      * @param transformer A {@link Function} which take as a parameter the existing payload body
      * {@link BlockingIterable} and returns the new payload body {@link BlockingIterable}. It is assumed the existing
      * payload body {@link BlockingIterable} will be transformed/consumed or else no more responses may be processed.
@@ -170,7 +170,7 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
     BlockingStreamingHttpResponse transformRawPayloadBody(UnaryOperator<BlockingIterable<?>> transformer);
 
     /**
-     * Return a {@link BlockingStreamingHttpResponse} with its underlying payload transformed to {@link Buffer}s,
+     * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload transformed to {@link Buffer}s,
      * with access to the trailers.
      * @param stateSupplier Create a new state {@link Object} that will be provided to the {@code transformer} on each
      * invocation. The state will be persistent for each {@link Subscriber} of the underlying payload body.
@@ -185,7 +185,7 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
                                                 BiFunction<T, HttpHeaders, HttpHeaders> trailersTransformer);
 
     /**
-     * Return a {@link BlockingStreamingHttpResponse} with its underlying payload transformed to {@link Object}s,
+     * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload transformed to {@link Object}s,
      * with access to the trailers.
      * @param stateSupplier Create a new state {@link Object} that will be provided to the {@code transformer} on each
      * invocation. The state will be persistent for each {@link Subscriber} of the underlying payload body.
@@ -200,14 +200,14 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
                                                    BiFunction<T, HttpHeaders, HttpHeaders> trailersTransformer);
 
     /**
-     * Translate this {@link BlockingStreamingHttpResponse} to a {@link HttpResponse}.
+     * Translates this {@link BlockingStreamingHttpResponse} to a {@link HttpResponse}.
      * @return a {@link Single} that completes with a {@link HttpResponse} representation of this
      * {@link BlockingStreamingHttpResponse}.
      */
     Single<? extends HttpResponse> toResponse();
 
     /**
-     * Translate this {@link BlockingStreamingHttpResponse} to a {@link StreamingHttpResponse}.
+     * Translates this {@link BlockingStreamingHttpResponse} to a {@link StreamingHttpResponse}.
      * @return a {@link StreamingHttpResponse} representation of this {@link BlockingStreamingHttpResponse}.
      */
     StreamingHttpResponse toStreamingResponse();

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequest.java
@@ -22,14 +22,14 @@ import io.servicetalk.buffer.api.Buffer;
  */
 public interface HttpRequest extends HttpRequestMetaData, TrailersHolder {
     /**
-     * Get the underlying payload as a {@link Buffer}.
+     * Gets the underlying payload as a {@link Buffer}.
      *
      * @return The {@link Buffer} representation of the underlying payload.
      */
     Buffer payloadBody();
 
     /**
-     * Get and deserialize the payload body.
+     * Gets and deserializes the payload body.
      *
      * @param deserializer The function that deserializes the underlying {@link Object}.
      * @param <T> The resulting type of the deserialization operation.
@@ -40,7 +40,7 @@ public interface HttpRequest extends HttpRequestMetaData, TrailersHolder {
     }
 
     /**
-     * Return an {@link HttpRequest} with its underlying payload set to {@code payloadBody}.
+     * Returns an {@link HttpRequest} with its underlying payload set to {@code payloadBody}.
      *
      * @param payloadBody the underlying payload.
      * @return An {@link HttpRequest} with the new serialized payload body.
@@ -48,7 +48,7 @@ public interface HttpRequest extends HttpRequestMetaData, TrailersHolder {
     HttpRequest payloadBody(Buffer payloadBody);
 
     /**
-     * Return an {@link HttpRequest} with its underlying payload set to the results of serialization of {@code pojo}.
+     * Returns an {@link HttpRequest} with its underlying payload set to the results of serialization of {@code pojo}.
      *
      * @param pojo The object to serialize.
      * @param serializer The {@link HttpSerializer} which converts {@code pojo} into bytes.
@@ -58,14 +58,14 @@ public interface HttpRequest extends HttpRequestMetaData, TrailersHolder {
     <T> HttpRequest payloadBody(T pojo, HttpSerializer<T> serializer);
 
     /**
-     * Translate this {@link HttpRequest} to a {@link StreamingHttpRequest}.
+     * Translates this {@link HttpRequest} to a {@link StreamingHttpRequest}.
      *
      * @return a {@link StreamingHttpRequest} representation of this {@link HttpRequest}.
      */
     StreamingHttpRequest toStreamingRequest();
 
     /**
-     * Translate this {@link HttpRequest} to a {@link BlockingStreamingHttpRequest}.
+     * Translates this {@link HttpRequest} to a {@link BlockingStreamingHttpRequest}.
      *
      * @return a {@link BlockingStreamingHttpRequest} representation of this {@link HttpRequest}.
      */

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponse.java
@@ -22,14 +22,14 @@ import io.servicetalk.buffer.api.Buffer;
  */
 public interface HttpResponse extends HttpResponseMetaData, TrailersHolder {
     /**
-     * Get the underlying payload as a {@link Buffer}.
+     * Gets the underlying payload as a {@link Buffer}.
      *
      * @return The {@link Buffer} representation of the underlying payload.
      */
     Buffer payloadBody();
 
     /**
-     * Get and deserialize the payload body.
+     * Gets and deserializes the payload body.
      *
      * @param deserializer The function that deserializes the underlying {@link Object}.
      * @param <T> The resulting type of the deserialization operation.
@@ -40,7 +40,7 @@ public interface HttpResponse extends HttpResponseMetaData, TrailersHolder {
     }
 
     /**
-     * Return an {@link HttpResponse} with its underlying payload set to {@code payloadBody}.
+     * Returns an {@link HttpResponse} with its underlying payload set to {@code payloadBody}.
      *
      * @param payloadBody the underlying payload.
      * @return An {@link HttpResponse} with the new serialized payload body.
@@ -48,7 +48,7 @@ public interface HttpResponse extends HttpResponseMetaData, TrailersHolder {
     HttpResponse payloadBody(Buffer payloadBody);
 
     /**
-     * Return an {@link HttpResponse} with its underlying payload set to the results of serialization of {@code pojo}.
+     * Returns an {@link HttpResponse} with its underlying payload set to the results of serialization of {@code pojo}.
      *
      * @param pojo The object to serialize.
      * @param serializer The {@link HttpSerializer} which converts {@code pojo} into bytes.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequest.java
@@ -31,13 +31,13 @@ import java.util.function.UnaryOperator;
  */
 public interface StreamingHttpRequest extends HttpRequestMetaData {
     /**
-     * Get the underlying payload as a {@link Publisher} of {@link Buffer}s.
+     * Gets the underlying payload as a {@link Publisher} of {@link Buffer}s.
      * @return The {@link Publisher} of {@link Buffer} representation of the underlying
      */
     Publisher<Buffer> payloadBody();
 
     /**
-     * Get and deserialize the payload body.
+     * Gets and deserializes the payload body.
      * @param deserializer The function that deserializes the underlying {@link Publisher}.
      * @param <T> The resulting type of the deserialization operation.
      * @return The results of the deserialization operation.
@@ -47,14 +47,14 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
     }
 
     /**
-     * Get a {@link Publisher} that combines the raw payload body concatenated with the {@link HttpHeaders trailers}.
+     * Gets a {@link Publisher} that combines the raw payload body concatenated with the {@link HttpHeaders trailers}.
      * @return a {@link Publisher} that combines the raw payload body concatenated with the
      * {@link HttpHeaders trailers}.
      */
     Publisher<Object> payloadBodyAndTrailers();
 
     /**
-     * Return a {@link StreamingHttpRequest} with its underlying payload set to {@code payloadBody}.
+     * Returns a {@link StreamingHttpRequest} with its underlying payload set to {@code payloadBody}.
      * <p>
      * A best effort will be made to apply back pressure to the existing {@link Publisher} payload body. If this default
      * policy is not sufficient you can use {@link #transformPayloadBody(UnaryOperator)} for more fine grain control.
@@ -67,7 +67,7 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
     StreamingHttpRequest payloadBody(Publisher<Buffer> payloadBody);
 
     /**
-     * Return a {@link StreamingHttpRequest} with its underlying payload set to the result of serialization.
+     * Returns a {@link StreamingHttpRequest} with its underlying payload set to the result of serialization.
      * <p>
      * A best effort will be made to apply back pressure to the existing {@link Publisher} payload body. If this default
      * policy is not sufficient you can use {@link #transformPayloadBody(Function, HttpSerializer)} for more fine grain
@@ -83,7 +83,7 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
     <T> StreamingHttpRequest payloadBody(Publisher<T> payloadBody, HttpSerializer<T> serializer);
 
     /**
-     * Return a {@link StreamingHttpRequest} with its underlying payload transformed to the result of serialization.
+     * Returns a {@link StreamingHttpRequest} with its underlying payload transformed to the result of serialization.
      * @param transformer A {@link Function} which take as a parameter the existing payload body {@link Publisher} and
      * returns the new payload body {@link Publisher} prior to serialization. It is assumed the existing payload body
      * {@link Publisher} will be transformed/consumed or else no more requests may be processed.
@@ -95,7 +95,7 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
                                                   HttpSerializer<T> serializer);
 
     /**
-     * Return a {@link StreamingHttpRequest} with its underlying payload transformed to the result of serialization.
+     * Returns a {@link StreamingHttpRequest} with its underlying payload transformed to the result of serialization.
      * @param transformer A {@link Function} which take as a parameter the existing payload body {@link Publisher} and
      * returns the new payload body {@link Publisher} prior to serialization. It is assumed the existing payload body
      * {@link Publisher} will be transformed/consumed or else no more requests may be processed.
@@ -113,7 +113,7 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
     }
 
     /**
-     * Return a {@link StreamingHttpRequest} with its underlying payload transformed to {@link Buffer}s.
+     * Returns a {@link StreamingHttpRequest} with its underlying payload transformed to {@link Buffer}s.
      * @param transformer A {@link UnaryOperator} which take as a parameter the existing payload body {@link Publisher}
      * and returns the new payload body {@link Publisher}. It is assumed the existing payload body {@link Publisher}
      * will be transformed/consumed or else no more requests may be processed.
@@ -122,7 +122,7 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
     StreamingHttpRequest transformPayloadBody(UnaryOperator<Publisher<Buffer>> transformer);
 
     /**
-     * Return a {@link StreamingHttpRequest} with its underlying payload transformed. Note that the raw objects of the
+     * Returns a {@link StreamingHttpRequest} with its underlying payload transformed. Note that the raw objects of the
      * underlying {@link Publisher} may be exposed. The object types are not guaranteed to be homogeneous.
      * @param transformer Responsible for transforming the payload body.
      * @return A {@link StreamingHttpRequest} with the new payload body.
@@ -130,7 +130,7 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
     StreamingHttpRequest transformRawPayloadBody(UnaryOperator<Publisher<?>> transformer);
 
     /**
-     * Return a {@link StreamingHttpRequest} with its underlying payload transformed to {@link Buffer}s,
+     * Returns a {@link StreamingHttpRequest} with its underlying payload transformed to {@link Buffer}s,
      * with access to the trailers.
      * @param stateSupplier Create a new state {@link Object} that will be provided to the {@code transformer} on each
      * invocation. The state will be persistent for each {@link Subscriber} of the underlying payload body.
@@ -145,7 +145,7 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
                                        BiFunction<T, HttpHeaders, HttpHeaders> trailersTransformer);
 
     /**
-     * Return a {@link StreamingHttpRequest} with its underlying payload transformed to {@link Object}s,
+     * Returns a {@link StreamingHttpRequest} with its underlying payload transformed to {@link Object}s,
      * with access to the trailers.
      * @param stateSupplier Create a new state {@link Object} that will be provided to the {@code transformer} on each
      * invocation. The state will be persistent for each {@link Subscriber} of the underlying payload body.
@@ -160,7 +160,7 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
                                           BiFunction<T, HttpHeaders, HttpHeaders> trailersTransformer);
 
     /**
-     * Translate this {@link StreamingHttpRequest} to a {@link HttpRequest}.
+     * Translates this {@link StreamingHttpRequest} to a {@link HttpRequest}.
      * @return a {@link Single} that completes with a {@link HttpRequest} representation of this
      * {@link StreamingHttpRequest}.
      */

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpResponse.java
@@ -32,13 +32,13 @@ import java.util.function.UnaryOperator;
 public interface StreamingHttpResponse extends HttpResponseMetaData {
 
     /**
-     * Get the underlying payload as a {@link Publisher} of {@link Buffer}s.
+     * Gets the underlying payload as a {@link Publisher} of {@link Buffer}s.
      * @return The {@link Publisher} of {@link Buffer} representation of the underlying
      */
     Publisher<Buffer> payloadBody();
 
     /**
-     * Get and deserialize the payload body.
+     * Gets and deserializes the payload body.
      * @param deserializer The function that deserializes the underlying {@link Publisher}.
      * @param <T> The resulting type of the deserialization operation.
      * @return The results of the deserialization operation.
@@ -48,14 +48,14 @@ public interface StreamingHttpResponse extends HttpResponseMetaData {
     }
 
     /**
-     * Get a {@link Publisher} that combines the raw payload body concatenated with the {@link HttpHeaders trailers}.
+     * Gets a {@link Publisher} that combines the raw payload body concatenated with the {@link HttpHeaders trailers}.
      * @return a {@link Publisher} that combines the raw payload body concatenated with the
      * {@link HttpHeaders trailers}.
      */
     Publisher<Object> payloadBodyAndTrailers();
 
     /**
-     * Return a {@link StreamingHttpResponse} with its underlying payload set to {@code payloadBody}.
+     * Returns a {@link StreamingHttpResponse} with its underlying payload set to {@code payloadBody}.
      * <p>
      * A best effort will be made to apply back pressure to the existing {@link Publisher} payload body. If this default
      * policy is not sufficient you can use {@link #transformPayloadBody(UnaryOperator)} for more fine grain control.
@@ -68,7 +68,7 @@ public interface StreamingHttpResponse extends HttpResponseMetaData {
     StreamingHttpResponse payloadBody(Publisher<Buffer> payloadBody);
 
     /**
-     * Return a {@link StreamingHttpResponse} with its underlying payload set to the result of serialization.
+     * Returns a {@link StreamingHttpResponse} with its underlying payload set to the result of serialization.
      * <p>
      * A best effort will be made to apply back pressure to the existing {@link Publisher} payload body. If this default
      * policy is not sufficient you can use {@link #transformPayloadBody(Function, HttpSerializer)} for more fine grain
@@ -84,7 +84,7 @@ public interface StreamingHttpResponse extends HttpResponseMetaData {
     <T> StreamingHttpResponse payloadBody(Publisher<T> payloadBody, HttpSerializer<T> serializer);
 
     /**
-     * Return a {@link StreamingHttpResponse} with its underlying payload transformed to the result of serialization.
+     * Returns a {@link StreamingHttpResponse} with its underlying payload transformed to the result of serialization.
      * @param transformer A {@link Function} which take as a parameter the existing payload body {@link Publisher} and
      * returns the new payload body {@link Publisher} prior to serialization. It is assumed the existing payload body
      * {@link Publisher} will be transformed/consumed or else no more responses may be processed.
@@ -96,7 +96,7 @@ public interface StreamingHttpResponse extends HttpResponseMetaData {
                                                    HttpSerializer<T> serializer);
 
     /**
-     * Return a {@link StreamingHttpResponse} with its underlying payload transformed to the result of serialization.
+     * Returns a {@link StreamingHttpResponse} with its underlying payload transformed to the result of serialization.
      * @param transformer A {@link Function} which take as a parameter the existing payload body {@link Publisher} and
      * returns the new payload body {@link Publisher} prior to serialization. It is assumed the existing payload body
      * {@link Publisher} will be transformed/consumed or else no more requests may be processed.
@@ -114,7 +114,7 @@ public interface StreamingHttpResponse extends HttpResponseMetaData {
     }
 
     /**
-     * Return a {@link StreamingHttpResponse} with its underlying payload transformed to {@link Buffer}s.
+     * Returns a {@link StreamingHttpResponse} with its underlying payload transformed to {@link Buffer}s.
      * @param transformer A {@link Function} which take as a parameter the existing payload body {@link Publisher} and
      * returns the new payload body {@link Publisher}. It is assumed the existing payload body {@link Publisher} will be
      * transformed/consumed or else no more responses may be processed.
@@ -123,7 +123,7 @@ public interface StreamingHttpResponse extends HttpResponseMetaData {
     StreamingHttpResponse transformPayloadBody(UnaryOperator<Publisher<Buffer>> transformer);
 
     /**
-     * Return a {@link StreamingHttpResponse} with its underlying payload transformed. Note that the raw objects of the
+     * Returns a {@link StreamingHttpResponse} with its underlying payload transformed. Note that the raw objects of the
      * underlying {@link Publisher} may be exposed. The object types are not guaranteed to be homogeneous.
      * @param transformer Responsible for transforming the payload body.
      * @return A {@link StreamingHttpResponse} with the new payload body.
@@ -131,7 +131,7 @@ public interface StreamingHttpResponse extends HttpResponseMetaData {
     StreamingHttpResponse transformRawPayloadBody(UnaryOperator<Publisher<?>> transformer);
 
     /**
-     * Return a {@link StreamingHttpResponse} with its underlying payload transformed to {@link Buffer}s,
+     * Returns a {@link StreamingHttpResponse} with its underlying payload transformed to {@link Buffer}s,
      * with access to the trailers.
      * @param stateSupplier Create a new state {@link Object} that will be provided to the {@code transformer} on each
      * invocation. The state will be persistent for each {@link Subscriber} of the underlying payload body.
@@ -146,7 +146,7 @@ public interface StreamingHttpResponse extends HttpResponseMetaData {
                                         BiFunction<T, HttpHeaders, HttpHeaders> trailersTransformer);
 
     /**
-     * Return a {@link StreamingHttpResponse} with its underlying payload transformed to {@link Object}s,
+     * Returns a {@link StreamingHttpResponse} with its underlying payload transformed to {@link Object}s,
      * with access to the trailers.
      * @param stateSupplier Create a new state {@link Object} that will be provided to the {@code transformer} on each
      * invocation. The state will be persistent for each {@link Subscriber} of the underlying payload body.
@@ -161,14 +161,14 @@ public interface StreamingHttpResponse extends HttpResponseMetaData {
                                            BiFunction<T, HttpHeaders, HttpHeaders> trailersTransformer);
 
     /**
-     * Translate this {@link StreamingHttpResponse} to a {@link HttpResponse}.
+     * Translates this {@link StreamingHttpResponse} to a {@link HttpResponse}.
      * @return a {@link Single} that completes with a {@link HttpResponse} representation of this
      * {@link StreamingHttpResponse}.
      */
     Single<? extends HttpResponse> toResponse();
 
     /**
-     * Translate this {@link StreamingHttpResponse} to a {@link BlockingStreamingHttpResponse}.
+     * Translates this {@link StreamingHttpResponse} to a {@link BlockingStreamingHttpResponse}.
      * @return a {@link BlockingStreamingHttpResponse} representation of this {@link StreamingHttpResponse}.
      */
     BlockingStreamingHttpResponse toBlockingStreamingResponse();


### PR DESCRIPTION
__Motivation__

Users may not realize that payload mutators are not setters but actually return a new HTTP request/response instance.

__Modifications__

Replace "Set" with "Return" as the first word of the Javadoc for these mutators to avoid confusion with a setter.

__Results__

Less confused users.