### PR TITLE
Test users may consume request payload body on response path

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConsumeRequestPayloadOnResponsePathTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConsumeRequestPayloadOnResponsePathTest.java
@@ -86,6 +86,12 @@ public class ConsumeRequestPayloadOnResponsePathTest {
     @Test
     public void testConsumeRequestPayloadAfterResponsePayloadSent() throws Exception {
         test((responseSingle, request) -> responseSingle.flatMap(response -> success(
+                response.transformPayloadBody(payloadBody -> payloadBody.concatWith(consumePayloadBody(request))))));
+    }
+
+    @Test
+    public void testConsumeRequestPayloadAfterTrailersSent() throws Exception {
+        test((responseSingle, request) -> responseSingle.flatMap(response -> success(
                 response.transformRawPayloadBody(payloadBody -> payloadBody.concatWith(consumePayloadBody(request))))));
     }
 


### PR DESCRIPTION
Motivation:

Verify that users may consume request payload body on response path and
ST doesn't drain it before that.

Modifications:

Add `ConsumeRequestPayloadOnResponsePathTest` which tests different
use cases:
  - (ConsumeReqPayload -> SendResponseMeta) -> SendResponsePayload -> SendTrailers;
  - SendResponseMeta -> (ConsumeReqPayload -> SendResponsePayload -> SendTrailers);
  - SendResponseMeta -> (SendResponsePayload -> ConsumeReqPayload)  -> SendTrailers;
  - (SendResponseMeta -> ConsumeReqPayload) -> SendResponsePayload -> SendTrailers;
  - SendResponseMeta -> (SendResponsePayload -> ConsumeReqPayload) -> SendTrailers;
  - SendResponseMeta -> (SendResponsePayload -> SendTrailers -> ConsumeReqPayload);
  - (SendResponseMeta || ConsumeReqPayload) -> SendResponsePayload -> SendTrailers;
  - (ConsumeReqPayload || SendResponseMeta) -> SendResponsePayload -> SendTrailers;
  - SendResponseMeta -> (ConsumeReqPayload || SendResponsePayload) -> SendTrailers;
  - SendResponseMeta -> (ConsumeReqPayload || SendResponsePayload -> SendTrailers);

Result:

Making sure users may consume request payload body on response path.