### PR TITLE
Fix broken `license` task in composite build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,10 +130,10 @@ task publishToMavenLocal(overwrite: true) {
 
 task license(overwrite: true) {
   dependsOn licenseRoot
-  dependsOn gradle.includedBuilds*.task(':license')
+  dependsOn findTasks('license', ['servicetalk-examples'])
 }
 
 task licenseFormat(overwrite: true) {
   dependsOn licenseFormatRoot
-  dependsOn gradle.includedBuilds*.task(':licenseFormat')
+  dependsOn findTasks('licenseFormat', ['servicetalk-examples'])
 }


### PR DESCRIPTION
Motivation:

`./gradlew license` doesn't work because `servicetalk-examples` module
does not have `license-gradle-plugin`.

Modifications:

- Filter out `servicetalk-examples` from the list of dependent modules
for `license` task.

Result:

`./gradlew license` works as expected for composite build.