### PR TITLE
NettyHttpServerConnectionTest using doAfterSubscribe incorrectly

### DIFF
--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestSubscription.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestSubscription.java
@@ -19,6 +19,8 @@ import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.internal.FlowControlUtil;
 
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
 
 /**
  * A {@link Subscription} that tracks requests and cancellation.
@@ -26,16 +28,25 @@ import java.util.concurrent.atomic.AtomicLong;
 public final class TestSubscription implements Subscription {
 
     private final AtomicLong requested = new AtomicLong();
+    private final AtomicReference<Thread> waitingThreadRef = new AtomicReference<>();
     private volatile boolean cancelled;
 
     @Override
     public void request(final long n) {
         requested.accumulateAndGet(n, FlowControlUtil::addWithOverflowProtection);
+        Thread waitingThread = waitingThreadRef.get();
+        if (waitingThread != null) {
+            LockSupport.unpark(waitingThread);
+        }
     }
 
     @Override
     public void cancel() {
         cancelled = true;
+        Thread waitingThread = waitingThreadRef.get();
+        if (waitingThread != null) {
+            LockSupport.unpark(waitingThread);
+        }
     }
 
     /**
@@ -54,5 +65,39 @@ public final class TestSubscription implements Subscription {
      */
     public boolean isCancelled() {
         return cancelled;
+    }
+
+    /**
+     * Wait until the {@link Subscription#request(long)} amount exceeds {@code amount}.
+     *
+     * @param amount the amount to wait for.
+     */
+    public void waitUntilRequested(long amount) {
+        if (!waitingThreadRef.compareAndSet(null, Thread.currentThread())) {
+            throw new IllegalStateException("only a single waiter thread at a time is supported");
+        }
+
+        // Before we park we must check the condition to avoid deadlock, so no do/while.
+        while (requested.get() < amount) {
+            LockSupport.park();
+        }
+
+        waitingThreadRef.set(null);
+    }
+
+    /**
+     * Wait until {@link #cancel()} is called.
+     */
+    public void waitUntilCancelled() {
+        if (!waitingThreadRef.compareAndSet(null, Thread.currentThread())) {
+            throw new IllegalStateException("only a single waiter thread at a time is supported");
+        }
+
+        // Before we park we must check the condition to avoid deadlock, so no do/while.
+        while (!cancelled) {
+            LockSupport.park();
+        }
+
+        waitingThreadRef.set(null);
     }
 }


### PR DESCRIPTION
Motivation:
NettyHttpServerConnectionTest is using doAfterSubscribe on the payload Publisher in an attempt to know when the TestPublisher used for Payload publishing can be used by the JUnit thread. However the TestPublisher uses a composition of Function<Subscriber, Subscriber> to provide the Subscriber behavior. One of these Functions calls onSubscribe, but the TestPublisher doesn't set its subscriber member variable until after this Function composition chain completes. This leads to NettyHttpServerConnectionTest using the TestPublisher#onNext before it has a reference to the Subscriber, and fails the test.

Modifications:
- The trigger point for NettyHttpServerConnectionTest should be after the TestPublisher's handleSubscribe method completes.
- NettyHttpServerConnectionTest should also wait for requestN demand before
  delivering data.
- TestPublisher methods that interact with the Subscriber should block the
  calling thread until the Subscriber actually arrives. This will make test
sequencing more natural so tests don't have to create custom trigger points for
when the Subscriber is set.

Result:
More reliable NettyHttpServerConnectionTest test execution.
Fixes https://github.com/servicetalk/servicetalk/issues/350