### PR TITLE
Test sources incorrectly named an internal method.

### DIFF
--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestCompletable.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestCompletable.java
@@ -82,7 +82,6 @@ public final class TestCompletable extends Completable implements CompletableSou
                 Subscriber currSubscriber = this.subscriber;
                 if (subscriberUpdater.compareAndSet(this, currSubscriber, newSubscriber)) {
                     if (currSubscriber instanceof WaitingSubscriber) {
-                        @SuppressWarnings("unchecked")
                         final WaitingSubscriber waiter = (WaitingSubscriber) currSubscriber;
                         waiter.realSubscriber(newSubscriber);
                     }
@@ -316,24 +315,24 @@ public final class TestCompletable extends Completable implements CompletableSou
 
         @Override
         public void onSubscribe(final Cancellable cancellable) {
-            waitForSubscription().onSubscribe(cancellable);
+            waitForSubscriber().onSubscribe(cancellable);
         }
 
         @Override
         public void onComplete() {
-            waitForSubscription().onComplete();
+            waitForSubscriber().onComplete();
         }
 
         @Override
         public void onError(final Throwable t) {
-            waitForSubscription().onError(t);
+            waitForSubscriber().onError(t);
         }
 
         void realSubscriber(Subscriber subscriber) {
             realSubscriberSingle.onSuccess(subscriber);
         }
 
-        private Subscriber waitForSubscription() {
+        private Subscriber waitForSubscriber() {
             try {
                 return realSubscriberSingle.toFuture().get();
             } catch (InterruptedException | ExecutionException e) {

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestPublisher.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestPublisher.java
@@ -373,29 +373,29 @@ public final class TestPublisher<T> extends Publisher<T> implements PublisherSou
 
         @Override
         public void onSubscribe(final Subscription subscription) {
-            waitForSubscription().onSubscribe(subscription);
+            waitForSubscriber().onSubscribe(subscription);
         }
 
         @Override
         public void onNext(@Nullable final T t) {
-            waitForSubscription().onNext(t);
+            waitForSubscriber().onNext(t);
         }
 
         @Override
         public void onError(final Throwable t) {
-            waitForSubscription().onError(t);
+            waitForSubscriber().onError(t);
         }
 
         @Override
         public void onComplete() {
-            waitForSubscription().onComplete();
+            waitForSubscriber().onComplete();
         }
 
         void realSubscriber(Subscriber<? super T> subscriber) {
             realSubscriberSingle.onSuccess(subscriber);
         }
 
-        private Subscriber<? super T> waitForSubscription() {
+        private Subscriber<? super T> waitForSubscriber() {
             try {
                 return realSubscriberSingle.toFuture().get();
             } catch (InterruptedException | ExecutionException e) {

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestSingle.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestSingle.java
@@ -320,24 +320,24 @@ public final class TestSingle<T> extends Single<T> implements SingleSource<T> {
 
         @Override
         public void onSubscribe(final Cancellable cancellable) {
-            waitForSubscription().onSubscribe(cancellable);
+            waitForSubscriber().onSubscribe(cancellable);
         }
 
         @Override
         public void onSuccess(@Nullable final T t) {
-            waitForSubscription().onSuccess(t);
+            waitForSubscriber().onSuccess(t);
         }
 
         @Override
         public void onError(final Throwable t) {
-            waitForSubscription().onError(t);
+            waitForSubscriber().onError(t);
         }
 
         void realSubscriber(Subscriber<? super T> subscriber) {
             realSubscriberSingle.onSuccess(subscriber);
         }
 
-        private Subscriber<? super T> waitForSubscription() {
+        private Subscriber<? super T> waitForSubscriber() {
             try {
                 return realSubscriberSingle.toFuture().get();
             } catch (InterruptedException | ExecutionException e) {


### PR DESCRIPTION
__Motivation__

`WaitingSubscriber` in the different test sources named a method as `waitForSubscription` when actually it waits for `Subscriber`

__Modification__

Renamed the method to `waitForSubscriber`

__Result__

Name matches the implementation.