### PR TITLE
Add unit test for HttpResponseDecoder for empty line trailer terminator

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
@@ -13,6 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.servicetalk.http.netty;
 
 import io.servicetalk.buffer.api.Buffer;


### PR DESCRIPTION
Motivation:
There was a bug recently found in Netty where the decoder would discard a
trailer if there was an empty line that terminates the trailers was parsed in a
separate buffer.

Modifications:
- Add a unit test to HttpResponseDecoderTest to verify this scenario is handled
correctly.

Result:
Better test coverage for HttpResponseDecoder, and confirmation we are not
subject to the same bug.