### PR TITLE
Remove Supplier arguments from Completable#repeat[When]

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -609,16 +609,14 @@ public abstract class Completable {
      *
      * @param shouldRepeat {@link IntPredicate} that given the repeat count determines if the operation should be
      * repeated
-     * @param valueSupplier {@link Supplier} that is called every time this {@link Completable} completes. The value
-     * returned is emitted from the returned {@link Publisher}
      * @param <T> Type of items provided by the passed {@link Supplier} and emitted by the returned {@link Publisher}.
      * @return A {@link Publisher} that emits the value returned by the passed {@link Supplier} everytime this
      * {@link Completable} completes.
      *
      * @see <a href="http://reactivex.io/documentation/operators/repeat.html">ReactiveX repeat operator.</a>
      */
-    public final <T> Publisher<T> repeat(IntPredicate shouldRepeat, Supplier<? extends T> valueSupplier) {
-        return toSingle().<T>map(__ -> valueSupplier.get()).repeat(shouldRepeat);
+    public final <T> Publisher<T> repeat(IntPredicate shouldRepeat) {
+        return this.<T>toSingle().repeat(shouldRepeat);
     }
 
     /**
@@ -643,16 +641,13 @@ public abstract class Completable {
      * @param repeatWhen {@link IntFunction} that given the repeat count returns a {@link Completable}.
      * If this {@link Completable} emits an error repeat is terminated, otherwise, original {@link Completable} is
      * re-subscribed when this {@link Completable} completes.
-     * @param valueSupplier {@link Supplier} that is called every time this {@link Completable} completes. The value
-     * returned is emitted from the returned {@link Publisher}
      * @param <T> Type of items provided by the passed {@link Supplier} and emitted by the returned {@link Publisher}.
      * @return A {@link Completable} that completes after all re-subscriptions completes.
      *
      * @see <a href="http://reactivex.io/documentation/operators/retry.html">ReactiveX retry operator.</a>
      */
-    public final <T> Publisher<T> repeatWhen(IntFunction<? extends Completable> repeatWhen,
-                                             Supplier<? extends T> valueSupplier) {
-        return toSingle().<T>map(__ -> valueSupplier.get()).repeatWhen(repeatWhen);
+    public final <T> Publisher<T> repeatWhen(IntFunction<? extends Completable> repeatWhen) {
+        return this.<T>toSingle().repeatWhen(repeatWhen);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
@@ -18,15 +18,14 @@ package io.servicetalk.concurrent.api;
 import java.time.Duration;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.IntFunction;
-import java.util.function.Supplier;
 
 import static io.servicetalk.concurrent.api.Completable.error;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
- * A set of strategies to use for repeating with {@link Publisher#repeatWhen(IntFunction)}, {@link Single#repeatWhen(IntFunction)}
- * and {@link Completable#repeatWhen(IntFunction, Supplier)} or in general.
+ * A set of strategies to use for repeating with {@link Publisher#repeatWhen(IntFunction)},
+ * {@link Single#repeatWhen(IntFunction)} and {@link Completable#repeatWhen(IntFunction)} or in general.
  */
 public final class RepeatStrategies {
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/RepeatTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/RepeatTest.java
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api.completable;
 import org.junit.Test;
 
 import java.util.Collection;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Completable.error;
@@ -30,11 +30,11 @@ public class RepeatTest {
 
     @Test
     public void repeatValueSupplier() throws Exception {
-        Collection<Integer> repeats = completed().repeat(count -> count < 2, new Supplier<Integer>() {
+        Collection<Integer> repeats = completed().repeat(count -> count < 2).map(new Function<Object, Integer>() {
             private int count;
 
             @Override
-            public Integer get() {
+            public Integer apply(final Object o) {
                 return ++count;
             }
         }).toFuture().get();
@@ -44,15 +44,14 @@ public class RepeatTest {
     @Test
     public void repeatWhenValueSupplier() throws Exception {
         Collection<Integer> repeats = completed().repeatWhen(count ->
-                        count < 2 ? completed() : error(DELIBERATE_EXCEPTION),
-                new Supplier<Integer>() {
-                    private int count;
-
-                    @Override
-                    public Integer get() {
-                        return ++count;
-                    }
-                }).toFuture().get();
+                        count < 2 ? completed() : error(DELIBERATE_EXCEPTION)).map(
+            new Function<Object, Integer>() {
+                private int count;
+            @Override
+            public Integer apply(final Object o) {
+                return ++count;
+            }
+        }).toFuture().get();
         assertThat("Unexpected items received.", repeats, contains(1, 2));
     }
 }


### PR DESCRIPTION
Motivation:
Completable#repeat[When] operators currently require a Supplier argument. However the same can be accomplished via applying a map operator externally. We should keep operator signatures minimal and rely upon composabilty when possible.

Modifications:
- Remove Supplier argument from Completable#repeat[When] operators

Result:
More minimal operators that rely upon composition.