### PR TITLE
Update to Jackson 2.9.8

### DIFF
--- a/servicetalk-bom-internal/gradle.properties
+++ b/servicetalk-bom-internal/gradle.properties
@@ -31,7 +31,7 @@ mockitoCoreVersion=2.19.0
 reactiveStreamsVersion=1.0.2
 rxJavaVersion=2.1.13
 jcToolsVersion=2.1.2
-jacksonVersion=2.9.5
+jacksonVersion=2.9.8
 
 openTracingVersion=0.31.0
 


### PR DESCRIPTION
__Motivation__

JSON deserialization can be used as an attack vector. Jackson regularly fixes [CVEs](https://github.com/FasterXML/jackson-databind/issues?utf8=✓&q=label%3ACVE) to address such issues. It is thus important to stay up to date with Jackson releases.

__Modification__

Update to Jackson `2.9.8`.

__Result__

Jackson version is `2.9.8`.