### PR TITLE
Allow different shells to be used in scripts.

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/resources/io/servicetalk/gradle/plugin/internal/checkstyle/copyright-sh-script-style.header
+++ b/servicetalk-gradle-plugin-internal/src/main/resources/io/servicetalk/gradle/plugin/internal/checkstyle/copyright-sh-script-style.header
@@ -1,4 +1,4 @@
-^#!/bin/sh$
+^#!/bin/bash$
 ^#$
 ^# Copyright © 20\d{2}(-20\d{2}|, 20\d{2})* Apple Inc\. and the ServiceTalk project authors$
 ^#$

--- a/servicetalk-gradle-plugin-internal/src/main/resources/io/servicetalk/gradle/plugin/internal/docs/publish-docs.sh
+++ b/servicetalk-gradle-plugin-internal/src/main/resources/io/servicetalk/gradle/plugin/internal/docs/publish-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright © 2018 Apple Inc. and the ServiceTalk project authors
 #

--- a/servicetalk-test-resources/src/main/resources/io/servicetalk/test/resources/generate-certs.sh
+++ b/servicetalk-test-resources/src/main/resources/io/servicetalk/test/resources/generate-certs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright © 2018 Apple Inc. and the ServiceTalk project authors
 #


### PR DESCRIPTION
Motivation:

Specifying that all scripts must use `/bin/sh` shebang means we cannot use
any functionality not from the original `sh` shell, because some operating
systems install an sh-compliant shell in `/bin/sh`. This limits us from
using the more powerful functionality of shells such as bash.

Modifications:

Update checkstyle rule to allow for `bash` and `zsh` shebangs, in addition
to `sh`.

Results:

Scripts with `bash` and `zsh` shebang won't fail checkstyle.