### PR TITLE
TestExecutor scheduled time management

### DIFF
--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestExecutorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestExecutorTest.java
@@ -205,8 +205,15 @@ public class TestExecutorTest {
 
     @Test
     public void testExecuteNextScheduledTask() {
-        TestExecutor fixture = new TestExecutor();
+        testExecuteNextScheduledTask(new TestExecutor());
+    }
 
+    @Test
+    public void testScheduleDoesNotOverflow() {
+        testExecuteNextScheduledTask(new TestExecutor(Long.MAX_VALUE - 1));
+    }
+
+    private void testExecuteNextScheduledTask(TestExecutor fixture) {
         AtomicInteger i = new AtomicInteger();
 
         fixture.schedule(i::incrementAndGet, 1000, NANOSECONDS);

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestExecutor.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestExecutor.java
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.CompletableSource;
 
 import java.util.Iterator;
-import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.SortedMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -39,9 +39,23 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 public class TestExecutor implements Executor {
 
     private final Queue<RunnableWrapper> tasks = new ConcurrentLinkedQueue<>();
-    private final ConcurrentNavigableMap<Long, Queue<RunnableWrapper>> scheduledTasksByNano = new ConcurrentSkipListMap<>();
-    private long currentNanos = ThreadLocalRandom.current().nextLong();
+    private final ConcurrentNavigableMap<Long, Queue<RunnableWrapper>> scheduledTasksByNano =
+            new ConcurrentSkipListMap<>();
+    private final long nanoOffset;
+    private long currentNanos;
     private CompletableProcessor closeProcessor = new CompletableProcessor();
+
+    /**
+     * Create a new instance.
+     */
+    public TestExecutor() {
+        this(ThreadLocalRandom.current().nextLong());
+    }
+
+    TestExecutor(final long epochNanos) {
+        currentNanos = epochNanos;
+        nanoOffset = epochNanos - Long.MIN_VALUE;
+    }
 
     @Override
     public Cancellable execute(final Runnable task) throws RejectedExecutionException {
@@ -54,14 +68,15 @@ public class TestExecutor implements Executor {
     public Cancellable schedule(final Runnable task, final long delay, final TimeUnit unit)
             throws RejectedExecutionException {
         final RunnableWrapper wrappedTask = new RunnableWrapper(task);
-        final long scheduledNanos = currentNanos() + unit.toNanos(delay);
-
+        final long scheduledNanos = currentScheduledNanos() + unit.toNanos(delay);
         final Queue<RunnableWrapper> tasksForNanos = scheduledTasksByNano.computeIfAbsent(scheduledNanos,
                 k -> new ConcurrentLinkedQueue<>());
         tasksForNanos.add(wrappedTask);
 
         return () -> scheduledTasksByNano.computeIfPresent(scheduledNanos, (k, tasks) -> {
-            tasks.remove(wrappedTask);
+            if (tasks.remove(wrappedTask) && tasks.isEmpty()) {
+                removedScheduledQueue(scheduledNanos);
+            }
             return tasks;
         });
     }
@@ -80,6 +95,26 @@ public class TestExecutor implements Executor {
                 closeProcessor.onComplete();
             }
         };
+    }
+
+    /**
+     * What we want to accomplish is using a {@link ConcurrentNavigableMap} and leverage the strict ordering to obtain
+     * the next scheduled task. We therefore shift the valid set of numbers for long such that the starting value
+     * (aka epoch) maps to {@code 0}. Use the set of {@code long} numbers above, lets assume the epoch is
+     * {@code MAX_VALUE-1}. That results in the following re-mapping.
+     * <pre>
+     *   MIN_VALUE, MIN_VALUE+1, ... 0, 1, 2, ... MAX_VALUE-1, MAX_VALUE <- valid long numbers
+     *   MAX_VALUE-1, MAX_VALUE, MIN_VALUE, MIN_VALUE+1, ... -1, 0, 1, MAX_VALUE-2 <- remapped
+     * </pre>
+     * So if the {@link #currentNanos()} time is {@code MIN_VALUE+1} that means we overflowed
+     * (which is OK and expected), however the adjusted time for scheduling should be {@code MIN_VALUE+3}.
+     * {@code (MIN_VALUE+1) - epoch - MIN_VALUE} translates to
+     * {@code (MIN_VALUE+1) - (MAX_VALUE-1) - MIN_VALUE = (MIN_VALUE+3)}. The {@code epoch - MIN_VALUE} is computed
+     * upfront as {@link #nanoOffset}.
+     * @return the time used for scheduling and interaction with {@link #scheduledTasksByNano}.
+     */
+    private long currentScheduledNanos() {
+        return currentNanos() - nanoOffset;
     }
 
     /**
@@ -174,10 +209,9 @@ public class TestExecutor implements Executor {
      * @return this.
      */
     public TestExecutor executeScheduledTasks() {
-        SortedMap<Long, Queue<RunnableWrapper>> headMap = scheduledTasksByNano.headMap(currentNanos + 1);
-
-        for (Iterator<Map.Entry<Long, Queue<RunnableWrapper>>> i = headMap.entrySet().iterator(); i.hasNext();) {
-            final Map.Entry<Long, Queue<RunnableWrapper>> entry = i.next();
+        SortedMap<Long, Queue<RunnableWrapper>> headMap = scheduledTasksByNano.headMap(currentScheduledNanos(), true);
+        for (Iterator<Entry<Long, Queue<RunnableWrapper>>> i = headMap.entrySet().iterator(); i.hasNext();) {
+            final Entry<Long, Queue<RunnableWrapper>> entry = i.next();
             execute(entry.getValue());
             i.remove();
         }
@@ -191,17 +225,30 @@ public class TestExecutor implements Executor {
      * @return this.
      */
     public TestExecutor executeNextScheduledTask() {
-        SortedMap<Long, Queue<RunnableWrapper>> headMap = scheduledTasksByNano.headMap(currentNanos + 1);
-
-        for (Iterator<Map.Entry<Long, Queue<RunnableWrapper>>> i = headMap.entrySet().iterator(); i.hasNext();) {
-            final Map.Entry<Long, Queue<RunnableWrapper>> entry = i.next();
-            if (executeOne(entry.getValue())) {
-                return this;
-            } else {
-                i.remove();
+        ConcurrentNavigableMap<Long, Queue<RunnableWrapper>> headMap =
+                scheduledTasksByNano.headMap(currentScheduledNanos(), true);
+        Entry<Long, Queue<RunnableWrapper>> entry = headMap.firstEntry();
+        if (entry != null && executeOne(entry.getValue())) {
+            if (entry.getValue().isEmpty()) {
+                removedScheduledQueue(entry.getKey());
             }
+            return this;
         }
         throw new IllegalStateException("No scheduled tasks to execute");
+    }
+
+    private void removedScheduledQueue(Long scheduledNanos) {
+        final Queue<RunnableWrapper> removedQueue = scheduledTasksByNano.remove(scheduledNanos);
+
+        // There maybe concurrent access to this Executor and other tasks schedule, so if in the mean time
+        // someone inserts something into the queue we should attempt to add it back to the Map.
+        if (!removedQueue.isEmpty()) {
+            final Queue<RunnableWrapper> existingQueue =
+                    scheduledTasksByNano.putIfAbsent(scheduledNanos, removedQueue);
+            if (existingQueue != null) {
+                existingQueue.addAll(removedQueue);
+            }
+        }
     }
 
     private static void execute(Queue<RunnableWrapper> tasks) {


### PR DESCRIPTION
Motivation:
TestExecutor initializes its time to a random number to simulate the behavior of
System.nanoTime(). A ConcurrentNavigableMap is used to store all scheduled tasks
and an offset from the currentNanos is taken in an attempt to get the next set
of Runnables that have expired and should be executed. However if the initial
value is sufficiently high such that the scheduled task offset would overflow
this approach will not work because the ConcurrentNavigableMap lookup based upon
currentNanos won't give the correct next set of tasks to execute.

Modifications:
- We should transpose the epoch time onto Long.MIN_VALUE so that overflow only
  occurs when the full domain of the long type is exhausted. This requires that
when ever we use time for managing scheduled tasks we use the transposed time
instead of the raw currentNanos.
- executeNextScheduledTask should get the first entry, which should always be
  the next to expire and ready to execute. If a task is executed, we should
check if the queue is empty and remove it from the underlying
ConcurrentNavigableMap.

Result:
More correct time management in TestExecutor for scheduled tasks.