### PR TITLE
Simplify TestSubscription wait implementation

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionTest.java
@@ -145,7 +145,7 @@ public class NettyHttpServerConnectionTest {
         String payloadBodyString = "foo";
         TestSubscription testSubscription1 = new TestSubscription();
         responsePublisher.onSubscribe(testSubscription1);
-        testSubscription1.waitUntilRequested(1);
+        testSubscription1.awaitRequestNUninterruptibly(1);
         responsePublisher.onNext(DEFAULT_ALLOCATOR.fromAscii(payloadBodyString));
         responsePublisher.onComplete();
         customFlushSender.flush();

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyPipelinedConnectionTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyPipelinedConnectionTest.java
@@ -190,7 +190,7 @@ public class DefaultNettyPipelinedConnectionTest {
         toSource(requester.request(writePublisher2)).subscribe(secondReadSubscriber);
         secondReadSubscriber.request(1);
         readSubscriber.cancel();
-        testSubscription.waitUntilCancelled();
+        testSubscription.awaitCancelledUninterruptibly();
         assertTrue(writePublisher2.isSubscribed());
         writePublisher2.onNext(1);
         writePublisher2.onComplete();


### PR DESCRIPTION
Motivation:
TestSubscription supports waiting for requestN demand and cancellation, however it uses LockSupport to accomplish this. We can just use simpler synchornized, notifyAll, and wait to simplify the concurrency instead.

Modifications:
- Remove the LockSupport code in TestSubscription and just use synchornized, notifyAll, and wait.

Result:
Simplified concurrency code in TestSubscription.