### PR TITLE
Drain request payload body if a streaming filter responds

### DIFF
--- a/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/DefaultFallbackServiceStreaming.java
+++ b/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/DefaultFallbackServiceStreaming.java
@@ -22,11 +22,9 @@ import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpService;
 
+import static io.servicetalk.concurrent.api.Single.success;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
-import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
-import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
-import static io.servicetalk.http.api.HttpResponseStatus.NOT_FOUND;
 
 final class DefaultFallbackServiceStreaming extends StreamingHttpService {
 
@@ -40,11 +38,9 @@ final class DefaultFallbackServiceStreaming extends StreamingHttpService {
     public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
                                                 final StreamingHttpRequest request,
                                                 final StreamingHttpResponseFactory factory) {
-        final StreamingHttpResponse response = factory.newResponse(NOT_FOUND).version(request.version());
-        response.headers().set(CONTENT_LENGTH, ZERO)
-                .set(CONTENT_TYPE, TEXT_PLAIN);
         // TODO(derek): Set keepalive once we have an isKeepAlive helper method.
-        return Single.success(response);
+        return success(factory.notFound().version(request.version()).setHeader(CONTENT_LENGTH, ZERO))
+                .concatWith(request.payloadBody().ignoreElements());
     }
 
     static StreamingHttpService instance() {

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/BaseHttpPredicateRouterBuilderTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/BaseHttpPredicateRouterBuilderTest.java
@@ -45,6 +45,7 @@ import java.util.Spliterator;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Executors.immediate;
+import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static java.util.Arrays.asList;
 import static org.mockito.ArgumentMatchers.any;
@@ -86,6 +87,7 @@ public abstract class BaseHttpPredicateRouterBuilderTest {
         when(executionCtx.executor()).thenReturn(immediate());
         when(request.version()).thenReturn(HTTP_1_1);
         when(request.headers()).thenReturn(headers);
+        when(request.payloadBody()).thenReturn(empty());
         when(factory.newResponse(any(HttpResponseStatus.class))).thenAnswer((Answer<StreamingHttpResponse>) invocation -> {
             HttpResponseStatus status = invocation.getArgument(0);
             return reqRespFactory.newResponse(status);

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/DefaultFallbackServiceTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/DefaultFallbackServiceTest.java
@@ -35,9 +35,8 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import static io.servicetalk.concurrent.api.Executors.immediate;
+import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
-import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
-import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseStatus.NOT_FOUND;
@@ -62,6 +61,7 @@ public class DefaultFallbackServiceTest {
     @Before
     public void setUp() {
         when(request.version()).thenReturn(HTTP_1_1);
+        when(request.payloadBody()).thenReturn(empty());
         when(ctx.executionContext()).thenReturn(executionCtx);
         when(executionCtx.executor()).thenReturn(immediate());
     }
@@ -77,6 +77,5 @@ public class DefaultFallbackServiceTest {
         assertEquals(HTTP_1_1, response.version());
         assertEquals(NOT_FOUND, response.status());
         assertEquals(ZERO, response.headers().get(CONTENT_LENGTH));
-        assertEquals(TEXT_PLAIN, response.headers().get(CONTENT_TYPE));
     }
 }


### PR DESCRIPTION
Motivation:

In #400 we allow users to disable automatic draining of the request
payload body by ServiceTalk if they know thay they are consuming it by
themselves (via aggregated API or manually). However, if they use the
predicate router or Basic auth filter, the request payload body may not
be consumed by ServiceTalk in case of 404 or 401 status codes.

Modifications:

- Drain a request payload body in `DefaultFallbackServiceStreaming`
after sending a 404 response;
- Drain a request payload body in `BasicAuthHttpServiceFilterBuilder`
after sending a 401/407 response;
- Update tests;

Result:

`DefaultFallbackServiceStreaming` and `BasicAuthHttpServiceFilterBuilder`
drain the request payload body if they respond which will allow users to
disable automatic draining of the payload body.