### PR TITLE
SingleToCompletionStageTest.acceptEitherNull failure

### DIFF
--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletionStageTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletionStageTest.java
@@ -1087,7 +1087,7 @@ public class SingleToCompletionStageTest {
 
     private static Consumer<? super String> stOrJdkThread(AtomicReference<String> ref) {
         return val -> {
-            verifyInJdkExecutorThread();
+            verifyInStOrJdkThread();
             ref.set(val);
         };
     }
@@ -1117,13 +1117,6 @@ public class SingleToCompletionStageTest {
         return () -> {
             verifyInJUnitThread();
             ref.set(true);
-        };
-    }
-
-    private static BiFunction<? super String, ? super Double, ? extends Integer> strLenDoubleStThread() {
-        return (str, dbl) -> {
-            verifyInStExecutorThread();
-            return (int) (strLen(str) + dbl);
         };
     }
 


### PR DESCRIPTION
Motivaiton:
SingleToCompletionStageTest#stOrJdkThread only allows the thread to be a JDK thread, instead of a JDK thread or a ST thread.

Modifications:
- SingleToCompletionStageTest#stOrJdkThread should allow for JDK or ST thread

Result:
Fixes https://github.com/servicetalk/servicetalk/issues/417.