### PR TITLE
Override toString for HttpResponseStatus implementations

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponseStatus.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponseStatus.java
@@ -19,6 +19,7 @@ import io.servicetalk.buffer.api.Buffer;
 
 import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.DEFAULT_RO_ALLOCATOR;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.toStatusClass;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;
 
 final class DefaultHttpResponseStatus implements HttpResponseStatus {
@@ -57,6 +58,11 @@ final class DefaultHttpResponseStatus implements HttpResponseStatus {
     @Override
     public StatusClass statusClass() {
         return statusClass;
+    }
+
+    @Override
+    public String toString() {
+        return Integer.toString(statusCode) + ' ' + reasonPhrase.toString(US_ASCII);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponseStatuses.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponseStatuses.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.PREFER_DIRECT_RO_ALLOCATOR;
 import static io.servicetalk.http.api.DefaultHttpResponseStatus.statusCodeToBuffer;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.toStatusClass;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -302,7 +303,6 @@ public enum HttpResponseStatuses implements HttpResponseStatus {
      */
     INSUFFICIENT_STORAGE(507, PREFER_DIRECT_RO_ALLOCATOR.fromAscii("Insufficient Storage")),
 
-
     /**
      * 510 Not Extended (RFC2774)
      */
@@ -346,15 +346,20 @@ public enum HttpResponseStatuses implements HttpResponseStatus {
         buffer.writeBytes(reasonPhrase, reasonPhrase.readerIndex(), reasonPhrase.readableBytes());
     }
 
+    @Override
+    public String toString() {
+        return Integer.toString(code) + ' ' + reasonPhrase.toString(US_ASCII);
+    }
+
     /**
      * Get a {@link HttpResponseStatus} for the specified {@code statusCode} and {@code reasonPhrase}. If the
      * {@code statusCode} and {@code reasonPhrase} match those of an existing constant, the constant will be returned,
      * otherwise a new instance will be returned.
      *
      * @param statusCode the three digit <a href="https://tools.ietf.org/html/rfc7231#section-6">status-code</a>
-     *                   indicating status of the response.
+     * indicating status of the response.
      * @param reasonPhrase the <a href="https://tools.ietf.org/html/rfc7230.html#section-3.1.2">reason-phrase</a>
-     *                     portion of the response.
+     * portion of the response.
      * @return a {@link HttpResponseStatus}.
      */
     public static HttpResponseStatus getResponseStatus(final int statusCode, final Buffer reasonPhrase) {

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpResponseStatusesTests.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpResponseStatusesTests.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import static io.servicetalk.buffer.api.EmptyBuffer.EMPTY_BUFFER;
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.http.api.HttpResponseStatuses.OK;
+import static io.servicetalk.http.api.HttpResponseStatuses.SWITCHING_PROTOCOLS;
 import static io.servicetalk.http.api.HttpResponseStatuses.getResponseStatus;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -31,5 +32,12 @@ public class HttpResponseStatusesTests {
         assertThat(getResponseStatus(200, DEFAULT_ALLOCATOR.fromAscii("OK")), is(OK));
         assertThat(getResponseStatus(200, EMPTY_BUFFER), is(OK));
         assertThat(getResponseStatus(200, DEFAULT_ALLOCATOR.fromAscii("YES")), is(not(OK)));
+    }
+
+    @Test
+    public void toStringRendering() {
+        assertThat(SWITCHING_PROTOCOLS.toString(), is("101 Switching Protocols"));
+        assertThat(getResponseStatus(555, DEFAULT_ALLOCATOR.fromAscii("Movie Area Code")).toString(),
+                is("555 Movie Area Code"));
     }
 }


### PR DESCRIPTION
__Motivation__

HttpResponseStatus implementations to do implement toString and thus have heterogeneous string rendering:

- HttpResponseStatuses is rendered as Enum#toString
- DefaultHttpResponseStatus is rendered as Object#toString

This isn't user friendly.

__Modifications__

Unify string rendering of HttpResponseStatus implementations to the familiar form:

    <status code> <space> <reason phrase>

__Results__

Users can log/print HttpResponseStatus.