### PR TITLE
Completable when converted to other sources should have an option to provide a value

### DIFF
--- a/servicetalk-client-api/src/test/java/io/servicetalk/client/api/DefaultClientGroupTest.java
+++ b/servicetalk-client-api/src/test/java/io/servicetalk/client/api/DefaultClientGroupTest.java
@@ -34,7 +34,7 @@ public class DefaultClientGroupTest {
     public void requestingClientFromClosedClientGroupShouldNotHang() throws Exception {
         DefaultClientGroup<String, ListenableAsyncCloseable> cg =
                 new DefaultClientGroup<>(s -> emptyAsyncCloseable());
-        cg.closeAsync().toFuture().get();
+        cg.closeAsync().toVoidFuture().get();
 
         try {
             cg.get("foo");

--- a/servicetalk-client-internal/src/test/java/io/servicetalk/client/internal/ReservableRequestConcurrencyControllerMultiTest.java
+++ b/servicetalk-client-internal/src/test/java/io/servicetalk/client/internal/ReservableRequestConcurrencyControllerMultiTest.java
@@ -48,7 +48,7 @@ public class ReservableRequestConcurrencyControllerMultiTest extends AbstractReq
             // Test coldness
             assertFalse(controller.tryReserve());
 
-            release.toFuture().get();
+            release.toVoidFuture().get();
         }
     }
 

--- a/servicetalk-client-internal/src/test/java/io/servicetalk/client/internal/ReservableRequestConcurrencyControllerOnlySingleTest.java
+++ b/servicetalk-client-internal/src/test/java/io/servicetalk/client/internal/ReservableRequestConcurrencyControllerOnlySingleTest.java
@@ -49,7 +49,7 @@ public class ReservableRequestConcurrencyControllerOnlySingleTest
             // Test coldness
             assertFalse(controller.tryReserve());
 
-            release.toFuture().get();
+            release.toVoidFuture().get();
         }
     }
 

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/TaskBasedSignalOffloaderExecutorRejectionTests.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/TaskBasedSignalOffloaderExecutorRejectionTests.java
@@ -98,7 +98,7 @@ public class TaskBasedSignalOffloaderExecutorRejectionTests {
     @Test
     public void completableSubscribeRejects() throws Exception {
         rejectNextTask.set(true);
-        completed().subscribeOn(executor).toFuture().get();
+        completed().subscribeOn(executor).toVoidFuture().get();
         verifyRejectedTasks(1, 1);
     }
 
@@ -122,7 +122,7 @@ public class TaskBasedSignalOffloaderExecutorRejectionTests {
     public void completableOnSubscribeRejects() throws Exception {
         rejectNextTask.set(true);
         expectRejection();
-        Completable.never().publishOn(executor).toFuture().get();
+        Completable.never().publishOn(executor).toVoidFuture().get();
         verifyRejectedTasks(1, 1);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -552,7 +552,7 @@ public abstract class Completable {
      * @see <a href="http://reactivex.io/documentation/operators/retry.html">ReactiveX retry operator.</a>
      */
     public final Completable retry(BiIntPredicate<Throwable> shouldRetry) {
-        return toSingle().retry(shouldRetry).ignoreResult();
+        return toVoidSingle().retry(shouldRetry).ignoreResult();
     }
 
     /**
@@ -592,7 +592,7 @@ public abstract class Completable {
      * @see <a href="http://reactivex.io/documentation/operators/retry.html">ReactiveX retry operator.</a>
      */
     public final Completable retryWhen(BiIntFunction<Throwable, Completable> retryWhen) {
-        return toSingle().retryWhen(retryWhen).ignoreResult();
+        return toVoidSingle().retryWhen(retryWhen).ignoreResult();
     }
 
     /**
@@ -1082,34 +1082,80 @@ public abstract class Completable {
      * Converts this {@code Completable} to a {@link Single}.
      * <p>
      * The return value's {@link SingleSource.Subscriber#onSuccess(Object)} value is undefined. If you need a specific
-     * value you can also use {@link #concatWith(Single)} with a {@link Single#success(Object)}.
-     * @param <T> The value type of the resulting {@link Single}.
+     * value you can also use {@link #toSingle(Supplier)}.
      * @return A {@link Single} that mirrors the terminal signal from this {@link Completable}.
      */
-    public final <T> Single<T> toSingle() {
-        return new CompletableToSingle<>(this, executor);
+    public final Single<Void> toVoidSingle() {
+        return toSingle(() -> null);
+    }
+
+    /**
+     * Converts this {@code Completable} to a {@link Single} that terminates with the value supplied by the
+     * {@code valueSupplier} if this {@link Completable} terminates successfully. If this {@link Completable} terminates
+     * with a failure, the returned {@link Single} will terminate will the same failure.
+     *
+     * @param valueSupplier {@link Supplier} to supply the result of the returned {@link Single} when this
+     * {@link Completable} terminates successfully.
+     * @param <T> The value type of the resulting {@link Single}.
+     * @return A {@link Single} that terminates with the value supplied by the {@code valueSupplier} if this
+     * {@link Completable} terminates successfully. If this {@link Completable} terminates with a failure, the returned
+     * {@link Single} will terminate with the same failure.
+     */
+    public final <T> Single<T> toSingle(Supplier<T> valueSupplier) {
+        return new CompletableToSingle<>(this, executor, valueSupplier);
     }
 
     /**
      * Converts this {@code Completable} to a {@link CompletionStage}.
      * <p>
-     * The {@link CompletionStage}'s value is undefined.
-     * @param <T> The value type of the resulting {@link Single}.
+     * The {@link CompletionStage}'s value is undefined. If you need a specific value you can use
+     * {@link #toCompletionStage(Supplier)}.
      * @return A {@link CompletionStage} that mirrors the terminal signal from this {@link Completable}.
      */
-    public final <T> CompletionStage<T> toCompletionStage() {
-        return this.<T>toSingle().toCompletionStage();
+    public final CompletionStage<Void> toVoidCompletionStage() {
+        return this.toVoidSingle().toCompletionStage();
+    }
+
+    /**
+     * Converts this {@code Completable} to a {@link CompletionStage} that terminates with the value supplied by the
+     * {@code valueSupplier} if this {@link Completable} terminates successfully. If this {@link Completable} terminates
+     * with a failure, the returned {@link CompletionStage} will terminate with the same failure.
+     *
+     * @param valueSupplier {@link Supplier} to supply the result of the returned {@link CompletionStage} when this
+     * {@link Completable} terminates successfully.
+     * @param <T> The value type of the resulting {@link Single}.
+     * @return A {@link CompletionStage}  that terminates with the value supplied by the
+     * {@code valueSupplier} if this {@link Completable} terminates successfully. If this {@link Completable} terminates
+     * with a failure, the returned {@link CompletionStage} will terminate with the same failure.
+     */
+    public final <T> CompletionStage<T> toCompletionStage(Supplier<T> valueSupplier) {
+        return this.toSingle(valueSupplier).toCompletionStage();
     }
 
     /**
      * Converts this {@code Completable} to a {@link Future}.
      * <p>
-     * The {@link Future}'s value is undefined.
-     * @param <T> The value type of the resulting {@link Single}.
+     * The {@link Future}'s value is undefined. If you need a specific value you can use {@link #toFuture(Supplier)}.
      * @return A {@link Future} that mirrors the terminal signal from this {@link Completable}.
      */
-    public final <T> Future<T> toFuture() {
-        return this.<T>toSingle().toFuture();
+    public final Future<Void> toVoidFuture() {
+        return this.toVoidSingle().toFuture();
+    }
+
+    /**
+     * Converts this {@code Completable} to a {@link Future} that terminates with the value supplied by the
+     * {@code valueSupplier} if this {@link Completable} terminates successfully. If this {@link Completable} terminates
+     * with a failure, the returned {@link Future} will terminate with the same failure.
+     *
+     * @param valueSupplier {@link Supplier} to supply the result of the returned {@link Future} when this
+     * {@link Completable} terminates successfully.
+     * @param <T> The value type of the resulting {@link Single}.
+     * @return A {@link Future}  that terminates with the value supplied by the
+     * {@code valueSupplier} if this {@link Completable} terminates successfully. If this {@link Completable} terminates
+     * with a failure, the returned {@link Future} will terminate with the same failure.
+     */
+    public final <T> Future<T> toFuture(Supplier<T> valueSupplier) {
+        return this.toSingle(valueSupplier).toFuture();
     }
 
     //

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultCompositeCloseable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultCompositeCloseable.java
@@ -105,7 +105,7 @@ final class DefaultCompositeCloseable implements CompositeCloseable {
     @Override
     public void close() throws Exception {
         try {
-            closeAsync().toFuture().get();
+            closeAsync().toVoidFuture().get();
         } catch (final ExecutionException e) {
             final Throwable cause = e.getCause();
             if (cause != null) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -382,7 +382,7 @@ public abstract class Publisher<T> {
      * @see #flatMapCompletableDelayError(Function)
      */
     public final Completable flatMapCompletable(Function<? super T, Completable> mapper) {
-        return flatMapSingle(t -> mapper.apply(t).toSingle()).ignoreElements();
+        return flatMapSingle(t -> mapper.apply(t).toVoidSingle()).ignoreElements();
     }
 
     /**
@@ -419,7 +419,7 @@ public abstract class Publisher<T> {
      * @see #flatMapCompletableDelayError(Function, int)
      */
     public final Completable flatMapCompletable(Function<? super T, Completable> mapper, int maxConcurrency) {
-        return flatMapSingle(t -> mapper.apply(t).toSingle(), maxConcurrency).ignoreElements();
+        return flatMapSingle(t -> mapper.apply(t).toVoidSingle(), maxConcurrency).ignoreElements();
     }
 
     /**
@@ -465,7 +465,7 @@ public abstract class Publisher<T> {
      * @see #flatMapSingleDelayError(Function, int)
      */
     public final Completable flatMapCompletableDelayError(Function<? super T, Completable> mapper) {
-        return flatMapSingleDelayError(t -> mapper.apply(t).toSingle()).ignoreElements();
+        return flatMapSingleDelayError(t -> mapper.apply(t).toVoidSingle()).ignoreElements();
     }
 
     /**
@@ -509,7 +509,7 @@ public abstract class Publisher<T> {
      * @see #flatMapSingleDelayError(Function, int)
      */
     public final Completable flatMapCompletableDelayError(Function<? super T, Completable> mapper, int maxConcurrency) {
-        return flatMapSingleDelayError(t -> mapper.apply(t).toSingle(), maxConcurrency).ignoreElements();
+        return flatMapSingleDelayError(t -> mapper.apply(t).toVoidSingle(), maxConcurrency).ignoreElements();
     }
 
     /**

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AsyncContextDisableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AsyncContextDisableTest.java
@@ -53,7 +53,7 @@ public class AsyncContextDisableTest {
                 assertEquals(expectedValue, actualValue.get());
                 actualValue.set(null);
                 Completable.completed().publishOn(executor)
-                        .doBeforeComplete(() -> actualValue.set(AsyncContext.get(K1))).toFuture().get();
+                        .doBeforeComplete(() -> actualValue.set(AsyncContext.get(K1))).toVoidFuture().get();
                 assertEquals(expectedValue, actualValue.get());
                 actualValue.set(null);
 
@@ -69,9 +69,9 @@ public class AsyncContextDisableTest {
                 }
             } finally {
                 if (executor2 != null) {
-                    executor2.closeAsync().toFuture().get();
+                    executor2.closeAsync().toVoidFuture().get();
                 }
-                executor.closeAsync().toFuture().get();
+                executor.closeAsync().toVoidFuture().get();
             }
         }
     }
@@ -96,11 +96,11 @@ public class AsyncContextDisableTest {
                     assertNull(actualValue.get());
                     actualValue.set(null);
                     Completable.completed().publishOn(executor)
-                            .doBeforeComplete(() -> actualValue.set(AsyncContext.get(K1))).toFuture().get();
+                            .doBeforeComplete(() -> actualValue.set(AsyncContext.get(K1))).toVoidFuture().get();
                     assertNull(actualValue.get());
                     actualValue.set(null);
                 } finally {
-                    executor.closeAsync().toFuture().get();
+                    executor.closeAsync().toVoidFuture().get();
                 }
             } finally {
                 AsyncContext.enable();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcatWithOrderingTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcatWithOrderingTest.java
@@ -38,7 +38,7 @@ public class ConcatWithOrderingTest {
                 .concatWith(completable(3))
                 .concatWith(completable(4))
                 .concatWith(completable(5))
-                .toFuture().get();
+                .toVoidFuture().get();
 
         assertResult(sb);
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultAsyncContextProviderTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultAsyncContextProviderTest.java
@@ -163,7 +163,7 @@ public class DefaultAsyncContextProviderTest {
         }).doBeforeFinally(() -> f3.complete(AsyncContext.current().copy()));
 
         AsyncContext.put(K1, "v1.1");
-        completable.toFuture().get();
+        completable.toVoidFuture().get();
 
         assertEquals("v1.2", f1.get().get(K1));
         assertEquals("v1.2", f2.get().get(K1));
@@ -279,7 +279,7 @@ public class DefaultAsyncContextProviderTest {
         }).doBeforeFinally(() -> f3.complete(AsyncContext.current().copy()));
 
         AsyncContext.put(K1, "v1.1");
-        completable.toFuture().get();
+        completable.toVoidFuture().get();
 
         assertEquals("v1.2", f1.get().get(K1));
         assertEquals("v1.2", f2.get().get(K1));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultExecutorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultExecutorTest.java
@@ -183,12 +183,12 @@ public final class DefaultExecutorTest {
 
     @Test
     public void timerRaw() throws Exception {
-        executor.timer(1, NANOSECONDS).toFuture().get();
+        executor.timer(1, NANOSECONDS).toVoidFuture().get();
     }
 
     @Test
     public void timerDuration() throws Exception {
-        executor.timer(ofNanos(1)).toFuture().get();
+        executor.timer(ofNanos(1)).toVoidFuture().get();
     }
 
     @Test
@@ -236,7 +236,7 @@ public final class DefaultExecutorTest {
         Executor executor = from(new RejectAllScheduler());
         expected.expect(ExecutionException.class);
         expected.expectCause(instanceOf(RejectedExecutionException.class));
-        executor.timer(1, NANOSECONDS).toFuture().get();
+        executor.timer(1, NANOSECONDS).toVoidFuture().get();
     }
 
     @Test
@@ -244,13 +244,13 @@ public final class DefaultExecutorTest {
         Executor executor = from(new RejectAllScheduler());
         expected.expect(ExecutionException.class);
         expected.expectCause(instanceOf(RejectedExecutionException.class));
-        executor.timer(ofNanos(1)).toFuture().get();
+        executor.timer(ofNanos(1)).toVoidFuture().get();
     }
 
     @Test
     public void submitRunnable() throws Throwable {
         Task submitted = new Task();
-        executor.submit(submitted).toFuture().get();
+        executor.submit(submitted).toVoidFuture().get();
         submitted.awaitDone();
     }
 
@@ -260,9 +260,9 @@ public final class DefaultExecutorTest {
         Task submitted2 = new Task();
         AtomicBoolean returnedSubmitted1 = new AtomicBoolean();
         Supplier<Runnable> runnableSupplier = () -> returnedSubmitted1.getAndSet(true) ? submitted2 : submitted1;
-        executor.submitRunnable(runnableSupplier).toFuture().get();
+        executor.submitRunnable(runnableSupplier).toVoidFuture().get();
         submitted1.awaitDone();
-        executor.submitRunnable(runnableSupplier).toFuture().get();
+        executor.submitRunnable(runnableSupplier).toVoidFuture().get();
         submitted2.awaitDone();
     }
 
@@ -271,7 +271,7 @@ public final class DefaultExecutorTest {
         Executor executor = from(new RejectAllExecutor());
         expected.expect(ExecutionException.class);
         expected.expectCause(instanceOf(RejectedExecutionException.class));
-        executor.submit(() -> { }).toFuture().get();
+        executor.submit(() -> { }).toVoidFuture().get();
     }
 
     @Test
@@ -279,7 +279,7 @@ public final class DefaultExecutorTest {
         Executor executor = from(new RejectAllExecutor());
         expected.expect(ExecutionException.class);
         expected.expectCause(instanceOf(RejectedExecutionException.class));
-        executor.submitRunnable(() -> () -> { }).toFuture().get();
+        executor.submitRunnable(() -> () -> { }).toVoidFuture().get();
     }
 
     @Test
@@ -288,7 +288,7 @@ public final class DefaultExecutorTest {
         expected.expectCause(instanceOf(DeliberateException.class));
         executor.submit((Runnable) () -> {
             throw DELIBERATE_EXCEPTION;
-        }).toFuture().get();
+        }).toVoidFuture().get();
     }
 
     @Test
@@ -297,7 +297,7 @@ public final class DefaultExecutorTest {
         expected.expectCause(instanceOf(DeliberateException.class));
         executor.submitRunnable(() -> () -> {
             throw DELIBERATE_EXCEPTION;
-        }).toFuture().get();
+        }).toVoidFuture().get();
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
@@ -80,7 +80,7 @@ public class PublisherFlatMapSingleTest {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        executor.closeAsync().toFuture().get();
+        executor.closeAsync().toVoidFuture().get();
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SourceAdaptersTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SourceAdaptersTest.java
@@ -197,7 +197,7 @@ public class SourceAdaptersTest {
             s.onSubscribe(IGNORE_CANCEL);
             s.onComplete();
         };
-        fromSource(src).toFuture().get();
+        fromSource(src).toVoidFuture().get();
     }
 
     @Test
@@ -207,7 +207,7 @@ public class SourceAdaptersTest {
             s.onError(DELIBERATE_EXCEPTION);
         };
 
-        Future<Integer> future = fromSource(src).toFuture();
+        Future<Void> future = fromSource(src).toVoidFuture();
         expectedException.expect(ExecutionException.class);
         expectedException.expectCause(sameInstance(DELIBERATE_EXCEPTION));
         future.get();
@@ -218,7 +218,7 @@ public class SourceAdaptersTest {
         Cancellable srcCancellable = mock(Cancellable.class);
         CompletableSource source = s -> s.onSubscribe(srcCancellable);
 
-        fromSource(source).toFuture().cancel(true);
+        fromSource(source).toVoidFuture().cancel(true);
         verify(srcCancellable).cancel();
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SubscribeThrowsTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SubscribeThrowsTest.java
@@ -112,7 +112,7 @@ public class SubscribeThrowsTest {
         };
         expectedException.expect(instanceOf(ExecutionException.class));
         expectedException.expectCause(is(DELIBERATE_EXCEPTION));
-        c.toFuture().get();
+        c.toVoidFuture().get();
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestExecutorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestExecutorTest.java
@@ -226,8 +226,8 @@ public class TestExecutorTest {
     @Test
     public void testCloseAsync() throws Exception {
         TestExecutor fixture = new TestExecutor();
-        Future<String> closeFuture = fixture.closeAsync().toFuture();
-        Future<String> onCloseFuture = fixture.onClose().toFuture();
+        Future<Void> closeFuture = fixture.closeAsync().toVoidFuture();
+        Future<Void> onCloseFuture = fixture.onClose().toVoidFuture();
 
         assertNull(closeFuture.get());
         assertTrue(closeFuture.isDone());

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CollectTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CollectTest.java
@@ -43,20 +43,20 @@ public class CollectTest {
 
     @Test
     public void collectVarArgSuccess() throws Exception {
-        collect(completed(), completed()).toFuture().get();
+        collect(completed(), completed()).toVoidFuture().get();
     }
 
     @Test
     public void collectVarArgMaxConcurrencySuccess() throws Exception {
         // Just testing that the method works. As it uses existing operators, we don't require elaborate tests
-        collect(1, completed(), completed()).toFuture().get();
+        collect(1, completed(), completed()).toVoidFuture().get();
     }
 
     @Test
     public void collectVarArgFailure() throws Exception {
         AtomicBoolean secondSubscribed = new AtomicBoolean();
         Future<Void> future = collect(error(DELIBERATE_EXCEPTION),
-                completed().doBeforeSubscribe(__ -> secondSubscribed.set(true))).toFuture();
+                completed().doBeforeSubscribe(__ -> secondSubscribed.set(true))).toVoidFuture();
         try {
             future.get();
             fail();
@@ -70,7 +70,7 @@ public class CollectTest {
     public void collectVarArgDelayError() throws Exception {
         AtomicBoolean secondSubscribed = new AtomicBoolean();
         Future<Void> future = collectDelayError(error(DELIBERATE_EXCEPTION),
-                completed().doBeforeSubscribe(__ -> secondSubscribed.set(true))).toFuture();
+                completed().doBeforeSubscribe(__ -> secondSubscribed.set(true))).toVoidFuture();
         try {
             future.get();
             fail();
@@ -85,7 +85,7 @@ public class CollectTest {
     public void collectVarArgDelayErrorMaxConcurrency() throws Exception {
         AtomicBoolean secondSubscribed = new AtomicBoolean();
         Future<Void> future = collectDelayError(1, error(DELIBERATE_EXCEPTION),
-                completed().doBeforeSubscribe(__ -> secondSubscribed.set(true))).toFuture();
+                completed().doBeforeSubscribe(__ -> secondSubscribed.set(true))).toVoidFuture();
         try {
             future.get();
             fail();
@@ -98,20 +98,20 @@ public class CollectTest {
 
     @Test
     public void collectIterableSuccess() throws Exception {
-        collect(asList(completed(), completed())).toFuture().get();
+        collect(asList(completed(), completed())).toVoidFuture().get();
     }
 
     @Test
     public void collectIterableMaxConcurrencySuccess() throws Exception {
         // Just testing that the method works. As it uses existing operators, we don't require elaborate tests
-        collect(asList(completed(), completed()), 1).toFuture().get();
+        collect(asList(completed(), completed()), 1).toVoidFuture().get();
     }
 
     @Test
     public void collectIterableFailure() throws Exception {
         AtomicBoolean secondSubscribed = new AtomicBoolean();
         Future<Void> future = collect(asList(error(DELIBERATE_EXCEPTION),
-                completed().doBeforeSubscribe(__ -> secondSubscribed.set(true)))).toFuture();
+                completed().doBeforeSubscribe(__ -> secondSubscribed.set(true)))).toVoidFuture();
         try {
             future.get();
             fail();
@@ -125,7 +125,7 @@ public class CollectTest {
     public void collectIterableDelayError() throws Exception {
         AtomicBoolean secondSubscribed = new AtomicBoolean();
         Future<Void> future = collectDelayError(asList(error(DELIBERATE_EXCEPTION),
-                completed().doBeforeSubscribe(__ -> secondSubscribed.set(true)))).toFuture();
+                completed().doBeforeSubscribe(__ -> secondSubscribed.set(true)))).toVoidFuture();
         try {
             future.get();
             fail();
@@ -140,7 +140,7 @@ public class CollectTest {
     public void collectIterableDelayErrorMaxConcurrency() throws Exception {
         AtomicBoolean secondSubscribed = new AtomicBoolean();
         Future<Void> future = collectDelayError(asList(error(DELIBERATE_EXCEPTION),
-                completed().doBeforeSubscribe(__ -> secondSubscribed.set(true))), 1).toFuture();
+                completed().doBeforeSubscribe(__ -> secondSubscribed.set(true))), 1).toVoidFuture();
         try {
             future.get();
             fail();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubFirstOrErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubFirstOrErrorTest.java
@@ -56,7 +56,7 @@ public class PubFirstOrErrorTest {
         executorRule.executor().submit(() -> {
             publisher.onNext("hello");
             publisher.onComplete();
-        }).toFuture().get();
+        }).toVoidFuture().get();
         listenerRule.verifySuccess("hello");
     }
 
@@ -66,7 +66,7 @@ public class PubFirstOrErrorTest {
         executorRule.executor().submit(() -> {
             publisher.onNext("foo", "bar");
             publisher.onComplete();
-        }).toFuture().get();
+        }).toVoidFuture().get();
         listenerRule.verifyFailure(IllegalArgumentException.class);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToCompletableTest.java
@@ -92,7 +92,7 @@ public class PubToCompletableTest {
                         currentThread()));
             }
             analyzed.countDown();
-        }).subscribeOn(executorRule.executor()).ignoreElements().toFuture().get();
+        }).subscribeOn(executorRule.executor()).ignoreElements().toVoidFuture().get();
         analyzed.await();
         assertThat("Unexpected errors observed: " + errors, errors, hasSize(0));
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatWhenTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatWhenTest.java
@@ -60,7 +60,7 @@ public class RepeatWhenTest {
     @After
     public void tearDown() throws Exception {
         if (executor != null) {
-            executor.closeAsync().toFuture().get();
+            executor.closeAsync().toVoidFuture().get();
         }
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RetryWhenTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RetryWhenTest.java
@@ -81,7 +81,7 @@ public class RetryWhenTest {
     @After
     public void tearDown() throws Exception {
         if (executor != null) {
-            executor.closeAsync().toFuture().get();
+            executor.closeAsync().toVoidFuture().get();
         }
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/RetryWhenTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/RetryWhenTest.java
@@ -75,7 +75,7 @@ public class RetryWhenTest {
     @After
     public void tearDown() throws Exception {
         if (executor != null) {
-            executor.closeAsync().toFuture().get();
+            executor.closeAsync().toVoidFuture().get();
         }
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/tck/CompletableAbstractOffloaderTckTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/tck/CompletableAbstractOffloaderTckTest.java
@@ -35,7 +35,7 @@ abstract class CompletableAbstractOffloaderTckTest extends AbstractCompletableOp
 
     @AfterMethod
     public void tearDown() throws Exception {
-        executor.closeAsync().toFuture().get();
+        executor.closeAsync().toVoidFuture().get();
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/tck/PublisherAbstractOffloaderTckTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/tck/PublisherAbstractOffloaderTckTest.java
@@ -35,7 +35,7 @@ abstract class PublisherAbstractOffloaderTckTest extends AbstractPublisherOperat
 
     @AfterMethod
     public void tearDown() throws Exception {
-        executor.closeAsync().toFuture().get();
+        executor.closeAsync().toVoidFuture().get();
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/tck/SingleAbstractOffloaderTckTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/tck/SingleAbstractOffloaderTckTest.java
@@ -35,7 +35,7 @@ abstract class SingleAbstractOffloaderTckTest extends AbstractSingleOperatorTckT
 
     @AfterMethod
     public void tearDown() throws Exception {
-        executor.closeAsync().toFuture().get();
+        executor.closeAsync().toVoidFuture().get();
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/tck/SingleFlatMapCompletableTckTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/tck/SingleFlatMapCompletableTckTest.java
@@ -25,7 +25,7 @@ public class SingleFlatMapCompletableTckTest extends AbstractSingleOperatorTckTe
 
     @Override
     protected Single<Object> composeSingle(Single<Integer> single) {
-        return single.flatMapCompletable(v -> Completable.completed()).toSingle();
+        return single.flatMapCompletable(v -> Completable.completed()).toSingle(Object::new);
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderCompletableTest.java
@@ -206,7 +206,7 @@ public class SignalOffloaderCompletableTest {
 
         void shutdown() {
             try {
-                executor.closeAsync().toFuture().get();
+                executor.closeAsync().toVoidFuture().get();
             } catch (Exception e) {
                 LOGGER.warn("Failed to close the executor {}.", executor, e);
             }
@@ -215,7 +215,7 @@ public class SignalOffloaderCompletableTest {
         void awaitTermination() throws Exception {
             // Submit a task, since we use a single thread executor, this means all previous tasks have been
             // completed.
-            executor.submit(() -> { }).toFuture().get();
+            executor.submit(() -> { }).toVoidFuture().get();
         }
 
         Cancellable sendOnSubscribe(Subscriber offloaded) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderConcurrentCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderConcurrentCompletableTest.java
@@ -92,7 +92,7 @@ public class SignalOffloaderConcurrentCompletableTest {
             results[i] = pairs[i].sendResult();
         }
 
-        completed().mergeDelayError(results).toFuture().get();
+        completed().mergeDelayError(results).toVoidFuture().get();
         state.awaitTermination();
 
         for (int i = 0; i < entityCount; i++) {
@@ -115,7 +115,7 @@ public class SignalOffloaderConcurrentCompletableTest {
 
         void shutdown() {
             try {
-                executor.closeAsync().toFuture().get();
+                executor.closeAsync().toVoidFuture().get();
                 emitters.shutdownNow();
             } catch (Exception e) {
                 LOGGER.warn("Failed to close the executor {}.", executor, e);
@@ -125,7 +125,7 @@ public class SignalOffloaderConcurrentCompletableTest {
         void awaitTermination() throws Exception {
             // Submit a task, since we use a single thread executor, this means all previous tasks have been
             // completed.
-            executor.submit(() -> { }).toFuture().get();
+            executor.submit(() -> { }).toVoidFuture().get();
         }
 
         SubscriberCancellablePair newPair() {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderConcurrentPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderConcurrentPublisherTest.java
@@ -100,7 +100,7 @@ public class SignalOffloaderConcurrentPublisherTest {
             results[i] = pairs[i].sendItems((i + 1) * 100);
         }
 
-        completed().mergeDelayError(results).toFuture().get();
+        completed().mergeDelayError(results).toVoidFuture().get();
         state.awaitTermination();
 
         for (int i = 0; i < entityCount; i++) {
@@ -112,7 +112,7 @@ public class SignalOffloaderConcurrentPublisherTest {
     @Test
     public void concurrentSignalsFromSubscriberAndSubscription() throws Exception {
         OffloaderHolder.SubscriberSubscriptionPair pair = state.newPair(10_000);
-        pair.sendItems(10_000).toFuture().get();
+        pair.sendItems(10_000).toVoidFuture().get();
         state.awaitTermination();
         pair.subscriber.verifyNoErrors();
         pair.subscription.verifyRequested(10_000);
@@ -132,7 +132,7 @@ public class SignalOffloaderConcurrentPublisherTest {
 
         void shutdown() {
             try {
-                executor.closeAsync().toFuture().get();
+                executor.closeAsync().toVoidFuture().get();
                 emitters.shutdownNow();
             } catch (Exception e) {
                 LOGGER.warn("Failed to close the executor {}.", executor, e);
@@ -142,7 +142,7 @@ public class SignalOffloaderConcurrentPublisherTest {
         void awaitTermination() throws Exception {
             // Submit a task, since we use a single thread executor, this means all previous tasks have been
             // completed.
-            executor.submit(() -> { }).toFuture().get();
+            executor.submit(() -> { }).toVoidFuture().get();
         }
 
         SubscriberSubscriptionPair newPair(int expectedItems) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderConcurrentSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderConcurrentSingleTest.java
@@ -93,7 +93,7 @@ public class SignalOffloaderConcurrentSingleTest {
             results[i] = pairs[i].sendResult(i);
         }
 
-        completed().mergeDelayError(results).toFuture().get();
+        completed().mergeDelayError(results).toVoidFuture().get();
         state.awaitTermination();
 
         for (int i = 0; i < entityCount; i++) {
@@ -116,7 +116,7 @@ public class SignalOffloaderConcurrentSingleTest {
 
         void shutdown() {
             try {
-                executor.closeAsync().toFuture().get();
+                executor.closeAsync().toVoidFuture().get();
                 emitters.shutdownNow();
             } catch (Exception e) {
                 LOGGER.warn("Failed to close the executor {}.", executor, e);
@@ -126,7 +126,7 @@ public class SignalOffloaderConcurrentSingleTest {
         void awaitTermination() throws Exception {
             // Submit a task, since we use a single thread executor, this means all previous tasks have been
             // completed.
-            executor.submit(() -> { }).toFuture().get();
+            executor.submit(() -> { }).toVoidFuture().get();
         }
 
         SubscriberCancellablePair newPair(int expectedResult) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderPublisherTest.java
@@ -270,7 +270,7 @@ public class SignalOffloaderPublisherTest {
 
         void shutdown() {
             try {
-                executor.closeAsync().toFuture().get();
+                executor.closeAsync().toVoidFuture().get();
             } catch (Exception e) {
                 LOGGER.warn("Failed to close the executor {}.", executor, e);
             }
@@ -279,7 +279,7 @@ public class SignalOffloaderPublisherTest {
         OffloaderHolder awaitTermination() throws Exception {
             // Submit a task, since we use a single thread executor, this means all previous tasks have been
             // completed.
-            executor.submit(() -> { }).toFuture().get();
+            executor.submit(() -> { }).toVoidFuture().get();
             return this;
         }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderSingleTest.java
@@ -214,7 +214,7 @@ public class SignalOffloaderSingleTest {
 
         void shutdown() {
             try {
-                executor.closeAsync().toFuture().get();
+                executor.closeAsync().toVoidFuture().get();
             } catch (Exception e) {
                 LOGGER.warn("Failed to close the executor {}.", executor, e);
             }
@@ -223,7 +223,7 @@ public class SignalOffloaderSingleTest {
         void awaitTermination() throws Exception {
             // Submit a task, since we use a single thread executor, this means all previous tasks have been
             // completed.
-            executor.submit(() -> { }).toFuture().get();
+            executor.submit(() -> { }).toVoidFuture().get();
         }
 
         Cancellable sendOnSubscribe(Subscriber<? super String> offloaded) {

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/BlockingTestUtils.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/BlockingTestUtils.java
@@ -200,7 +200,7 @@ public final class BlockingTestUtils {
      * @throws InterruptedException if the thread was interrupted while waiting for termination.
      */
     public static void awaitIndefinitely(Completable source) throws ExecutionException, InterruptedException {
-        source.toFuture().get();
+        source.toVoidFuture().get();
     }
 
     /**
@@ -231,7 +231,7 @@ public final class BlockingTestUtils {
      */
     public static void await(Completable source, long timeout, TimeUnit timeoutUnit)
             throws ExecutionException, InterruptedException, TimeoutException {
-        source.toFuture().get(timeout, timeoutUnit);
+        source.toVoidFuture().get(timeout, timeoutUnit);
     }
 
     private static <T> T enforceNonNull(@Nullable T result, NullPointerException npe) throws ExecutionException {

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/ExecutorRule.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/ExecutorRule.java
@@ -92,7 +92,7 @@ public final class ExecutorRule<E extends Executor> extends ExternalResource {
     @Override
     protected void after() {
         try {
-            executor.closeAsync().toFuture().get();
+            executor.closeAsync().toVoidFuture().get();
         } catch (ExecutionException | InterruptedException e) {
             throw new RuntimeException(e);
         }

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererTest.java
@@ -90,9 +90,9 @@ public class DefaultDnsServiceDiscovererTest {
 
     @After
     public void tearDown() throws Exception {
-        discoverer.closeAsync().toFuture().get();
+        discoverer.closeAsync().toVoidFuture().get();
         dnsServer.stop();
-        nettyIoExecutor.closeAsync().toFuture().get();
+        nettyIoExecutor.closeAsync().toVoidFuture().get();
     }
 
     @Test
@@ -122,7 +122,7 @@ public class DefaultDnsServiceDiscovererTest {
             assertThat(subscriber.activeCount(), equalTo(0));
             assertThat(subscriber.inactiveCount(), equalTo(0));
         } finally {
-            discoverer.closeAsync().toFuture().get();
+            discoverer.closeAsync().toVoidFuture().get();
         }
     }
 
@@ -359,7 +359,7 @@ public class DefaultDnsServiceDiscovererTest {
             assertThat(subscriber.activeCount(), equalTo(expectedActiveCount));
             assertThat(subscriber.inactiveCount(), equalTo(expectedInactiveCount));
         } finally {
-            discoverer.closeAsync().toFuture().get();
+            discoverer.closeAsync().toVoidFuture().get();
         }
     }
 
@@ -441,7 +441,7 @@ public class DefaultDnsServiceDiscovererTest {
             assertThat(subscriber.inactiveCount(), equalTo(expectedInactiveCount));
         } finally {
             responseLatch.countDown();
-            discoverer.closeAsync().toFuture().get();
+            discoverer.closeAsync().toVoidFuture().get();
         }
     }
 
@@ -512,7 +512,7 @@ public class DefaultDnsServiceDiscovererTest {
             latchOnSubscribe.await();
         } finally {
             try {
-                discoverer.closeAsync().toFuture().get();
+                discoverer.closeAsync().toVoidFuture().get();
                 fail("Expected exception");
             } catch (ExecutionException e) {
                 assertThat(e.getCause().getCause(), equalTo(DELIBERATE_EXCEPTION));

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/backends/BackendsStarter.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/backends/BackendsStarter.java
@@ -82,7 +82,7 @@ public final class BackendsStarter {
             allServicesOnClose = allServicesOnClose.merge(ratingService.onClose());
 
             // Await termination of all backends started by this class.
-            allServicesOnClose.toFuture().get();
+            allServicesOnClose.toVoidFuture().get();
         }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingUtils.java
@@ -148,7 +148,7 @@ final class BlockingUtils {
         // It is assumed that users will always apply timeouts at the StreamingHttpService layer (e.g. via filter). So
         // we don't apply any explicit timeout here and just wait forever.
         try {
-            source.toFuture().get();
+            source.toVoidFuture().get();
         } catch (final ExecutionException e) {
             throwException(e.getCause());
         }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequester.java
@@ -85,7 +85,7 @@ public abstract class HttpRequester implements HttpRequestFactory, ListenableAsy
 
     @Override
     public final void close() {
-        awaitTermination(closeAsyncGracefully().toFuture());
+        awaitTermination(closeAsyncGracefully().toVoidFuture());
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequester.java
@@ -93,6 +93,6 @@ public abstract class StreamingHttpRequester implements
 
     @Override
     public final void close() {
-        awaitTermination(closeAsyncGracefully().toFuture());
+        awaitTermination(closeAsyncGracefully().toVoidFuture());
     }
 }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractBlockingStreamingHttpRequesterTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractBlockingStreamingHttpRequesterTest.java
@@ -201,7 +201,7 @@ public abstract class AbstractBlockingStreamingHttpRequesterTest {
             throw new IllegalStateException("shouldn't be called!");
         });
         StreamingHttpRequester asyncRequester = toStreamingRequester(syncRequester);
-        asyncRequester.closeAsync().toFuture().get();
+        asyncRequester.closeAsync().toVoidFuture().get();
         assertTrue(((TestHttpRequester) syncRequester).isClosed());
     }
 

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpServiceTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpServiceTest.java
@@ -271,7 +271,7 @@ public class BlockingStreamingHttpServiceTest {
             }
         };
         StreamingHttpService asyncService = syncService.asStreamingService();
-        asyncService.closeAsync().toFuture().get();
+        asyncService.closeAsync().toVoidFuture().get();
         assertTrue(closedCalled.get());
     }
 

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpExecutionStrategyTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpExecutionStrategyTest.java
@@ -122,7 +122,7 @@ public class DefaultHttpExecutionStrategyTest {
 
     @After
     public void tearDown() throws Exception {
-        executor.closeAsync().toFuture().get();
+        executor.closeAsync().toVoidFuture().get();
     }
 
     @Test

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractClientEffectiveStrategyTest.java
@@ -94,7 +94,7 @@ public class AbstractClientEffectiveStrategyTest {
 
     @After
     public void tearDown() throws Exception {
-        newCompositeCloseable().appendAll(client, context, ioExecutor).closeAsync().toFuture().get();
+        newCompositeCloseable().appendAll(client, context, ioExecutor).closeAsync().toVoidFuture().get();
     }
 
     protected void assertNoOffload(final ClientOffloadPoint offloadPoint) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractEchoServerBasedHttpRequesterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractEchoServerBasedHttpRequesterTest.java
@@ -71,7 +71,7 @@ public abstract class AbstractEchoServerBasedHttpRequesterTest {
 
     @AfterClass
     public static void stopServer() throws Exception {
-        serverContext.closeAsync().toFuture().get();
+        serverContext.closeAsync().toVoidFuture().get();
     }
 
     private static class EchoServiceStreaming extends StreamingHttpService {
@@ -122,7 +122,7 @@ public abstract class AbstractEchoServerBasedHttpRequesterTest {
             assertThat(headers.get("test-req-header-transfer-encoding"), equalTo(CHUNKED));
             assertThat(respBody.toFuture().get(), equalTo("Testing123"));
         } finally {
-            requester.closeAsync().toFuture().get();
+            requester.closeAsync().toVoidFuture().get();
         }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -241,6 +241,6 @@ public abstract class AbstractNettyHttpServerTest {
     }
 
     void assertConnectionClosed() throws Exception {
-        httpConnection.onClose().toFuture().get();
+        httpConnection.onClose().toVoidFuture().get();
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractServerEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractServerEffectiveStrategyTest.java
@@ -100,7 +100,7 @@ public class AbstractServerEffectiveStrategyTest {
         if (context != null) {
             closeable.append(context);
         }
-        closeable.appendAll(serviceExecutor, ioExecutor).closeAsync().toFuture().get();
+        closeable.appendAll(serviceExecutor, ioExecutor).closeAsync().toVoidFuture().get();
     }
 
     protected BlockingHttpClient context(ServerContext context) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConsumeRequestPayloadOnResponsePathTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConsumeRequestPayloadOnResponsePathTest.java
@@ -91,7 +91,7 @@ public class ConsumeRequestPayloadOnResponsePathTest {
         test((responseSingle, request) -> responseSingle.map(response ->
                 response.transformRaw(() -> null, (payloadChunk, __) -> payloadChunk, (__, trailers) -> {
                     try {
-                        consumePayloadBody(request).toFuture().get();
+                        consumePayloadBody(request).toVoidFuture().get();
                     } catch (Exception e) {
                         PlatformDependent.throwException(e);
                     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
@@ -54,7 +54,7 @@ public class DefaultMultiAddressUrlHttpClientBuilderTest {
                 .executionStrategy(defaultStrategy(CTX.executor()))
                 .buildStreaming();
         assertNotNull(newRequester);
-        newRequester.closeAsync().toFuture().get();
+        newRequester.closeAsync().toVoidFuture().get();
     }
 
     @Test
@@ -64,7 +64,7 @@ public class DefaultMultiAddressUrlHttpClientBuilderTest {
                 .executionStrategy(defaultStrategy(CTX.executor()))
                 .build();
         assertNotNull(newAggregatedRequester);
-        newAggregatedRequester.closeAsync().toFuture().get();
+        newAggregatedRequester.closeAsync().toVoidFuture().get();
     }
 
     @Test
@@ -96,7 +96,7 @@ public class DefaultMultiAddressUrlHttpClientBuilderTest {
                 .ioExecutor(CTX.ioExecutor())
                 .executionStrategy(defaultStrategy(CTX.executor()))
                 .buildStreaming();
-        newRequester.closeAsync().toFuture().get();
+        newRequester.closeAsync().toVoidFuture().get();
         verify(mockedServiceDiscoverer, never()).closeAsync();
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOverrideTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOverrideTest.java
@@ -91,7 +91,7 @@ public class FlushStrategyOverrideTest {
 
     @After
     public void tearDown() throws Exception {
-        newCompositeCloseable().appendAll(conn, client, serverCtx).closeAsync().toFuture().get();
+        newCompositeCloseable().appendAll(conn, client, serverCtx).closeAsync().toVoidFuture().get();
     }
 
     @Test

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
@@ -65,10 +65,10 @@ public class HttpAuthConnectionFactoryClientTest {
     @After
     public void teardown() throws Exception {
         if (client != null) {
-            client.closeAsync().toFuture().get();
+            client.closeAsync().toVoidFuture().get();
         }
         if (serverContext != null) {
-            serverContext.closeAsync().toFuture().get();
+            serverContext.closeAsync().toVoidFuture().get();
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientAsyncContextTest.java
@@ -97,7 +97,7 @@ public class HttpClientAsyncContextTest {
         request.headers().set(REQUEST_ID_HEADER, requestId);
         StreamingHttpResponse response = connection.request(request).toFuture().get();
         assertEquals(OK, response.status());
-        response.payloadBody().ignoreElements().toFuture().get();
+        response.payloadBody().ignoreElements().toVoidFuture().get();
     }
 
     private static void assertAsyncContext(@Nullable CharSequence requestId, Queue<Throwable> errorQueue) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientOverrideOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientOverrideOffloadingTest.java
@@ -99,7 +99,7 @@ public class HttpClientOverrideOffloadingTest {
 
     @After
     public void tearDown() throws Exception {
-        newCompositeCloseable().appendAll(client, server, ioExecutor, executor).closeAsync().toFuture().get();
+        newCompositeCloseable().appendAll(client, server, ioExecutor, executor).closeAsync().toVoidFuture().get();
     }
 
     @Test
@@ -110,7 +110,7 @@ public class HttpClientOverrideOffloadingTest {
                 errors.add(new AssertionError("Invalid thread found providing the connection. Thread: "
                         + currentThread()));
             }
-        }).toFuture().get().closeAsync().toFuture().get();
+        }).toFuture().get().closeAsync().toVoidFuture().get();
         assertThat("Unexpected errors: " + errors, errors, hasSize(0));
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionEmptyPayloadTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionEmptyPayloadTest.java
@@ -105,7 +105,7 @@ public class HttpConnectionEmptyPayloadTest {
             assertNotNull(contentLength);
             assertEquals(expectedContentLength, parseInt(contentLength.toString()));
             // Drain the current response content so we will be able to read the next response.
-            response.payloadBody().ignoreElements().toFuture().get();
+            response.payloadBody().ignoreElements().toVoidFuture().get();
 
             response = awaitIndefinitelyNonNull(response2Single);
             assertEquals(OK, response.status());
@@ -124,7 +124,7 @@ public class HttpConnectionEmptyPayloadTest {
             contentLength = response.headers().get(CONTENT_LENGTH);
             assertNotNull(contentLength);
             assertEquals(expectedContentLength, parseInt(contentLength.toString()));
-            response.payloadBody().ignoreElements().toFuture().get();
+            response.payloadBody().ignoreElements().toVoidFuture().get();
         }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
@@ -221,7 +221,7 @@ public class HttpOffloadingTest {
 
     @Test
     public void serverOnCloseIsOffloaded() throws Exception {
-        serverContext.closeAsync().toFuture().get();
+        serverContext.closeAsync().toVoidFuture().get();
         subscribeTo(inEventLoop(), errors, serverContext.onClose());
         terminated.await();
         assertThat("Unexpected errors.", errors, is(empty()));
@@ -232,7 +232,7 @@ public class HttpOffloadingTest {
         subscribeTo(inEventLoop(), errors,
                 httpConnection.settingStream(MAX_CONCURRENCY).doAfterFinally(terminated::countDown),
                 "Client settings stream: ");
-        httpConnection.closeAsyncGracefully().toFuture().get();
+        httpConnection.closeAsyncGracefully().toVoidFuture().get();
         terminated.await();
         assertThat("Unexpected errors.", errors, is(empty()));
     }
@@ -253,7 +253,7 @@ public class HttpOffloadingTest {
 
     @Test
     public void clientOnCloseIsOffloaded() throws Exception {
-        connectionContext.closeAsync().toFuture().get();
+        connectionContext.closeAsync().toVoidFuture().get();
         subscribeTo(inEventLoop(), errors, connectionContext.onClose());
         terminated.await();
         assertThat("Unexpected errors.", errors, is(empty()));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -455,11 +455,11 @@ public class HttpRequestEncoderTest {
 
             StreamingHttpRequest request = reqRespFactory.post("/closeme");
 
-            serverCloseTrigger.toFuture().get();
+            serverCloseTrigger.toVoidFuture().get();
             Completable write = conn.write(from(request, allocator.fromAscii("Bye"), EmptyHttpHeaders.INSTANCE));
 
             try {
-                write.toFuture().get();
+                write.toVoidFuture().get();
                 fail("Should not complete normally");
             } catch (ExecutionException e) {
                 CloseHandler closeHandler = closeHandlerRef.get();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServiceAsyncContextTest.java
@@ -326,7 +326,7 @@ public class HttpServiceAsyncContextTest {
         StreamingHttpResponse response = connection.request(request).toFuture().get();
         assertEquals(OK, response.status());
         assertTrue(request.headers().contains(REQUEST_ID_HEADER, requestId));
-        response.payloadBodyAndTrailers().ignoreElements().toFuture().get();
+        response.payloadBodyAndTrailers().ignoreElements().toVoidFuture().get();
     }
 
     private static void assertAsyncContext(@Nullable CharSequence requestId, Queue<Throwable> errorQueue) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpStreamingClientOverrideOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpStreamingClientOverrideOffloadingTest.java
@@ -106,7 +106,7 @@ public class HttpStreamingClientOverrideOffloadingTest {
 
     @After
     public void tearDown() throws Exception {
-        newCompositeCloseable().appendAll(client, server, ioExecutor, executor).closeAsync().toFuture().get();
+        newCompositeCloseable().appendAll(client, server, ioExecutor, executor).closeAsync().toVoidFuture().get();
     }
 
     @Test
@@ -116,7 +116,7 @@ public class HttpStreamingClientOverrideOffloadingTest {
                 throw new AssertionError("Invalid thread found providing the connection. Thread: "
                         + currentThread());
             }
-        }).toFuture().get().closeAsync().toFuture().get();
+        }).toFuture().get().closeAsync().toVoidFuture().get();
     }
 
     @Test

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientSslTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientSslTest.java
@@ -134,10 +134,10 @@ public class MultiAddressUrlHttpClientSslTest {
     @AfterClass
     public static void afterClass() throws Exception {
         if (serverCtx != null) {
-            serverCtx.closeAsync().toFuture().get();
+            serverCtx.closeAsync().toVoidFuture().get();
         }
         if (secureServerCtx != null) {
-            secureServerCtx.closeAsync().toFuture().get();
+            secureServerCtx.closeAsync().toVoidFuture().get();
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerTest.java
@@ -296,7 +296,7 @@ public class NettyHttpServerTest extends AbstractNettyHttpServerTest {
 
         // Use a very high timeout for the graceful close. It should happen quite quickly because there are no
         // active requests/responses.
-        closeAsyncGracefully(serverContext(), 1000, SECONDS).toFuture().get();
+        closeAsyncGracefully(serverContext(), 1000, SECONDS).toVoidFuture().get();
         assertConnectionClosed();
     }
 
@@ -326,7 +326,7 @@ public class NettyHttpServerTest extends AbstractNettyHttpServerTest {
         final StreamingHttpRequest request1 = reqRespFactory.newRequest(GET, SVC_TEST_PUBLISHER);
         makeRequest(request1);
 
-        serverContext().closeAsync().toFuture().get();
+        serverContext().closeAsync().toVoidFuture().get();
 
         assertConnectionClosed();
     }
@@ -344,7 +344,7 @@ public class NettyHttpServerTest extends AbstractNettyHttpServerTest {
 
         onCloseListener.verifyNoEmissions();
 
-        closeAsyncGracefully(serverContext(), 10, MILLISECONDS).toFuture().get();
+        closeAsyncGracefully(serverContext(), 10, MILLISECONDS).toVoidFuture().get();
 
         onCloseListener.verifyCompletion();
 
@@ -364,7 +364,7 @@ public class NettyHttpServerTest extends AbstractNettyHttpServerTest {
 
         onCloseListener.verifyNoEmissions();
 
-        serverContext().closeAsync().toFuture().get();
+        serverContext().closeAsync().toVoidFuture().get();
 
         onCloseListener.verifyCompletion();
 
@@ -378,7 +378,7 @@ public class NettyHttpServerTest extends AbstractNettyHttpServerTest {
         final StreamingHttpRequest request1 = reqRespFactory.newRequest(GET, SVC_TEST_PUBLISHER);
         makeRequest(request1);
 
-        closeAsyncGracefully(serverContext(), 500, MILLISECONDS).toFuture().get();
+        closeAsyncGracefully(serverContext(), 500, MILLISECONDS).toVoidFuture().get();
 
         assertConnectionClosed();
     }
@@ -393,7 +393,7 @@ public class NettyHttpServerTest extends AbstractNettyHttpServerTest {
         closeAsyncGracefully(serverContext(), 1000, SECONDS).subscribe();
         // Wait 500 millis for the "immediate" close to happen, since there are multiple threads involved.
         // If it takes any longer than that, it probably didn't work, but the graceful close would make the test pass.
-        serverContext().closeAsync().toFuture().get();
+        serverContext().closeAsync().toVoidFuture().get();
 
         assertConnectionClosed();
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NoOffloadsStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NoOffloadsStrategyTest.java
@@ -73,7 +73,7 @@ public class NoOffloadsStrategyTest {
         if (context != null) {
             closeables.append(context);
         }
-        closeables.append(ioExecutor).closeAsync().toFuture().get();
+        closeables.append(ioExecutor).closeAsync().toVoidFuture().get();
     }
 
     @Test

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PartitionedHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PartitionedHttpClientTest.java
@@ -357,7 +357,7 @@ public class PartitionedHttpClientTest {
 
         @Override
         public void close() throws Exception {
-            newCompositeCloseable().prependAll(udClient, clients).closeAsync().toFuture().get();
+            newCompositeCloseable().prependAll(udClient, clients).closeAsync().toVoidFuture().get();
         }
     }
 }

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractJerseyStreamingHttpServiceTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractJerseyStreamingHttpServiceTest.java
@@ -114,12 +114,12 @@ public abstract class AbstractJerseyStreamingHttpServiceTest {
 
     @After
     public final void closeClient() throws Exception {
-        httpClient.closeAsync().toFuture().get();
+        httpClient.closeAsync().toVoidFuture().get();
     }
 
     @After
     public final void closeServer() throws Exception {
-        serverContext.closeAsync().toFuture().get();
+        serverContext.closeAsync().toVoidFuture().get();
     }
 
     protected abstract Application application();

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilderTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilderTest.java
@@ -255,7 +255,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
                 .when((ctx, req) -> true).thenRouteTo(serviceC)
                 .buildStreaming();
 
-        service.closeAsync().toFuture().get();
+        service.closeAsync().toVoidFuture().get();
 
         verify(serviceA).closeAsync();
         verify(serviceB).closeAsync();
@@ -284,7 +284,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
 
         try {
             final Completable completable = service.closeAsync();
-            completable.toFuture().get();
+            completable.toVoidFuture().get();
             fail("Expected an exception from `await`");
         } catch (final ExecutionException e) {
             assertSame(DELIBERATE_EXCEPTION, e.getCause());

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpServerOverrideOffloadingTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpServerOverrideOffloadingTest.java
@@ -83,7 +83,7 @@ public class HttpServerOverrideOffloadingTest {
 
     @After
     public void tearDown() throws Exception {
-        newCompositeCloseable().appendAll(client, server, ioExecutor, executor).closeAsync().toFuture().get();
+        newCompositeCloseable().appendAll(client, server, ioExecutor, executor).closeAsync().toVoidFuture().get();
     }
 
     private static boolean isInServerEventLoop(Thread thread) {

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/PredicateRouterOffloadingTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/PredicateRouterOffloadingTest.java
@@ -89,7 +89,7 @@ public class PredicateRouterOffloadingTest {
         if (context != null) {
             closeable.append(context);
         }
-        closeable.closeAsync().toFuture().get();
+        closeable.closeAsync().toVoidFuture().get();
     }
 
     @Test

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/auth/BasicAuthHttpServiceFilterBuilderTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/auth/BasicAuthHttpServiceFilterBuilderTest.java
@@ -355,7 +355,7 @@ public class BasicAuthHttpServiceFilterBuilderTest {
 
         assertFalse(credentialsVerifierClosed.get());
         assertFalse(nextServiceClosed.get());
-        service.closeAsync().toFuture().get();
+        service.closeAsync().toVoidFuture().get();
         assertTrue(credentialsVerifierClosed.get());
         assertTrue(nextServiceClosed.get());
     }

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingUtils.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/BlockingUtils.java
@@ -53,7 +53,7 @@ final class BlockingUtils {
         // It is assumed that users will always apply timeouts at another layer. So we don't
         // apply any explicit timeout here and just wait forever.
         try {
-            source.toFuture().get();
+            source.toVoidFuture().get();
         } catch (final ExecutionException e) {
             throwException(e.getCause());
         } catch (InterruptedException e) {

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/CommanderUtils.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/CommanderUtils.java
@@ -59,7 +59,7 @@ final class CommanderUtils {
                     Single.class.getSimpleName() + " cannot be subscribed to after the transaction has completed.");
         }
         // Currently, we do not offload subscribes for `connection.request()` hence the order of subscribes is the
-        // order of writes, so using `toFuture()` is sufficient. When we have the ability to override `Executor` per
+        // order of writes, so using `toVoidFuture()` is sufficient. When we have the ability to override `Executor` per
         // request, we will use that to make sure subscribes are not offloaded.
         final SingleProcessor<T> single = new SingleProcessor<>();
         singles.add(single);

--- a/servicetalk-redis-api/src/test/java/io/servicetalk/redis/api/CommanderUtilsTest.java
+++ b/servicetalk-redis-api/src/test/java/io/servicetalk/redis/api/CommanderUtilsTest.java
@@ -117,7 +117,7 @@ public class CommanderUtilsTest {
 
         thrown.expect(ExecutionException.class);
         thrown.expectCause(is(initialException));
-        execCompletable.toFuture().get();
+        execCompletable.toVoidFuture().get();
     }
 
     @Test
@@ -131,7 +131,7 @@ public class CommanderUtilsTest {
         thrown.expect(ExecutionException.class);
         thrown.expectCause(is(initialException));
         thrown.expectCause(hasProperty("suppressed", array(is(releaseException))));
-        execCompletable.toFuture().get();
+        execCompletable.toVoidFuture().get();
     }
 
     private static final class TestCommander {

--- a/servicetalk-redis-api/src/test/java/io/servicetalk/redis/api/DefaultRedisExecutionStrategyTest.java
+++ b/servicetalk-redis-api/src/test/java/io/servicetalk/redis/api/DefaultRedisExecutionStrategyTest.java
@@ -101,7 +101,7 @@ public class DefaultRedisExecutionStrategyTest {
 
     @After
     public void tearDown() throws Exception {
-        executor.closeAsync().toFuture().get();
+        executor.closeAsync().toVoidFuture().get();
     }
 
     @Test

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BufferRedisCommanderTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BufferRedisCommanderTest.java
@@ -343,7 +343,7 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
         Future<String> value2 = tcc.set(key("a-key"), buf("a-value3"));
         Future<Buffer> value3 = tcc.ping(buf("in-transac"));
         Future<Buffer> value4 = tcc.get(key("a-key"));
-        tcc.exec().toFuture().get();
+        tcc.exec().toVoidFuture().get();
         postReleaseLatch.await();
         assertThat(value1.get(), is(1L));
         assertThat(value2.get(), is("OK"));
@@ -408,7 +408,7 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
                 asList(buf("1000"), buf("100000000")));
 
         Future<Buffer> pingFuture = tcc.ping(buf("in-transac"));
-        tcc.exec().toFuture().cancel(true);
+        tcc.exec().toVoidFuture().cancel(true);
         postCloseLatch.await();
 
         assertThrowsClosedChannelException(pingFuture::get);
@@ -427,7 +427,7 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
                 asList(buf("1000"), buf("100000000"))).toFuture();
 
         Future<Buffer> pingFuture = tcc.ping(buf("in-transac"));
-        tcc.exec().toFuture().cancel(true);
+        tcc.exec().toVoidFuture().cancel(true);
         postCloseLatch.await();
 
         assertThrowsClosedChannelException(pingFuture::get);
@@ -477,7 +477,7 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
     public void transactionCloseAsync() throws Exception {
         final TransactedBufferRedisCommander tcc = awaitIndefinitelyNonNull(commandClient.multi());
 
-        tcc.closeAsync().toFuture().get();
+        tcc.closeAsync().toVoidFuture().get();
 
         thrown.expect(ExecutionException.class);
         thrown.expectCause(is(instanceOf(ClosedChannelException.class)));

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/NoOffloadsStrategyTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/NoOffloadsStrategyTest.java
@@ -47,7 +47,7 @@ public class NoOffloadsStrategyTest {
     @After
     public void tearDown() throws Exception {
         if (client != null) {
-            client.closeAsync().toFuture().get();
+            client.closeAsync().toVoidFuture().get();
         }
     }
 
@@ -56,7 +56,7 @@ public class NoOffloadsStrategyTest {
         String testThread = currentThread().getName();
         client = builder.executionStrategy(noOffloadsStrategy()).build();
         final AtomicReference<Thread> executorThread = new AtomicReference<>();
-        client.executionContext().executor().submit(() -> executorThread.set(currentThread())).toFuture().get();
+        client.executionContext().executor().submit(() -> executorThread.set(currentThread())).toVoidFuture().get();
         assertThat("Unexpected thread for the server executor.", executorThread.get().getName(),
                 not(startsWith(testThread)));
     }
@@ -71,7 +71,7 @@ public class NoOffloadsStrategyTest {
             }
         }).build();
         final AtomicReference<Thread> executorThread = new AtomicReference<>();
-        client.executionContext().executor().submit(() -> executorThread.set(currentThread())).toFuture().get();
+        client.executionContext().executor().submit(() -> executorThread.set(currentThread())).toVoidFuture().get();
         assertThat("Unexpected thread for the server executor.", executorThread.get().getName(),
                 startsWith(testThread));
     }

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisAuthConnectionFactoryConnectionTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisAuthConnectionFactoryConnectionTest.java
@@ -67,7 +67,7 @@ public class RedisAuthConnectionFactoryConnectionTest {
                     connection.closeAsync().onErrorResume(cause -> completed()).concatWith(success(connection)))
                     .ignoreResult()
                     .onErrorResume(cause -> completed())
-                    .concatWith(ioExecutor.closeAsync()).toFuture().get();
+                    .concatWith(ioExecutor.closeAsync()).toVoidFuture().get();
         }
     }
 

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisClientOffloadingTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisClientOffloadingTest.java
@@ -152,7 +152,7 @@ public class RedisClientOffloadingTest {
         subscribeTo(RedisTestEnvironment::isInClientEventLoop, errors,
                 connection.settingStream(MAX_CONCURRENCY).doAfterFinally(terminated::countDown),
                 "Client settings stream: ");
-        connection.closeAsyncGracefully().toFuture().get();
+        connection.closeAsyncGracefully().toVoidFuture().get();
         terminated.await();
         assertThat("Unexpected errors.", errors, is(empty()));
     }
@@ -175,7 +175,7 @@ public class RedisClientOffloadingTest {
 
     @Test
     public void onCloseIsOffloaded() throws Exception {
-        connectionContext.closeAsync().toFuture().get();
+        connectionContext.closeAsync().toVoidFuture().get();
         subscribeTo(RedisTestEnvironment::isInClientEventLoop, errors,
                 connectionContext.onClose().doAfterFinally(terminated::countDown));
         terminated.await();

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisClientOverrideOffloadingTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisClientOverrideOffloadingTest.java
@@ -95,7 +95,7 @@ public class RedisClientOverrideOffloadingTest {
 
     @After
     public void tearDown() throws Exception {
-        newCompositeCloseable().appendAll(client, ioExecutor, executor).closeAsync().toFuture().get();
+        newCompositeCloseable().appendAll(client, ioExecutor, executor).closeAsync().toVoidFuture().get();
     }
 
     @Test
@@ -105,7 +105,7 @@ public class RedisClientOverrideOffloadingTest {
                 throw new AssertionError("Invalid thread found providing the connection. Thread: "
                         + currentThread());
             }
-        }).toFuture().get().closeAsync().toFuture().get();
+        }).toFuture().get().closeAsync().toVoidFuture().get();
     }
 
     @Test

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisCommanderTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisCommanderTest.java
@@ -331,7 +331,7 @@ public class RedisCommanderTest extends BaseRedisClientTest {
         Future<String> value2 = tcc.set(key("a-key"), "a-value3");
         Future<String> value3 = tcc.ping("in-transac");
         Future<String> value4 = tcc.get(key("a-key"));
-        tcc.exec().toFuture().get();
+        tcc.exec().toVoidFuture().get();
         postReleaseLatch.await();
         assertThat(value1.get(), is(1L));
         assertThat(value2.get(), is("OK"));
@@ -395,7 +395,7 @@ public class RedisCommanderTest extends BaseRedisClientTest {
         Future<Long> longFuture = tcc.evalLong(EVAL_SLEEP_SCRIPT, 0, emptyList(), emptyList());
 
         Future<String> pingFuture = tcc.ping("in-transac");
-        tcc.exec().toFuture().cancel(true);
+        tcc.exec().toVoidFuture().cancel(true);
         postCloseLatch.await();
 
         assertThrowsClosedChannelException(pingFuture::get);
@@ -413,7 +413,7 @@ public class RedisCommanderTest extends BaseRedisClientTest {
         Future<Long> longFuture = commandClient.evalLong(EVAL_SLEEP_SCRIPT, 0, emptyList(), emptyList()).toFuture();
 
         Future<String> pingFuture = tcc.ping("in-transac");
-        tcc.exec().toFuture().cancel(true);
+        tcc.exec().toVoidFuture().cancel(true);
         postCloseLatch.await();
 
         assertThrowsClosedChannelException(pingFuture::get);
@@ -461,7 +461,7 @@ public class RedisCommanderTest extends BaseRedisClientTest {
     public void transactionCloseAsync() throws Exception {
         final TransactedRedisCommander tcc = awaitIndefinitelyNonNull(commandClient.multi());
 
-        tcc.closeAsync().toFuture().get();
+        tcc.closeAsync().toVoidFuture().get();
 
         thrown.expect(ExecutionException.class);
         thrown.expectCause(is(instanceOf(ClosedChannelException.class)));

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
@@ -125,6 +125,6 @@ public abstract class AbstractTcpServerTest {
 
     @After
     public void stopServer() throws Exception {
-        serverContext.closeAsync().toFuture().get();
+        serverContext.closeAsync().toVoidFuture().get();
     }
 }

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpConnectorTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpConnectorTest.java
@@ -55,10 +55,10 @@ public final class TcpConnectorTest extends AbstractTcpServerTest {
 
     private static void testWriteAndRead(NettyConnection<Buffer, Buffer> connection)
             throws ExecutionException, InterruptedException {
-        connection.writeAndFlush(connection.executionContext().bufferAllocator().fromAscii("Hello")).toFuture().get();
+        connection.writeAndFlush(connection.executionContext().bufferAllocator().fromAscii("Hello")).toVoidFuture().get();
         String response = connection.read().first().map(buffer -> buffer.toString(defaultCharset())).toFuture().get();
         assertThat("Unexpected response.", response, is("Hello"));
-        connection.onClose().toFuture().get();
+        connection.onClose().toVoidFuture().get();
     }
 
     @Test
@@ -71,7 +71,7 @@ public final class TcpConnectorTest extends AbstractTcpServerTest {
     public void testConnectToUnknownPort() throws Exception {
         thrown.expectCause(anyOf(instanceOf(RetryableConnectException.class),
                 instanceOf(ClosedChannelException.class)));
-        serverContext.closeAsync().toFuture().get();
+        serverContext.closeAsync().toVoidFuture().get();
         // Closing the server to increase probability of finding a port on which no one is listening.
         client.connectBlocking(CLIENT_CTX, serverAddress);
     }
@@ -108,7 +108,7 @@ public final class TcpConnectorTest extends AbstractTcpServerTest {
                             return context;
                         })
                 ).toFuture().get();
-        connection.closeAsync().toFuture().get();
+        connection.closeAsync().toVoidFuture().get();
 
         registeredLatch.await();
         activeLatch.await();

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpServerBinderConnectionAcceptorTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpServerBinderConnectionAcceptorTest.java
@@ -147,7 +147,7 @@ public class TcpServerBinderConnectionAcceptorTest extends AbstractTcpServerTest
         try {
             NettyConnection<Buffer, Buffer> connection = client.connectBlocking(CLIENT_CTX, serverAddress);
             final Buffer buffer = connection.executionContext().bufferAllocator().fromAscii("Hello");
-            connection.writeAndFlush(buffer).toFuture().get();
+            connection.writeAndFlush(buffer).toVoidFuture().get();
             Single<Buffer> read = connection.read().first();
             Buffer responseBuffer = awaitIndefinitelyNonNull(read);
             assertEquals("Did not receive response payload echoing request",

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServerContext.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServerContext.java
@@ -46,11 +46,11 @@ public interface ServerContext extends ListenableAsyncCloseable, AutoCloseable {
      * This method will return when {@link #onClose()} terminates either successfully or unsuccessfully.
      */
     default void awaitShutdown() {
-        awaitTermination(onClose().toFuture());
+        awaitTermination(onClose().toVoidFuture());
     }
 
     @Override
     default void close() {
-        awaitTermination(closeAsyncGracefully().toFuture());
+        awaitTermination(closeAsyncGracefully().toVoidFuture());
     }
 }

--- a/servicetalk-transport-api/src/test/java/io/servicetalk/transport/api/ConnectionAcceptorTest.java
+++ b/servicetalk-transport-api/src/test/java/io/servicetalk/transport/api/ConnectionAcceptorTest.java
@@ -59,7 +59,7 @@ public class ConnectionAcceptorTest {
         f.append(original -> new OrderVerifyingConnectionAcceptorAdapter(original, order, 1))
                 .append(original -> new OrderVerifyingConnectionAcceptorAdapter(original, order, 2))
                 .append(original -> new OrderVerifyingConnectionAcceptorAdapter(original, order, 3))
-                .create(ACCEPT_ALL).accept(context).toFuture().get();
+                .create(ACCEPT_ALL).accept(context).toVoidFuture().get();
         assertThat("Unexpected filter order.", order, contains(1, 2, 3));
     }
 

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/ChannelSetTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/ChannelSetTest.java
@@ -149,7 +149,7 @@ public class ChannelSetTest {
         // closeAsyncGracefully must complete.
         closeAsyncGracefullyCompletable.onComplete();
 
-        fixture.onClose().toFuture().get();
+        fixture.onClose().toVoidFuture().get();
 
         subscriberRule1.verifyCompletion();
         subscriberRule2.verifyCompletion();
@@ -166,7 +166,7 @@ public class ChannelSetTest {
         subscriberRule1.listen(gracefulCompletable);
         verify(nettyConnection, never()).closeAsyncGracefully();
 
-        fixture.onClose().toFuture().get();
+        fixture.onClose().toVoidFuture().get();
 
         subscriberRule1.verifyCompletion();
         subscriberRule2.verifyCompletion();
@@ -189,7 +189,7 @@ public class ChannelSetTest {
 
         listener.operationComplete(channelCloseFuture);
 
-        fixture.onClose().toFuture().get();
+        fixture.onClose().toVoidFuture().get();
 
         subscriberRule1.verifyCompletion();
         subscriberRule2.verifyCompletion();
@@ -206,7 +206,7 @@ public class ChannelSetTest {
         subscriberRule2.listen(gracefulCompletable2);
         verify(nettyConnection, times(1)).closeAsyncGracefully();
 
-        gracefulCompletable1.toFuture().get();
+        gracefulCompletable1.toVoidFuture().get();
         subscriberRule2.verifyCompletion();
         verify(channel).close();
     }
@@ -222,7 +222,7 @@ public class ChannelSetTest {
         subscriberRule2.listen(closeCompletable2);
         verify(channel, times(1)).close();
 
-        fixture.onClose().toFuture().get();
+        fixture.onClose().toVoidFuture().get();
 
         subscriberRule1.verifyCompletion();
         subscriberRule2.verifyCompletion();
@@ -234,7 +234,7 @@ public class ChannelSetTest {
         Completable completable = closeAsyncGracefully(fixture, 100, MILLISECONDS);
         subscriberRule1.listen(completable);
         verify(nettyConnection).closeAsyncGracefully();
-        fixture.onClose().toFuture().get();
+        fixture.onClose().toVoidFuture().get();
         verify(channel).close();
         subscriberRule1.verifyCompletion();
     }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
@@ -368,7 +368,7 @@ public class DefaultNettyConnectionTest {
         CloseHandler closeHandler = forPipelinedRequestResponse(true, channel.config());
         setupWithCloseHandler(closeHandler);
         closeListener.listen(conn.onClosing());
-        conn.closeAsyncGracefully().toFuture().get();
+        conn.closeAsyncGracefully().toVoidFuture().get();
         closeListener.verifyCompletion();
     }
 
@@ -377,7 +377,7 @@ public class DefaultNettyConnectionTest {
         CloseHandler closeHandler = forPipelinedRequestResponse(true, channel.config());
         setupWithCloseHandler(closeHandler);
         closeListener.listen(conn.onClosing());
-        conn.closeAsync().toFuture().get();
+        conn.closeAsync().toVoidFuture().get();
         closeListener.verifyCompletion();
     }
 
@@ -487,7 +487,7 @@ public class DefaultNettyConnectionTest {
         channel.pipeline().fireExceptionCaught(DELIBERATE_EXCEPTION);
         toSource(conn.read()).subscribe(subscriber);
         assertThat(subscriber.takeError(), is(DELIBERATE_EXCEPTION));
-        conn.onClose().toFuture().get();
+        conn.onClose().toVoidFuture().get();
     }
 
     @Test
@@ -495,6 +495,6 @@ public class DefaultNettyConnectionTest {
         channel.close().get();
         toSource(conn.read()).subscribe(subscriber);
         assertThat(subscriber.takeError(), instanceOf(ClosedChannelException.class));
-        conn.onClose().toFuture().get();
+        conn.onClose().toVoidFuture().get();
     }
 }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberOutOfEventloopTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberOutOfEventloopTest.java
@@ -105,7 +105,7 @@ public class WriteStreamSubscriberOutOfEventloopTest extends AbstractOutOfEventl
         this.subscriber.onError(DELIBERATE_EXCEPTION);
 
         try {
-            subject.toFuture().get();
+            subject.toVoidFuture().get();
             fail();
         } catch (ExecutionException cause) {
             assertSame(cause.getCause(), DELIBERATE_EXCEPTION);


### PR DESCRIPTION
__Motivation__

`Completable.toSingle()`, `Completable.toCompletionStage()` and `Completable.toFuture()` converts to a source which emits a value.
These conversions today emit a `null` which may be surprising. We should provide a way for users to specify a "default result"

__Modification__

- Added new methods `toVoid*()` to preserve the old behavior. These methods are useful for cases when the user actually do not care about a value. eg: completable.toVoidSingle().flatMap(__ -> success("Hello"), completable.toFuture.get()
- Modified `to*` methods to take a `Supplier<T>`

__Result__

Intuitive no-value => value based source conversions.