### PR TITLE
Conditional filters decouples async context

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ConditionalHttpClientFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ConditionalHttpClientFilter.java
@@ -37,22 +37,11 @@ final class ConditionalHttpClientFilter extends StreamingHttpClientFilter {
     protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                     final HttpExecutionStrategy strategy,
                                                     final StreamingHttpRequest request) {
-        return new Single<StreamingHttpResponse>() {
-            @Override
-            protected void handleSubscribe(final Subscriber<? super StreamingHttpResponse> subscriber) {
-                predicatedRequest(delegate, strategy, request).subscribe(subscriber);
-            }
-        };
-    }
-
-    private Single<StreamingHttpResponse> predicatedRequest(final StreamingHttpRequester delegate,
-                                                            final HttpExecutionStrategy strategy,
-                                                            final StreamingHttpRequest request) {
         boolean b;
         try {
             b = predicate.test(request);
         } catch (Throwable t) {
-            return error(new RuntimeException("Unexpected predicate failure", t));
+            return error(t);
         }
 
         if (b) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ConditionalHttpConnectionFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ConditionalHttpConnectionFilter.java
@@ -35,21 +35,11 @@ final class ConditionalHttpConnectionFilter extends StreamingHttpConnectionFilte
 
     @Override
     public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy, final StreamingHttpRequest req) {
-        return new Single<StreamingHttpResponse>() {
-            @Override
-            protected void handleSubscribe(final Subscriber<? super StreamingHttpResponse> subscriber) {
-                predicatedRequest(strategy, req).subscribe(subscriber);
-            }
-        };
-    }
-
-    private Single<StreamingHttpResponse> predicatedRequest(final HttpExecutionStrategy strategy,
-                                                            final StreamingHttpRequest req) {
         boolean b;
         try {
             b = predicate.test(req);
         } catch (Throwable t) {
-            return error(new RuntimeException("Unexpected predicate failure", t));
+            return error(t);
         }
 
         if (b) {


### PR DESCRIPTION
__Motivation__

Conditional filters create a `Single` but do not share the context on subscribe.
This makes it such that the context within a filter chain is decoupled from the previous filters and hence changes made to the context after a conditional filter will not be available to the filters before it.

__Modification__

We decided initially to make these filters such that the predicates are invoked on each subscribe.
The benefit was considered to be simplicity of predicate that it is invoked each time a request is sent.
Considering the complexity of managing contexts and an additional layer of indirection, it seems we can avoid this as we expect predicates to be evaluated based on immutable request properties and hence the result of the predicate must be idempotent.

__Result__

Conditional filters now preserve the context mutations.