### PR TITLE
Completable.repeat() should return a Publisher

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -608,13 +608,17 @@ public abstract class Completable {
      * }</pre>
      *
      * @param shouldRepeat {@link IntPredicate} that given the repeat count determines if the operation should be
-     * repeated.
-     * @return A {@link Completable} that completes after all re-subscriptions completes.
+     * repeated
+     * @param valueSupplier {@link Supplier} that is called every time this {@link Completable} completes. The value
+     * returned is emitted from the returned {@link Publisher}
+     * @param <T> Type of items provided by the passed {@link Supplier} and emitted by the returned {@link Publisher}.
+     * @return A {@link Publisher} that emits the value returned by the passed {@link Supplier} everytime this
+     * {@link Completable} completes.
      *
      * @see <a href="http://reactivex.io/documentation/operators/repeat.html">ReactiveX repeat operator.</a>
      */
-    public final Completable repeat(IntPredicate shouldRepeat) {
-        return toPublisher().repeat(shouldRepeat).ignoreElements();
+    public final <T> Publisher<T> repeat(IntPredicate shouldRepeat, Supplier<T> valueSupplier) {
+        return toSingle().map(__ -> valueSupplier.get()).repeat(shouldRepeat);
     }
 
     /**
@@ -639,13 +643,15 @@ public abstract class Completable {
      * @param repeatWhen {@link IntFunction} that given the repeat count returns a {@link Completable}.
      * If this {@link Completable} emits an error repeat is terminated, otherwise, original {@link Completable} is
      * re-subscribed when this {@link Completable} completes.
-     *
+     * @param valueSupplier {@link Supplier} that is called every time this {@link Completable} completes. The value
+     * returned is emitted from the returned {@link Publisher}
+     * @param <T> Type of items provided by the passed {@link Supplier} and emitted by the returned {@link Publisher}.
      * @return A {@link Completable} that completes after all re-subscriptions completes.
      *
      * @see <a href="http://reactivex.io/documentation/operators/retry.html">ReactiveX retry operator.</a>
      */
-    public final Completable repeatWhen(IntFunction<Completable> repeatWhen) {
-        return toPublisher().repeatWhen(repeatWhen).ignoreElements();
+    public final <T> Publisher<T> repeatWhen(IntFunction<Completable> repeatWhen, Supplier<T> valueSupplier) {
+        return toSingle().map(__ -> valueSupplier.get()).repeatWhen(repeatWhen);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
@@ -18,6 +18,7 @@ package io.servicetalk.concurrent.api;
 import java.time.Duration;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.IntFunction;
+import java.util.function.Supplier;
 
 import static io.servicetalk.concurrent.api.Completable.error;
 import static java.util.Objects.requireNonNull;
@@ -25,7 +26,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
  * A set of strategies to use for repeating with {@link Publisher#repeatWhen(IntFunction)}, {@link Single#repeatWhen(IntFunction)}
- * and {@link Completable#repeatWhen(IntFunction)} or in general.
+ * and {@link Completable#repeatWhen(IntFunction, Supplier)} or in general.
  */
 public final class RepeatStrategies {
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/RepeatTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/RepeatTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api.completable;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+
+import static io.servicetalk.concurrent.api.Completable.completed;
+import static io.servicetalk.concurrent.api.Completable.error;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+public class RepeatTest {
+
+    @Test
+    public void repeatValueSupplier() throws Exception {
+        Collection<Integer> repeats = completed().repeat(count -> count < 2, new Supplier<Integer>() {
+            private int count;
+
+            @Override
+            public Integer get() {
+                return ++count;
+            }
+        }).toFuture().get();
+        assertThat("Unexpected items received.", repeats, contains(1, 2));
+    }
+
+    @Test
+    public void repeatWhenValueSupplier() throws Exception {
+        Collection<Integer> repeats = completed().repeatWhen(count ->
+                        count < 2 ? completed() : error(DELIBERATE_EXCEPTION),
+                new Supplier<Integer>() {
+                    private int count;
+
+                    @Override
+                    public Integer get() {
+                        return ++count;
+                    }
+                }).toFuture().get();
+        assertThat("Unexpected items received.", repeats, contains(1, 2));
+    }
+}


### PR DESCRIPTION
__Motivation__

Today Completable.repeat() returns a Completable, this has a few disadvantages:

- Inconsistency with Single#repeat() which returns a Publisher.
- Naturally repeat of an action that provides a single result (termination in this case), should produce multiple items (null for Completable). For cases, when multiple items are not required, one can use ignoreElements() to convert it back to a Completable. repeat() itself returning a Publisher makes it impossible to then convert to multi-values as the returned Completable only terminates when all repeats have terminated.
- Since, Executor#timer() returns a Completable, using exec.timer(…).repeat() does not provide timer ticks which would be the intent to repeat the timer(). A workaround for this is exec.timer(…).toSingle().repeat() which is OK but is not ideal.

So, we should change Completable.repeat() to return a Publisher<T>.
If someone wants to get a Completable, they can use `repeat().ignoreElements()`

__Modification__

Modified `repeat()` to now take a `Supplier<T>` and return a `Publisher<T>`

__Result__

More useful `repeat()`