### PR TITLE
Share code for termination from source

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/EmptyPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/EmptyPublisher.java
@@ -19,7 +19,7 @@ import org.reactivestreams.Subscriber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.servicetalk.concurrent.internal.EmptySubscription.EMPTY_SUBSCRIPTION;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 
 final class EmptyPublisher<T> extends AbstractSynchronousPublisher<T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(EmptyPublisher.class);
@@ -31,17 +31,7 @@ final class EmptyPublisher<T> extends AbstractSynchronousPublisher<T> {
 
     @Override
     void doSubscribe(Subscriber<? super T> subscriber) {
-        try {
-            subscriber.onSubscribe(EMPTY_SUBSCRIPTION);
-        } catch (Throwable t) {
-            LOGGER.debug("Ignoring exception from onSubscribe of Subscriber {}.", subscriber, t);
-            return;
-        }
-        try {
-            subscriber.onComplete();
-        } catch (Throwable t) {
-            LOGGER.debug("Ignoring exception from onComplete of Subscriber {}.", subscriber, t);
-        }
+        deliverTerminalFromSource(subscriber);
     }
 
     @SuppressWarnings("unchecked")

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ErrorPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ErrorPublisher.java
@@ -16,14 +16,11 @@
 package io.servicetalk.concurrent.api;
 
 import org.reactivestreams.Subscriber;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import static io.servicetalk.concurrent.internal.EmptySubscription.EMPTY_SUBSCRIPTION;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 import static java.util.Objects.requireNonNull;
 
 final class ErrorPublisher<T> extends AbstractSynchronousPublisher<T> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ErrorPublisher.class);
     private final Throwable cause;
 
     ErrorPublisher(Throwable cause) {
@@ -32,16 +29,6 @@ final class ErrorPublisher<T> extends AbstractSynchronousPublisher<T> {
 
     @Override
     void doSubscribe(Subscriber<? super T> subscriber) {
-        try {
-            subscriber.onSubscribe(EMPTY_SUBSCRIPTION);
-        } catch (Throwable t) {
-            LOGGER.debug("Ignoring exception from onSubscribe of Subscriber {}.", subscriber, t);
-            return;
-        }
-        try {
-            subscriber.onError(cause);
-        } catch (Throwable t) {
-            LOGGER.debug("Ignoring exception from onError of Subscriber {}.", subscriber, t);
-        }
+        deliverTerminalFromSource(subscriber, cause);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FailedCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FailedCompletable.java
@@ -15,14 +15,10 @@
  */
 package io.servicetalk.concurrent.api;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 import static java.util.Objects.requireNonNull;
 
 final class FailedCompletable extends AbstractSynchronousCompletable {
-    private static final Logger LOGGER = LoggerFactory.getLogger(FailedCompletable.class);
     private final Throwable cause;
 
     FailedCompletable(Throwable cause) {
@@ -31,16 +27,6 @@ final class FailedCompletable extends AbstractSynchronousCompletable {
 
     @Override
     void doSubscribe(final Subscriber subscriber) {
-        try {
-            subscriber.onSubscribe(IGNORE_CANCEL);
-        } catch (Throwable t) {
-            LOGGER.debug("Ignoring exception from onSubscribe of Subscriber {}.", subscriber, t);
-            return;
-        }
-        try {
-            subscriber.onError(cause);
-        } catch (Throwable t) {
-            LOGGER.debug("Ignoring exception from onError of Subscriber {}.", subscriber, t);
-        }
+        deliverTerminalFromSource(subscriber, cause);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FailedSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FailedSingle.java
@@ -15,14 +15,10 @@
  */
 package io.servicetalk.concurrent.api;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 import static java.util.Objects.requireNonNull;
 
 final class FailedSingle<T> extends AbstractSynchronousSingle<T> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(FailedSingle.class);
     private final Throwable cause;
 
     FailedSingle(Throwable cause) {
@@ -31,16 +27,6 @@ final class FailedSingle<T> extends AbstractSynchronousSingle<T> {
 
     @Override
     void doSubscribe(final Subscriber<? super T> subscriber) {
-        try {
-            subscriber.onSubscribe(IGNORE_CANCEL);
-        } catch (Throwable t) {
-            LOGGER.debug("Ignoring exception from onSubscribe of Subscriber {}.", subscriber, t);
-            return;
-        }
-        try {
-            subscriber.onError(cause);
-        } catch (Throwable t) {
-            LOGGER.debug("Ignoring exception from onError of Subscriber {}.", subscriber, t);
-        }
+        deliverTerminalFromSource(subscriber, cause);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromArrayPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromArrayPublisher.java
@@ -20,8 +20,8 @@ import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.servicetalk.concurrent.internal.EmptySubscription.EMPTY_SUBSCRIPTION;
 import static io.servicetalk.concurrent.internal.FlowControlUtil.addWithOverflowProtection;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
 import static java.lang.Math.min;
@@ -49,17 +49,7 @@ final class FromArrayPublisher<T> extends AbstractSynchronousPublisher<T> {
                 LOGGER.debug("Ignoring exception from onSubscribe of Subscriber {}.", s, t);
             }
         } else {
-            try {
-                s.onSubscribe(EMPTY_SUBSCRIPTION);
-            } catch (Throwable t) {
-                LOGGER.debug("Ignoring exception from onSubscribe of Subscriber {}.", s, t);
-                return;
-            }
-            try {
-                s.onComplete();
-            } catch (Throwable t) {
-                LOGGER.debug("Ignoring exception from onComplete of Subscriber {}.", s, t);
-            }
+            deliverTerminalFromSource(s);
         }
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromInputStreamPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromInputStreamPublisher.java
@@ -15,6 +15,8 @@
  */
 package io.servicetalk.concurrent.api;
 
+import io.servicetalk.concurrent.internal.DuplicateSubscribeException;
+
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
@@ -25,8 +27,8 @@ import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.internal.EmptySubscription.EMPTY_SUBSCRIPTION;
 import static io.servicetalk.concurrent.internal.FlowControlUtil.addWithOverflowProtection;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
 import static java.lang.Math.min;
@@ -79,17 +81,7 @@ final class FromInputStreamPublisher extends Publisher<byte[]> {
                 LOGGER.debug("Ignoring exception from onSubscribe of Subscriber {}.", subscriber, t);
             }
         } else {
-            try {
-                subscriber.onSubscribe(EMPTY_SUBSCRIPTION);
-            } catch (Throwable t) {
-                LOGGER.debug("Ignoring exception from onSubscribe of Subscriber {}.", subscriber, t);
-                return;
-            }
-            try {
-                subscriber.onError(new IllegalStateException("Publisher already subscribed to"));
-            } catch (Throwable t) {
-                LOGGER.debug("Ignoring exception from onError of Subscriber {}.", subscriber, t);
-            }
+            deliverTerminalFromSource(subscriber, new DuplicateSubscribeException(null, subscriber));
         }
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/FromInputStreamPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/FromInputStreamPublisherTest.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
+import io.servicetalk.concurrent.internal.DuplicateSubscribeException;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 
 import org.junit.Before;
@@ -81,7 +82,7 @@ public class FromInputStreamPublisherTest {
         sub1.subscribe(pub);
 
         sub2.subscribe(pub);
-        sub2.verifyFailure(IllegalStateException.class);
+        sub2.verifyFailure(DuplicateSubscribeException.class);
 
         sub1.request(1).verifySuccess();
     }
@@ -94,7 +95,7 @@ public class FromInputStreamPublisherTest {
         sub1.request(1).verifyFailure(IOException.class);
 
         sub2.subscribe(pub);
-        sub2.verifyFailure(IllegalStateException.class);
+        sub2.verifyFailure(DuplicateSubscribeException.class);
     }
 
     @Test
@@ -105,7 +106,7 @@ public class FromInputStreamPublisherTest {
         sub1.request(1).verifySuccess();
 
         sub2.subscribe(pub);
-        sub2.verifyFailure(IllegalStateException.class);
+        sub2.verifyFailure(DuplicateSubscribeException.class);
     }
 
     @Test


### PR DESCRIPTION
Motivation:
There is common code related to terminating a Subscriber from a source that is duplicated in multiple locations.

Modifications:
- Share this code in a common location where possible

Result:
SubscriberUtils has more methods with shared code to terminate a Subscriber.