### PR TITLE
Add filter to configure timeout on HTTP requests

### DIFF
--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/GatewayServer.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/GatewayServer.java
@@ -119,8 +119,7 @@ public final class GatewayServer {
                                 .maxRetries(3)
                                 .buildWithExponentialBackoffAndJitter(ofMillis(100)))
                         // Apply a timeout filter for the client to guard against latent clients.
-                        .appendClientFilter(new TimeoutHttpRequesterFilter.Builder()
-                                .buildWithTimeout(ofMillis(500)))
+                        .appendClientFilter(new TimeoutHttpRequesterFilter(ofMillis(500)))
                         .ioExecutor(ioExecutor)
                         .buildStreaming());
     }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilter.java
@@ -40,9 +40,25 @@ public final class TimeoutHttpRequesterFilter implements HttpClientFilterFactory
     @Nullable
     private final Executor timeoutExecutor;
 
-    private TimeoutHttpRequesterFilter(final Duration duration, @Nullable final Executor timeoutExecutor) {
+    /**
+     * Creates a new instance.
+     *
+     * @param duration the timeout {@link Duration}
+     */
+    public TimeoutHttpRequesterFilter(final Duration duration) {
         this.duration = duration;
-        this.timeoutExecutor = timeoutExecutor;
+        this.timeoutExecutor = null;
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param duration the timeout {@link Duration}
+     * @param timeoutExecutor the {@link Executor} to use for managing the timer notifications
+     */
+    public TimeoutHttpRequesterFilter(final Duration duration, final Executor timeoutExecutor) {
+        this.duration = duration;
+        this.timeoutExecutor = requireNonNull(timeoutExecutor);
     }
 
     private Single<StreamingHttpResponse> request(final StreamingHttpRequestFunction delegate,
@@ -86,35 +102,5 @@ public final class TimeoutHttpRequesterFilter implements HttpClientFilterFactory
                 return mergeWith;
             }
         };
-    }
-
-    /**
-     * A builder for {@link TimeoutHttpRequesterFilter}.
-     */
-    public static final class Builder {
-        @Nullable
-        private Executor timeoutExecutor;
-
-        /**
-         * Specifies the {@link Executor} to use for managing the timer notifications.
-         *
-         * @param timeoutExecutor the {@link Executor} to use for managing the timer notifications
-         * @return {@code this}
-         */
-        public Builder timeoutExecutor(final Executor timeoutExecutor) {
-            this.timeoutExecutor = requireNonNull(timeoutExecutor);
-            return this;
-        }
-
-        /**
-         * Creates a new {@link TimeoutHttpRequesterFilter} which adds the provided {@link Duration} as the timeout
-         * for requests.
-         *
-         * @param duration the timeout {@link Duration}
-         * @return a new {@link TimeoutHttpRequesterFilter}
-         */
-        public TimeoutHttpRequesterFilter buildWithTimeout(Duration duration) {
-            return new TimeoutHttpRequesterFilter(requireNonNull(duration), timeoutExecutor);
-        }
     }
 }


### PR DESCRIPTION
__Motivation__

We have convenience filters for HTTP for retry, redirect, logging, etc… but we don’t have something for timeouts, which makes it a little involved for our users.

__Modifications__

- Add `TimeoutHttpRequesterFilter`
- Use this new filter in `GatewayServer`

__Results__

More consistent / less involved way of setting HTTP timeouts.