### PR TITLE
Mark concurrent-api-internal dependency as implementation in http-api

### DIFF
--- a/servicetalk-http-api/build.gradle
+++ b/servicetalk-http-api/build.gradle
@@ -34,7 +34,6 @@ dependencies {
   api "io.servicetalk:servicetalk-buffer-api:$project.version"
   api "io.servicetalk:servicetalk-client-api:$project.version"
   api "io.servicetalk:servicetalk-concurrent-api:$project.version"
-  api "io.servicetalk:servicetalk-concurrent-api-internal:$project.version"
   api "io.servicetalk:servicetalk-serialization-api:$project.version"
   api "io.servicetalk:servicetalk-transport-api:$project.version"
 
@@ -42,6 +41,7 @@ dependencies {
   implementation "io.servicetalk:servicetalk-annotations:$project.version"
   implementation "io.servicetalk:servicetalk-client-internal:$project.version"
   implementation "io.servicetalk:servicetalk-concurrent-internal:$project.version"
+  implementation "io.servicetalk:servicetalk-concurrent-api-internal:$project.version"
   implementation "org.slf4j:slf4j-api"
 
   testImplementation "io.servicetalk:servicetalk-buffer-netty:$project.version"


### PR DESCRIPTION
Motivation:

`servicetalk-http-api` does not exposes
`servicetalk-concurrent-api-internal` as part of the public API. We can
mark it as `implementation` instead of `api`.

Modifications:

- Mark `servicetalk-concurrent-api-internal` dependency as `implementation`
instead of `api` in `servicetalk-http-api`;

Result:

`servicetalk-http-api` does not exposes
`servicetalk-concurrent-api-internal` module as public API.