### PR TITLE
Asynchronous connection filtering results in read events being discarded

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/AbstractChannelReadHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/AbstractChannelReadHandler.java
@@ -83,7 +83,7 @@ public abstract class AbstractChannelReadHandler<T> extends ChannelInboundHandle
 
     @Override
     public final void channelInactive(ChannelHandlerContext ctx) {
-        disposePublisher();
+        notifyPublisherOfChannelInboundClosed();
         ctx.fireChannelInactive();
     }
 
@@ -94,8 +94,8 @@ public abstract class AbstractChannelReadHandler<T> extends ChannelInboundHandle
         // the current netty version) gets triggered reliably at the appropriate time.
         if (evt == ChannelInputShutdownReadComplete.INSTANCE) {
             // Since we are only reading data, if the inbound is shutdown, it is equivalent to channel closure, so we
-            // dispose the publisher.
-            disposePublisher();
+            // notify the publisher the inbound has closed.
+            notifyPublisherOfChannelInboundClosed();
             closeHandler.channelClosedInbound(ctx);
         }
         ctx.fireUserEventTriggered(evt);
@@ -136,10 +136,9 @@ public abstract class AbstractChannelReadHandler<T> extends ChannelInboundHandle
      */
     protected abstract void onPublisherCreation(ChannelHandlerContext ctx, Publisher<T> newPublisher);
 
-    private void disposePublisher() {
+    private void notifyPublisherOfChannelInboundClosed() {
         if (publisher != null) {
-            publisher.dispose();
-            publisher = null;
+            publisher.channelInboundClosed();
         }
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
@@ -40,9 +40,8 @@ import static io.servicetalk.concurrent.internal.ThrowableUtil.unknownStackTrace
 import static java.util.Objects.requireNonNull;
 
 final class NettyChannelPublisher<T> extends Publisher<T> {
-
     private static final ClosedChannelException CLOSED_CHANNEL_EXCEPTION =
-            unknownStackTrace(new ClosedChannelException(), NettyChannelPublisher.class, "dispose");
+            unknownStackTrace(new ClosedChannelException(), NettyChannelPublisher.class, "channelInboundClosed");
 
     // All state is only touched from eventloop.
     private long requestCount;
@@ -121,7 +120,7 @@ final class NettyChannelPublisher<T> extends Publisher<T> {
         }
     }
 
-    void dispose() {
+    void channelInboundClosed() {
         assertInEventloop();
         fatalError = CLOSED_CHANNEL_EXCEPTION;
         exceptionCaught(CLOSED_CHANNEL_EXCEPTION);
@@ -275,7 +274,7 @@ final class NettyChannelPublisher<T> extends Publisher<T> {
             subscriber.onSubscribe(EMPTY_SUBSCRIPTION);
             subscriber.onError(new DuplicateSubscribeException(subscription.associatedSub, subscriber));
         } else {
-            requestCount = 0; /*Don't pollute requested count between subscribers */
+            requestCount = 0; // Don't pollute requested count between subscribers
             subscription = new SubscriptionImpl(subscriber);
             this.subscription = subscription;
             subscriber.onSubscribe(subscription);


### PR DESCRIPTION
Motivation:
AbstractContextFilterChannelHandler invokes the ConnectionAcceptor which will
asynchronously complete on another thread (e.g. when offloading is enabled).
This may result in some events being delayed (e.g. channelActive) while others
are not (e.g. ChannelInputShutdownReadComplete). AbstractChannelReadHandler
assumes that when the channel becomes inactive (e.g. channelInactive or
ChannelInputShutdownReadComplete) that it can discard the NettyChannelPublisher
which may result in events being dropped if channelActive is deferred.

Modifications:
- Pipeline events are delivered out of order by
AbstractContextFilterChannelHandler. However it can be challenging to determine
which user events it is OK to defer and what events are allowed to propagate. So
while AbstractChannelReadHandler isn't necessarily incorrect the proposed change
is to avoid discarding the NettyChannelPublisher as a short term fix. I would
like to propose a more complete fix in a followup PR which also simplifies the
channel initialization process.

Result:
Channel inbound events are delivered in the presence of asynchronous channel
pipeline initialization and delayed pipeline events.

Fixes #249
Fixes #250
Fixes #214
Fixes #226