### PR TITLE
Specify a version of `servicetalk-gradle-plugin-internal` in composite

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,7 @@ buildscript {
   }
 
   dependencies {
-    // The plugin is brought in via composite build inclusion, so no need to specify a version.
-    classpath "io.servicetalk:servicetalk-gradle-plugin-internal"
+    classpath "io.servicetalk:servicetalk-gradle-plugin-internal:$project.version"
   }
 }
 


### PR DESCRIPTION
Motivation:

Without the version for `servicetalk-gradle-plugin-internal` gradle
cannot resolve the version if users use
`--include-build /path/to/servicetalk` to build their projects with ST
source code.

Modifications:

- Specify a version of `servicetalk-gradle-plugin-internal` in composite
`build.gradle`;

Result:

Users can build their gradle projects with ST source code using
`--include-build /path/to/servicetalk`.