### PR TITLE
DefaultNettyPipelinedConnectionTest#testWriteCancelAndThenWrite verif…

### DIFF
--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/AutoOnSubscribeSubscriberFunction.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/AutoOnSubscribeSubscriberFunction.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 
-public final class AutoOnSubscribeSubscriberFunction<T> implements Function<Subscriber<? super T>, Subscriber<? super T>> {
-
+public final class AutoOnSubscribeSubscriberFunction<T>
+        implements Function<Subscriber<? super T>, Subscriber<? super T>> {
     private final List<Subscription> subscriptions = new CopyOnWriteArrayList<>();
 
     @Override


### PR DESCRIPTION
…y cancel at writePublisher1

Motivation:
DefaultNettyPipelinedConnectionTest#testWriteCancelAndThenWrite used to verify that the cancel operation propagated to the publisher, but it no longer does.

Modifications:
- Add back verification that the cancel is propagated to the source

Result:
DefaultNettyPipelinedConnectionTest#testWriteCancelAndThenWrite verifies cancel is propagated through.