### PR TITLE
Remove a custom Gradle's task `package`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,10 +78,6 @@ task javadoc {
   dependsOn findTasks('javadoc')
 }
 
-task 'package' {
-  dependsOn findTasks('package', ['servicetalk-examples'])
-}
-
 task test {
   dependsOn findTasks('test')
 }

--- a/servicetalk-gradle-plugin-internal/build.gradle
+++ b/servicetalk-gradle-plugin-internal/build.gradle
@@ -131,5 +131,3 @@ idea {
 if (!hasProperty('releaseBuild') && !version.toString().endsWith("-SNAPSHOT")) {
   version += "-SNAPSHOT"
 }
-
-task('package', dependsOn: assemble)

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkCorePlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkCorePlugin.groovy
@@ -147,8 +147,6 @@ class ServiceTalkCorePlugin implements Plugin<Project> {
           jcenter()
         }
       }
-
-      task("package", dependsOn: assemble)
     }
   }
 


### PR DESCRIPTION
Motivation:

We used a custom Gradle's task `package` in the past which was an alias
for the default Gradle's task `assemble`. It's not required anymore.

Modifications:

- Remove definition of a custom Gradle's task `package` from our plugin
and composite build.

Result:

No `package` task for Gradle.