### PR TITLE
Rename `SSLContextFactory` to `SslContextFactory`

### DIFF
--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientConfig.java
@@ -25,7 +25,7 @@ import java.io.InputStream;
 import java.net.SocketOption;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.transport.netty.internal.SSLContextFactory.forClient;
+import static io.servicetalk.transport.netty.internal.SslContextFactory.forClient;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
@@ -29,7 +29,7 @@ import java.net.SocketOption;
 import java.util.Map;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.transport.netty.internal.SSLContextFactory.forServer;
+import static io.servicetalk.transport.netty.internal.SslContextFactory.forServer;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslContextFactory.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslContextFactory.java
@@ -31,9 +31,9 @@ import static java.util.Objects.requireNonNull;
 /**
  * A factory for creating {@link SslContext}s.
  */
-public final class SSLContextFactory {
+public final class SslContextFactory {
 
-    private SSLContextFactory() {
+    private SslContextFactory() {
         // No instances.
     }
 


### PR DESCRIPTION
Motivation:

All our other SSL-related classes, like `SslConfig` has `Ssl` as a
prefix instead of upper case `SSL`.

Modifications:

- Rename `SSLContextFactory` to `SslContextFactory`;

Result:

`SslContextFactory` has a consistent name with other SSL-related classes.