### PR TITLE
AsyncContext API wrap method rename

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractAsynchronousCompletableOperator.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractAsynchronousCompletableOperator.java
@@ -48,7 +48,7 @@ abstract class AbstractAsynchronousCompletableOperator extends AbstractNoHandleS
         // with the original contextMap. Otherwise some other context may leak into this subscriber chain from the other
         // side of the asynchronous boundary.
         final Subscriber operatorSubscriber = signalOffloader.offloadSubscriber(
-                contextProvider.wrap(subscriber, contextMap));
+                contextProvider.wrapCompletableSubscriber(subscriber, contextMap));
         // Subscriber to use to subscribe to the original source. Since this is an asynchronous operator, it may call
         // Cancellable method from EventLoop (if the asynchronous source created/obtained inside this operator uses
         // EventLoop) which may execute blocking code on EventLoop, eg: doBeforeCancel(). So, we should offload

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractAsynchronousPublisherOperator.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractAsynchronousPublisherOperator.java
@@ -51,7 +51,7 @@ abstract class AbstractAsynchronousPublisherOperator<T, R> extends AbstractNoHan
         // with the original contextMap. Otherwise some other context may leak into this subscriber chain from the other
         // side of the asynchronous boundary.
         final Subscriber<? super R> operatorSubscriber = signalOffloader.offloadSubscriber(
-                contextProvider.wrap(subscriber, contextMap));
+                contextProvider.wrapPublisherSubscriber(subscriber, contextMap));
         // Subscriber to use to subscribe to the original source. Since this is an asynchronous operator, it may call
         // Subscription methods from EventLoop (if the asynchronous source created/obtained inside this operator uses
         // EventLoop) which may execute blocking code on EventLoop, eg: doBeforeRequest(). So, we should offload

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractAsynchronousSingleOperator.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractAsynchronousSingleOperator.java
@@ -51,7 +51,7 @@ abstract class AbstractAsynchronousSingleOperator<T, R> extends AbstractNoHandle
         // with the original contextMap. Otherwise some other context may leak into this subscriber chain from the other
         // side of the asynchronous boundary.
         final Subscriber<? super R> operatorSubscriber = signalOffloader.offloadSubscriber(
-                contextProvider.wrap(subscriber, contextMap));
+                contextProvider.wrapSingleSubscriber(subscriber, contextMap));
         // Subscriber to use to subscribe to the original source. Since this is an asynchronous operator, it may call
         // Cancellable method from EventLoop (if the asynchronous source created/obtained inside this operator uses
         // EventLoop) which may execute blocking code on EventLoop, eg: doBeforeCancel(). So, we should offload

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractMergeCompletableOperator.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractMergeCompletableOperator.java
@@ -45,7 +45,7 @@ abstract class AbstractMergeCompletableOperator extends AbstractNoHandleSubscrib
         // with the original contextMap. Otherwise some other context may leak into this subscriber chain from the other
         // side of the asynchronous boundary.
         final Subscriber operatorSubscriber = signalOffloader.offloadSubscriber(
-                contextProvider.wrap(subscriber, contextMap));
+                contextProvider.wrapCompletableSubscriber(subscriber, contextMap));
         MergeSubscriber mergeSubscriber = apply(operatorSubscriber);
         // Subscriber to use to subscribe to the original source. Since this is an asynchronous operator, it may call
         // Cancellable method from EventLoop (if the asynchronous source created/obtained inside this operator uses

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractSynchronousCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractSynchronousCompletable.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.CompletableSource.Subscriber;
 import io.servicetalk.concurrent.internal.SignalOffloader;
 
 /**
@@ -33,7 +32,8 @@ abstract class AbstractSynchronousCompletable extends AbstractNoHandleSubscribeC
         //
         // We need to wrap the Subscriber to save/restore the AsyncContext on each operation or else the AsyncContext
         // may leak from another thread.
-        doSubscribe(signalOffloader.offloadSubscriber(contextProvider.wrap(subscriber, contextMap)));
+        doSubscribe(signalOffloader.offloadSubscriber(
+                contextProvider.wrapCompletableSubscriber(subscriber, contextMap)));
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractSynchronousPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractSynchronousPublisher.java
@@ -33,7 +33,7 @@ abstract class AbstractSynchronousPublisher<T> extends AbstractNoHandleSubscribe
         //
         // We need to wrap the Subscriber to save/restore the AsyncContext on each operation or else the AsyncContext
         // may leak from another thread.
-        doSubscribe(signalOffloader.offloadSubscriber(contextProvider.wrap(subscriber, contextMap)));
+        doSubscribe(signalOffloader.offloadSubscriber(contextProvider.wrapPublisherSubscriber(subscriber, contextMap)));
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractSynchronousSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractSynchronousSingle.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.SingleSource.Subscriber;
 import io.servicetalk.concurrent.internal.SignalOffloader;
 
 /**
@@ -34,7 +33,7 @@ abstract class AbstractSynchronousSingle<T> extends AbstractNoHandleSubscribeSin
         //
         // We need to wrap the Subscriber to save/restore the AsyncContext on each operation or else the AsyncContext
         // may leak from another thread.
-        doSubscribe(signalOffloader.offloadSubscriber(contextProvider.wrap(subscriber, contextMap)));
+        doSubscribe(signalOffloader.offloadSubscriber(contextProvider.wrapSingleSubscriber(subscriber, contextMap)));
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContext.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContext.java
@@ -72,15 +72,6 @@ public final class AsyncContext {
     }
 
     /**
-     * Restores a previously saved {@link AsyncContextMap}.
-     *
-     * @param contextMap the {@link AsyncContextMap} to use.
-     */
-    public static void replace(AsyncContextMap contextMap) {
-        provider().contextMap(contextMap);
-    }
-
-    /**
      * Convenience method for adding a value to the current context.
      *
      * @param key   the key used to index {@code value}. Cannot be {@code null}.
@@ -185,8 +176,8 @@ public final class AsyncContext {
      * @param executor The executor to wrap.
      * @return The wrapped executor.
      */
-    public static java.util.concurrent.Executor wrap(java.util.concurrent.Executor executor) {
-        return provider().wrap(executor);
+    public static java.util.concurrent.Executor wrapJdkExecutor(java.util.concurrent.Executor executor) {
+        return provider().wrapJdkExecutor(executor);
     }
 
     /**
@@ -195,8 +186,8 @@ public final class AsyncContext {
      * @param executor The executor to wrap.
      * @return The wrapped executor.
      */
-    public static Executor wrap(Executor executor) {
-        return provider().wrap(executor);
+    public static Executor wrapExecutor(Executor executor) {
+        return provider().wrapExecutor(executor);
     }
 
     /**
@@ -204,8 +195,8 @@ public final class AsyncContext {
      * @param executor The executor to wrap.
      * @return The wrapped executor.
      */
-    public static ExecutorService wrap(ExecutorService executor) {
-        return provider().wrap(executor);
+    public static ExecutorService wrapJdkExecutorService(ExecutorService executor) {
+        return provider().wrapJdkExecutorService(executor);
     }
 
     /**
@@ -213,8 +204,8 @@ public final class AsyncContext {
      * @param executor The executor to wrap.
      * @return The wrapped executor.
      */
-    public static ScheduledExecutorService wrap(ScheduledExecutorService executor) {
-        return provider().wrap(executor);
+    public static ScheduledExecutorService wrapJdkScheduledExecutorService(ScheduledExecutorService executor) {
+        return provider().wrapJdkScheduledExecutorService(executor);
     }
 
     /**
@@ -222,9 +213,9 @@ public final class AsyncContext {
      * @param runnable The runnable to wrap.
      * @return The wrapped {@link Runnable}.
      */
-    public static Runnable wrap(Runnable runnable) {
+    public static Runnable wrapRunnable(Runnable runnable) {
         AsyncContextProvider provider = provider();
-        return provider.wrap(runnable, provider.contextMap());
+        return provider.wrapRunnable(runnable, provider.contextMap());
     }
 
     /**
@@ -233,9 +224,9 @@ public final class AsyncContext {
      * @param <T> The type of data consumed by {@code consumer}.
      * @return The wrapped {@link Consumer}.
      */
-    public static <T> Consumer<T> wrap(Consumer<T> consumer) {
+    public static <T> Consumer<T> wrapConsumer(Consumer<T> consumer) {
         AsyncContextProvider provider = provider();
-        return provider.wrap(consumer, provider.contextMap());
+        return provider.wrapConsumer(consumer, provider.contextMap());
     }
 
     /**
@@ -245,9 +236,9 @@ public final class AsyncContext {
      * @param <U> The type of data returned by {@code func}.
      * @return The wrapped {@link Function}.
      */
-    public static <T, U> Function<T, U> wrap(Function<T, U> func) {
+    public static <T, U> Function<T, U> wrapFunction(Function<T, U> func) {
         AsyncContextProvider provider = provider();
-        return provider.wrap(func, provider.contextMap());
+        return provider.wrapFunction(func, provider.contextMap());
     }
 
     /**
@@ -257,9 +248,9 @@ public final class AsyncContext {
      * @param <U> The type of data consumed by {@code func}.
      * @return The wrapped {@link BiConsumer}.
      */
-    public static <T, U> BiConsumer<T, U> wrap(BiConsumer<T, U> consumer) {
+    public static <T, U> BiConsumer<T, U> wrapBiConsume(BiConsumer<T, U> consumer) {
         AsyncContextProvider provider = provider();
-        return provider.wrap(consumer, provider.contextMap());
+        return provider.wrapBiConsumer(consumer, provider.contextMap());
     }
 
     /**
@@ -270,9 +261,9 @@ public final class AsyncContext {
      * @param <V> The type of data returned by {@code func}.
      * @return The wrapped {@link BiFunction}.
      */
-    public static <T, U, V> BiFunction<T, U, V> wrap(BiFunction<T, U, V> func) {
+    public static <T, U, V> BiFunction<T, U, V> wrapBiFunction(BiFunction<T, U, V> func) {
         AsyncContextProvider provider = provider();
-        return provider.wrap(func, provider.contextMap());
+        return provider.wrapBiFunction(func, provider.contextMap());
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextExecutorPlugin.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextExecutorPlugin.java
@@ -24,6 +24,6 @@ final class AsyncContextExecutorPlugin implements ExecutorPlugin {
 
     @Override
     public Executor wrapExecutor(final Executor executor) {
-        return AsyncContext.wrap(executor);
+        return AsyncContext.wrapExecutor(executor);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextProvider.java
@@ -65,7 +65,8 @@ interface AsyncContextProvider {
      * @param current The current {@link AsyncContextMap}.
      * @return The wrapped subscriber.
      */
-    CompletableSource.Subscriber wrap(CompletableSource.Subscriber subscriber, AsyncContextMap current);
+    CompletableSource.Subscriber wrapCompletableSubscriber(CompletableSource.Subscriber subscriber,
+                                                           AsyncContextMap current);
 
     /**
      * Wrap the {@link Cancellable} to ensure it is able to track
@@ -85,7 +86,7 @@ interface AsyncContextProvider {
      * @param <T> Type of the {@link Single}.
      * @return The wrapped subscriber.
      */
-    <T> SingleSource.Subscriber<T> wrap(SingleSource.Subscriber<T> subscriber, AsyncContextMap current);
+    <T> SingleSource.Subscriber<T> wrapSingleSubscriber(SingleSource.Subscriber<T> subscriber, AsyncContextMap current);
 
     /**
      * Wrap an {@link Subscription} to ensure it is able to track {@link AsyncContext} correctly.
@@ -104,35 +105,22 @@ interface AsyncContextProvider {
      * @param <T> the type of element signaled to the {@link Subscriber}.
      * @return The wrapped subscriber.
      */
-    <T> PublisherSource.Subscriber<T> wrap(PublisherSource.Subscriber<T> subscriber, AsyncContextMap current);
+    <T> PublisherSource.Subscriber<T> wrapPublisherSubscriber(PublisherSource.Subscriber<T> subscriber,
+                                                              AsyncContextMap current);
 
     /**
      * Wrap an {@link Executor} to ensure it is able to track {@link AsyncContext} correctly.
      * @param executor The executor to wrap.
      * @return The wrapped executor.
      */
-    java.util.concurrent.Executor wrap(java.util.concurrent.Executor executor);
-
-    /**
-     * Make a best effort to unwrap a {@link Executor} so that it no longer tracks {@link AsyncContext}.
-     * @param executor The {@link Executor} to unwrap.
-     * @return The result of the unwrap attempt.
-     */
-    java.util.concurrent.Executor unwrap(java.util.concurrent.Executor executor);
+    java.util.concurrent.Executor wrapJdkExecutor(java.util.concurrent.Executor executor);
 
     /**
      * Wrap an {@link ExecutorService} to ensure it is able to track {@link AsyncContext} correctly.
      * @param executor The executor to wrap.
      * @return The wrapped executor.
      */
-    ExecutorService wrap(ExecutorService executor);
-
-    /**
-     * Make a best effort to unwrap a {@link ExecutorService} so that it no longer tracks {@link AsyncContext}.
-     * @param executor The {@link ExecutorService} to unwrap.
-     * @return The result of the unwrap attempt.
-     */
-    ExecutorService unwrap(ExecutorService executor);
+    ExecutorService wrapJdkExecutorService(ExecutorService executor);
 
     /**
      * Wrap an {@link Executor} to ensure it is able to track {@link AsyncContext}
@@ -140,15 +128,7 @@ interface AsyncContextProvider {
      * @param executor The executor to wrap.
      * @return The wrapped executor.
      */
-    Executor wrap(Executor executor);
-
-    /**
-     * Make a best effort to unwrap a {@link Executor} so that it no longer tracks
-     * {@link AsyncContext}.
-     * @param executor The executor to unwrap.
-     * @return The result of the unwrap attempt.
-     */
-    io.servicetalk.concurrent.Executor unwrap(io.servicetalk.concurrent.Executor executor);
+    Executor wrapExecutor(Executor executor);
 
     /**
      * Wrap a {@link CompletableFuture} so that {@link AsyncContext} is preserved from listener methods.
@@ -156,21 +136,14 @@ interface AsyncContextProvider {
      * @param <T> The type of data for {@link CompletableFuture}.
      * @return the wrapped {@link CompletableFuture}.
      */
-    <T> CompletableFuture<T> wrap(CompletableFuture<T> future, AsyncContextMap current);
+    <T> CompletableFuture<T> wrapCompletableFuture(CompletableFuture<T> future, AsyncContextMap current);
 
     /**
      * Wrap a {@link ScheduledExecutorService} to ensure it is able to track {@link AsyncContext} correctly.
      * @param executor The executor to wrap.
      * @return The wrapped executor.
      */
-    ScheduledExecutorService wrap(ScheduledExecutorService executor);
-
-    /**
-     * Make a best effort to unwrap a {@link ScheduledExecutorService} so that it no longer tracks {@link AsyncContext}.
-     * @param executor The {@link ScheduledExecutorService} to wrap.
-     * @return The result of the unwrap attempt.
-     */
-    ScheduledExecutorService unwrap(ScheduledExecutorService executor);
+    ScheduledExecutorService wrapJdkScheduledExecutorService(ScheduledExecutorService executor);
 
     /**
      * Wrap a {@link Runnable} to ensure it is able to track {@link AsyncContext} correctly.
@@ -178,7 +151,7 @@ interface AsyncContextProvider {
      * @param contextMap The {@link AsyncContext}.
      * @return The wrapped {@link Runnable}.
      */
-    Runnable wrap(Runnable runnable, AsyncContextMap contextMap);
+    Runnable wrapRunnable(Runnable runnable, AsyncContextMap contextMap);
 
     /**
      * Wrap a {@link Consumer} to ensure it is able to track {@link AsyncContext} correctly.
@@ -187,7 +160,7 @@ interface AsyncContextProvider {
      * @param <T> The type of data consumed by {@code consumer}.
      * @return The wrapped {@link Consumer}.
      */
-    <T> Consumer<T> wrap(Consumer<T> consumer, AsyncContextMap contextMap);
+    <T> Consumer<T> wrapConsumer(Consumer<T> consumer, AsyncContextMap contextMap);
 
     /**
      * Wrap a {@link Consumer} to ensure it is able to track {@link AsyncContext} correctly.
@@ -195,8 +168,8 @@ interface AsyncContextProvider {
      * @param <T> The type of data consumed by {@code consumer}.
      * @return The wrapped {@link Consumer}.
      */
-    default <T> Consumer<T> wrap(Consumer<T> consumer) {
-        return wrap(consumer, contextMap());
+    default <T> Consumer<T> wrapConsumer(Consumer<T> consumer) {
+        return wrapConsumer(consumer, contextMap());
     }
 
     /**
@@ -207,7 +180,7 @@ interface AsyncContextProvider {
      * @param <U> The type of data returned by {@code func}.
      * @return The wrapped {@link Function}.
      */
-    <T, U> Function<T, U> wrap(Function<T, U> func, AsyncContextMap contextMap);
+    <T, U> Function<T, U> wrapFunction(Function<T, U> func, AsyncContextMap contextMap);
 
     /**
      * Wrap a {@link BiFunction} to ensure it is able to track {@link AsyncContext} correctly.
@@ -217,7 +190,7 @@ interface AsyncContextProvider {
      * @param <U> The type of data consumed by {@code func}.
      * @return The wrapped {@link BiConsumer}.
      */
-    <T, U> BiConsumer<T, U> wrap(BiConsumer<T, U> consumer, AsyncContextMap contextMap);
+    <T, U> BiConsumer<T, U> wrapBiConsumer(BiConsumer<T, U> consumer, AsyncContextMap contextMap);
 
     /**
      * Wrap a {@link BiFunction} to ensure it is able to track {@link AsyncContext} correctly.
@@ -228,5 +201,5 @@ interface AsyncContextProvider {
      * @param <V> The type of data returned by {@code func}.
      * @return The wrapped {@link BiFunction}.
      */
-    <T, U, V> BiFunction<T, U, V> wrap(BiFunction<T, U, V> func, AsyncContextMap contextMap);
+    <T, U, V> BiFunction<T, U, V> wrapBiFunction(BiFunction<T, U, V> func, AsyncContextMap contextMap);
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -1546,7 +1546,7 @@ public abstract class Completable {
             subscriber.onError(t);
             return;
         }
-        signalOffloader.offloadSubscribe(offloadedSubscriber, provider.wrap((Consumer<Subscriber>)
+        signalOffloader.offloadSubscribe(offloadedSubscriber, provider.wrapConsumer(
                 s -> handleSubscribe(s, signalOffloader, contextMap, provider), contextMap));
     }
 
@@ -1568,7 +1568,8 @@ public abstract class Completable {
     void handleSubscribe(Subscriber subscriber, SignalOffloader signalOffloader, AsyncContextMap contextMap,
                          AsyncContextProvider contextProvider) {
         try {
-            Subscriber offloaded = signalOffloader.offloadSubscriber(contextProvider.wrap(subscriber, contextMap));
+            Subscriber offloaded = signalOffloader.offloadSubscriber(
+                    contextProvider.wrapCompletableSubscriber(subscriber, contextMap));
             handleSubscribe(offloaded);
         } catch (Throwable t) {
             LOGGER.warn("Unexpected exception from subscribe(), assuming no interaction with the Subscriber.", t);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableConcatWithCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableConcatWithCompletable.java
@@ -56,7 +56,8 @@ final class CompletableConcatWithCompletable extends AbstractNoHandleSubscribeCo
         // eventloop. Important thing to note is that once the next Completable is subscribed we never touch the
         // Cancellable of the original Completable. So, we do not need to do anything special there.
         // In order to cover for this case ((2) above) we always offload the passed Subscriber here.
-        Subscriber offloadSubscriber = offloader.offloadSubscriber(contextProvider.wrap(subscriber, contextMap));
+        Subscriber offloadSubscriber = offloader.offloadSubscriber(
+                contextProvider.wrapCompletableSubscriber(subscriber, contextMap));
         original.delegateSubscribe(new ConcatWithSubscriber(offloadSubscriber, next), offloader,
                 contextMap, contextProvider);
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableConcatWithSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableConcatWithSingle.java
@@ -60,7 +60,7 @@ final class CompletableConcatWithSingle<T> extends AbstractNoHandleSubscribeSing
         // of the original Completable. So, we do not need to do anything special there.
         // In order to cover for this case ((2) above) we always offload the passed Subscriber here.
         Subscriber<? super T> offloadSubscriber = offloader.offloadSubscriber(
-                contextProvider.wrap(subscriber, contextMap));
+                contextProvider.wrapSingleSubscriber(subscriber, contextMap));
         original.delegateSubscribe(new ConcatWithSubscriber<>(offloadSubscriber, next), offloader,
                 contextMap, contextProvider);
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableMergeWithPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableMergeWithPublisher.java
@@ -77,7 +77,7 @@ final class CompletableMergeWithPublisher<T> extends AbstractNoHandleSubscribePu
                AsyncContextProvider contextProvider) {
             // The CompletableSubscriber and offloadedSubscriber may interact with the subscriber, so we need to wrap it
             // and make sure the expected context is restored.
-            subscriber = contextProvider.wrap(subscriber, contextMap);
+            subscriber = contextProvider.wrapPublisherSubscriber(subscriber, contextMap);
 
             completableSubscriber = new CompletableSubscriber(subscriber);
             // This is used only to deliver signals that originate from the mergeWith Publisher. Since, we need to

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ContextPreservingCompletableFuture.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ContextPreservingCompletableFuture.java
@@ -50,215 +50,223 @@ final class ContextPreservingCompletableFuture<T> extends CompletableFuture<T> {
     // CompletionStage begin
     @Override
     public <U> CompletableFuture<U> thenApply(final Function<? super T, ? extends U> fn) {
-        return newContextPreservingFuture(delegate.thenApply(INSTANCE.wrap(fn, saved)), saved);
+        return newContextPreservingFuture(delegate.thenApply(INSTANCE.wrapFunction(fn, saved)), saved);
     }
 
     @Override
     public <U> CompletableFuture<U> thenApplyAsync(final Function<? super T, ? extends U> fn) {
-        return newContextPreservingFuture(delegate.thenApplyAsync(INSTANCE.wrap(fn, saved)), saved);
+        return newContextPreservingFuture(delegate.thenApplyAsync(INSTANCE.wrapFunction(fn, saved)), saved);
     }
 
     @Override
     public <U> CompletableFuture<U> thenApplyAsync(final Function<? super T, ? extends U> fn,
                                                    final java.util.concurrent.Executor executor) {
-        return newContextPreservingFuture(delegate.thenApplyAsync(INSTANCE.wrap(fn, saved), executor), saved);
+        return newContextPreservingFuture(delegate.thenApplyAsync(INSTANCE.wrapFunction(fn, saved), executor), saved);
     }
 
     @Override
     public CompletableFuture<Void> thenAccept(final Consumer<? super T> action) {
-        return newContextPreservingFuture(delegate.thenAccept(INSTANCE.wrap(action, saved)), saved);
+        return newContextPreservingFuture(delegate.thenAccept(INSTANCE.wrapConsumer(action, saved)), saved);
     }
 
     @Override
     public CompletableFuture<Void> thenAcceptAsync(final Consumer<? super T> action) {
-        return newContextPreservingFuture(delegate.thenAcceptAsync(INSTANCE.wrap(action, saved)), saved);
+        return newContextPreservingFuture(delegate.thenAcceptAsync(INSTANCE.wrapConsumer(action, saved)), saved);
     }
 
     @Override
     public CompletableFuture<Void> thenAcceptAsync(final Consumer<? super T> action,
                                                    final java.util.concurrent.Executor executor) {
-        return newContextPreservingFuture(delegate.thenAcceptAsync(INSTANCE.wrap(action, saved), executor), saved);
+        return newContextPreservingFuture(delegate.thenAcceptAsync(INSTANCE.wrapConsumer(action, saved), executor),
+                saved);
     }
 
     @Override
     public CompletableFuture<Void> thenRun(final Runnable action) {
-        return newContextPreservingFuture(delegate.thenRun(INSTANCE.wrap(action, saved)), saved);
+        return newContextPreservingFuture(delegate.thenRun(INSTANCE.wrapRunnable(action, saved)), saved);
     }
 
     @Override
     public CompletableFuture<Void> thenRunAsync(final Runnable action) {
-        return newContextPreservingFuture(delegate.thenRunAsync(INSTANCE.wrap(action, saved)), saved);
+        return newContextPreservingFuture(delegate.thenRunAsync(INSTANCE.wrapRunnable(action, saved)), saved);
     }
 
     @Override
     public CompletableFuture<Void> thenRunAsync(final Runnable action, final java.util.concurrent.Executor executor) {
-        return newContextPreservingFuture(delegate.thenRunAsync(INSTANCE.wrap(action, saved), executor), saved);
+        return newContextPreservingFuture(delegate.thenRunAsync(INSTANCE.wrapRunnable(action, saved), executor), saved);
     }
 
     @Override
     public <U, V> CompletableFuture<V> thenCombine(final CompletionStage<? extends U> other,
                                                    final BiFunction<? super T, ? super U, ? extends V> fn) {
-        return newContextPreservingFuture(delegate.thenCombine(other, INSTANCE.wrap(fn, saved)), saved);
+        return newContextPreservingFuture(delegate.thenCombine(other, INSTANCE.wrapBiFunction(fn, saved)), saved);
     }
 
     @Override
     public <U, V> CompletableFuture<V> thenCombineAsync(final CompletionStage<? extends U> other,
                                                         final BiFunction<? super T, ? super U, ? extends V> fn) {
-        return newContextPreservingFuture(delegate.thenCombineAsync(other, INSTANCE.wrap(fn, saved)), saved);
+        return newContextPreservingFuture(delegate.thenCombineAsync(other, INSTANCE.wrapBiFunction(fn, saved)), saved);
     }
 
     @Override
     public <U, V> CompletableFuture<V> thenCombineAsync(final CompletionStage<? extends U> other,
                                                         final BiFunction<? super T, ? super U, ? extends V> fn,
                                                         final java.util.concurrent.Executor executor) {
-        return newContextPreservingFuture(delegate.thenCombineAsync(other, INSTANCE.wrap(fn, saved), executor), saved);
+        return newContextPreservingFuture(delegate.thenCombineAsync(other, INSTANCE.wrapBiFunction(fn, saved),
+                executor), saved);
     }
 
     @Override
     public <U> CompletableFuture<Void> thenAcceptBoth(final CompletionStage<? extends U> other,
                                                       final BiConsumer<? super T, ? super U> action) {
-        return newContextPreservingFuture(delegate.thenAcceptBoth(other, INSTANCE.wrap(action, saved)), saved);
+        return newContextPreservingFuture(delegate.thenAcceptBoth(other, INSTANCE.wrapBiConsumer(action, saved)),
+                saved);
     }
 
     @Override
     public <U> CompletableFuture<Void> thenAcceptBothAsync(final CompletionStage<? extends U> other,
                                                            final BiConsumer<? super T, ? super U> action) {
-        return newContextPreservingFuture(delegate.thenAcceptBothAsync(other, INSTANCE.wrap(action, saved)), saved);
+        return newContextPreservingFuture(delegate.thenAcceptBothAsync(other, INSTANCE.wrapBiConsumer(action, saved)),
+                saved);
     }
 
     @Override
     public <U> CompletableFuture<Void> thenAcceptBothAsync(final CompletionStage<? extends U> other,
                                                            final BiConsumer<? super T, ? super U> action,
                                                            final java.util.concurrent.Executor executor) {
-        return newContextPreservingFuture(delegate.thenAcceptBothAsync(other, INSTANCE.wrap(action, saved), executor),
-                saved);
+        return newContextPreservingFuture(delegate.thenAcceptBothAsync(other, INSTANCE.wrapBiConsumer(action, saved),
+                executor), saved);
     }
 
     @Override
     public CompletableFuture<Void> runAfterBoth(final CompletionStage<?> other, final Runnable action) {
-        return newContextPreservingFuture(delegate.runAfterBoth(other, INSTANCE.wrap(action, saved)), saved);
+        return newContextPreservingFuture(delegate.runAfterBoth(other, INSTANCE.wrapRunnable(action, saved)), saved);
     }
 
     @Override
     public CompletableFuture<Void> runAfterBothAsync(final CompletionStage<?> other, final Runnable action) {
-        return newContextPreservingFuture(delegate.runAfterBothAsync(other, INSTANCE.wrap(action, saved)), saved);
+        return newContextPreservingFuture(delegate.runAfterBothAsync(other, INSTANCE.wrapRunnable(action, saved)),
+                saved);
     }
 
     @Override
     public CompletableFuture<Void> runAfterBothAsync(final CompletionStage<?> other, final Runnable action,
                                                      final java.util.concurrent.Executor executor) {
-        return newContextPreservingFuture(delegate.runAfterBothAsync(other, INSTANCE.wrap(action, saved), executor),
-                saved);
+        return newContextPreservingFuture(delegate.runAfterBothAsync(other, INSTANCE.wrapRunnable(action, saved),
+                executor), saved);
     }
 
     @Override
     public <U> CompletableFuture<U> applyToEither(final CompletionStage<? extends T> other,
                                                   final Function<? super T, U> fn) {
-        return newContextPreservingFuture(delegate.applyToEither(other, INSTANCE.wrap(fn, saved)), saved);
+        return newContextPreservingFuture(delegate.applyToEither(other, INSTANCE.wrapFunction(fn, saved)), saved);
     }
 
     @Override
     public <U> CompletableFuture<U> applyToEitherAsync(final CompletionStage<? extends T> other,
                                                        final Function<? super T, U> fn) {
-        return newContextPreservingFuture(delegate.applyToEitherAsync(other, INSTANCE.wrap(fn, saved)), saved);
+        return newContextPreservingFuture(delegate.applyToEitherAsync(other, INSTANCE.wrapFunction(fn, saved)), saved);
     }
 
     @Override
     public <U> CompletableFuture<U> applyToEitherAsync(final CompletionStage<? extends T> other,
                                                        final Function<? super T, U> fn,
                                                        final java.util.concurrent.Executor executor) {
-        return newContextPreservingFuture(delegate.applyToEitherAsync(other, INSTANCE.wrap(fn, saved), executor),
-                saved);
+        return newContextPreservingFuture(delegate.applyToEitherAsync(other, INSTANCE.wrapFunction(fn, saved),
+                executor), saved);
     }
 
     @Override
     public CompletableFuture<Void> acceptEither(final CompletionStage<? extends T> other,
                                                 final Consumer<? super T> action) {
-        return newContextPreservingFuture(delegate.acceptEither(other, INSTANCE.wrap(action, saved)), saved);
+        return newContextPreservingFuture(delegate.acceptEither(other, INSTANCE.wrapConsumer(action, saved)), saved);
     }
 
     @Override
     public CompletableFuture<Void> acceptEitherAsync(final CompletionStage<? extends T> other,
                                                      final Consumer<? super T> action) {
-        return newContextPreservingFuture(delegate.acceptEitherAsync(other, INSTANCE.wrap(action, saved)), saved);
+        return newContextPreservingFuture(delegate.acceptEitherAsync(other, INSTANCE.wrapConsumer(action, saved)),
+                saved);
     }
 
     @Override
     public CompletableFuture<Void> acceptEitherAsync(final CompletionStage<? extends T> other,
                                                      final Consumer<? super T> action,
                                                      final java.util.concurrent.Executor executor) {
-        return newContextPreservingFuture(delegate.acceptEitherAsync(other, INSTANCE.wrap(action, saved), executor),
-                saved);
+        return newContextPreservingFuture(delegate.acceptEitherAsync(other, INSTANCE.wrapConsumer(action, saved),
+                executor), saved);
     }
 
     @Override
     public CompletableFuture<Void> runAfterEither(final CompletionStage<?> other, final Runnable action) {
-        return newContextPreservingFuture(delegate.runAfterEither(other, INSTANCE.wrap(action, saved)), saved);
+        return newContextPreservingFuture(delegate.runAfterEither(other, INSTANCE.wrapRunnable(action, saved)), saved);
     }
 
     @Override
     public CompletableFuture<Void> runAfterEitherAsync(final CompletionStage<?> other, final Runnable action) {
-        return newContextPreservingFuture(delegate.runAfterEitherAsync(other, INSTANCE.wrap(action, saved)), saved);
+        return newContextPreservingFuture(delegate.runAfterEitherAsync(other, INSTANCE.wrapRunnable(action, saved)),
+                saved);
     }
 
     @Override
     public CompletableFuture<Void> runAfterEitherAsync(final CompletionStage<?> other, final Runnable action,
                                                        final java.util.concurrent.Executor executor) {
-        return newContextPreservingFuture(delegate.runAfterEitherAsync(other, INSTANCE.wrap(action, saved), executor),
-                saved);
+        return newContextPreservingFuture(delegate.runAfterEitherAsync(other, INSTANCE.wrapRunnable(action, saved),
+                executor), saved);
     }
 
     @Override
     public <U> CompletableFuture<U> thenCompose(final Function<? super T, ? extends CompletionStage<U>> fn) {
-        return newContextPreservingFuture(delegate.thenCompose(INSTANCE.wrap(fn, saved)), saved);
+        return newContextPreservingFuture(delegate.thenCompose(INSTANCE.wrapFunction(fn, saved)), saved);
     }
 
     @Override
     public <U> CompletableFuture<U> thenComposeAsync(final Function<? super T, ? extends CompletionStage<U>> fn) {
-        return newContextPreservingFuture(delegate.thenComposeAsync(INSTANCE.wrap(fn, saved)), saved);
+        return newContextPreservingFuture(delegate.thenComposeAsync(INSTANCE.wrapFunction(fn, saved)), saved);
     }
 
     @Override
     public <U> CompletableFuture<U> thenComposeAsync(final Function<? super T, ? extends CompletionStage<U>> fn,
                                                      final java.util.concurrent.Executor executor) {
-        return newContextPreservingFuture(delegate.thenComposeAsync(INSTANCE.wrap(fn, saved), executor), saved);
+        return newContextPreservingFuture(delegate.thenComposeAsync(INSTANCE.wrapFunction(fn, saved), executor), saved);
     }
 
     @Override
     public CompletableFuture<T> exceptionally(final Function<Throwable, ? extends T> fn) {
-        return newContextPreservingFuture(delegate.exceptionally(INSTANCE.wrap(fn, saved)), saved);
+        return newContextPreservingFuture(delegate.exceptionally(INSTANCE.wrapFunction(fn, saved)), saved);
     }
 
     @Override
     public CompletableFuture<T> whenComplete(final BiConsumer<? super T, ? super Throwable> action) {
-        return newContextPreservingFuture(delegate.whenComplete(INSTANCE.wrap(action, saved)), saved);
+        return newContextPreservingFuture(delegate.whenComplete(INSTANCE.wrapBiConsumer(action, saved)), saved);
     }
 
     @Override
     public CompletableFuture<T> whenCompleteAsync(final BiConsumer<? super T, ? super Throwable> action) {
-        return newContextPreservingFuture(delegate.whenCompleteAsync(INSTANCE.wrap(action, saved)), saved);
+        return newContextPreservingFuture(delegate.whenCompleteAsync(INSTANCE.wrapBiConsumer(action, saved)), saved);
     }
 
     @Override
     public CompletableFuture<T> whenCompleteAsync(final BiConsumer<? super T, ? super Throwable> action,
                                                   final java.util.concurrent.Executor executor) {
-        return newContextPreservingFuture(delegate.whenCompleteAsync(INSTANCE.wrap(action, saved), executor), saved);
+        return newContextPreservingFuture(delegate.whenCompleteAsync(INSTANCE.wrapBiConsumer(action, saved), executor),
+                saved);
     }
 
     @Override
     public <U> CompletableFuture<U> handle(final BiFunction<? super T, Throwable, ? extends U> fn) {
-        return newContextPreservingFuture(delegate.handle(INSTANCE.wrap(fn, saved)), saved);
+        return newContextPreservingFuture(delegate.handle(INSTANCE.wrapBiFunction(fn, saved)), saved);
     }
 
     @Override
     public <U> CompletableFuture<U> handleAsync(final BiFunction<? super T, Throwable, ? extends U> fn) {
-        return newContextPreservingFuture(delegate.handleAsync(INSTANCE.wrap(fn, saved)), saved);
+        return newContextPreservingFuture(delegate.handleAsync(INSTANCE.wrapBiFunction(fn, saved)), saved);
     }
 
     @Override
     public <U> CompletableFuture<U> handleAsync(final BiFunction<? super T, Throwable, ? extends U> fn,
                                                 final Executor executor) {
-        return newContextPreservingFuture(delegate.handleAsync(INSTANCE.wrap(fn, saved), executor), saved);
+        return newContextPreservingFuture(delegate.handleAsync(INSTANCE.wrapBiFunction(fn, saved), executor), saved);
     }
     // CompletionStage end
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ContextPreservingExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ContextPreservingExecutor.java
@@ -35,9 +35,4 @@ final class ContextPreservingExecutor implements Executor {
         return executor instanceof ContextPreservingExecutor ? (ContextPreservingExecutor) executor :
                 new ContextPreservingExecutor(executor);
     }
-
-    static Executor unwrap(Executor executor) {
-        return executor instanceof ContextPreservingExecutor ? ((ContextPreservingExecutor) executor).delegate :
-                executor;
-    }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ContextPreservingExecutorService.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ContextPreservingExecutorService.java
@@ -105,9 +105,4 @@ class ContextPreservingExecutorService<X extends ExecutorService> implements Exe
         return executor instanceof ContextPreservingExecutorService ? executor :
                 new ContextPreservingExecutorService<>(executor);
     }
-
-    static ExecutorService unwrap(ExecutorService executor) {
-        return executor instanceof ContextPreservingExecutorService ?
-                ((ContextPreservingExecutorService) executor).delegate : executor;
-    }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ContextPreservingScheduledExecutorService.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ContextPreservingScheduledExecutorService.java
@@ -50,9 +50,4 @@ final class ContextPreservingScheduledExecutorService extends ContextPreservingE
         return executor instanceof ContextPreservingScheduledExecutorService ? executor :
                 new ContextPreservingScheduledExecutorService(executor);
     }
-
-    static ScheduledExecutorService unwrap(ScheduledExecutorService executor) {
-        return executor instanceof ContextPreservingScheduledExecutorService ?
-                ((ContextPreservingScheduledExecutorService) executor).delegate : executor;
-    }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ContextPreservingStExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ContextPreservingStExecutor.java
@@ -52,9 +52,4 @@ final class ContextPreservingStExecutor implements Executor {
         return delegate instanceof ContextPreservingStExecutor ? delegate :
                 new ContextPreservingStExecutor(delegate);
     }
-
-    static io.servicetalk.concurrent.Executor unwrap(io.servicetalk.concurrent.Executor delegate) {
-        return delegate instanceof ContextPreservingStExecutor ?
-                ((ContextPreservingStExecutor) delegate).delegate : delegate;
-    }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultAsyncContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultAsyncContextProvider.java
@@ -54,7 +54,8 @@ final class DefaultAsyncContextProvider implements AsyncContextProvider {
     }
 
     @Override
-    public CompletableSource.Subscriber wrap(CompletableSource.Subscriber subscriber, AsyncContextMap current) {
+    public CompletableSource.Subscriber wrapCompletableSubscriber(CompletableSource.Subscriber subscriber,
+                                                                  AsyncContextMap current) {
         return new ContextPreservingCompletableSubscriber(subscriber, current);
     }
 
@@ -65,7 +66,8 @@ final class DefaultAsyncContextProvider implements AsyncContextProvider {
     }
 
     @Override
-    public <T> SingleSource.Subscriber<T> wrap(SingleSource.Subscriber<T> subscriber, AsyncContextMap current) {
+    public <T> SingleSource.Subscriber<T> wrapSingleSubscriber(SingleSource.Subscriber<T> subscriber,
+                                                               AsyncContextMap current) {
         return new ContextPreservingSingleSubscriber<>(subscriber, current);
     }
 
@@ -75,77 +77,57 @@ final class DefaultAsyncContextProvider implements AsyncContextProvider {
     }
 
     @Override
-    public <T> Subscriber<T> wrap(Subscriber<T> subscriber, AsyncContextMap current) {
+    public <T> Subscriber<T> wrapPublisherSubscriber(Subscriber<T> subscriber, AsyncContextMap current) {
         return new ContextPreservingSubscriber<>(subscriber, current);
     }
 
     @Override
-    public Executor wrap(Executor executor) {
+    public Executor wrapJdkExecutor(Executor executor) {
         return ContextPreservingExecutor.of(executor);
     }
 
     @Override
-    public Executor unwrap(final Executor executor) {
-        return ContextPreservingExecutor.unwrap(executor);
-    }
-
-    @Override
-    public ExecutorService wrap(ExecutorService executor) {
+    public ExecutorService wrapJdkExecutorService(ExecutorService executor) {
         return ContextPreservingExecutorService.of(executor);
     }
 
     @Override
-    public ExecutorService unwrap(final ExecutorService executor) {
-        return ContextPreservingExecutorService.unwrap(executor);
-    }
-
-    @Override
-    public io.servicetalk.concurrent.api.Executor wrap(final io.servicetalk.concurrent.api.Executor executor) {
+    public io.servicetalk.concurrent.api.Executor wrapExecutor(final io.servicetalk.concurrent.api.Executor executor) {
         return ContextPreservingStExecutor.of(executor);
     }
 
     @Override
-    public io.servicetalk.concurrent.Executor unwrap(final io.servicetalk.concurrent.Executor executor) {
-        return ContextPreservingStExecutor.unwrap(executor);
-    }
-
-    @Override
-    public <T> CompletableFuture<T> wrap(final CompletableFuture<T> future, AsyncContextMap current) {
+    public <T> CompletableFuture<T> wrapCompletableFuture(final CompletableFuture<T> future, AsyncContextMap current) {
         return ContextPreservingCompletableFuture.newContextPreservingFuture(future, current);
     }
 
     @Override
-    public ScheduledExecutorService wrap(ScheduledExecutorService executor) {
+    public ScheduledExecutorService wrapJdkScheduledExecutorService(ScheduledExecutorService executor) {
         return ContextPreservingScheduledExecutorService.of(executor);
     }
 
     @Override
-    public ScheduledExecutorService unwrap(final ScheduledExecutorService executor) {
-        return ContextPreservingScheduledExecutorService.unwrap(executor);
-    }
-
-    @Override
-    public Runnable wrap(final Runnable runnable, final AsyncContextMap contextMap) {
+    public Runnable wrapRunnable(final Runnable runnable, final AsyncContextMap contextMap) {
         return new ContextPreservingRunnable(runnable, contextMap);
     }
 
     @Override
-    public <T> Consumer<T> wrap(final Consumer<T> consumer, final AsyncContextMap contextMap) {
+    public <T> Consumer<T> wrapConsumer(final Consumer<T> consumer, final AsyncContextMap contextMap) {
         return new ContextPreservingConsumer<>(consumer, contextMap);
     }
 
     @Override
-    public <T, U> Function<T, U> wrap(Function<T, U> func, AsyncContextMap contextMap) {
+    public <T, U> Function<T, U> wrapFunction(Function<T, U> func, AsyncContextMap contextMap) {
         return new ContextPreservingFunction<>(func, contextMap);
     }
 
     @Override
-    public <T, U> BiConsumer<T, U> wrap(BiConsumer<T, U> consumer, AsyncContextMap contextMap) {
+    public <T, U> BiConsumer<T, U> wrapBiConsumer(BiConsumer<T, U> consumer, AsyncContextMap contextMap) {
         return new ContextPreservingBiConsumer<>(consumer, contextMap);
     }
 
     @Override
-    public <T, U, V> BiFunction<T, U, V> wrap(BiFunction<T, U, V> func, AsyncContextMap contextMap) {
+    public <T, U, V> BiFunction<T, U, V> wrapBiFunction(BiFunction<T, U, V> func, AsyncContextMap contextMap) {
         return new ContextPreservingBiFunction<>(func, contextMap);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/NoopAsyncContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/NoopAsyncContextProvider.java
@@ -54,8 +54,8 @@ final class NoopAsyncContextProvider implements AsyncContextProvider {
     }
 
     @Override
-    public CompletableSource.Subscriber wrap(final CompletableSource.Subscriber subscriber,
-                                             final AsyncContextMap current) {
+    public CompletableSource.Subscriber wrapCompletableSubscriber(final CompletableSource.Subscriber subscriber,
+                                                                  final AsyncContextMap current) {
         return subscriber;
     }
 
@@ -66,8 +66,8 @@ final class NoopAsyncContextProvider implements AsyncContextProvider {
     }
 
     @Override
-    public <T> SingleSource.Subscriber<T> wrap(final SingleSource.Subscriber<T> subscriber,
-                                               final AsyncContextMap current) {
+    public <T> SingleSource.Subscriber<T> wrapSingleSubscriber(final SingleSource.Subscriber<T> subscriber,
+                                                               final AsyncContextMap current) {
         return subscriber;
     }
 
@@ -77,77 +77,59 @@ final class NoopAsyncContextProvider implements AsyncContextProvider {
     }
 
     @Override
-    public <T> Subscriber<T> wrap(final Subscriber<T> subscriber, final AsyncContextMap current) {
+    public <T> Subscriber<T> wrapPublisherSubscriber(final Subscriber<T> subscriber, final AsyncContextMap current) {
         return subscriber;
     }
 
     @Override
-    public Executor wrap(final Executor executor) {
+    public Executor wrapJdkExecutor(final Executor executor) {
         return executor;
     }
 
     @Override
-    public Executor unwrap(final Executor executor) {
+    public ExecutorService wrapJdkExecutorService(final ExecutorService executor) {
         return executor;
     }
 
     @Override
-    public ExecutorService wrap(final ExecutorService executor) {
+    public io.servicetalk.concurrent.api.Executor wrapExecutor(final io.servicetalk.concurrent.api.Executor executor) {
         return executor;
     }
 
     @Override
-    public ExecutorService unwrap(final ExecutorService executor) {
-        return executor;
-    }
-
-    @Override
-    public io.servicetalk.concurrent.api.Executor wrap(final io.servicetalk.concurrent.api.Executor executor) {
-        return executor;
-    }
-
-    @Override
-    public io.servicetalk.concurrent.Executor unwrap(final io.servicetalk.concurrent.Executor executor) {
-        return executor;
-    }
-
-    @Override
-    public <T> CompletableFuture<T> wrap(final CompletableFuture<T> future, final AsyncContextMap contextMap) {
+    public <T> CompletableFuture<T> wrapCompletableFuture(final CompletableFuture<T> future,
+                                                          final AsyncContextMap contextMap) {
         return future;
     }
 
     @Override
-    public ScheduledExecutorService wrap(final ScheduledExecutorService executor) {
+    public ScheduledExecutorService wrapJdkScheduledExecutorService(final ScheduledExecutorService executor) {
         return executor;
     }
 
     @Override
-    public ScheduledExecutorService unwrap(final ScheduledExecutorService executor) {
-        return executor;
-    }
-
-    @Override
-    public Runnable wrap(final Runnable runnable, final AsyncContextMap contextMap) {
+    public Runnable wrapRunnable(final Runnable runnable, final AsyncContextMap contextMap) {
         return runnable;
     }
 
     @Override
-    public <T> Consumer<T> wrap(final Consumer<T> consumer, final AsyncContextMap contextMap) {
+    public <T> Consumer<T> wrapConsumer(final Consumer<T> consumer, final AsyncContextMap contextMap) {
         return consumer;
     }
 
     @Override
-    public <T, U> Function<T, U> wrap(final Function<T, U> func, final AsyncContextMap contextMap) {
+    public <T, U> Function<T, U> wrapFunction(final Function<T, U> func, final AsyncContextMap contextMap) {
         return func;
     }
 
     @Override
-    public <T, U> BiConsumer<T, U> wrap(final BiConsumer<T, U> consumer, final AsyncContextMap contextMap) {
+    public <T, U> BiConsumer<T, U> wrapBiConsumer(final BiConsumer<T, U> consumer, final AsyncContextMap contextMap) {
         return consumer;
     }
 
     @Override
-    public <T, U, V> BiFunction<T, U, V> wrap(final BiFunction<T, U, V> func, final AsyncContextMap contextMap) {
+    public <T, U, V> BiFunction<T, U, V> wrapBiFunction(final BiFunction<T, U, V> func,
+                                                        final AsyncContextMap contextMap) {
         return func;
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnCompletables.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnCompletables.java
@@ -35,7 +35,8 @@ final class PublishAndSubscribeOnCompletables {
     static void deliverOnSubscribeAndOnError(Subscriber subscriber, SignalOffloader signalOffloader,
                                              AsyncContextMap contextMap, AsyncContextProvider contextProvider,
                                              Throwable cause) {
-        subscriber = signalOffloader.offloadSubscriber(contextProvider.wrap(subscriber, contextMap));
+        subscriber = signalOffloader.offloadSubscriber(
+                contextProvider.wrapCompletableSubscriber(subscriber, contextMap));
         subscriber.onSubscribe(IGNORE_CANCEL);
         subscriber.onError(cause);
     }
@@ -86,7 +87,8 @@ final class PublishAndSubscribeOnCompletables {
             // chain. If there is already an Executor defined for original, it will be used to offload signals until
             // they hit this operator.
             original.subscribeWithSharedContext(
-                    signalOffloader.offloadSubscriber(contextProvider.wrap(subscriber, contextMap)), contextProvider);
+                    signalOffloader.offloadSubscriber(
+                            contextProvider.wrapCompletableSubscriber(subscriber, contextMap)), contextProvider);
         }
     }
 
@@ -129,7 +131,8 @@ final class PublishAndSubscribeOnCompletables {
             // chain. If there is already an Executor defined for original, it will be used to offload signals until
             // they hit this operator.
             original.subscribeWithSharedContext(
-                    signalOffloader.offloadSubscriber(contextProvider.wrap(subscriber, contextMap)), contextProvider);
+                    signalOffloader.offloadSubscriber(
+                            contextProvider.wrapCompletableSubscriber(subscriber, contextMap)), contextProvider);
         }
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnPublishers.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnPublishers.java
@@ -35,7 +35,7 @@ final class PublishAndSubscribeOnPublishers {
     static <T> void deliverOnSubscribeAndOnError(Subscriber<? super T> subscriber, SignalOffloader signalOffloader,
                                                  AsyncContextMap contextMap, AsyncContextProvider contextProvider,
                                                  Throwable cause) {
-        subscriber = signalOffloader.offloadSubscriber(contextProvider.wrap(subscriber, contextMap));
+        subscriber = signalOffloader.offloadSubscriber(contextProvider.wrapPublisherSubscriber(subscriber, contextMap));
         subscriber.onSubscribe(EMPTY_SUBSCRIPTION);
         subscriber.onError(cause);
     }
@@ -86,7 +86,7 @@ final class PublishAndSubscribeOnPublishers {
             // chain. If there is already an Executor defined for original, it will be used to offload signals until
             // they hit this operator.
             original.subscribeWithSharedContext(
-                    signalOffloader.offloadSubscriber(contextProvider.wrap(subscriber, contextMap)));
+                    signalOffloader.offloadSubscriber(contextProvider.wrapPublisherSubscriber(subscriber, contextMap)));
         }
     }
 
@@ -130,7 +130,7 @@ final class PublishAndSubscribeOnPublishers {
             // chain. If there is already an Executor defined for original, it will be used to offload signals until
             // they hit this operator.
             original.subscribeWithSharedContext(
-                    signalOffloader.offloadSubscriber(contextProvider.wrap(subscriber, contextMap)));
+                    signalOffloader.offloadSubscriber(contextProvider.wrapPublisherSubscriber(subscriber, contextMap)));
         }
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnSingles.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnSingles.java
@@ -35,7 +35,7 @@ final class PublishAndSubscribeOnSingles {
     static <T> void deliverOnSubscribeAndOnError(SingleSource.Subscriber<? super T> subscriber,
                                                  SignalOffloader signalOffloader, AsyncContextMap contextMap,
                                                  AsyncContextProvider contextProvider, Throwable cause) {
-        subscriber = signalOffloader.offloadSubscriber(contextProvider.wrap(subscriber, contextMap));
+        subscriber = signalOffloader.offloadSubscriber(contextProvider.wrapSingleSubscriber(subscriber, contextMap));
         subscriber.onSubscribe(IGNORE_CANCEL);
         subscriber.onError(cause);
     }
@@ -86,7 +86,8 @@ final class PublishAndSubscribeOnSingles {
             // chain. If there is already an Executor defined for original, it will be used to offload signals until
             // they hit this operator.
             original.subscribeWithSharedContext(
-                    signalOffloader.offloadSubscriber(contextProvider.wrap(subscriber, contextMap)), contextProvider);
+                    signalOffloader.offloadSubscriber(
+                            contextProvider.wrapSingleSubscriber(subscriber, contextMap)), contextProvider);
         }
     }
 
@@ -129,7 +130,8 @@ final class PublishAndSubscribeOnSingles {
             // chain. If there is already an Executor defined for original, it will be used to offload signals until
             // they hit this operator.
             original.subscribeWithSharedContext(
-                    signalOffloader.offloadSubscriber(contextProvider.wrap(subscriber, contextMap)), contextProvider);
+                    signalOffloader.offloadSubscriber(
+                            contextProvider.wrapSingleSubscriber(subscriber, contextMap)), contextProvider);
         }
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2415,7 +2415,8 @@ public abstract class Publisher<T> {
      * @param subscriber the subscriber.
      */
     final void subscribeWithSharedContext(Subscriber<? super T> subscriber) {
-        subscribeWithContext(subscriber, AsyncContext.provider(), AsyncContext.current());
+        AsyncContextProvider provider = AsyncContext.provider();
+        subscribeWithContext(subscriber, provider, provider.contextMap());
     }
 
     /**
@@ -2451,7 +2452,7 @@ public abstract class Publisher<T> {
             subscriber.onError(t);
             return;
         }
-        signalOffloader.offloadSubscribe(offloadedSubscriber, provider.wrap((Consumer<Subscriber<? super T>>)
+        signalOffloader.offloadSubscribe(offloadedSubscriber, provider.wrapConsumer(
                 s -> handleSubscribe(s, signalOffloader, contextMap, provider), contextMap));
     }
 
@@ -2474,7 +2475,7 @@ public abstract class Publisher<T> {
                          AsyncContextProvider contextProvider) {
         try {
             Subscriber<? super T> offloaded =
-                    signalOffloader.offloadSubscriber(contextProvider.wrap(subscriber, contextMap));
+                    signalOffloader.offloadSubscriber(contextProvider.wrapPublisherSubscriber(subscriber, contextMap));
             handleSubscribe(offloaded);
         } catch (Throwable t) {
             LOGGER.warn("Unexpected exception from subscribe(), assuming no interaction with the Subscriber.", t);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ResumeCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ResumeCompletable.java
@@ -104,7 +104,7 @@ final class ResumeCompletable extends AbstractNoHandleSubscribeCompletable {
             // the new Completable. This is the reason we use the original offloader now to offload signals which
             // originate from this new Completable.
             final Subscriber offloadedSubscriber = signalOffloader.offloadSubscriber(
-                    contextProvider.wrap(this, contextMap));
+                    contextProvider.wrapCompletableSubscriber(this, contextMap));
             next.subscribeInternal(offloadedSubscriber);
         }
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ResumePublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ResumePublisher.java
@@ -111,7 +111,7 @@ final class ResumePublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
             // the new Publisher. This is the reason we use the original offloader now to offload signals which
             // originate from this new Publisher.
             final Subscriber<? super T> offloadedSubscriber = signalOffloader.offloadSubscriber(
-                    contextProvider.wrap(this, contextMap));
+                    contextProvider.wrapPublisherSubscriber(this, contextMap));
             next.subscribeInternal(offloadedSubscriber);
         }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ResumeSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ResumeSingle.java
@@ -112,7 +112,7 @@ final class ResumeSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
             // the new Single. This is the reason we use the original offloader now to offload signals which
             // originate from this new Single.
             final Subscriber<? super T> offloadedSubscriber = signalOffloader.offloadSubscriber(
-                    contextProvider.wrap(this, contextMap));
+                    contextProvider.wrapSingleSubscriber(this, contextMap));
             next.subscribeInternal(offloadedSubscriber);
         }
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1509,7 +1509,7 @@ public abstract class Single<T> {
             subscriber.onError(t);
             return;
         }
-        signalOffloader.offloadSubscribe(offloadedSubscriber, provider.wrap((Consumer<Subscriber<? super T>>)
+        signalOffloader.offloadSubscribe(offloadedSubscriber, provider.wrapConsumer(
                 s -> handleSubscribe(s, signalOffloader, contextMap, provider), contextMap));
     }
 
@@ -1533,7 +1533,7 @@ public abstract class Single<T> {
                          AsyncContextProvider contextProvider) {
         try {
             Subscriber<? super T> offloaded =
-                    signalOffloader.offloadSubscriber(contextProvider.wrap(subscriber, contextMap));
+                    signalOffloader.offloadSubscriber(contextProvider.wrapSingleSubscriber(subscriber, contextMap));
             handleSubscribe(offloaded);
         } catch (Throwable t) {
             LOGGER.warn("Unexpected exception from subscribe(), assuming no interaction with the Subscriber.", t);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleFlatMapCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleFlatMapCompletable.java
@@ -97,8 +97,8 @@ final class SingleFlatMapCompletable<T> extends AbstractNoHandleSubscribeComplet
             // The static AsyncContext should be the same as the original contextMap at this point because we are
             // being notified in the Subscriber path, but we make sure that it is restored after the asynchronous
             // boundary and use an isolated copy to subscribe to the new source.
-            next.subscribeInternal(signalOffloader.offloadSubscriber(contextProvider.wrap((Subscriber) this,
-                    contextMap)));
+            next.subscribeInternal(signalOffloader.offloadSubscriber(
+                    contextProvider.wrapCompletableSubscriber(this, contextMap)));
         }
 
         @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleFlatMapPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleFlatMapPublisher.java
@@ -112,7 +112,7 @@ final class SingleFlatMapPublisher<T, R> extends AbstractNoHandleSubscribePublis
             // being notified in the Subscriber path, but we make sure that it is restored after the asynchronous
             // boundary and explicitly use it to subscribe.
             next.subscribeInternal((Subscriber<? super R>)
-                    signalOffloader.offloadSubscriber(contextProvider.wrap((Subscriber<R>) this, contextMap)));
+                    signalOffloader.offloadSubscriber(contextProvider.wrapPublisherSubscriber(this, contextMap)));
         }
 
         @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleToCompletableFuture.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleToCompletableFuture.java
@@ -40,7 +40,7 @@ final class SingleToCompletableFuture<T> extends CompletableFuture<T> implements
     static <X> CompletableFuture<X> createAndSubscribe(Single<X> original) {
         SingleToCompletableFuture<X> future = new SingleToCompletableFuture<>();
         AsyncContextProvider provider = AsyncContext.provider();
-        return provider.wrap((CompletableFuture<X>) future, original.subscribeAndReturnContext(future, provider));
+        return provider.wrapCompletableFuture(future, original.subscribeAndReturnContext(future, provider));
     }
 
     static <X> CompletableFuture<X> createForFutureAndSubscribe(Single<X> original) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutPublisher.java
@@ -291,7 +291,7 @@ final class TimeoutPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
         }
 
         private void offloadTimeout(Throwable cause) {
-            signalOffloader.offloadSignal(cause, contextProvider.wrap(this::processTimeout));
+            signalOffloader.offloadSignal(cause, contextProvider.wrapConsumer(this::processTimeout));
         }
 
         private void processTimeout(Throwable cause) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultAsyncContextProviderTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultAsyncContextProviderTest.java
@@ -373,19 +373,19 @@ public class DefaultAsyncContextProviderTest {
         };
 
         new ContextCaptureRunnable()
-                .runAndWait(INSTANCE.wrap((Executor) executor))
+                .runAndWait(INSTANCE.wrapJdkExecutor(executor))
                 .verifyContext(verifier);
 
         new ContextCaptureRunnable()
-                .runAndWait(INSTANCE.wrap((ExecutorService) executor))
+                .runAndWait(INSTANCE.wrapJdkExecutorService(executor))
                 .verifyContext(verifier);
 
         new ContextCaptureCallable<String>()
-                .runAndWait(INSTANCE.wrap((ExecutorService) executor))
+                .runAndWait(INSTANCE.wrapJdkExecutorService(executor))
                 .verifyContext(verifier);
 
         new ContextCaptureCallable<String>()
-                .scheduleAndWait(INSTANCE.wrap(executor))
+                .scheduleAndWait(INSTANCE.wrapJdkScheduledExecutorService(executor))
                 .verifyContext(verifier);
     }
 
@@ -399,7 +399,7 @@ public class DefaultAsyncContextProviderTest {
 
         new ContextCapturer()
                 .runAndWait(collector -> {
-                    Function<Void, Void> f = INSTANCE.wrap(v -> {
+                    Function<Void, Void> f = INSTANCE.wrapFunction(v -> {
                         collector.complete(AsyncContext.current());
                         return v;
                     }, AsyncContext.current());
@@ -409,14 +409,14 @@ public class DefaultAsyncContextProviderTest {
 
         new ContextCapturer()
                 .runAndWait(collector -> {
-                    Consumer<Void> c = INSTANCE.wrap((Consumer<Void>) v -> collector.complete(AsyncContext.current()));
+                    Consumer<Void> c = INSTANCE.wrapConsumer(v -> collector.complete(AsyncContext.current()));
                     executor.execute(() -> c.accept(null));
                 })
                 .verifyContext(verifier);
 
         new ContextCapturer()
                 .runAndWait(collector -> {
-                    BiFunction<Void, Void, Void> bf = INSTANCE.wrap((v1, v2) -> {
+                    BiFunction<Void, Void, Void> bf = INSTANCE.wrapBiFunction((v1, v2) -> {
                         collector.complete(AsyncContext.current());
                         return v1;
                     }, AsyncContext.current());
@@ -426,7 +426,7 @@ public class DefaultAsyncContextProviderTest {
 
         new ContextCapturer()
                 .runAndWait(collector -> {
-                    BiConsumer<Void, Void> bc = INSTANCE.wrap((v1, v2) -> {
+                    BiConsumer<Void, Void> bc = INSTANCE.wrapBiConsumer((v1, v2) -> {
                         collector.complete(AsyncContext.current());
                     }, AsyncContext.current());
                     executor.execute(() -> bc.accept(null, null));


### PR DESCRIPTION
Motivation:
AsyncContext has many methods designed to wrap objects to preserve context. Most of these methods are named wrap() and the method signatures can overlap when we have objects that may override multiple types. We can qualify the method name to clarify what is being wrapped and also avoid unnecessary casting.

Modifications:
- Publisher#subscribeWithSharedContext should share the AsyncContextProvider
- Qualify all AsyncContext wrapper method names

Result:
More clarify around the AsyncContext wrapper APIs.