### PR TITLE
Use immediate() executor for internal retry strategy in default DNS SD

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -34,6 +34,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.client.api.ServiceDiscovererFilterFactory.identity;
+import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.RetryStrategies.retryWithConstantBackoffAndJitter;
 import static io.servicetalk.transport.netty.internal.GlobalExecutionContext.globalExecutionContext;
 
@@ -234,7 +235,7 @@ public final class DefaultDnsServiceDiscovererBuilder {
             final ServiceDiscovererFilterFactory<String, InetAddress, ServiceDiscovererEvent<InetAddress>>
                     defaultFilterFactory = serviceDiscoverer -> new RetryingDnsServiceDiscovererFilter(
                     serviceDiscoverer, retryWithConstantBackoffAndJitter(
-                    Integer.MAX_VALUE, t -> true, Duration.ofSeconds(60), globalExecutionContext().executor()));
+                    Integer.MAX_VALUE, t -> true, Duration.ofSeconds(60), immediate()));
             factory = defaultFilterFactory.append(factory);
         }
         return factory.create(new DefaultDnsServiceDiscoverer(


### PR DESCRIPTION
Motivation:

1. Users have to disable default retry filter in
`DefaultDnsServiceDiscovererBuilder` or implement their own
retry filter to avoid initialization of `GlobalExecutionContext`.
2. Use of cached thread pool executor is not required to schedule
retries, we may use global scheduler via `immediate()` instead.

Modifications:

- Use `immediate()` executor for internal default retry filter for
`DefaultDnsServiceDiscovererBuilder`;

Result:

`DefaultDnsServiceDiscovererBuilder` does not initialize
`GlobalExecutionContext` only for retry filter.