### PR TITLE
Fixing DefaultDnsServiceDiscovererTest.preferIpv4

### DIFF
--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererTest.java
@@ -462,7 +462,7 @@ public class DefaultDnsServiceDiscovererTest {
 
         latch.await();
         assertNull(throwableRef.get());
-        assertThat(subscriber.activeEventAddresses.size(), equalTo(expectedActiveCount));
+        assertThat(subscriber.activeEventAddresses.size(), greaterThanOrEqualTo(expectedActiveCount));
         assertThat(subscriber.activeEventAddresses.get(0), equalTo(ipv4));
         assertThat(subscriber.inactiveEventAddresses.size(), equalTo(expectedInactiveCount));
     }


### PR DESCRIPTION
Motivation:

On CI, when tests are often slow, this was failing.
In some cases, a 2nd scheduled resolution would happening. Sometimes this
would happen before the netty DNS cache had expired the entry, resulting
in the cached entry being returned. The cached entry includes both the
IPv4 and IPv6 addresses, resulting in the test failing due to asserting
only a single address was returned.

Modifications:

Allow more than one address to be returned, asserting that the first
address is the IPv4 address. This is in line with how IPV4_PREFERRED
ensures that IPv4 addresses are first, but that IPv6 addresses are not
necessarily filtered out.

Results:

Test passes reliably, even on CI.