### PR TITLE
ConnectionAcceptor updates

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -21,7 +21,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpHeadersFactory;
 import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.StreamingHttpService;
-import io.servicetalk.transport.api.ConnectionAcceptorFilter;
+import io.servicetalk.transport.api.ConnectionAcceptor;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.SslConfig;
@@ -135,14 +135,14 @@ final class DefaultHttpServerBuilder extends HttpServerBuilder {
     }
 
     @Override
-    public Single<ServerContext> doListen(final ConnectionAcceptorFilter connectionAcceptorFilter,
+    public Single<ServerContext> doListen(@Nullable final ConnectionAcceptor connectionAcceptor,
                                           final StreamingHttpService service) {
         ReadOnlyHttpServerConfig roConfig = this.config.asReadOnly();
         Executor executor = service.executionStrategy().executor();
         if (executor != null) {
             executionContextBuilder.executor(executor);
         }
-        return NettyHttpServer.bind(executionContextBuilder.build(), roConfig, address, connectionAcceptorFilter,
+        return NettyHttpServer.bind(executionContextBuilder.build(), roConfig, address, connectionAcceptor,
                 service);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -86,7 +86,8 @@ final class NettyHttpServer {
     }
 
     static Single<ServerContext> bind(final ExecutionContext executionContext, final ReadOnlyHttpServerConfig config,
-                                      final SocketAddress address, final ConnectionAcceptor connectionAcceptor,
+                                      final SocketAddress address,
+                                      @Nullable final ConnectionAcceptor connectionAcceptor,
                                       final StreamingHttpService service) {
         // This state is read only, so safe to keep a copy across Subscribers
         final ReadOnlyTcpServerConfig tcpServerConfig = config.tcpConfig();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -30,7 +30,7 @@ import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.test.resources.DefaultTestCerts;
 import io.servicetalk.transport.api.ConnectionAcceptor;
-import io.servicetalk.transport.api.ConnectionAcceptorFilter;
+import io.servicetalk.transport.api.ConnectionAcceptorAdapter;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.SslConfig;
@@ -141,7 +141,7 @@ public abstract class AbstractNettyHttpServerTest {
             serverBuilder.sslConfig(sslConfig);
         }
         serverContext = awaitIndefinitelyNonNull(serverBuilder.ioExecutor(serverIoExecutor)
-                .appendConnectionAcceptorFilter(original -> new ConnectionAcceptorFilter(connectionAcceptor))
+                .appendConnectionAcceptorFilter(original -> new ConnectionAcceptorAdapter(connectionAcceptor))
                 .listenStreaming(service)
                 .doBeforeSuccess(ctx -> LOGGER.debug("Server started on {}.", ctx.listenAddress()))
                 .doBeforeError(throwable -> LOGGER.debug("Failed starting server on {}.", bindAddress)));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -76,7 +76,6 @@ import static io.servicetalk.http.api.HttpHeaderValues.KEEP_ALIVE;
 import static io.servicetalk.http.api.HttpProtocolVersions.HTTP_1_1;
 import static io.servicetalk.http.api.HttpRequestMetaDataFactory.newRequestMetaData;
 import static io.servicetalk.http.api.HttpRequestMethods.GET;
-import static io.servicetalk.transport.api.ConnectionAcceptor.ACCEPT_ALL;
 import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -407,7 +406,7 @@ public class HttpRequestEncoderTest {
             ReadOnlyTcpServerConfig sConfig = new TcpServerConfig(true).asReadOnly();
             ServerContext serverContext = resources.prepend(
                     TcpServerBinder.bind(localAddress(0), sConfig,
-                            SEC, ACCEPT_ALL,
+                            SEC, null,
                             channel -> DefaultNettyConnection.initChannel(channel, SEC.bufferAllocator(),
                                     SEC.executor(), new TerminalPredicate<>(o -> o instanceof HttpHeaders),
                                     UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, defaultFlushStrategy(),

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServiceAsyncContextTest.java
@@ -34,7 +34,7 @@ import io.servicetalk.http.api.StreamingHttpRequester;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpService;
-import io.servicetalk.transport.api.ConnectionAcceptorFilter;
+import io.servicetalk.transport.api.ConnectionAcceptorAdapter;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.IoThreadFactory;
 import io.servicetalk.transport.netty.internal.ExecutionContextRule;
@@ -301,7 +301,7 @@ public class HttpServiceAsyncContextTest {
         StreamingHttpService service = newEmptyAsyncContextService(serverUseImmediate);
         CompositeCloseable compositeCloseable = AsyncCloseables.newCompositeCloseable();
         ServerContext ctx = compositeCloseable.append(HttpServers.forAddress(localAddress(0))
-                .appendConnectionAcceptorFilter(original -> new ConnectionAcceptorFilter(context -> {
+                .appendConnectionAcceptorFilter(original -> new ConnectionAcceptorAdapter(context -> {
                     AsyncContext.put(K1, "v1");
                     return success(true);
                 }))

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionTest.java
@@ -27,7 +27,6 @@ import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpService;
-import io.servicetalk.transport.api.ConnectionAcceptorFilter;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.ExecutionContextRule;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
@@ -108,8 +107,7 @@ public class NettyHttpServerConnectionTest {
 
         serverContext = HttpServers.forAddress(localAddress(0))
                 .ioExecutor(contextRule.ioExecutor())
-                .appendConnectionAcceptorFilter(original -> new ConnectionAcceptorFilter(original,
-                        (ctx, accepted) -> {
+                .appendConnectionAcceptorFilter(original -> original.append(ctx -> {
                             customCancellableRef.set(
                                     ((NettyConnectionContext) ctx).updateFlushStrategy(current -> customStrategy));
                             return success(true);

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
@@ -33,6 +33,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.transport.api.ConnectionAcceptor.ACCEPT_ALL;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
@@ -92,7 +93,8 @@ public class TcpServer {
      * @throws ExecutionException If the server start failed.
      * @throws InterruptedException If the calling thread was interrupted waiting for the server to start.
      */
-    public ServerContext bind(ExecutionContext executionContext, int port, ConnectionAcceptor connectionAcceptor,
+    public ServerContext bind(ExecutionContext executionContext, int port,
+                              @Nullable ConnectionAcceptor connectionAcceptor,
                               Function<NettyConnection<Buffer, Buffer>, Completable> service)
             throws ExecutionException, InterruptedException {
         return TcpServerBinder.bind(localAddress(port), config,

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionAcceptor.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionAcceptor.java
@@ -44,6 +44,28 @@ public interface ConnectionAcceptor extends AsyncCloseable {
      */
     Single<Boolean> accept(ConnectionContext context);
 
+    /**
+     * Returns a composed {@link ConnectionAcceptor} that first applies {@code this} {@link ConnectionAcceptor}, and if
+     * this is successful then applies {@code after} {@link ConnectionAcceptor}.
+     * <p>
+     * The order of execution of these filters are in order of append. If 3 filters are added as follows:
+     * <pre>
+     *     this.append(filter1).append(filter2).append(filter3)
+     * </pre>
+     * accepting a connection by a filter wrapped by this filter chain, the order of invocation of these filters will
+     * be:
+     * <pre>
+     *     this =&gt; filter1 =&gt; filter2 =&gt; filter3
+     * </pre>
+     * @param after the {@link ConnectionAcceptor} to apply after {@code this} {@link ConnectionAcceptor} is
+     * applied
+     * @return a composed {@link ConnectionAcceptor} that first applies {@code this} {@link ConnectionAcceptor}, and if
+     * this is successful then applies {@code after} {@link ConnectionAcceptor}.
+     */
+    default ConnectionAcceptor append(ConnectionAcceptor after) {
+        return new ConnectionAcceptorAppender(this, after);
+    }
+
     @Override
     default Completable closeAsync() {
         return completed();

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionAcceptorAdapter.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionAcceptorAdapter.java
@@ -18,46 +18,27 @@ package io.servicetalk.transport.api;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 
-import java.util.function.BiFunction;
-import javax.annotation.Nullable;
+import static java.util.Objects.requireNonNull;
 
 /**
  * An implementation of {@link ConnectionAcceptor} that delegates all methods to another {@link ConnectionAcceptor}.
  */
-public class ConnectionAcceptorFilter implements ConnectionAcceptor {
+public class ConnectionAcceptorAdapter implements ConnectionAcceptor {
 
     private final ConnectionAcceptor delegate;
-    @Nullable
-    private final BiFunction<ConnectionContext, Boolean, Single<Boolean>> apply;
 
     /**
      * New instance.
      *
      * @param delegate {@link ConnectionAcceptor} to delegate all calls to.
      */
-    public ConnectionAcceptorFilter(final ConnectionAcceptor delegate) {
-        this.delegate = delegate;
-        apply = null;
-    }
-
-    /**
-     * New instance.
-     *
-     * @param delegate {@link ConnectionAcceptor} to delegate all calls to.
-     * @param apply A {@link BiFunction} that is called after {@link ConnectionAcceptor#accept(ConnectionContext)} is
-     * called on the passed {@code delegate}. The second argument to the {@link BiFunction} is the result from the
-     * {@code delegate}.
-     */
-    public ConnectionAcceptorFilter(final ConnectionAcceptor delegate,
-                                    final BiFunction<ConnectionContext, Boolean, Single<Boolean>> apply) {
-        this.delegate = delegate;
-        this.apply = apply;
+    public ConnectionAcceptorAdapter(final ConnectionAcceptor delegate) {
+        this.delegate = requireNonNull(delegate);
     }
 
     @Override
     public Single<Boolean> accept(final ConnectionContext context) {
-        return apply == null ? delegate.accept(context) :
-                delegate.accept(context).flatMap(result -> apply.apply(context, result != null && result));
+        return delegate.accept(context);
     }
 
     @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionAcceptorAppender.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionAcceptorAppender.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.api;
+
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.CompositeCloseable;
+import io.servicetalk.concurrent.api.Single;
+
+import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
+import static io.servicetalk.concurrent.api.Single.success;
+import static java.util.Objects.requireNonNull;
+
+final class ConnectionAcceptorAppender implements ConnectionAcceptor {
+    private final ConnectionAcceptor first;
+    private final ConnectionAcceptor second;
+    private final CompositeCloseable closeable;
+
+    ConnectionAcceptorAppender(ConnectionAcceptor first, ConnectionAcceptor second) {
+        this.first = requireNonNull(first);
+        this.second = requireNonNull(second);
+        closeable = newCompositeCloseable().appendAll(first, second);
+    }
+
+    @Override
+    public Single<Boolean> accept(final ConnectionContext context) {
+        return first.accept(context).flatMap(firstResult ->
+                firstResult != null && firstResult ? second.accept(context) : success(firstResult));
+    }
+
+    @Override
+    public Completable closeAsync() {
+        return closeable.closeAsync();
+    }
+
+    @Override
+    public Completable closeAsyncGracefully() {
+        return closeable.closeAsyncGracefully();
+    }
+}

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionAcceptorFactory.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionAcceptorFactory.java
@@ -18,18 +18,18 @@ package io.servicetalk.transport.api;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A factory of {@link ConnectionAcceptorFilter}.
+ * A factory of {@link ConnectionAcceptorAdapter}.
  */
 @FunctionalInterface
-public interface ConnectionAcceptorFilterFactory {
+public interface ConnectionAcceptorFactory {
 
     /**
-     * Create a {@link ConnectionAcceptorFilter} using the provided {@link ConnectionAcceptor}.
+     * Create a {@link ConnectionAcceptor} using the provided {@link ConnectionAcceptor}.
      *
      * @param original {@link ConnectionAcceptor} to filter
-     * @return {@link ConnectionAcceptorFilter} using the provided {@link ConnectionAcceptor}
+     * @return {@link ConnectionAcceptor} using the provided {@link ConnectionAcceptor}
      */
-    ConnectionAcceptorFilter create(ConnectionAcceptor original);
+    ConnectionAcceptor create(ConnectionAcceptor original);
 
     /**
      * Returns a composed function that first applies the {@code before} function to its input, and then applies
@@ -48,7 +48,7 @@ public interface ConnectionAcceptorFilterFactory {
      * @return a composed function that first applies the {@code before}
      * function and then applies this function
      */
-    default ConnectionAcceptorFilterFactory append(ConnectionAcceptorFilterFactory before) {
+    default ConnectionAcceptorFactory append(ConnectionAcceptorFactory before) {
         requireNonNull(before);
         return service -> create(before.create(service));
     }
@@ -58,7 +58,7 @@ public interface ConnectionAcceptorFilterFactory {
      *
      * @return a function that always returns its input {@link ConnectionAcceptor}.
      */
-    static ConnectionAcceptorFilterFactory identity() {
-        return ConnectionAcceptorFilter::new;
+    static ConnectionAcceptorFactory identity() {
+        return original -> original;
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyServerContext.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyServerContext.java
@@ -25,6 +25,7 @@ import io.servicetalk.transport.api.ServerContext;
 import io.netty.channel.Channel;
 
 import java.net.SocketAddress;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.concurrent.api.AsyncCloseables.toListenableAsyncCloseable;
@@ -68,11 +69,12 @@ public final class NettyServerContext implements ServerContext {
      * @return A new {@link NettyServerContext} instance.
      */
     public static ServerContext wrap(Channel listenChannel, ListenableAsyncCloseable channelSetCloseable,
-                                     AsyncCloseable closeBefore, ExecutionContext executionContext) {
+                                     @Nullable AsyncCloseable closeBefore, ExecutionContext executionContext) {
         final NettyChannelListenableAsyncCloseable channelCloseable =
                 new NettyChannelListenableAsyncCloseable(listenChannel, executionContext.executor());
-        final CompositeCloseable closeAsync = newCompositeCloseable().appendAll(
-                closeBefore, channelCloseable, channelSetCloseable);
+        final CompositeCloseable closeAsync = closeBefore == null ?
+                newCompositeCloseable().appendAll(channelCloseable, channelSetCloseable) :
+                newCompositeCloseable().appendAll(closeBefore, channelCloseable, channelSetCloseable);
         return new NettyServerContext(listenChannel, toListenableAsyncCloseable(closeAsync), executionContext);
     }
 


### PR DESCRIPTION
Motivation:
ConnectionAcceptor has a partner class ConnectionAcceptorFilter that is required
by the ConnectionAcceptorFilterFactory. However we can relax this constraint and
just require a ConnectionAcceptor and remove the filter naming convention. The
user can determine their control flow via typical delegation, and we can
accommodate the append on success pattern as first class citizen.

Modifications:
- Rename ConnectionAcceptorFilter to ConnectionAcceptorAdapter, and make it so
  this class only supports delegation.
- Add a means of appending and execution on success for ConnectionAcceptor. This
  is a common pattern for filtering, metrics, and insights.
- Allow the ConnectionAcceptor to be null to avoid special case checks for
  ACCEPT_ALL internally.

Result:
Clarified ConnectionAcceptor interface with standard way to append on success.