### PR TITLE
Fix test cases in ConsumeRequestPayloadOnResponsePathTest

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConsumeRequestPayloadOnResponsePathTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConsumeRequestPayloadOnResponsePathTest.java
@@ -18,6 +18,7 @@ package io.servicetalk.http.netty;
 import io.servicetalk.buffer.api.CompositeBuffer;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.internal.PlatformDependent;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.HttpResponse;
@@ -92,7 +93,7 @@ public class ConsumeRequestPayloadOnResponsePathTest {
                     try {
                         consumePayloadBody(request).toFuture().get();
                     } catch (Exception e) {
-                        e.printStackTrace();
+                        PlatformDependent.throwException(e);
                     }
                     return trailers;
                 })));
@@ -101,6 +102,8 @@ public class ConsumeRequestPayloadOnResponsePathTest {
     @Test
     public void testConsumeRequestPayloadAfterTrailersSent() throws Exception {
         test((responseSingle, request) -> responseSingle.map(response ->
+                // It doesn't use the BufferAllocator from HttpServiceContext to simplify the test and avoid using
+                // TriFunction. It doesn't change the behavior of this test.
                 newResponseWithTrailers(response.status(), response.version(), response.headers(), DEFAULT_ALLOCATOR,
                         response.payloadBodyAndTrailers().concatWith(consumePayloadBody(request)))));
     }


### PR DESCRIPTION
Motivation:

Test cases when filter consumes request payload body before/after
response trailers were implemented incorrectly by using
`transformRawPayloadBody`, because it doesn't include trailers and
`consumePayloadBody` was concatenated with response payload body.
Instead we should invoke `consumePayloadBody` in `transformTrailers`
function for "before-trailers" case and concatenate it with
`payloadBodyAndTrailers()` for "after-trailers" case.

Modifications:

- Reimplement `testConsumeRequestPayloadBeforeTrailersSent` to
invoke `consumePayloadBody` in `transformTrailers` function;
- Reimplement `testConsumeRequestPayloadAfterTrailersSent` to concat
`consumePayloadBody` after `payloadBodyAndTrailers()`;
- Remove `testConsumeRequestPayloadAndTrailersSent` which duplicates
`testConsumeRequestPayloadAndResponsePayloadSent`;

Result:

Correct behavior for use cases which consume request payload body
before/after trailers.