### PR TITLE
Close connection if it could not be added to the queue in RR LB

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -340,11 +340,6 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends ListenableA
         }
 
         boolean addConnection(C connection) {
-            if (removed) {
-                connection.closeAsync().subscribe();
-                return false;
-            }
-
             assert connections != null;
             final boolean added = connections.offer(connection);
             if (!added || removed) {


### PR DESCRIPTION
Motivation:

If RR LB will use a bounded queue instead of unbounded for the
connections of a host, it will not close the newly created connection
if queue rejects it.

Modifications:

- Close a newly created connection if queue rejects it;

Result:

No connection resource leak.