### PR TITLE
MaxRequestLimitExceededException exception from closed connection is confusing

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionClosedException.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionClosedException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.client.api;
+
+/**
+ * Thrown when the connection is no longer available.
+ */
+public class ConnectionClosedException extends RuntimeException {
+
+    /**
+     * Creates a new instance.
+     *
+     * @param message the detail message.
+     */
+    public ConnectionClosedException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param message the detail message.
+     * @param cause the original cause.
+     */
+    public ConnectionClosedException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/servicetalk-client-internal/src/main/java/io/servicetalk/client/internal/RequestConcurrencyController.java
+++ b/servicetalk-client-internal/src/main/java/io/servicetalk/client/internal/RequestConcurrencyController.java
@@ -21,11 +21,30 @@ import io.servicetalk.concurrent.api.Publisher;
  * An interface which allows controlling reserving connections which maybe used concurrently.
  */
 public interface RequestConcurrencyController {
+
+    /**
+     * Result of the {@link #tryRequest()} call.
+     */
+    enum Result {
+        /**
+         * Selecting the resource succeeded.
+         */
+        Accepted,
+        /**
+         * Selecting the resource was denied, but may succeed at later time.
+         */
+        RejectedTemporary,
+        /**
+         * Selecting the resource was denied, and will not succeed at later time.
+         */
+        RejectedPermanently
+    }
+
     /**
      * Attempts to reserve a connection for a single request, needs to be followed by {@link #requestFinished()}.
-     * @return {@code true} if this connection is available and reserved for performing a single request.
+     * @return {@link Result#Accepted} if this connection is available and reserved for performing a single request.
      */
-    boolean tryRequest();
+    Result tryRequest();
 
     /**
      * Must be called after {@link #tryRequest()} to signify the request has completed. This method should be called

--- a/servicetalk-client-internal/src/main/java/io/servicetalk/client/internal/RequestConcurrencyControllerOnlySingle.java
+++ b/servicetalk-client-internal/src/main/java/io/servicetalk/client/internal/RequestConcurrencyControllerOnlySingle.java
@@ -18,6 +18,10 @@ package io.servicetalk.client.internal;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 
+import static io.servicetalk.client.internal.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.internal.RequestConcurrencyController.Result.RejectedPermanently;
+import static io.servicetalk.client.internal.RequestConcurrencyController.Result.RejectedTemporary;
+
 final class RequestConcurrencyControllerOnlySingle extends AbstractRequestConcurrencyController {
     RequestConcurrencyControllerOnlySingle(final Publisher<Integer> maxConcurrencySettingStream,
                                            final Completable onClose) {
@@ -25,8 +29,14 @@ final class RequestConcurrencyControllerOnlySingle extends AbstractRequestConcur
     }
 
     @Override
-    public boolean tryRequest() {
+    public Result tryRequest() {
         // No concurrency means we have to have 0 requests!
-        return getLastSeenMaxValue(1) > 0 && casPendingRequests(0, 1);
+        if (getLastSeenMaxValue(1) > 0) {
+            if (casPendingRequests(0, 1)) {
+                return Accepted;
+            }
+            return RejectedTemporary;
+        }
+        return RejectedPermanently;
     }
 }

--- a/servicetalk-client-internal/src/main/java/io/servicetalk/client/internal/ReservableRequestConcurrencyController.java
+++ b/servicetalk-client-internal/src/main/java/io/servicetalk/client/internal/ReservableRequestConcurrencyController.java
@@ -22,6 +22,7 @@ import io.servicetalk.concurrent.api.Completable;
  * A {@link RequestConcurrencyController} that also allows to {@link #tryReserve()} a connection for exclusive use.
  */
 public interface ReservableRequestConcurrencyController extends RequestConcurrencyController {
+
     /**
      * Attempts to reserve a connection for exclusive use until {@link #releaseAsync()} is called.
      * @return {@code true} if this connection is available and reserved for performing a single request.

--- a/servicetalk-client-internal/src/main/java/io/servicetalk/client/internal/ReservableRequestConcurrencyControllerMulti.java
+++ b/servicetalk-client-internal/src/main/java/io/servicetalk/client/internal/ReservableRequestConcurrencyControllerMulti.java
@@ -18,6 +18,10 @@ package io.servicetalk.client.internal;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 
+import static io.servicetalk.client.internal.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.internal.RequestConcurrencyController.Result.RejectedPermanently;
+import static io.servicetalk.client.internal.RequestConcurrencyController.Result.RejectedTemporary;
+
 final class ReservableRequestConcurrencyControllerMulti extends AbstractReservableRequestConcurrencyController {
     private final int maxRequests;
 
@@ -29,15 +33,18 @@ final class ReservableRequestConcurrencyControllerMulti extends AbstractReservab
     }
 
     @Override
-    public boolean tryRequest() {
+    public Result tryRequest() {
         final int maxConcurrency = getLastSeenMaxValue(maxRequests);
         for (;;) {
             final int currentPending = getPendingRequests();
-            if (currentPending < 0 || currentPending >= maxConcurrency) {
-                return false;
+            if (currentPending < 0) {
+                return RejectedPermanently;
+            }
+            if (currentPending >= maxConcurrency) {
+                return RejectedTemporary;
             }
             if (casPendingRequests(currentPending, currentPending + 1)) {
-                return true;
+                return Accepted;
             }
         }
     }

--- a/servicetalk-client-internal/src/test/java/io/servicetalk/client/internal/ReservableRequestConcurrencyControllerMultiTest.java
+++ b/servicetalk-client-internal/src/test/java/io/servicetalk/client/internal/ReservableRequestConcurrencyControllerMultiTest.java
@@ -20,10 +20,13 @@ import io.servicetalk.concurrent.api.Publisher;
 
 import org.junit.Test;
 
+import static io.servicetalk.client.internal.RequestConcurrencyController.Result.Accepted;
 import static io.servicetalk.concurrent.api.Completable.never;
 import static io.servicetalk.concurrent.api.Publisher.just;
 import static io.servicetalk.concurrent.internal.Await.awaitIndefinitely;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class ReservableRequestConcurrencyControllerMultiTest extends AbstractRequestConcurrencyControllerMultiTest {
@@ -53,7 +56,7 @@ public class ReservableRequestConcurrencyControllerMultiTest extends AbstractReq
     @Test
     public void reserveFailsWhenPendingRequest() {
         ReservableRequestConcurrencyController controller = newController(just(10), never(), 10);
-        assertTrue(controller.tryRequest());
+        assertThat(controller.tryRequest(), is(Accepted));
         assertFalse(controller.tryReserve());
     }
 }

--- a/servicetalk-client-internal/src/test/java/io/servicetalk/client/internal/ReservableRequestConcurrencyControllerOnlySingleTest.java
+++ b/servicetalk-client-internal/src/test/java/io/servicetalk/client/internal/ReservableRequestConcurrencyControllerOnlySingleTest.java
@@ -20,15 +20,18 @@ import io.servicetalk.concurrent.api.Publisher;
 
 import org.junit.Test;
 
+import static io.servicetalk.client.internal.RequestConcurrencyController.Result.Accepted;
 import static io.servicetalk.client.internal.ReservableRequestConcurrencyControllers.newSingleController;
 import static io.servicetalk.concurrent.api.Completable.never;
 import static io.servicetalk.concurrent.api.Publisher.just;
 import static io.servicetalk.concurrent.internal.Await.awaitIndefinitely;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public class ReservableRequestConcurrencyControllerOnlySingleTest extends
-                                                                  AbstractRequestConcurrencyControllerOnlySingleTest {
+public class ReservableRequestConcurrencyControllerOnlySingleTest
+        extends AbstractRequestConcurrencyControllerOnlySingleTest {
     @Override
     protected ReservableRequestConcurrencyController newController(final Publisher<Integer> maxSetting,
                                                                    final Completable onClose) {
@@ -54,7 +57,7 @@ public class ReservableRequestConcurrencyControllerOnlySingleTest extends
     @Test
     public void reserveFailsWhenPendingRequest() {
         ReservableRequestConcurrencyController controller = newController(just(10), never());
-        assertTrue(controller.tryRequest());
+        assertThat(controller.tryRequest(), is(Accepted));
         assertFalse(controller.tryReserve());
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultStreamingHttpClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultStreamingHttpClient.java
@@ -27,12 +27,13 @@ import io.servicetalk.transport.api.ExecutionContext;
 
 import java.util.function.Function;
 
+import static io.servicetalk.client.internal.RequestConcurrencyController.Result.Accepted;
 import static java.util.Objects.requireNonNull;
 
 final class DefaultStreamingHttpClient extends StreamingHttpClient {
 
     private static final Function<LoadBalancedStreamingHttpConnection, LoadBalancedStreamingHttpConnection>
-            SELECTOR_FOR_REQUEST = conn -> conn.tryRequest() ? conn : null;
+            SELECTOR_FOR_REQUEST = conn -> conn.tryRequest() == Accepted ? conn : null;
     private static final Function<LoadBalancedStreamingHttpConnection, LoadBalancedStreamingHttpConnection>
             SELECTOR_FOR_RESERVE = conn -> conn.tryReserve() ? conn : null;
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpConnection.java
@@ -53,7 +53,7 @@ final class LoadBalancedStreamingHttpConnection extends StreamingHttpClient.Rese
     }
 
     @Override
-    public boolean tryRequest() {
+    public Result tryRequest() {
         return limiter.tryRequest();
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConcurrentRequestsHttpConnectionFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConcurrentRequestsHttpConnectionFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,10 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.client.api.ConnectionClosedException;
 import io.servicetalk.client.api.MaxRequestLimitExceededException;
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.CompletableProcessor;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.PublisherRule;
 import io.servicetalk.concurrent.api.Single;
@@ -26,6 +28,9 @@ import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.http.api.DefaultHttpHeadersFactory;
 import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpHeaderNames;
+import io.servicetalk.http.api.HttpRequester;
+import io.servicetalk.http.api.HttpResponse;
 import io.servicetalk.http.api.StreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
@@ -33,32 +38,46 @@ import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.TestStreamingHttpConnection;
 import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ExecutionContext;
+import io.servicetalk.transport.api.ServerContext;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
+import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 import static io.servicetalk.buffer.api.EmptyBuffer.EMPTY_BUFFER;
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.Publisher.just;
 import static io.servicetalk.concurrent.api.Single.error;
 import static io.servicetalk.concurrent.api.Single.success;
 import static io.servicetalk.concurrent.internal.Await.awaitIndefinitely;
 import static io.servicetalk.concurrent.internal.Await.awaitIndefinitelyNonNull;
+import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
 import static io.servicetalk.http.api.StreamingHttpConnection.SettingKey.MAX_CONCURRENCY;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
-public class HttpConnectionConcurrentRequestsFilterTest {
+public class ConcurrentRequestsHttpConnectionFilterTest {
+
     private static final BufferAllocator allocator = DEFAULT_ALLOCATOR;
     private static final StreamingHttpRequestResponseFactory reqRespFactory =
             new DefaultStreamingHttpRequestResponseFactory(allocator, DefaultHttpHeadersFactory.INSTANCE);
+
+    @Rule
+    public final MockitoRule rule = MockitoJUnit.rule();
     @Mock
     private ExecutionContext executionContext;
     @Mock
@@ -117,5 +136,98 @@ public class HttpConnectionConcurrentRequestsFilterTest {
 
         // Verify that a new request can be made after the first request completed.
         awaitIndefinitelyNonNull(limitedConnection.request(limitedConnection.get("/baz")));
+    }
+
+    @Test
+    public void throwMaxConcurrencyExceededOnOversubscribedConnection() throws Exception {
+        try (ServerContext serverContext = HttpServers.forPort(0)
+                .listenAndAwait((ctx, request, responseFactory) ->
+                        Single.success(responseFactory.ok().payloadBody("Test", textSerializer())));
+
+             HttpRequester connection = new DefaultHttpConnectionBuilder<>()
+                     .maxPipelinedRequests(2)
+                     .build(serverContext.listenAddress())
+                     .toFuture().get()) {
+
+            Single<? extends HttpResponse> resp1 = connection.request(connection.get("/one"));
+            Single<? extends HttpResponse> resp2 = connection.request(connection.get("/two"));
+            Single<? extends HttpResponse> resp3 = connection.request(connection.get("/three"));
+
+            try {
+                Publisher.from(resp1, resp2, resp3)
+                        .flatMapSingle(Function.identity())
+                        .toFuture().get();
+
+                fail("Should not allow three concurrent requests to complete normally");
+            } catch (ExecutionException e) {
+                assertThat(e.getCause(), instanceOf(MaxRequestLimitExceededException.class));
+            }
+        }
+    }
+
+    @Test
+    public void throwConnectionClosedOnConnectionClose() throws Exception {
+        final CompletableProcessor serverClosed = new CompletableProcessor();
+
+        try (ServerContext serverContext = HttpServers.forPort(0)
+                .listenStreamingAndAwait((ctx, request, responseFactory) -> {
+                    ctx.onClose().subscribe(serverClosed);
+                    return Single.success(responseFactory.ok().setHeader(HttpHeaderNames.CONNECTION, "close"));
+                });
+
+             HttpRequester connection = new DefaultHttpConnectionBuilder<>()
+                     .maxPipelinedRequests(99)
+                     .build(serverContext.listenAddress())
+                     .toFuture().get()) {
+
+            Single<? extends HttpResponse> resp1 = connection.request(connection.get("/one"));
+            Single<? extends HttpResponse> resp2 = connection.request(connection.get("/two"));
+
+            resp1.toFuture().get();
+
+            try {
+                serverClosed.concatWith(resp2).toFuture().get();
+                fail("Should not allow request to complete normally on a closed connection");
+            } catch (ExecutionException e) {
+                assertThat(e.getCause(), instanceOf(ConnectionClosedException.class));
+                assertThat(e.getCause().getCause(), instanceOf(ClosedChannelException.class));
+            }
+        }
+    }
+
+    @Test
+    public void throwConnectionClosedWithCauseOnUnexpectedConnectionClose() throws Exception {
+        try (ServerContext serverContext = HttpServers.forPort(0)
+                .listenStreamingAndAwait((ctx, request, responseFactory) -> {
+                    ctx.closeAsync().subscribe();
+                    return Single.never();
+                });
+
+             HttpRequester connection = new DefaultHttpConnectionBuilder<>()
+                     .maxPipelinedRequests(99)
+                     .build(serverContext.listenAddress())
+                     .toFuture().get()) {
+
+            Single<? extends HttpResponse> resp1 = connection.request(connection.get("/one"));
+            Single<? extends HttpResponse> resp2 = connection.request(connection.get("/two"));
+
+            final AtomicReference<Throwable> ioEx = new AtomicReference<>();
+
+            empty()
+                    .concatWith(resp1).onErrorResume(reset -> {
+                        ioEx.set(reset); // Capture connection reset
+                        return empty();
+                    })
+                    .concatWith(connection.onClose()).toFuture().get();
+
+            try {
+                resp2.toFuture().get();
+                fail("Should not allow request to complete normally on a closed connection");
+            } catch (ExecutionException e) {
+                assertThat(e.getCause(), instanceOf(ConnectionClosedException.class));
+                assertThat(e.getCause().getCause(), instanceOf(IOException.class));
+                assertThat(e.getCause().getCause(), equalTo(ioEx.get())); // Assert connection reset
+            }
+        }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionAcceptorTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionAcceptorTest.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.MaxRequestLimitExceededException;
+import io.servicetalk.client.api.NoAvailableHostException;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.internal.DeliberateException;
@@ -148,7 +149,9 @@ public class NettyHttpServerConnectionAcceptorTest extends AbstractNettyHttpServ
             if (filterMode.expectAccept) {
                 throw new AssertionError("Unexpected exception while reading/writing request/response", e);
             }
-            assertThat(e.getCause(), anyOf(instanceOf(IOException.class), instanceOf(MaxRequestLimitExceededException.class)));
+            assertThat(e.getCause(), anyOf(instanceOf(IOException.class),
+                    instanceOf(MaxRequestLimitExceededException.class),
+                    instanceOf(NoAvailableHostException.class)));
         }
 
         if (getSslEnabled()) {

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/DefaultRedisClientBuilder.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/DefaultRedisClientBuilder.java
@@ -50,6 +50,7 @@ import java.util.function.Function;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.client.internal.RequestConcurrencyController.Result.Accepted;
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.loadbalancer.RoundRobinLoadBalancer.newRoundRobinFactory;
 import static io.servicetalk.redis.api.RedisExecutionStrategies.defaultStrategy;
@@ -66,7 +67,7 @@ import static java.util.Objects.requireNonNull;
 final class DefaultRedisClientBuilder<U, R> implements RedisClientBuilder<U, R> {
 
     public static final Function<LoadBalancedRedisConnection, LoadBalancedRedisConnection> SELECTOR_FOR_REQUEST =
-            conn -> conn.tryRequest() ? conn : null;
+            conn -> conn.tryRequest() == Accepted ? conn : null;
     public static final Function<LoadBalancedRedisConnection, LoadBalancedRedisConnection> SELECTOR_FOR_RESERVE =
             conn -> conn.tryReserve() ? conn : null;
     private static final RedisClientFilterFactory LB_READY_FILTER =

--- a/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/LoadBalancedRedisConnection.java
+++ b/servicetalk-redis-netty/src/main/java/io/servicetalk/redis/netty/LoadBalancedRedisConnection.java
@@ -80,7 +80,7 @@ final class LoadBalancedRedisConnection extends ReservedRedisConnection
     }
 
     @Override
-    public boolean tryRequest() {
+    public Result tryRequest() {
         return limiter.tryRequest();
     }
 

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/LoadBalancedRedisConnectionTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/LoadBalancedRedisConnectionTest.java
@@ -23,6 +23,7 @@ import io.servicetalk.redis.api.RedisRequest;
 
 import org.junit.Test;
 
+import static io.servicetalk.client.internal.RequestConcurrencyController.Result.Accepted;
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Completable.never;
 import static io.servicetalk.concurrent.api.Publisher.just;
@@ -30,7 +31,8 @@ import static io.servicetalk.concurrent.internal.Await.awaitIndefinitely;
 import static io.servicetalk.redis.api.RedisData.PONG;
 import static io.servicetalk.redis.api.RedisProtocolSupport.Command.PING;
 import static io.servicetalk.redis.api.RedisRequests.newRequest;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -46,10 +48,10 @@ public class LoadBalancedRedisConnectionTest {
         when(delegate.request(any(), any(RedisRequest.class))).thenReturn(just(PONG));
         LoadBalancedRedisConnection connection = new LoadBalancedRedisConnection(delegate,
                 ReservableRequestConcurrencyControllers.newController(just(1), never(), 1));
-        assertTrue(connection.tryRequest());
+        assertThat(connection.tryRequest(), is(Accepted));
         awaitIndefinitely(connection.request(newRequest(PING)));
         connection.requestFinished();
-        assertTrue(connection.tryRequest());
+        assertThat(connection.tryRequest(), is(Accepted));
         connection.closeAsync().subscribe();
     }
 }


### PR DESCRIPTION
__Motivation__

With an `HttpConnection` (not `HttpClient`), if a request is sent on a closed connection, instead of a `ClosedChannelException` (or any `IOException`), users receive `MaxRequestLimitExceededException`. This is somewhat confusing because it’s not an `IOException`, it’s a RetryableException.
By combining connection status and `transportError` we can provide more clear error messages to the user.

__Modifications__

- enhance `RequestConcurrencyController` to allow exposing an unavailable connection state
- enhance `ConcurrentRequestsHttpConnectionFilter` to leverage transport errors and connection state

__Result__

Users won't get confusing error messages suggesting wrong configuration when the connection is closed.