### PR TITLE
Optimize conversion of buffered request/response to another types

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BufferHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BufferHttpRequest.java
@@ -19,8 +19,10 @@ import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.buffer.api.BufferAllocator;
 
 import static io.servicetalk.buffer.api.EmptyBuffer.EMPTY_BUFFER;
+import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.Publisher.just;
 import static io.servicetalk.concurrent.api.Single.success;
+import static io.servicetalk.concurrent.internal.BlockingIterables.emptyBlockingIterable;
 import static io.servicetalk.concurrent.internal.BlockingIterables.singletonBlockingIterable;
 import static java.util.Objects.requireNonNull;
 
@@ -153,14 +155,15 @@ final class BufferHttpRequest extends DefaultHttpRequestMetaData implements Http
 
     @Override
     public StreamingHttpRequest toStreamingRequest() {
-        return new BufferStreamingHttpRequest(method(), requestTarget(), version(),
-                headers(), success(trailers), allocator, just(payloadBody));
+        return new BufferStreamingHttpRequest(method(), requestTarget(), version(), headers(), success(trailers),
+                allocator, payloadBody.readableBytes() == 0 ? empty() : just(payloadBody));
     }
 
     @Override
     public BlockingStreamingHttpRequest toBlockingStreamingRequest() {
         return new BufferBlockingStreamingHttpRequest(method(), requestTarget(), version(), headers(),
-                success(trailers), allocator, singletonBlockingIterable(payloadBody));
+                success(trailers), allocator,
+                payloadBody.readableBytes() == 0 ? emptyBlockingIterable() : singletonBlockingIterable(payloadBody));
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BufferHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BufferHttpResponse.java
@@ -19,8 +19,10 @@ import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.buffer.api.BufferAllocator;
 
 import static io.servicetalk.buffer.api.EmptyBuffer.EMPTY_BUFFER;
+import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.Publisher.just;
 import static io.servicetalk.concurrent.api.Single.success;
+import static io.servicetalk.concurrent.internal.BlockingIterables.emptyBlockingIterable;
 import static io.servicetalk.concurrent.internal.BlockingIterables.singletonBlockingIterable;
 import static java.util.Objects.requireNonNull;
 
@@ -89,13 +91,13 @@ final class BufferHttpResponse extends DefaultHttpResponseMetaData implements Ht
     @Override
     public StreamingHttpResponse toStreamingResponse() {
         return new BufferStreamingHttpResponse(status(), version(), headers(), success(trailers), allocator,
-                just(payloadBody));
+                payloadBody.readableBytes() == 0 ? empty() : just(payloadBody));
     }
 
     @Override
     public BlockingStreamingHttpResponse toBlockingStreamingResponse() {
-        return new BufferBlockingStreamingHttpResponse(status(), version(), headers(), success(trailers),
-                allocator, singletonBlockingIterable(payloadBody));
+        return new BufferBlockingStreamingHttpResponse(status(), version(), headers(), success(trailers), allocator,
+                payloadBody.readableBytes() == 0 ? emptyBlockingIterable() : singletonBlockingIterable(payloadBody));
     }
 
     @Override


### PR DESCRIPTION
Motivation:

We may reduce allocation of new objects when we convert
`BufferHttpRequest`/`BufferHttpResponse` to streaming/blocking-iterable
API if the payload is empty.

Modifications:

- Check the amount of readable bytes of payload body before wrapping it
with `Publisher`/`BlockingIterable`;

Result:

Less object allocation when users covert buffered request/response with
empty payload body to another types.