### PR TITLE
Add HttpClients#forMultiAddressUrl(serviceDiscoverer)

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -64,6 +64,7 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseabl
 import static io.servicetalk.concurrent.api.AsyncCloseables.toListenableAsyncCloseable;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
+import static io.servicetalk.http.api.MultiAddressHttpClientFilterFactory.identity;
 import static io.servicetalk.http.api.SslConfigProviders.plainByDefault;
 import static io.servicetalk.transport.api.SslConfigBuilder.forClient;
 import static java.util.Objects.requireNonNull;
@@ -77,7 +78,8 @@ import static java.util.Objects.requireNonNull;
  *
  * @see <a href="https://tools.ietf.org/html/rfc7230#section-5.3.2">absolute-form rfc7230#section-5.3.2</a>
  */
-final class DefaultMultiAddressUrlHttpClientBuilder extends MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> {
+final class DefaultMultiAddressUrlHttpClientBuilder extends MultiAddressHttpClientBuilder<HostAndPort,
+        InetSocketAddress> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultMultiAddressUrlHttpClientBuilder.class);
 
@@ -89,7 +91,7 @@ final class DefaultMultiAddressUrlHttpClientBuilder extends MultiAddressHttpClie
     private final DefaultSingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builderTemplate;
     private SslConfigProvider sslConfigProvider = plainByDefault();
     private int maxRedirects = DEFAULT_MAX_REDIRECTS;
-    private MultiAddressHttpClientFilterFactory<HostAndPort> clientFilterFunction = MultiAddressHttpClientFilterFactory.identity();
+    private MultiAddressHttpClientFilterFactory<HostAndPort> clientFilterFunction = identity();
     @Nullable
     private Function<HostAndPort, CharSequence> hostHeaderTransformer;
 
@@ -119,7 +121,8 @@ final class DefaultMultiAddressUrlHttpClientBuilder extends MultiAddressHttpClie
                     keyFactory, executionContext, clientFactory.builderTemplate.executionStrategy()));
 
             // Need to wrap the top level client (group) in order for non-relative redirects to work
-            client = maxRedirects <= 0 ? client : new RedirectingHttpRequesterFilter(false, maxRedirects).create(client);
+            client = maxRedirects <= 0 ? client :
+                    new RedirectingHttpRequesterFilter(false, maxRedirects).create(client);
 
             return new StreamingHttpClientWithDependencies(client, toListenableAsyncCloseable(closeables),
                     reqRespFactory, clientFactory.builderTemplate.executionStrategy());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -88,7 +88,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
         this.serviceDiscoverer = requireNonNull(serviceDiscoverer);
     }
 
-    private DefaultSingleAddressHttpClientBuilder(
+    DefaultSingleAddressHttpClientBuilder(
             final ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer) {
         address = null; // Unknown address - template builder pending override via: copy(address)
         config = new HttpClientConfig(new TcpClientConfig(false));

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -59,6 +59,26 @@ public final class HttpClients {
     }
 
     /**
+     * Creates a {@link MultiAddressHttpClientBuilder} for clients capable of parsing an <a
+     * href="https://tools.ietf.org/html/rfc7230#section-5.3.2">absolute-form URL</a>, connecting to multiple addresses
+     * with default {@link LoadBalancer} and user provided {@link ServiceDiscoverer}.
+     * <p>
+     * When a <a href="https://tools.ietf.org/html/rfc3986#section-4.2">relative URL</a> is passed in the {@link
+     * StreamingHttpRequest#requestTarget(String)} this client requires a {@link HttpHeaderNames#HOST} present in
+     * order to infer the remote address.
+     *
+     * @param serviceDiscoverer The {@link ServiceDiscoverer} to resolve addresses of remote servers to connect to.
+     * The lifecycle of the provided {@link ServiceDiscoverer} should be managed by the caller.
+     * @return new builder with default configuration
+     */
+    public static MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forMultiAddressUrl(
+            final ServiceDiscoverer<HostAndPort, InetSocketAddress, ? extends ServiceDiscovererEvent<InetSocketAddress>>
+                    serviceDiscoverer) {
+        return new DefaultMultiAddressUrlHttpClientBuilder(
+                new DefaultSingleAddressHttpClientBuilder<>(serviceDiscoverer));
+    }
+
+    /**
      * Creates a {@link SingleAddressHttpClientBuilder} for an address with default {@link LoadBalancer} and DNS {@link
      * ServiceDiscoverer}.
      *

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
@@ -92,8 +92,7 @@ public class DefaultMultiAddressUrlHttpClientBuilderTest {
     public void buildWithProvidedServiceDiscoverer() throws Exception {
         ServiceDiscoverer<HostAndPort, InetSocketAddress,
                 ServiceDiscovererEvent<InetSocketAddress>> mockedServiceDiscoverer = mock(ServiceDiscoverer.class);
-        StreamingHttpRequester newRequester = HttpClients.forMultiAddressUrl()
-                .serviceDiscoverer(mockedServiceDiscoverer)
+        StreamingHttpRequester newRequester = HttpClients.forMultiAddressUrl(mockedServiceDiscoverer)
                 .ioExecutor(CTX.ioExecutor())
                 .executionStrategy(defaultStrategy(CTX.executor()))
                 .buildStreaming();


### PR DESCRIPTION
__Motivation__

When users create `SingleAddressClient`, they may provide a custom SD for the static factory method `HttpClients#forSingleAddress(SD, Address)`.

It helps to avoid initialization of `GlobalDnsServiceDiscoverer`, which also initializes `GlobalExecutionContext`.

If users need `MultiAddressHttpClient` they don’t have a way to skip initialization of `GlobalDnsServiceDiscoverer` & `GlobalExecutionContext`,
which allocates unnecessary `IoExecutor` and `CachedTheadPoolExecutor`.

As a result, users have leaked resources, which they may not clean up or avoid.

__Modifications__

Add a `HttpClients#forMultiAddressUrl(serviceDiscoverer)` static factory method.

__Results__

Users can provide a `ServiceDiscoverer` when creating `MultiAddressHttpClientBuilder` with a static factory method of `HttpClients`.