### PR TITLE
DefaultCompositeCloseable to cache the getCause() result

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultCompositeCloseable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultCompositeCloseable.java
@@ -107,9 +107,10 @@ final class DefaultCompositeCloseable implements CompositeCloseable {
         try {
             closeAsync().toFuture().get();
         } catch (final ExecutionException e) {
-            if (e.getCause() != null) {
+            final Throwable cause = e.getCause();
+            if (cause != null) {
                 // unwrap original cause of ExecutionException:
-                throwException(e.getCause());
+                throwException(cause);
             }
             throwException(e);
         }


### PR DESCRIPTION
Motivation:
DefaultCompositeCloseable calls getCause() multiple successive times in the same method. The method is synchronized and involves a conditional statement.

Modifications:
- Cache the result of getCause() in a local variable to avoid multiple calls

Result:
Less calls to a synchronized method.