### PR TITLE
Re-enable SubscriberUtilsTest#calculateSourceRequestedConcurrentE

### DIFF
--- a/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/SubscriberUtilsTest.java
+++ b/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/SubscriberUtilsTest.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.concurrent.internal;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -25,7 +24,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -101,7 +99,8 @@ public class SubscriberUtilsTest {
         emitted = Long.MAX_VALUE - 4;
         requestN = Long.MAX_VALUE;
         sourceRequested = Long.MAX_VALUE - 3;
-        assertEquals(3, calculateSourceRequested(requestNUpdater, sourceRequestedUpdater, emittedUpdater, Integer.MAX_VALUE, this));
+        assertEquals(3, calculateSourceRequested(requestNUpdater, sourceRequestedUpdater, emittedUpdater,
+                Integer.MAX_VALUE, this));
         assertEquals(Long.MAX_VALUE - 4, emitted);
         assertEquals(Long.MAX_VALUE, requestN);
         assertEquals(Long.MAX_VALUE, sourceRequested);
@@ -112,45 +111,48 @@ public class SubscriberUtilsTest {
         emitted = Long.MAX_VALUE - Integer.MAX_VALUE;
         requestN = Long.MAX_VALUE;
         sourceRequested = Long.MAX_VALUE - Integer.MAX_VALUE;
-        assertEquals(Integer.MAX_VALUE, calculateSourceRequested(requestNUpdater, sourceRequestedUpdater, emittedUpdater, Integer.MAX_VALUE, this));
+        assertEquals(Integer.MAX_VALUE, calculateSourceRequested(requestNUpdater, sourceRequestedUpdater,
+                emittedUpdater, Integer.MAX_VALUE, this));
         assertEquals(Long.MAX_VALUE - Integer.MAX_VALUE, emitted);
         assertEquals(Long.MAX_VALUE, requestN);
         assertEquals(Long.MAX_VALUE, sourceRequested);
     }
 
     @Test
-    public void calculateSourceRequestedConcurrentA() throws InterruptedException, ExecutionException, BrokenBarrierException {
-        calculateSourceRequestedConcurrentLoop(1000, 1, 3, 10, 10);
+    public void calculateSourceRequestedConcurrentA() throws Exception {
+        calculateSourceRequestedConcurrentLoop(333, 1, 3, 10, 10);
     }
 
     @Test
-    public void calculateSourceRequestedConcurrentB() throws InterruptedException, ExecutionException, BrokenBarrierException {
-        calculateSourceRequestedConcurrentLoop(100, 10, 6, 100, 123456);
+    public void calculateSourceRequestedConcurrentB() throws Exception {
+        calculateSourceRequestedConcurrentLoop(50, 5, 6, 100, 123456);
     }
 
     @Test
-    public void calculateSourceRequestedConcurrentC() throws InterruptedException, ExecutionException, BrokenBarrierException {
-        calculateSourceRequestedConcurrentLoop(20, 1, 3, 2, 900103);
+    public void calculateSourceRequestedConcurrentC() throws Exception {
+        calculateSourceRequestedConcurrentLoop(10, 1, 3, 2, 900103);
     }
 
     @Test
-    public void calculateSourceRequestedConcurrentD() throws InterruptedException, ExecutionException, BrokenBarrierException {
-        calculateSourceRequestedConcurrentLoop(1000, 1, 5635, 483, 800026);
+    public void calculateSourceRequestedConcurrentD() throws Exception {
+        calculateSourceRequestedConcurrentLoop(123, 1, 5635, 483, 800026);
     }
 
-    @Ignore("Test is flaky on CI")
     @Test
-    public void calculateSourceRequestedConcurrentE() throws InterruptedException, ExecutionException, BrokenBarrierException {
-        calculateSourceRequestedConcurrentLoop(1000, 7, 512, Integer.MAX_VALUE, 1000001);
+    public void calculateSourceRequestedConcurrentE() throws Exception {
+        calculateSourceRequestedConcurrentLoop(222, 6, 512, Integer.MAX_VALUE, 1000001);
     }
 
-    private void calculateSourceRequestedConcurrentLoop(final int iterations, final int consumerThreads, final int limit, final int maxRequest, final int totalExpectedCount) throws ExecutionException, InterruptedException, BrokenBarrierException {
+    private void calculateSourceRequestedConcurrentLoop(final int iterations, final int consumerThreads,
+                                                        final int limit, final int maxRequest,
+                                                        final int totalExpectedCount) throws Exception {
         for (int i = 0; i < iterations; ++i) {
             calculateSourceRequestedConcurrent(consumerThreads, limit, maxRequest, totalExpectedCount);
         }
     }
 
-    private void calculateSourceRequestedConcurrent(final int consumerThreads, final int limit, final int maxRequest, final int totalExpectedCount) throws ExecutionException, InterruptedException, BrokenBarrierException {
+    private void calculateSourceRequestedConcurrent(final int consumerThreads, final int limit, final int maxRequest,
+                                                    final int totalExpectedCount) throws Exception {
         assert consumerThreads > 0;
         requestN = 0;
         sourceRequested = 0;
@@ -173,14 +175,15 @@ public class SubscriberUtilsTest {
                 final Random random = ThreadLocalRandom.current();
                 while (produced < totalExpectedCount) {
                     int localProduced = random.nextInt(maxRequest) + 1;
-                    if (localProduced + produced > totalExpectedCount) {
+                    if (produced > totalExpectedCount - localProduced) {
                         localProduced = totalExpectedCount - produced;
                         produced = totalExpectedCount;
                     } else {
                         produced += localProduced;
                     }
                     requestNUpdater.addAndGet(this, localProduced);
-                    int amount = calculateSourceRequested(requestNUpdater, sourceRequestedUpdater, emittedUpdater, limit, this);
+                    int amount = calculateSourceRequested(requestNUpdater, sourceRequestedUpdater, emittedUpdater,
+                            limit, this);
                     assertTrue("invalid increment: " + amount, amount <= limit && amount >= 0);
                     totalCount.addAndGet(amount);
                     totalCountNotConsumed.addAndGet(amount);
@@ -207,13 +210,15 @@ public class SubscriberUtilsTest {
                                 continue;
                             }
                             localConsumed = random.nextInt(totalNotConsumed) + 1;
-                            if (totalCountNotConsumed.compareAndSet(totalNotConsumed, totalNotConsumed - localConsumed)) {
+                            if (totalCountNotConsumed.compareAndSet(totalNotConsumed,
+                                    totalNotConsumed - localConsumed)) {
                                 break;
                             }
                         }
                         totalCountConsumed.addAndGet(localConsumed);
                         emittedUpdater.addAndGet(this, localConsumed);
-                        int amount = calculateSourceRequested(requestNUpdater, sourceRequestedUpdater, emittedUpdater, limit, this);
+                        int amount = calculateSourceRequested(requestNUpdater, sourceRequestedUpdater, emittedUpdater,
+                                limit, this);
                         assertTrue("invalid decrement: " + amount, amount <= limit && amount >= 0);
                         totalCount.addAndGet(amount);
                         totalCountNotConsumed.addAndGet(amount);


### PR DESCRIPTION
Motivation:
SubscriberUtilsTest#calculateSourceRequestedConcurrentE is ignored. We should un-ignore it to ensure our concurrent utilities are working correctly.

Modifications:
- Reduce the parameters for the calculateSourceRequestedConcurrent tests to make them less demanding on CI where they may take 40+ seconds.

Result:
More SubscriberUtilsTest tests that take less time.