### PR TITLE
Fixing repeat test

### DIFF
--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatTest.java
@@ -69,12 +69,14 @@ public class RepeatTest {
 
     @Test
     public void testRequestAcrossRepeat() {
+        shouldRepeatValue = true;
         subscriberRule.request(3);
         source.sendItems(1, 2).onComplete();
         subscriberRule.verifyItems(1, 2);
         verify(shouldRepeat).test(1);
         source.verifySubscribed().sendItems(3);
-        subscriberRule.verifySuccess(3);
+        subscriberRule.verifyItems(3);
+        subscriberRule.verifyNoEmissions();
     }
 
     @Test


### PR DESCRIPTION
Motivation:

This test has been passing incorrectly.
Because the `repeat` was not repeating, the `onComplete` propagated to the
subscriber. `verifySubscribed` is passing only because the `TestPublisher`
is created with `preserveSubscriber`.
The intent of this test (based on the name) is to ensure that the 3rd item,
requested before the `onComplete,` is still requested after the repeat.

Modifications:

- Enable repeat for the test
- Assert that the subscriber does not receive any termination signals.

Results:

Test passes for the right reason.