### PR TITLE
HTTP Upgrade API remove

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClient.java
@@ -19,7 +19,6 @@ import io.servicetalk.http.api.BlockingHttpClientToHttpClient.ReservedBlockingHt
 import io.servicetalk.http.api.BlockingHttpClientToStreamingHttpClient.BlockingReservedStreamingHttpConnectionToReserved;
 import io.servicetalk.http.api.BlockingStreamingHttpClient.ReservedBlockingStreamingHttpConnection;
 import io.servicetalk.http.api.HttpClient.ReservedHttpConnection;
-import io.servicetalk.http.api.HttpClient.UpgradableHttpResponse;
 import io.servicetalk.http.api.StreamingHttpClient.ReservedStreamingHttpConnection;
 
 /**
@@ -63,22 +62,6 @@ public abstract class BlockingHttpClient extends BlockingHttpRequester {
      */
     public abstract ReservedBlockingHttpConnection reserveConnection(HttpExecutionStrategy strategy,
                                                                      HttpRequest request) throws Exception;
-
-    /**
-     * Attempt a <a href="https://tools.ietf.org/html/rfc7230.html#section-6.7">protocol upgrade</a>.
-     * As part of the <a href="https://tools.ietf.org/html/rfc7230.html#section-6.7">protocol upgrade</a> process there
-     * cannot be any pipelined requests pending or any pipeline requests issued during the upgrade process. That means
-     * the {@link BlockingHttpConnection} associated with the {@link UpgradableHttpResponse} will be
-     * reserved for exclusive use. The code responsible for determining the result of the upgrade attempt is responsible
-     * for calling {@link UpgradableHttpResponse#httpConnection(boolean)}.
-     *
-     * @param request the request which initiates the upgrade.
-     * @return An {@link UpgradableHttpResponse} for the upgrade attempt and also contains the
-     * {@link BlockingHttpConnection} used for the upgrade.
-     * @throws Exception if a exception occurs during the upgrade process.
-     * @see StreamingHttpClient#upgradeConnection(StreamingHttpRequest)
-     */
-    public abstract UpgradableHttpResponse upgradeConnection(HttpRequest request) throws Exception;
 
     /**
      * Convert this {@link BlockingHttpClient} to the {@link StreamingHttpClient} API.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClientToHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClientToHttpClient.java
@@ -45,11 +45,6 @@ final class BlockingHttpClientToHttpClient extends HttpClient {
     }
 
     @Override
-    public Single<? extends UpgradableHttpResponse> upgradeConnection(final HttpRequest request) {
-        return blockingToSingle(() -> client.upgradeConnection(request));
-    }
-
-    @Override
     public Single<HttpResponse> request(final HttpExecutionStrategy strategy, final HttpRequest request) {
         return BlockingUtils.request(client, strategy, request);
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClientToStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClientToStreamingHttpClient.java
@@ -45,12 +45,6 @@ final class BlockingHttpClientToStreamingHttpClient extends StreamingHttpClient 
     }
 
     @Override
-    public Single<? extends UpgradableStreamingHttpResponse> upgradeConnection(final StreamingHttpRequest request) {
-        return request.toRequest().flatMap(req -> blockingToSingle(() -> client.upgradeConnection(req))
-                .map(HttpClient.UpgradableHttpResponse::toStreamingResponse));
-    }
-
-    @Override
     public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
                                                  final StreamingHttpRequest request) {
         return BlockingUtils.request(client, strategy, request);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClientToStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClientToStreamingHttpClient.java
@@ -15,35 +15,18 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.buffer.api.Buffer;
-import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.concurrent.api.internal.SingleProcessor;
 import io.servicetalk.http.api.BlockingStreamingHttpClient.ReservedBlockingStreamingHttpConnection;
-import io.servicetalk.http.api.BlockingStreamingHttpClient.UpgradableBlockingStreamingHttpResponse;
-import io.servicetalk.http.api.HttpClient.UpgradableHttpResponse;
-import io.servicetalk.http.api.HttpDataSourceTranformations.BridgeFlowControlAndDiscardOperator;
-import io.servicetalk.http.api.HttpDataSourceTranformations.HttpBufferFilterOperator;
-import io.servicetalk.http.api.HttpDataSourceTranformations.HttpPayloadAndTrailersFromSingleOperator;
-import io.servicetalk.http.api.HttpDataSourceTranformations.SerializeBridgeFlowControlAndDiscardOperator;
 import io.servicetalk.http.api.StreamingHttpClientToBlockingStreamingHttpClient.ReservedStreamingHttpConnectionToBlockingStreaming;
-import io.servicetalk.http.api.StreamingHttpClientToBlockingStreamingHttpClient.UpgradableStreamingHttpResponseToBlockingStreaming;
-import io.servicetalk.http.api.StreamingHttpClientToHttpClient.UpgradableStreamingHttpResponseToUpgradableHttpResponse;
 import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ExecutionContext;
-
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
 
 import static io.servicetalk.concurrent.api.Completable.error;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.http.api.BlockingUtils.blockingToCompletable;
 import static io.servicetalk.http.api.BlockingUtils.blockingToSingle;
-import static io.servicetalk.http.api.HttpDataSourceTranformations.aggregatePayloadAndTrailers;
 import static java.util.Objects.requireNonNull;
 
 final class BlockingStreamingHttpClientToStreamingHttpClient extends StreamingHttpClient {
@@ -66,12 +49,6 @@ final class BlockingStreamingHttpClientToStreamingHttpClient extends StreamingHt
                                                                                final StreamingHttpRequest request) {
         return blockingToSingle(() -> new BlockingToReservedStreamingHttpConnection(
                     blockingClient.reserveConnection(strategy, request.toBlockingStreamingRequest())));
-    }
-
-    @Override
-    public Single<? extends UpgradableStreamingHttpResponse> upgradeConnection(final StreamingHttpRequest request) {
-        return blockingToSingle(() ->
-                blockingClient.upgradeConnection(request.toBlockingStreamingRequest()).toStreamingResponse());
     }
 
     @Override
@@ -153,145 +130,6 @@ final class BlockingStreamingHttpClientToStreamingHttpClient extends StreamingHt
         @Override
         ReservedBlockingStreamingHttpConnection asBlockingStreamingConnectionInternal() {
             return blockingReservedConnection;
-        }
-    }
-
-    static final class BlockingToUpgradableStreamingHttpResponse implements UpgradableStreamingHttpResponse {
-        private final UpgradableBlockingStreamingHttpResponse upgradeResponse;
-        private final Publisher<?> payloadBody;
-        private final Single<HttpHeaders> trailersSingle;
-        private final BufferAllocator allocator;
-
-        BlockingToUpgradableStreamingHttpResponse(UpgradableBlockingStreamingHttpResponse upgradeResponse,
-                                                  Publisher<?> payloadBody,
-                                                  Single<HttpHeaders> trailersSingle,
-                                                  BufferAllocator allocator) {
-            this.upgradeResponse = requireNonNull(upgradeResponse);
-            this.payloadBody = requireNonNull(payloadBody);
-            this.trailersSingle = requireNonNull(trailersSingle);
-            this.allocator = requireNonNull(allocator);
-        }
-
-        @Override
-        public ReservedStreamingHttpConnection httpConnection(final boolean releaseReturnsToClient) {
-            return new BlockingToReservedStreamingHttpConnection(
-                    upgradeResponse.httpConnection(releaseReturnsToClient));
-        }
-
-        @Override
-        public UpgradableStreamingHttpResponse payloadBody(final Publisher<Buffer> payloadBody) {
-            return transformPayloadBody(old -> payloadBody.liftSynchronous(
-                    new BridgeFlowControlAndDiscardOperator(old)));
-        }
-
-        @Override
-        public <T> UpgradableStreamingHttpResponse payloadBody(final Publisher<T> payloadBody,
-                                                               final HttpSerializer<T> serializer) {
-            return transformPayloadBody(old -> payloadBody.liftSynchronous(
-                    new SerializeBridgeFlowControlAndDiscardOperator<>(old)), serializer);
-        }
-
-        @Override
-        public Publisher<Buffer> payloadBody() {
-            return payloadBody.liftSynchronous(HttpBufferFilterOperator.INSTANCE);
-        }
-
-        @Override
-        public Publisher<Object> payloadBodyAndTrailers() {
-            return payloadBody
-                    .map(payload -> (Object) payload) // down cast to Object
-                    .concatWith(trailersSingle);
-        }
-
-        @Override
-        public <T> UpgradableStreamingHttpResponse transformPayloadBody(
-                final Function<Publisher<Buffer>, Publisher<T>> transformer, final HttpSerializer<T> serializer) {
-            return new BlockingToUpgradableStreamingHttpResponse(upgradeResponse,
-                    serializer.serialize(headers(), transformer.apply(payloadBody()), allocator),
-                    trailersSingle, allocator);
-        }
-
-        @Override
-        public UpgradableStreamingHttpResponse transformPayloadBody(
-                final UnaryOperator<Publisher<Buffer>> transformer) {
-            return new BlockingToUpgradableStreamingHttpResponse(upgradeResponse,
-                    transformer.apply(payloadBody()), trailersSingle, allocator);
-        }
-
-        @Override
-        public UpgradableStreamingHttpResponse transformRawPayloadBody(final UnaryOperator<Publisher<?>> transformer) {
-            return new BlockingToUpgradableStreamingHttpResponse(upgradeResponse, transformer.apply(payloadBody),
-                    trailersSingle, allocator);
-        }
-
-        @Override
-        public <T> UpgradableStreamingHttpResponse transform(
-                final Supplier<T> stateSupplier, final BiFunction<Buffer, T, Buffer> transformer,
-                final BiFunction<T, HttpHeaders, HttpHeaders> trailersTrans) {
-            final SingleProcessor<HttpHeaders> outTrailersSingle = new SingleProcessor<>();
-            return new BlockingToUpgradableStreamingHttpResponse(upgradeResponse, payloadBody()
-                    .liftSynchronous(new HttpPayloadAndTrailersFromSingleOperator<>(stateSupplier, transformer,
-                            trailersTrans, trailersSingle, outTrailersSingle)),
-                    outTrailersSingle, allocator);
-        }
-
-        @Override
-        public <T> UpgradableStreamingHttpResponse transformRaw(
-                final Supplier<T> stateSupplier, final BiFunction<Object, T, ?> transformer,
-                final BiFunction<T, HttpHeaders, HttpHeaders> trailersTrans) {
-            final SingleProcessor<HttpHeaders> outTrailersSingle = new SingleProcessor<>();
-            return new BlockingToUpgradableStreamingHttpResponse(upgradeResponse, payloadBody
-                    .liftSynchronous(new HttpPayloadAndTrailersFromSingleOperator<>(stateSupplier, transformer,
-                            trailersTrans, trailersSingle, outTrailersSingle)),
-                    outTrailersSingle, allocator);
-        }
-
-        @Override
-        public Single<? extends UpgradableHttpResponse> toResponse() {
-            return aggregatePayloadAndTrailers(payloadBodyAndTrailers(), allocator).map(pair -> {
-                assert pair.trailers != null;
-                return new UpgradableStreamingHttpResponseToUpgradableHttpResponse(
-                        upgradeResponse.toStreamingResponse(), pair.compositeBuffer, pair.trailers, allocator);
-            });
-        }
-
-        @Override
-        public UpgradableBlockingStreamingHttpResponse toBlockingStreamingResponse() {
-            return new UpgradableStreamingHttpResponseToBlockingStreaming(upgradeResponse.toStreamingResponse(),
-                    payloadBody.toIterable(), trailersSingle, allocator);
-        }
-
-        @Override
-        public HttpProtocolVersion version() {
-            return upgradeResponse.version();
-        }
-
-        @Override
-        public BlockingToUpgradableStreamingHttpResponse version(final HttpProtocolVersion version) {
-            upgradeResponse.version(version);
-            return this;
-        }
-
-        @Override
-        public HttpHeaders headers() {
-            return upgradeResponse.headers();
-        }
-
-        @Override
-        public String toString(final BiFunction<? super CharSequence, ? super CharSequence, CharSequence>
-                                               headerFilter) {
-            return upgradeResponse.toString(headerFilter);
-        }
-
-        @Override
-        public HttpResponseStatus status() {
-            return upgradeResponse.status();
-        }
-
-        @Override
-        public BlockingToUpgradableStreamingHttpResponse status(final HttpResponseStatus status) {
-            upgradeResponse.status(status);
-            return this;
         }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientToBlockingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientToBlockingHttpClient.java
@@ -40,13 +40,6 @@ final class HttpClientToBlockingHttpClient extends BlockingHttpClient {
     }
 
     @Override
-    public HttpClient.UpgradableHttpResponse upgradeConnection(final HttpRequest request) throws Exception {
-        // It is assumed that users will always apply timeouts at the StreamingHttpService layer (e.g. via filter).
-        // So we don't apply any explicit timeout here and just wait forever.
-        return blockingInvocation(client.upgradeConnection(request));
-    }
-
-    @Override
     public HttpResponse request(final HttpExecutionStrategy strategy, final HttpRequest request) throws Exception {
         return blockingInvocation(client.request(strategy, request));
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/LoadBalancerReadyStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/LoadBalancerReadyStreamingHttpClient.java
@@ -62,11 +62,6 @@ public final class LoadBalancerReadyStreamingHttpClient extends StreamingHttpCli
     }
 
     @Override
-    public Single<? extends UpgradableStreamingHttpResponse> upgradeConnection(final StreamingHttpRequest request) {
-        return delegate().upgradeConnection(request).retryWhen(retryWhenFunction());
-    }
-
-    @Override
     public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
                                                  final StreamingHttpRequest request) {
         return delegate().request(strategy, request).retryWhen(retryWhenFunction());

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilter.java
@@ -72,11 +72,6 @@ public class StreamingHttpClientFilter extends StreamingHttpClient {
     }
 
     @Override
-    public Single<? extends UpgradableStreamingHttpResponse> upgradeConnection(final StreamingHttpRequest request) {
-        return delegate.upgradeConnection(request);
-    }
-
-    @Override
     public final Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
         return request(defaultStrategy, request);
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingHttpClient.java
@@ -17,14 +17,12 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.BlockingIterable;
 import io.servicetalk.concurrent.api.Completable;
-import io.servicetalk.http.api.HttpClient.UpgradableHttpResponse;
 import io.servicetalk.http.api.StreamingHttpClient.ReservedStreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpConnection.SettingKey;
 import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ExecutionContext;
 
 import static io.servicetalk.http.api.BlockingUtils.blockingInvocation;
-import static io.servicetalk.http.api.StreamingHttpClientToHttpClient.doUpgradeConnection;
 import static java.util.Objects.requireNonNull;
 
 final class StreamingHttpClientToBlockingHttpClient extends BlockingHttpClient {
@@ -40,11 +38,6 @@ final class StreamingHttpClientToBlockingHttpClient extends BlockingHttpClient {
                                                             final HttpRequest request) throws Exception {
         return blockingInvocation(client.reserveConnection(strategy, request.toStreamingRequest())
                 .map(ReservedStreamingHttpConnectionToBlocking::new));
-    }
-
-    @Override
-    public UpgradableHttpResponse upgradeConnection(final HttpRequest request) throws Exception {
-        return blockingInvocation(doUpgradeConnection(client, request));
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingStreamingHttpClient.java
@@ -15,34 +15,13 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.buffer.api.Buffer;
-import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.concurrent.BlockingIterable;
-import io.servicetalk.concurrent.CloseableIterable;
 import io.servicetalk.concurrent.api.Completable;
-import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.concurrent.api.internal.SingleProcessor;
-import io.servicetalk.concurrent.internal.BlockingIterables;
-import io.servicetalk.http.api.BlockingStreamingHttpClientToStreamingHttpClient.BlockingToUpgradableStreamingHttpResponse;
-import io.servicetalk.http.api.HttpClient.UpgradableHttpResponse;
-import io.servicetalk.http.api.HttpDataSourceTranformations.HttpBufferFilterIterable;
-import io.servicetalk.http.api.HttpDataSourceTranformations.HttpBuffersAndTrailersIterable;
-import io.servicetalk.http.api.HttpDataSourceTranformations.HttpObjectsAndTrailersIterable;
 import io.servicetalk.http.api.StreamingHttpClient.ReservedStreamingHttpConnection;
-import io.servicetalk.http.api.StreamingHttpClient.UpgradableStreamingHttpResponse;
 import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ExecutionContext;
 
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
-
-import static io.servicetalk.concurrent.internal.BlockingIterables.from;
 import static io.servicetalk.http.api.BlockingUtils.blockingInvocation;
-import static io.servicetalk.http.api.HttpDataSourceTranformations.consumeOldPayloadBody;
-import static io.servicetalk.http.api.HttpDataSourceTranformations.consumeOldPayloadBodySerialized;
 import static java.util.Objects.requireNonNull;
 
 final class StreamingHttpClientToBlockingStreamingHttpClient extends BlockingStreamingHttpClient {
@@ -73,15 +52,6 @@ final class StreamingHttpClientToBlockingStreamingHttpClient extends BlockingStr
         // So we don't apply any explicit timeout here and just wait forever.
         return new ReservedStreamingHttpConnectionToBlockingStreaming(
                 blockingInvocation(client.reserveConnection(strategy, request.toStreamingRequest())));
-    }
-
-    @Override
-    public UpgradableBlockingStreamingHttpResponse upgradeConnection(
-            final BlockingStreamingHttpRequest request) throws Exception {
-        // It is assumed that users will always apply timeouts at the StreamingHttpService layer (e.g. via filter).
-        // So we don't apply any explicit timeout here and just wait forever.
-        return blockingInvocation(client.upgradeConnection(
-                request.toStreamingRequest())).toBlockingStreamingResponse();
     }
 
     @Override
@@ -147,147 +117,6 @@ final class StreamingHttpClientToBlockingStreamingHttpClient extends BlockingStr
         @Override
         ReservedStreamingHttpConnection asStreamingConnectionInternal() {
             return connection;
-        }
-    }
-
-    static final class UpgradableStreamingHttpResponseToBlockingStreaming implements
-                                                                    UpgradableBlockingStreamingHttpResponse {
-        private final UpgradableStreamingHttpResponse upgradeResponse;
-        private final BlockingIterable<?> payloadBody;
-        private final Single<HttpHeaders> trailersSingle;
-        private final BufferAllocator allocator;
-
-        UpgradableStreamingHttpResponseToBlockingStreaming(UpgradableStreamingHttpResponse upgradeResponse,
-                                                           BlockingIterable<?> payloadBody,
-                                                           Single<HttpHeaders> trailersSingle,
-                                                           BufferAllocator allocator) {
-            this.upgradeResponse = requireNonNull(upgradeResponse);
-            this.payloadBody = requireNonNull(payloadBody);
-            this.trailersSingle = requireNonNull(trailersSingle);
-            this.allocator = requireNonNull(allocator);
-        }
-
-        @Override
-        public ReservedBlockingStreamingHttpConnection httpConnection(final boolean releaseReturnsToClient) {
-            return new ReservedStreamingHttpConnectionToBlockingStreaming(
-                    upgradeResponse.httpConnection(releaseReturnsToClient));
-        }
-
-        @Override
-        public UpgradableBlockingStreamingHttpResponse payloadBody(final Iterable<Buffer> payloadBody) {
-            return transformPayloadBody(consumeOldPayloadBody(BlockingIterables.from(payloadBody)));
-        }
-
-        @Override
-        public UpgradableBlockingStreamingHttpResponse payloadBody(final CloseableIterable<Buffer> payloadBody) {
-            return transformPayloadBody(consumeOldPayloadBody(from(payloadBody)));
-        }
-
-        @Override
-        public <T> UpgradableBlockingStreamingHttpResponse payloadBody(final Iterable<T> payloadBody,
-                                                                       final HttpSerializer<T> serializer) {
-            return transformPayloadBody(consumeOldPayloadBodySerialized(BlockingIterables.from(payloadBody)),
-                    serializer);
-        }
-
-        @Override
-        public <T> UpgradableBlockingStreamingHttpResponse payloadBody(final CloseableIterable<T> payloadBody,
-                                                                       final HttpSerializer<T> serializer) {
-            return transformPayloadBody(consumeOldPayloadBodySerialized(from(payloadBody)), serializer);
-        }
-
-        @Override
-        public BlockingIterable<Buffer> payloadBody() {
-            return new HttpBufferFilterIterable(payloadBody);
-        }
-
-        @Override
-        public <T> UpgradableBlockingStreamingHttpResponse transformPayloadBody(
-                final Function<BlockingIterable<Buffer>, BlockingIterable<T>> transformer,
-                final HttpSerializer<T> serializer) {
-            return new UpgradableStreamingHttpResponseToBlockingStreaming(upgradeResponse,
-                    serializer.serialize(headers(), transformer.apply(payloadBody()), allocator),
-                    trailersSingle, allocator);
-        }
-
-        @Override
-        public UpgradableBlockingStreamingHttpResponse transformPayloadBody(
-                final UnaryOperator<BlockingIterable<Buffer>> transformer) {
-            return new UpgradableStreamingHttpResponseToBlockingStreaming(upgradeResponse,
-                    transformer.apply(payloadBody()), trailersSingle, allocator);
-        }
-
-        @Override
-        public UpgradableBlockingStreamingHttpResponse transformRawPayloadBody(
-                final UnaryOperator<BlockingIterable<?>> transformer) {
-            return new UpgradableStreamingHttpResponseToBlockingStreaming(upgradeResponse,
-                    transformer.apply(payloadBody), trailersSingle, allocator);
-        }
-
-        @Override
-        public <T> UpgradableBlockingStreamingHttpResponse transform(
-                final Supplier<T> stateSupplier, final BiFunction<Buffer, T, Buffer> transformer,
-                final BiFunction<T, HttpHeaders, HttpHeaders> trailersTrans) {
-            final SingleProcessor<HttpHeaders> outTrailersSingle = new SingleProcessor<>();
-            return new UpgradableStreamingHttpResponseToBlockingStreaming(upgradeResponse,
-                    new HttpBuffersAndTrailersIterable<>(payloadBody(), stateSupplier,
-                            transformer, trailersTrans, trailersSingle, outTrailersSingle),
-                    outTrailersSingle, allocator);
-        }
-
-        @Override
-        public <T> UpgradableBlockingStreamingHttpResponse transformRaw(
-                final Supplier<T> stateSupplier, final BiFunction<Object, T, ?> transformer,
-                final BiFunction<T, HttpHeaders, HttpHeaders> trailersTrans) {
-            final SingleProcessor<HttpHeaders> outTrailersSingle = new SingleProcessor<>();
-            return new UpgradableStreamingHttpResponseToBlockingStreaming(upgradeResponse,
-                    new HttpObjectsAndTrailersIterable<>(payloadBody, stateSupplier,
-                            transformer, trailersTrans, trailersSingle, outTrailersSingle),
-                    outTrailersSingle, allocator);
-        }
-
-        @Override
-        public Single<? extends UpgradableHttpResponse> toResponse() {
-            return toStreamingResponse().toResponse();
-        }
-
-        @Override
-        public UpgradableStreamingHttpResponse toStreamingResponse() {
-            return new BlockingToUpgradableStreamingHttpResponse(this, Publisher.from(payloadBody), trailersSingle,
-                    allocator);
-        }
-
-        @Override
-        public HttpProtocolVersion version() {
-            return upgradeResponse.version();
-        }
-
-        @Override
-        public UpgradableStreamingHttpResponseToBlockingStreaming version(final HttpProtocolVersion version) {
-            upgradeResponse.version(version);
-            return this;
-        }
-
-        @Override
-        public HttpHeaders headers() {
-            return upgradeResponse.headers();
-        }
-
-        @Override
-        public String toString(
-                final BiFunction<? super CharSequence, ? super CharSequence, CharSequence> headerFilter) {
-            return upgradeResponse.toString(headerFilter);
-        }
-
-        @Override
-        public HttpResponseStatus status() {
-            return upgradeResponse.status();
-        }
-
-        @Override
-        public UpgradableStreamingHttpResponseToBlockingStreaming status(final HttpResponseStatus status) {
-            upgradeResponse.status(status);
-            return this;
         }
     }
 }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpClientTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpClientTest.java
@@ -45,12 +45,6 @@ public class BlockingStreamingHttpClientTest extends AbstractBlockingStreamingHt
                     final HttpExecutionStrategy strategy, final StreamingHttpRequest request) {
                 return error(new UnsupportedOperationException());
             }
-
-            @Override
-            public Single<? extends UpgradableStreamingHttpResponse> upgradeConnection(
-                    final StreamingHttpRequest request) {
-                return error(new UnsupportedOperationException());
-            }
         };
     }
 
@@ -70,12 +64,6 @@ public class BlockingStreamingHttpClientTest extends AbstractBlockingStreamingHt
             @Override
             public ReservedBlockingStreamingHttpConnection reserveConnection(
                     final HttpExecutionStrategy strategy, final BlockingStreamingHttpRequest request) {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public UpgradableBlockingStreamingHttpResponse upgradeConnection(
-                    final BlockingStreamingHttpRequest request) {
                 throw new UnsupportedOperationException();
             }
         };

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/LoadBalancerReadyHttpClientTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/LoadBalancerReadyHttpClientTest.java
@@ -24,7 +24,6 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.http.api.StreamingHttpClient.ReservedStreamingHttpConnection;
-import io.servicetalk.http.api.StreamingHttpClient.UpgradableStreamingHttpResponse;
 import io.servicetalk.transport.api.ExecutionContext;
 
 import org.junit.Before;
@@ -76,18 +75,10 @@ public class LoadBalancerReadyHttpClientTest {
                 final StreamingHttpRequest request) {
             return defer(new DeferredSuccessSupplier<>(mockReservedConnection));
         }
-
-        @Override
-        public Single<? extends UpgradableStreamingHttpResponse> upgradeConnection(
-                final StreamingHttpRequest request) {
-            return defer(new DeferredSuccessSupplier<>(mockUpgradeResponse));
-        }
     };
 
     @Mock
     private ReservedStreamingHttpConnection mockReservedConnection;
-    @Mock
-    private UpgradableStreamingHttpResponse mockUpgradeResponse;
 
     @Before
     public void setup() {
@@ -105,11 +96,6 @@ public class LoadBalancerReadyHttpClientTest {
     }
 
     @Test
-    public void upgradeIsDelayed() throws InterruptedException {
-        verifyActionIsDelayedUntilAfterInitialized(filter -> filter.upgradeConnection(filter.get("/noop")));
-    }
-
-    @Test
     public void initializedFailedAlsoFailsRequest() throws InterruptedException {
         verifyOnInitializedFailedFailsAction(filter -> filter.request(filter.get("/noop")));
     }
@@ -117,11 +103,6 @@ public class LoadBalancerReadyHttpClientTest {
     @Test
     public void initializedFailedAlsoFailsReserve() throws InterruptedException {
         verifyOnInitializedFailedFailsAction(filter -> filter.reserveConnection(filter.get("/noop")));
-    }
-
-    @Test
-    public void initializedFailedAlsoFailsUpgrade() throws InterruptedException {
-        verifyOnInitializedFailedFailsAction(filter -> filter.upgradeConnection(filter.get("/noop")));
     }
 
     private void verifyOnInitializedFailedFailsAction(Function<StreamingHttpClient,

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpClient.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpClient.java
@@ -56,9 +56,4 @@ public class TestStreamingHttpClient extends StreamingHttpClient {
                                                                                final StreamingHttpRequest request) {
         return error(new UnsupportedOperationException());
     }
-
-    @Override
-    public Single<? extends UpgradableStreamingHttpResponse> upgradeConnection(final StreamingHttpRequest request) {
-        return error(new UnsupportedOperationException());
-    }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -317,24 +317,6 @@ final class DefaultMultiAddressUrlHttpClientBuilder
         }
 
         @Override
-        public Single<? extends UpgradableStreamingHttpResponse> upgradeConnection(final StreamingHttpRequest request) {
-            return new Single<UpgradableStreamingHttpResponse>() {
-                @Override
-                protected void handleSubscribe(final Subscriber<? super UpgradableStreamingHttpResponse> subscriber) {
-                    StreamingHttpClient streamingHttpClient;
-                    try {
-                        streamingHttpClient = selectClient(request);
-                    } catch (Throwable t) {
-                        subscriber.onSubscribe(IGNORE_CANCEL);
-                        subscriber.onError(t);
-                        return;
-                    }
-                    streamingHttpClient.upgradeConnection(request).subscribe(subscriber);
-                }
-            };
-        }
-
-        @Override
         public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
                                                      final StreamingHttpRequest request) {
             return new Single<StreamingHttpResponse>() {
@@ -392,12 +374,6 @@ final class DefaultMultiAddressUrlHttpClientBuilder
         public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
                                                                                    final StreamingHttpRequest request) {
             return httpClient.reserveConnection(strategy, request);
-        }
-
-        @Override
-        public Single<? extends UpgradableStreamingHttpResponse> upgradeConnection(
-                final StreamingHttpRequest request) {
-            return httpClient.upgradeConnection(request);
         }
 
         @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -173,24 +173,6 @@ class DefaultPartitionedHttpClientBuilder<U, R> implements PartitionedHttpClient
         }
 
         @Override
-        public Single<? extends UpgradableStreamingHttpResponse> upgradeConnection(final StreamingHttpRequest request) {
-            return new Single<UpgradableStreamingHttpResponse>() {
-                @Override
-                protected void handleSubscribe(final Subscriber<? super UpgradableStreamingHttpResponse> subscriber) {
-                    StreamingHttpClient streamingHttpClient;
-                    try {
-                        streamingHttpClient = selectClient(request);
-                    } catch (Throwable t) {
-                        subscriber.onSubscribe(IGNORE_CANCEL);
-                        subscriber.onError(t);
-                        return;
-                    }
-                    streamingHttpClient.upgradeConnection(request).subscribe(subscriber);
-                }
-            };
-        }
-
-        @Override
         public Completable onClose() {
             return group.onClose();
         }
@@ -227,11 +209,6 @@ class DefaultPartitionedHttpClientBuilder<U, R> implements PartitionedHttpClient
         @Override
         public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
                                                                                    final StreamingHttpRequest request) {
-            return error(ex);
-        }
-
-        @Override
-        public Single<? extends UpgradableStreamingHttpResponse> upgradeConnection(final StreamingHttpRequest request) {
             return error(ex);
         }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultStreamingHttpClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultStreamingHttpClient.java
@@ -27,7 +27,6 @@ import io.servicetalk.transport.api.ExecutionContext;
 
 import java.util.function.Function;
 
-import static io.servicetalk.concurrent.api.Single.error;
 import static java.util.Objects.requireNonNull;
 
 final class DefaultStreamingHttpClient extends StreamingHttpClient {
@@ -57,11 +56,6 @@ final class DefaultStreamingHttpClient extends StreamingHttpClient {
                                                                                final StreamingHttpRequest request) {
         return strategy.offloadReceive(executionContext.executor(),
                 loadBalancer.selectConnection(SELECTOR_FOR_RESERVE));
-    }
-
-    @Override
-    public Single<? extends UpgradableStreamingHttpResponse> upgradeConnection(final StreamingHttpRequest request) {
-        return error(new UnsupportedOperationException("Protocol upgrades not yet implemented"));
     }
 
     @Override

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RetryingHttpClientFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RetryingHttpClientFilter.java
@@ -75,14 +75,6 @@ public final class RetryingHttpClientFilter extends StreamingHttpClientFilter {
         return delegate().reserveConnection(request);
     }
 
-    @Override
-    public Single<? extends UpgradableStreamingHttpResponse> upgradeConnection(final StreamingHttpRequest request) {
-        if (isRetryable.test(request)) {
-            return delegate().upgradeConnection(request).retryWhen(strategy);
-        }
-        return delegate().upgradeConnection(request);
-    }
-
     /**
      * A builder for {@link RetryingHttpClientFilter}.
      */


### PR DESCRIPTION
__Motivation__

The API for HTTP Upgrade will most likely move to some utility class, so for now we decided to remove the API which is not currently implemented.
When we'll start to work on HTTP/2 we'll reintroduce an HTTP upgrade API.

__Modifications__

- remove upgradeConnection() and related API classes and conversions

__Result__

Incomplete API removed.