### PR TITLE
DefaultCompositeCloseable.close throws IOException instead of Exception

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultCompositeCloseable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultCompositeCloseable.java
@@ -19,7 +19,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.internal.Await.awaitIndefinitely;
@@ -104,11 +103,7 @@ final class DefaultCompositeCloseable implements CompositeCloseable {
 
     @Override
     public void close() throws Exception {
-        try {
-            awaitIndefinitely(closeAsync());
-        } catch (ExecutionException | InterruptedException e) {
-            throw new Exception(e);
-        }
+        awaitIndefinitely(closeAsync());
     }
 
     private void mergeCloseableDelayError(final AsyncCloseable closeable) {


### PR DESCRIPTION
Motivation:

`DefaultCompositeCloseable.close` incorrectly throws `IOException`
instead of `Exception`.

Modifications:

- Throw `Exception` instead of `IOException` in
`DefaultCompositeCloseable.close` method;
- Remove unnecessary `try-catch` block;

Result:

`DefaultCompositeCloseable.close` throws `Exception` like it is defined
in `AutoCloseable` interface.