### PR TITLE
Fixing a race condition in a DNS service discovery test.

### DIFF
--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererTest.java
@@ -272,6 +272,7 @@ public class DefaultDnsServiceDiscovererTest {
     @SuppressWarnings("unchecked")
     @Test
     public void exceptionInSubscriberOnErrorWhileClose() throws Exception {
+        recordStore.setDefaultResponse("apple.com", A, nextIp());
         CountDownLatch latchOnSubscribe = new CountDownLatch(1);
         ServiceDiscoverer<String, InetAddress, ServiceDiscovererEvent<InetAddress>> discoverer =
                 buildServiceDiscoverer(null);


### PR DESCRIPTION
Motivation:

The A record for `apple.com` was inadvertently removed from a test. This
resulted in an `onError` for resolution, while the test was depending on
`onError` due to closure. This lead to a race.

Modifications:

Add back an A record for `apple.com` in the test.

Results:

The test passes consistently.