### PR TITLE
RedisEncoder improvments followup

### DIFF
--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisRequests.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisRequests.java
@@ -29,9 +29,6 @@ import io.servicetalk.redis.api.RedisData.RequestRedisData;
 import io.servicetalk.redis.api.RedisProtocolSupport.Command;
 import io.servicetalk.redis.api.RedisProtocolSupport.SubCommand;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.RandomAccess;
@@ -52,9 +49,6 @@ import static java.util.Objects.requireNonNull;
  * Factory methods for creating {@link RedisRequest}s.
  */
 public final class RedisRequests {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(RedisRequests.class);
-
     private static final int NUMBER_CACHE_MIN = -1;
     private static final int NUMBER_CACHE_MAX = 32;
     private static final byte[][] NUMBER_CACHE = initNumberCache();

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/StringByteSizeUtil.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/StringByteSizeUtil.java
@@ -22,6 +22,8 @@
  */
 package io.servicetalk.redis.api;
 
+import static java.lang.Character.isHighSurrogate;
+
 /**
  * String byte size util.
  */
@@ -36,19 +38,20 @@ final class StringByteSizeUtil {
      * @param sequence string
      * @return number of bytes
      */
-    public static int numberOfBytesUtf8(final CharSequence sequence) {
-        int count = 0;
-        for (int i = 0, len = sequence.length(); i < len; i++) {
+    static int numberOfBytesUtf8(final CharSequence sequence) {
+        final int len = sequence.length();
+        int count = len;
+        for (int i = 0; i < len; ++i) {
             final char ch = sequence.charAt(i);
             if (ch <= 0x7F) {
-                count++;
+                // len is initialized to sequence.length(), so nothing to do here.
             } else if (ch <= 0x7FF) {
-                count += 2;
-            } else if (Character.isHighSurrogate(ch)) {
-                count += 4;
+                ++count;
+            } else if (isHighSurrogate(ch)) {
+                count += 3;
                 ++i;
             } else {
-                count += 3;
+                count += 2;
             }
         }
         return count;


### PR DESCRIPTION
Motivation:
StringByteSizeUtil#numberOfBytesUtf8 can be made package private and also less incrementing is required for ascii characters. RedisRequests also no longer uses the LOGGER instances, so it can be removed.