### PR TITLE
Add an 'assemble' task to the composite.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,10 @@ task build {
   dependsOn findTasks('build')
 }
 
+task assemble {
+  dependsOn findTasks('assemble')
+}
+
 task checkstyle {
   dependsOn findTasks('checkstyle',
     ['servicetalk-bom', 'servicetalk-bom-internal', 'servicetalk-examples', 'servicetalk-gradle-plugin-internal'])


### PR DESCRIPTION
Motivation:

When changing code and running benchmarks, it's often useful to re-build
the composite without running tests and code quality checks:
`./gradlew assemble publishToMavenLocal`

Modifications:

Added the 'assemble' task to the composite.

Results:

`./gradlew assemble` can be run from the composite.