### PR TITLE
RedisCommanderTest#transactionExec deleting value before setting it

### DIFF
--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BlockingBufferRedisCommanderTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BlockingBufferRedisCommanderTest.java
@@ -336,16 +336,16 @@ public class BlockingBufferRedisCommanderTest extends BaseRedisClientTest {
     @Test
     public void transactionExec() throws Exception {
         BlockingTransactedBufferRedisCommander tcc = commandClient.multi();
-        Future<Long> value1 = tcc.del(key("a-key"));
-        Future<String> value2 = tcc.set(key("a-key"), buf("a-value3"));
-        Future<Buffer> value3 = tcc.ping(buf("in-transac"));
-        Future<Buffer> value4 = tcc.get(key("a-key"));
+        Future<String> value1 = tcc.set(key("a-key"), buf("a-value3"));
+        Future<Buffer> value2 = tcc.get(key("a-key"));
+        Future<Long> value3 = tcc.del(key("a-key"));
+        Future<Buffer> value4 = tcc.ping(buf("in-transac"));
         tcc.exec();
         postReleaseLatch.await();
-        assertThat(value1.get(), is(1L));
-        assertThat(value2.get(), is("OK"));
-        assertThat(value3.get(), is(buf("in-transac")));
-        assertThat(value4.get(), is(buf("a-value3")));
+        assertThat(value1.get(), is("OK"));
+        assertThat(value2.get(), is(buf("a-value3")));
+        assertThat(value3.get(), is(1L));
+        assertThat(value4.get(), is(buf("in-transac")));
     }
 
     @Test

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BlockingRedisCommanderTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BlockingRedisCommanderTest.java
@@ -324,16 +324,16 @@ public class BlockingRedisCommanderTest extends BaseRedisClientTest {
     @Test
     public void transactionExec() throws Exception {
         BlockingTransactedRedisCommander tcc = commandClient.multi();
-        Future<Long> value1 = tcc.del(key("a-key"));
-        Future<String> value2 = tcc.set(key("a-key"), "a-value3");
-        Future<String> value3 = tcc.ping("in-transac");
-        Future<String> value4 = tcc.get(key("a-key"));
+        Future<String> value1 = tcc.set(key("a-key"), "a-value3");
+        Future<String> value2 = tcc.get(key("a-key"));
+        Future<Long> value3 = tcc.del(key("a-key"));
+        Future<String> value4 = tcc.ping("in-transac");
         tcc.exec();
         postReleaseLatch.await();
-        assertThat(value1.get(), is(1L));
-        assertThat(value2.get(), is("OK"));
-        assertThat(value3.get(), is("in-transac"));
-        assertThat(value4.get(), is("a-value3"));
+        assertThat(value1.get(), is("OK"));
+        assertThat(value2.get(), is("a-value3"));
+        assertThat(value3.get(), is(1L));
+        assertThat(value4.get(), is("in-transac"));
     }
 
     @Test

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BufferRedisCommanderTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BufferRedisCommanderTest.java
@@ -339,16 +339,16 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
     @Test
     public void transactionExec() throws Exception {
         final TransactedBufferRedisCommander tcc = awaitIndefinitelyNonNull(commandClient.multi());
-        Future<Long> value1 = tcc.del(key("a-key"));
-        Future<String> value2 = tcc.set(key("a-key"), buf("a-value3"));
-        Future<Buffer> value3 = tcc.ping(buf("in-transac"));
-        Future<Buffer> value4 = tcc.get(key("a-key"));
+        Future<String> value1 = tcc.set(key("a-key"), buf("a-value3"));
+        Future<Buffer> value2 = tcc.get(key("a-key"));
+        Future<Long> value3 = tcc.del(key("a-key"));
+        Future<Buffer> value4 = tcc.ping(buf("in-transac"));
         tcc.exec().toFuture().get();
         postReleaseLatch.await();
-        assertThat(value1.get(), is(1L));
-        assertThat(value2.get(), is("OK"));
-        assertThat(value3.get(), is(buf("in-transac")));
-        assertThat(value4.get(), is(buf("a-value3")));
+        assertThat(value1.get(), is("OK"));
+        assertThat(value2.get(), is(buf("a-value3")));
+        assertThat(value3.get(), is(1L));
+        assertThat(value4.get(), is(buf("in-transac")));
     }
 
     @Test

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisCommanderTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisCommanderTest.java
@@ -327,16 +327,16 @@ public class RedisCommanderTest extends BaseRedisClientTest {
     public void transactionExec() throws Exception {
         commandClient.set(key("a-key"), "prior").toFuture().get();
         final TransactedRedisCommander tcc = awaitIndefinitelyNonNull(commandClient.multi());
-        Future<Long> value1 = tcc.del(key("a-key"));
-        Future<String> value2 = tcc.set(key("a-key"), "a-value3");
-        Future<String> value3 = tcc.ping("in-transac");
-        Future<String> value4 = tcc.get(key("a-key"));
+        Future<String> value1 = tcc.set(key("a-key"), "a-value3");
+        Future<String> value2 = tcc.get(key("a-key"));
+        Future<Long> value3 = tcc.del(key("a-key"));
+        Future<String> value4 = tcc.ping("in-transac");
         tcc.exec().toFuture().get();
         postReleaseLatch.await();
-        assertThat(value1.get(), is(1L));
-        assertThat(value2.get(), is("OK"));
-        assertThat(value3.get(), is("in-transac"));
-        assertThat(value4.get(), is("a-value3"));
+        assertThat(value1.get(), is("OK"));
+        assertThat(value2.get(), is("a-value3"));
+        assertThat(value3.get(), is(1L));
+        assertThat(value4.get(), is("in-transac"));
     }
 
     @Test


### PR DESCRIPTION
Motivation:
RedisCommanderTest#transactionExec (and other API variations) is deleting a key before setting it, and asserting that the key was deleted. Other tests also happen to set this key but depending upon test execution order this key may not be set and the test may fail.

Modifications:
- The test should set, get, del, ping

Result:
Fixes https://github.com/servicetalk/servicetalk/issues/356