### PR TITLE
Require only `HttpRequestMetaData` to reserve an HTTP connection

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClient.java
@@ -36,32 +36,30 @@ public abstract class BlockingHttpClient extends BlockingHttpRequester {
     }
 
     /**
-     * Reserve a {@link ReservedBlockingHttpConnection} for handling the provided
-     * {@link HttpRequest} but <b>does not execute it</b>!
+     * Reserve a {@link BlockingHttpConnection} based on provided {@link HttpRequestMetaData}.
      *
-     * @param request Allows the underlying layers to know what {@link BlockingHttpConnection}s are valid to
-     * reserve. For example this may provide some insight into shard or other info.
+     * @param metaData Allows the underlying layers to know what {@link BlockingHttpConnection}s are valid to
+     * reserve for future {@link HttpRequest requests} with the same {@link HttpRequestMetaData}.
+     * For example this may provide some insight into shard or other info.
      * @return a {@link ReservedBlockingHttpConnection}.
      * @throws Exception if a exception occurs during the reservation process.
-     * @see StreamingHttpClient#reserveConnection(StreamingHttpRequest)
      */
-    public ReservedBlockingHttpConnection reserveConnection(HttpRequest request) throws Exception {
-        return reserveConnection(executionStrategy(), request);
+    public ReservedBlockingHttpConnection reserveConnection(HttpRequestMetaData metaData) throws Exception {
+        return reserveConnection(executionStrategy(), metaData);
     }
 
     /**
-     * Reserve a {@link ReservedBlockingHttpConnection} for handling the provided
-     * {@link HttpRequest} but <b>does not execute it</b>!
+     * Reserve a {@link BlockingHttpConnection} based on provided {@link HttpRequestMetaData}.
      *
      * @param strategy {@link HttpExecutionStrategy} to use.
-     * @param request Allows the underlying layers to know what {@link BlockingHttpConnection}s are valid to
-     * reserve. For example this may provide some insight into shard or other info.
+     * @param metaData Allows the underlying layers to know what {@link BlockingHttpConnection}s are valid to
+     * reserve for future {@link HttpRequest requests} with the same {@link HttpRequestMetaData}.
+     * For example this may provide some insight into shard or other info.
      * @return a {@link ReservedBlockingHttpConnection}.
      * @throws Exception if a exception occurs during the reservation process.
-     * @see StreamingHttpClient#reserveConnection(HttpExecutionStrategy, StreamingHttpRequest)
      */
     public abstract ReservedBlockingHttpConnection reserveConnection(HttpExecutionStrategy strategy,
-                                                                     HttpRequest request) throws Exception;
+                                                                     HttpRequestMetaData metaData) throws Exception;
 
     /**
      * Convert this {@link BlockingHttpClient} to the {@link StreamingHttpClient} API.
@@ -100,8 +98,8 @@ public abstract class BlockingHttpClient extends BlockingHttpRequester {
 
     /**
      * A special type of {@link BlockingHttpConnection} for the exclusive use of the caller of
-     * {@link #reserveConnection(HttpRequest)}.
-     * @see StreamingHttpClient.ReservedStreamingHttpConnection
+     * {@link #reserveConnection(HttpRequestMetaData)} and
+     * {@link #reserveConnection(HttpExecutionStrategy, HttpRequestMetaData)}.
      */
     public abstract static class ReservedBlockingHttpConnection extends BlockingHttpConnection {
         /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClientToHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClientToHttpClient.java
@@ -39,9 +39,9 @@ final class BlockingHttpClientToHttpClient extends HttpClient {
 
     @Override
     public Single<? extends ReservedHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
-                                                                      final HttpRequest request) {
+                                                                      final HttpRequestMetaData metaData) {
         return blockingToSingle(() -> new ReservedBlockingHttpConnectionToReservedHttpConnection(
-                client.reserveConnection(strategy, request)));
+                client.reserveConnection(strategy, metaData)));
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClientToStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClientToStreamingHttpClient.java
@@ -39,9 +39,9 @@ final class BlockingHttpClientToStreamingHttpClient extends StreamingHttpClient 
 
     @Override
     public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
-                                                                               final StreamingHttpRequest request) {
-        return request.toRequest().flatMap(req -> blockingToSingle(() ->
-                new BlockingReservedStreamingHttpConnectionToReserved(client.reserveConnection(strategy, req))));
+                                                                               final HttpRequestMetaData metaData) {
+        return blockingToSingle(() -> new BlockingReservedStreamingHttpConnectionToReserved(
+                client.reserveConnection(strategy, metaData)));
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClient.java
@@ -35,33 +35,30 @@ public abstract class BlockingStreamingHttpClient extends BlockingStreamingHttpR
     }
 
     /**
-     * Reserve a {@link BlockingStreamingHttpConnection} for handling the provided {@link BlockingStreamingHttpRequest}
-     * but <b>does not execute it</b>!
+     * Reserve a {@link BlockingStreamingHttpConnection} based on provided {@link HttpRequestMetaData}.
      *
-     * @param request Allows the underlying layers to know what {@link BlockingStreamingHttpConnection}s are valid to
-     * reserve. For example this may provide some insight into shard or other info.
-     * @return a {@link ReservedStreamingHttpConnection}.
+     * @param metaData Allows the underlying layers to know what {@link BlockingStreamingHttpConnection}s are valid to
+     * reserve for future {@link BlockingStreamingHttpRequest requests} with the same {@link HttpRequestMetaData}.
+     * For example this may provide some insight into shard or other info.
+     * @return a {@link ReservedBlockingStreamingHttpConnection}.
      * @throws Exception if a exception occurs during the reservation process.
-     * @see StreamingHttpClient#reserveConnection(StreamingHttpRequest)
      */
-    public ReservedBlockingStreamingHttpConnection reserveConnection(BlockingStreamingHttpRequest request)
-            throws Exception {
-        return reserveConnection(executionStrategy(), request);
+    public ReservedBlockingStreamingHttpConnection reserveConnection(HttpRequestMetaData metaData) throws Exception {
+        return reserveConnection(executionStrategy(), metaData);
     }
 
     /**
-     * Reserve a {@link BlockingStreamingHttpConnection} for handling the provided {@link BlockingStreamingHttpRequest}
-     * but <b>does not execute it</b>!
+     * Reserve a {@link BlockingStreamingHttpConnection} based on provided {@link HttpRequestMetaData}.
      *
      * @param strategy {@link HttpExecutionStrategy} to use.
-     * @param request Allows the underlying layers to know what {@link BlockingStreamingHttpConnection}s are valid to
-     * reserve. For example this may provide some insight into shard or other info.
-     * @return a {@link ReservedStreamingHttpConnection}.
+     * @param metaData Allows the underlying layers to know what {@link BlockingStreamingHttpConnection}s are valid to
+     * reserve for future {@link BlockingStreamingHttpRequest requests} with the same {@link HttpRequestMetaData}.
+     * For example this may provide some insight into shard or other info.
+     * @return a {@link ReservedBlockingStreamingHttpConnection}.
      * @throws Exception if a exception occurs during the reservation process.
-     * @see StreamingHttpClient#reserveConnection(HttpExecutionStrategy, StreamingHttpRequest)
      */
     public abstract ReservedBlockingStreamingHttpConnection reserveConnection(
-            HttpExecutionStrategy strategy, BlockingStreamingHttpRequest request) throws Exception;
+            HttpExecutionStrategy strategy, HttpRequestMetaData metaData) throws Exception;
 
     /**
      * Convert this {@link BlockingStreamingHttpClient} to the {@link StreamingHttpClient} API.
@@ -105,8 +102,8 @@ public abstract class BlockingStreamingHttpClient extends BlockingStreamingHttpR
 
     /**
      * A special type of {@link BlockingStreamingHttpConnection} for the exclusive use of the caller of
-     * {@link #reserveConnection(BlockingStreamingHttpRequest)}.
-     * @see ReservedStreamingHttpConnection
+     * {@link #reserveConnection(HttpRequestMetaData)} and
+     * {@link #reserveConnection(HttpExecutionStrategy, HttpRequestMetaData)}.
      */
     public abstract static class ReservedBlockingStreamingHttpConnection extends BlockingStreamingHttpConnection {
         /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClientToStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClientToStreamingHttpClient.java
@@ -46,9 +46,9 @@ final class BlockingStreamingHttpClientToStreamingHttpClient extends StreamingHt
 
     @Override
     public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
-                                                                               final StreamingHttpRequest request) {
+                                                                               final HttpRequestMetaData metaData) {
         return blockingToSingle(() -> new BlockingToReservedStreamingHttpConnection(
-                    blockingClient.reserveConnection(strategy, request.toBlockingStreamingRequest())));
+                blockingClient.reserveConnection(strategy, metaData)));
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClient.java
@@ -39,26 +39,28 @@ public abstract class HttpClient extends HttpRequester {
     }
 
     /**
-     * Reserve a {@link HttpConnection} for handling the provided {@link HttpRequest} but <b>does not execute it</b>!
+     * Reserve an {@link HttpConnection} based on provided {@link HttpRequestMetaData}.
      *
-     * @param request Allows the underlying layers to know what {@link HttpConnection}s are valid to reserve.
+     * @param metaData Allows the underlying layers to know what {@link HttpConnection}s are valid to
+     * reserve for future {@link HttpRequest requests} with the same {@link HttpRequestMetaData}.
      * For example this may provide some insight into shard or other info.
      * @return a {@link Single} that provides the {@link ReservedHttpConnection} upon completion.
      */
-    public Single<? extends ReservedHttpConnection> reserveConnection(HttpRequest request) {
-        return reserveConnection(executionStrategy(), request);
+    public Single<? extends ReservedHttpConnection> reserveConnection(HttpRequestMetaData metaData) {
+        return reserveConnection(executionStrategy(), metaData);
     }
 
     /**
-     * Reserve a {@link HttpConnection} for handling the provided {@link HttpRequest} but <b>does not execute it</b>!
+     * Reserve an {@link HttpConnection} based on provided {@link HttpRequestMetaData}.
      *
      * @param strategy {@link HttpExecutionStrategy} to use.
-     * @param request Allows the underlying layers to know what {@link HttpConnection}s are valid to reserve.
+     * @param metaData Allows the underlying layers to know what {@link HttpConnection}s are valid to
+     * reserve for future {@link HttpRequest requests} with the same {@link HttpRequestMetaData}.
      * For example this may provide some insight into shard or other info.
      * @return a {@link Single} that provides the {@link ReservedHttpConnection} upon completion.
      */
     public abstract Single<? extends ReservedHttpConnection> reserveConnection(HttpExecutionStrategy strategy,
-                                                                               HttpRequest request);
+                                                                               HttpRequestMetaData metaData);
 
     /**
      * Convert this {@link HttpClient} to the {@link StreamingHttpClient} API.
@@ -97,8 +99,8 @@ public abstract class HttpClient extends HttpRequester {
 
     /**
      * A special type of {@link HttpConnection} for the exclusive use of the caller of
-     * {@link #reserveConnection(HttpRequest)} and {@link #reserveConnection(HttpExecutionStrategy, HttpRequest)}.
-     * @see ReservedStreamingHttpConnection
+     * {@link #reserveConnection(HttpRequestMetaData)} and
+     * {@link #reserveConnection(HttpExecutionStrategy, HttpRequestMetaData)}.
      */
     public abstract static class ReservedHttpConnection extends HttpConnection {
         /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientToBlockingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientToBlockingHttpClient.java
@@ -34,9 +34,9 @@ final class HttpClientToBlockingHttpClient extends BlockingHttpClient {
 
     @Override
     public ReservedBlockingHttpConnection reserveConnection(final HttpExecutionStrategy strategy,
-                                                            final HttpRequest request) throws Exception {
+                                                            final HttpRequestMetaData metaData) throws Exception {
         return new ReservedHttpConnectionToReservedBlockingHttpConnection(
-                blockingInvocation(client.reserveConnection(strategy, request)));
+                blockingInvocation(client.reserveConnection(strategy, metaData)));
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientToStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientToStreamingHttpClient.java
@@ -34,8 +34,8 @@ final class HttpClientToStreamingHttpClient extends StreamingHttpClient {
 
     @Override
     public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
-                                                                               final StreamingHttpRequest request) {
-        return request.toRequest().flatMap(r -> client.reserveConnection(strategy, r))
+                                                                               final HttpRequestMetaData metaData) {
+        return client.reserveConnection(strategy, metaData)
                 .map(ReservedHttpConnectionToReservedStreamingHttpConnection::new);
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/LoadBalancerReadyStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/LoadBalancerReadyStreamingHttpClient.java
@@ -66,8 +66,8 @@ public final class LoadBalancerReadyStreamingHttpClient extends StreamingHttpCli
     @Override
     protected Single<? extends ReservedStreamingHttpConnection> reserveConnection(final StreamingHttpClient delegate,
                                                                                   final HttpExecutionStrategy strategy,
-                                                                                  final StreamingHttpRequest request) {
-        return delegate.reserveConnection(strategy, request).retryWhen(retryWhenFunction());
+                                                                                  final HttpRequestMetaData metaData) {
+        return delegate.reserveConnection(strategy, metaData).retryWhen(retryWhenFunction());
     }
 
     private BiIntFunction<Throwable, Completable> retryWhenFunction() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClient.java
@@ -40,27 +40,28 @@ public abstract class StreamingHttpClient extends StreamingHttpRequester {
     }
 
     /**
-     * Reserve a {@link StreamingHttpConnection} for handling the provided {@link StreamingHttpRequest} but <b>does not
-     * execute it</b>!
-     * @param request Allows the underlying layers to know what {@link StreamingHttpConnection}s are valid to reserve.
+     * Reserve a {@link StreamingHttpConnection} based on provided {@link HttpRequestMetaData}.
+     *
+     * @param metaData Allows the underlying layers to know what {@link StreamingHttpConnection}s are valid to
+     * reserve for future {@link StreamingHttpRequest requests} with the same {@link HttpRequestMetaData}.
      * For example this may provide some insight into shard or other info.
-     * @return a {@link ReservedStreamingHttpConnection}.
+     * @return a {@link Single} that provides the {@link ReservedStreamingHttpConnection} upon completion.
      */
-    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(StreamingHttpRequest request) {
-        return reserveConnection(executionStrategy(), request);
+    public Single<? extends ReservedStreamingHttpConnection> reserveConnection(HttpRequestMetaData metaData) {
+        return reserveConnection(executionStrategy(), metaData);
     }
 
     /**
-     * Reserve a {@link StreamingHttpConnection} for handling the provided {@link StreamingHttpRequest} but <b>does not
-     * execute it</b>!
+     * Reserve a {@link StreamingHttpConnection} based on provided {@link HttpRequestMetaData}.
      *
      * @param strategy {@link HttpExecutionStrategy} to use.
-     * @param request Allows the underlying layers to know what {@link StreamingHttpConnection}s are valid to reserve.
+     * @param metaData Allows the underlying layers to know what {@link StreamingHttpConnection}s are valid to
+     * reserve for future {@link StreamingHttpRequest requests} with the same {@link HttpRequestMetaData}.
      * For example this may provide some insight into shard or other info.
-     * @return a {@link ReservedStreamingHttpConnection}.
+     * @return a {@link Single} that provides the {@link ReservedStreamingHttpConnection} upon completion.
      */
     public abstract Single<? extends ReservedStreamingHttpConnection> reserveConnection(HttpExecutionStrategy strategy,
-                                                                                        StreamingHttpRequest request);
+                                                                                        HttpRequestMetaData metaData);
 
     /**
      * Convert this {@link StreamingHttpClient} to the {@link HttpClient} API.
@@ -109,8 +110,8 @@ public abstract class StreamingHttpClient extends StreamingHttpRequester {
 
     /**
      * A special type of {@link StreamingHttpConnection} for the exclusive use of the caller of
-     * {@link #reserveConnection(StreamingHttpRequest)} and
-     * {@link #reserveConnection(HttpExecutionStrategy, StreamingHttpRequest)}.
+     * {@link #reserveConnection(HttpRequestMetaData)} and
+     * {@link #reserveConnection(HttpExecutionStrategy, HttpRequestMetaData)}.
      */
     public abstract static class ReservedStreamingHttpConnection extends StreamingHttpConnection {
         /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilter.java
@@ -54,14 +54,14 @@ public class StreamingHttpClientFilter extends StreamingHttpClient {
 
     @Override
     public final Single<? extends ReservedStreamingHttpConnection> reserveConnection(
-            final StreamingHttpRequest request) {
-        return reserveConnection(defaultStrategy, request);
+            final HttpRequestMetaData metaData) {
+        return reserveConnection(defaultStrategy, metaData);
     }
 
     @Override
     public final Single<? extends ReservedStreamingHttpConnection> reserveConnection(
-            final HttpExecutionStrategy strategy, final StreamingHttpRequest request) {
-        return reserveConnection(delegate, strategy, request);
+            final HttpExecutionStrategy strategy, final HttpRequestMetaData metaData) {
+        return reserveConnection(delegate, strategy, metaData);
     }
 
     @Override
@@ -93,17 +93,17 @@ public class StreamingHttpClientFilter extends StreamingHttpClient {
     /**
      * Called when the filter needs to delegate the reserve connection request using the provided {@link
      * StreamingHttpClient} on which to call {@link StreamingHttpClient#reserveConnection(HttpExecutionStrategy,
-     * StreamingHttpRequest)}.
+     * HttpRequestMetaData)}.
      *
      * @param delegate the {@link StreamingHttpClient} to delegate requests to.
-     * @param strategy the {@link HttpExecutionStrategy} to use for executing the request.
-     * @param request The request for reserving the connection.
-     * @return the response.
+     * @param strategy the {@link HttpExecutionStrategy} to use for reserving a connection.
+     * @param metaData the {@link HttpRequestMetaData} for reserving a connection.
+     * @return a {@link Single} that provides the {@link ReservedStreamingHttpConnection} upon completion.
      */
     protected Single<? extends ReservedStreamingHttpConnection> reserveConnection(final StreamingHttpClient delegate,
                                                                                   final HttpExecutionStrategy strategy,
-                                                                                  final StreamingHttpRequest request) {
-        return delegate.reserveConnection(strategy, request).map(ClientFilterToReservedConnectionFilter::new);
+                                                                                  final HttpRequestMetaData metaData) {
+        return delegate.reserveConnection(strategy, metaData).map(ClientFilterToReservedConnectionFilter::new);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingHttpClient.java
@@ -35,8 +35,8 @@ final class StreamingHttpClientToBlockingHttpClient extends BlockingHttpClient {
 
     @Override
     public ReservedBlockingHttpConnection reserveConnection(final HttpExecutionStrategy strategy,
-                                                            final HttpRequest request) throws Exception {
-        return blockingInvocation(client.reserveConnection(strategy, request.toStreamingRequest())
+                                                            final HttpRequestMetaData metaData) throws Exception {
+        return blockingInvocation(client.reserveConnection(strategy, metaData)
                 .map(ReservedStreamingHttpConnectionToBlocking::new));
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingStreamingHttpClient.java
@@ -46,12 +46,12 @@ final class StreamingHttpClientToBlockingStreamingHttpClient extends BlockingStr
 
     @Override
     public ReservedBlockingStreamingHttpConnection reserveConnection(final HttpExecutionStrategy strategy,
-                                                                     final BlockingStreamingHttpRequest request)
+                                                                     final HttpRequestMetaData metaData)
             throws Exception {
         // It is assumed that users will always apply timeouts at the StreamingHttpService layer (e.g. via filter).
         // So we don't apply any explicit timeout here and just wait forever.
         return new ReservedStreamingHttpConnectionToBlockingStreaming(
-                blockingInvocation(client.reserveConnection(strategy, request.toStreamingRequest())));
+                blockingInvocation(client.reserveConnection(strategy, metaData)));
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToHttpClient.java
@@ -34,8 +34,8 @@ final class StreamingHttpClientToHttpClient extends HttpClient {
 
     @Override
     public Single<? extends ReservedHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
-                                                                      final HttpRequest request) {
-        return client.reserveConnection(strategy, request.toStreamingRequest())
+                                                                      final HttpRequestMetaData metaData) {
+        return client.reserveConnection(strategy, metaData)
                 .map(ReservedStreamingHttpConnectionToReservedHttpConnection::new);
     }
 

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpClientTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpClientTest.java
@@ -42,7 +42,7 @@ public class BlockingStreamingHttpClientTest extends AbstractBlockingStreamingHt
 
             @Override
             public Single<? extends ReservedStreamingHttpConnection> reserveConnection(
-                    final HttpExecutionStrategy strategy, final StreamingHttpRequest request) {
+                    final HttpExecutionStrategy strategy, final HttpRequestMetaData metaData) {
                 return error(new UnsupportedOperationException());
             }
         };
@@ -63,7 +63,7 @@ public class BlockingStreamingHttpClientTest extends AbstractBlockingStreamingHt
 
             @Override
             public ReservedBlockingStreamingHttpConnection reserveConnection(
-                    final HttpExecutionStrategy strategy, final BlockingStreamingHttpRequest request) {
+                    final HttpExecutionStrategy strategy, final HttpRequestMetaData metaData) {
                 throw new UnsupportedOperationException();
             }
         };

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/LoadBalancerReadyHttpClientTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/LoadBalancerReadyHttpClientTest.java
@@ -57,7 +57,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 public class LoadBalancerReadyHttpClientTest {
     private static final BufferAllocator allocator = DEFAULT_ALLOCATOR;
     private final StreamingHttpRequestResponseFactory reqRespFactory = new DefaultStreamingHttpRequestResponseFactory(
-            allocator, DefaultHttpHeadersFactory.INSTANCE);
+            allocator, INSTANCE);
     @Rule
     public final Timeout timeout = new ServiceTalkTestTimeout();
     @Rule
@@ -74,7 +74,7 @@ public class LoadBalancerReadyHttpClientTest {
 
         @Override
         public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
-                final StreamingHttpRequest request) {
+                                                                                   final HttpRequestMetaData metaData) {
             return defer(new DeferredSuccessSupplier<>(mockReservedConnection));
         }
     };
@@ -170,7 +170,7 @@ public class LoadBalancerReadyHttpClientTest {
         }
     }
 
-    private StreamingHttpResponse newOkResponse() {
+    private static StreamingHttpResponse newOkResponse() {
         return StreamingHttpResponses.newResponse(OK, HTTP_1_1, INSTANCE.newHeaders(), INSTANCE.newTrailers(),
                 DEFAULT_ALLOCATOR);
     }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/SimpleHttpRequesterFilterTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/SimpleHttpRequesterFilterTest.java
@@ -76,8 +76,8 @@ public class SimpleHttpRequesterFilterTest extends AbstractHttpRequesterFilterTe
                 protected Single<? extends ReservedStreamingHttpConnection> reserveConnection(
                         final StreamingHttpClient delegate,
                         final HttpExecutionStrategy strategy,
-                        final StreamingHttpRequest request) {
-                    return delegate.reserveConnection(strategy, request).map(r ->
+                        final HttpRequestMetaData metaData) {
+                    return delegate.reserveConnection(strategy, metaData).map(r ->
                             new ReservedStreamingHttpConnectionFilter(r) {
                                 @Override
                                 public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
@@ -153,8 +153,8 @@ public class SimpleHttpRequesterFilterTest extends AbstractHttpRequesterFilterTe
                 protected Single<? extends ReservedStreamingHttpConnection> reserveConnection(
                         final StreamingHttpClient delegate,
                         final HttpExecutionStrategy strategy,
-                        final StreamingHttpRequest request) {
-                    return delegate.reserveConnection(strategy, request)
+                        final HttpRequestMetaData metaData) {
+                    return delegate.reserveConnection(strategy, metaData)
                             .map(r -> new ReservedStreamingHttpConnectionFilter(r) {
                                 @Override
                                 public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
@@ -216,8 +216,8 @@ public class SimpleHttpRequesterFilterTest extends AbstractHttpRequesterFilterTe
                 protected Single<? extends ReservedStreamingHttpConnection> reserveConnection(
                         final StreamingHttpClient delegate,
                         final HttpExecutionStrategy strategy,
-                        final StreamingHttpRequest request) {
-                    return delegate.reserveConnection(strategy, request)
+                        final HttpRequestMetaData metaData) {
+                    return delegate.reserveConnection(strategy, metaData)
                             .map(r -> new ReservedStreamingHttpConnectionFilter(r) {
                                 @Override
                                 public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpRequesterFilterTest.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpRequesterFilterTest.java
@@ -318,7 +318,7 @@ public abstract class AbstractHttpRequesterFilterTest {
             protected Single<? extends ReservedStreamingHttpConnection> reserveConnection(
                     final StreamingHttpClient delegate,
                     final HttpExecutionStrategy strategy,
-                    final StreamingHttpRequest request) {
+                    final HttpRequestMetaData metaData) {
                 return success(AbstractHttpRequesterFilterTest.this.newReservedConnection(rwch));
             }
         };

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpClient.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpClient.java
@@ -53,7 +53,7 @@ public class TestStreamingHttpClient extends StreamingHttpClient {
 
     @Override
     public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
-                                                                               final StreamingHttpRequest request) {
+                                                                               final HttpRequestMetaData metaData) {
         return error(new UnsupportedOperationException());
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -136,14 +136,14 @@ class DefaultPartitionedHttpClientBuilder<U, R> implements PartitionedHttpClient
         }
 
         @Nonnull
-        private StreamingHttpClient selectClient(final StreamingHttpRequest request) {
-            return group.get(pabf.apply(request).build());
+        private StreamingHttpClient selectClient(final HttpRequestMetaData metaData) {
+            return group.get(pabf.apply(metaData).build());
         }
 
         @Override
         public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
-                                                                                   final StreamingHttpRequest request) {
-            return deferShareContext(() -> selectClient(request).reserveConnection(strategy, request));
+                                                                                   final HttpRequestMetaData metaData) {
+            return deferShareContext(() -> selectClient(metaData).reserveConnection(strategy, metaData));
         }
 
         @Override
@@ -182,7 +182,7 @@ class DefaultPartitionedHttpClientBuilder<U, R> implements PartitionedHttpClient
 
         @Override
         public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
-                                                                                   final StreamingHttpRequest request) {
+                                                                                   final HttpRequestMetaData metaData) {
             return error(ex);
         }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultStreamingHttpClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultStreamingHttpClient.java
@@ -19,6 +19,7 @@ import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
@@ -54,7 +55,7 @@ final class DefaultStreamingHttpClient extends StreamingHttpClient {
 
     @Override
     public Single<? extends ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
-                                                                               final StreamingHttpRequest request) {
+                                                                               final HttpRequestMetaData metaData) {
         return strategy.offloadReceive(executionContext.executor(),
                 loadBalancer.selectConnection(SELECTOR_FOR_RESERVE));
     }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilter.java
@@ -23,6 +23,7 @@ import io.servicetalk.http.api.HttpConnection;
 import io.servicetalk.http.api.HttpConnectionFilterFactory;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpHeaderNames;
+import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.ReservedStreamingHttpConnectionFilter;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
@@ -137,8 +138,8 @@ public final class RedirectingHttpRequesterFilter implements HttpClientFilterFac
             protected Single<? extends ReservedStreamingHttpConnection> reserveConnection(
                     final StreamingHttpClient delegate,
                     final HttpExecutionStrategy strategy,
-                    final StreamingHttpRequest request) {
-                return delegate.reserveConnection(strategy, request)
+                    final HttpRequestMetaData metaData) {
+                return delegate.reserveConnection(strategy, metaData)
                         .map(r -> new ReservedStreamingHttpConnectionFilter(r) {
                             @Override
                             public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,


### PR DESCRIPTION
Motivation:

It's not intuitive for users why `reserveConnection` requires a full
`HttpRequest` object, but does not send this request. We should clarify
that only `HttpRequestMetaData` is required to reserve a connection.

Modifications:

- Change signature of `reserveConnection` method to require
`HttpRequestMetaData`;
- Update javadoc;
- Resolve compilation errors;

Result:

`HttpClient.reserveConnection` and its variants require only
`HttpRequestMetaData` to reserve a connection.