### PR TITLE
Skip existing headers for license check

### DIFF
--- a/servicetalk-gradle-plugin-internal/build.gradle
+++ b/servicetalk-gradle-plugin-internal/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 license {
   header = file("$rootDir/src/main/resources/io/servicetalk/gradle/plugin/internal/license/HEADER.txt")
   strictCheck = true
+  skipExistingHeaders = true
   mapping {
     java = 'SLASHSTAR_STYLE'
     gradle = 'SLASHSTAR_STYLE'

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkCorePlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkCorePlugin.groovy
@@ -44,6 +44,7 @@ class ServiceTalkCorePlugin implements Plugin<Project> {
         header = null
         headerURI = getClass().getResource("license/HEADER.txt").toURI()
         strictCheck = true
+        skipExistingHeaders = true
         mapping {
           java = 'SLASHSTAR_STYLE'
           gradle = 'SLASHSTAR_STYLE'


### PR DESCRIPTION
Motivation:

Until it is not clear how to configure `license-gradle-plugin` for different
years in copyright header, let's skip analysis over files that have some
header already.

Modifications:

- Set `skipExistingHeaders` to `true`;

Result:

`license-gradle-plugin` verifies that all files have some header, but
does not check its content.