### PR TITLE
Tests to verify correct ordering of `concatWith` operators

### DIFF
--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcatWithOrderingTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcatWithOrderingTest.java
@@ -164,7 +164,7 @@ public class ConcatWithOrderingTest {
     }
 
     @Test
-    public void typeSteps() throws Exception {
+    public void completableSinglePublisherSingleCompletable() throws Exception {
         completable(1)
                 .concatWith(single(2))
                 .concatWith(publisher(3))
@@ -176,7 +176,7 @@ public class ConcatWithOrderingTest {
     }
 
     @Test
-    public void typeStepsReverse() throws Exception {
+    public void publisherSingleCompletableSinglePublisher() throws Exception {
         publisher(1)
                 .concatWith(single(2))
                 .concatWith(completable(3))


### PR DESCRIPTION
Motivation:

Test that different sources concatenated using `concatWith` operator
complete in the correct order.

Modifications:

- Add `ConcatWithOrderingTest`;

Result:

Tests which verify that `concatWith` chains sources results in the correct order.