### PR TITLE
LoadBalancerReady clients should retry only NoAvailableHostException

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/LoadBalancerReadyStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/LoadBalancerReadyStreamingHttpClient.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.LoadBalancerReadyEvent;
+import io.servicetalk.client.api.NoAvailableHostException;
 import io.servicetalk.client.api.RetryableException;
 import io.servicetalk.client.internal.LoadBalancerReadySubscriber;
 import io.servicetalk.concurrent.api.BiIntFunction;
@@ -70,7 +71,7 @@ public final class LoadBalancerReadyStreamingHttpClient extends StreamingHttpCli
     }
 
     private BiIntFunction<Throwable, Completable> retryWhenFunction() {
-        return (count, cause) -> count <= maxRetryCount && cause instanceof RetryableException ?
+        return (count, cause) -> count <= maxRetryCount && cause instanceof NoAvailableHostException ?
                 loadBalancerReadySubscriber.onHostsAvailable() : error(cause);
     }
 }

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/LoadBalancerReadyRedisClient.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/LoadBalancerReadyRedisClient.java
@@ -17,6 +17,7 @@ package io.servicetalk.redis.api;
 
 import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.LoadBalancerReadyEvent;
+import io.servicetalk.client.api.NoAvailableHostException;
 import io.servicetalk.client.api.RetryableException;
 import io.servicetalk.client.internal.LoadBalancerReadySubscriber;
 import io.servicetalk.concurrent.api.BiIntFunction;
@@ -67,7 +68,7 @@ public final class LoadBalancerReadyRedisClient extends RedisClientFilter {
     }
 
     private BiIntFunction<Throwable, Completable> retryWhenFunction() {
-        return (count, cause) -> count <= maxRetryCount && cause instanceof RetryableException ?
+        return (count, cause) -> count <= maxRetryCount && cause instanceof NoAvailableHostException ?
                 loadBalancerReadySubscriber.onHostsAvailable() : error(cause);
     }
 }


### PR DESCRIPTION
Motivation:

`LoadBalancerReady(Redis|StreamingHttp)Client` retries on any
`RetryableException`. It duplicates logic of `Retrying(Redis|Http)Filter`s.
We should limit the scope of `LoadBalancerReady(Redis|StreamingHttp)Client`
to `NoAvailableHostException` only, because this exception is a primary
purpose of `LoadBalancerReady`-clients.

Modifications:

- `LoadBalancerReadyRedisClient` and `LoadBalancerReadyStreamingHttpClient`
check for instance of `NoAvailableHostException` instead of `RetryableException`;

Result:

The scope of `LoadBalancerReady(Redis|StreamingHttp)Client`s limited to
`NoAvailableHostException` only.