### PR TITLE
Timeout operators may concurrently invoke Subscriber

### DIFF
--- a/servicetalk-concurrent-api-internal/src/main/java/io/servicetalk/concurrent/api/internal/SpScPublisherProcessor.java
+++ b/servicetalk-concurrent-api-internal/src/main/java/io/servicetalk/concurrent/api/internal/SpScPublisherProcessor.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api.internal;
+
+import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.internal.DuplicateSubscribeException;
+import io.servicetalk.concurrent.internal.FlowControlUtil;
+import io.servicetalk.concurrent.internal.QueueFullException;
+import io.servicetalk.concurrent.internal.TerminalNotification;
+
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.internal.PlatformDependent.newUnboundedSpscQueue;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
+
+/**
+ * A {@link Publisher} that allows for signals to be directly injected via {@link #sendOnNext(Object)},
+ * {@link #sendOnComplete()}, and {@link #sendOnError(Throwable)}. The threading restrictions for this class are:
+ * <ul>
+ * <li><strong>S</strong>ingle<strong>P</strong>roducer meaning only a single thread is allowed to interact with
+ * {@link #sendOnNext(Object)}, {@link #sendOnComplete()}, and {@link #sendOnError(Throwable)} methods.</li>
+ * <li><strong>S</strong>ingle<strong>C</strong>onsumer meaning only a single {@link PublisherSource.Subscriber} is
+ * supported. Other operators can be used to add support for multiple {@link PublisherSource.Subscriber}s if necessary.
+ * </li>
+ * </ul>
+ *
+ * @param <T> The type of {@link Publisher}.
+ */
+public final class SpScPublisherProcessor<T> extends SubscribablePublisher<T> {
+    private static final AtomicLongFieldUpdater<SpScPublisherProcessor> requestedUpdater =
+            AtomicLongFieldUpdater.newUpdater(SpScPublisherProcessor.class, "requested");
+    private static final AtomicIntegerFieldUpdater<SpScPublisherProcessor> onNextQueueSizeUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(SpScPublisherProcessor.class, "onNextQueueSize");
+    private static final AtomicReferenceFieldUpdater<SpScPublisherProcessor, Subscriber> subscriberUpdater =
+            AtomicReferenceFieldUpdater.newUpdater(SpScPublisherProcessor.class, Subscriber.class,
+                    "subscriber");
+    private static final long CANCELLED = Long.MIN_VALUE;
+    private static final Object NULL_TOKEN = new Object();
+    private static final Subscriber<?> CALLING_ON_SUBSCRIBE = newErrorSubscriber();
+    private static final Subscriber<?> DRAINING_SUBSCRIBER = newErrorSubscriber();
+    private static final Subscriber<?> TERMINATING_SUBSCRIBER = newErrorSubscriber();
+    private static final Subscriber<?> TERMINATED_SUBSCRIBER = newErrorSubscriber();
+
+    @Nullable
+    private volatile Subscriber<? super T> subscriber;
+    private volatile int onNextQueueSize;
+    private volatile long requested;
+    private final Queue<Object> signalQueue;
+    private final int maxOnNextQueueSize;
+
+    /**
+     * Create a new instance.
+     *
+     * @param maxOnNextQueueSize The maximum amount of {@link PublisherSource.Subscriber#onNext(Object)} signals that
+     * can be queued from {@link #sendOnNext(Object)}.
+     */
+    public SpScPublisherProcessor(int maxOnNextQueueSize) {
+        this(maxOnNextQueueSize, 2);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param maxOnNextQueueSize The maximum amount of {@link PublisherSource.Subscriber#onNext(Object)} signals that
+     * can be queued from {@link #sendOnNext(Object)}.
+     * @param initialQueueSize The initial size of the {@link Queue} to hold signals for the
+     * {@link #sendOnNext(Object)}, {@link #sendOnComplete()}, and {@link #sendOnError(Throwable)} methods.
+     */
+    private SpScPublisherProcessor(int maxOnNextQueueSize, int initialQueueSize) {
+        if (maxOnNextQueueSize <= 0) {
+            throw new IllegalArgumentException("maxOnNextQueueSize: " + maxOnNextQueueSize + " (expected >0)");
+        }
+        this.maxOnNextQueueSize = maxOnNextQueueSize;
+        signalQueue = newUnboundedSpscQueue(initialQueueSize);
+    }
+
+    @Override
+    protected void handleSubscribe(final Subscriber<? super T> s) {
+        for (;;) {
+            final Subscriber<? super T> subscriber = this.subscriber;
+            if (subscriber != null) {
+                deliverTerminalFromSource(s, new DuplicateSubscribeException(subscriber, s));
+                return;
+            } else if (subscriberUpdater.compareAndSet(this, null, CALLING_ON_SUBSCRIBE)) {
+                s.onSubscribe(new Subscription() {
+                    @Override
+                    public void request(final long n) {
+                        if (isRequestNValid(n)) {
+                            if (requestedUpdater.getAndAccumulate(SpScPublisherProcessor.this, n,
+                                    FlowControlUtil::addWithOverflowProtectionIfNotNegative) == 0) {
+                                drainQueue();
+                            }
+                        } else {
+                            for (;;) {
+                                final long requested = SpScPublisherProcessor.this.requested;
+                                if (requested < 0) {
+                                    break;
+                                } else if (requestedUpdater.compareAndSet(SpScPublisherProcessor.this,
+                                        requested, n == CANCELLED ? CANCELLED + 1 : n)) {
+                                    drainQueue();
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    @Override
+                    public void cancel() {
+                        if (requestedUpdater.getAndSet(SpScPublisherProcessor.this, CANCELLED) !=
+                                CANCELLED) {
+                            drainQueue(); // just to clear the queue and make objects eligible for GC.
+                        }
+                    }
+                });
+
+                // We hold off all interactions with the Subscriber until control flow returns from onSubscribe to
+                // avoid concurrently invoking the Subscriber.
+                if (subscriberUpdater.compareAndSet(this, CALLING_ON_SUBSCRIBE, s)) {
+                    drainQueue();
+                }
+                break;
+            }
+        }
+    }
+
+    /**
+     * Send an {@link PublisherSource.Subscriber#onNext(Object)} signal to the subscriber of this {@link Publisher}.
+     *
+     * @param t The signals for {@link PublisherSource.Subscriber#onNext(Object)}.
+     * @throws QueueFullException if the queue of signals would exceed the maximum size.
+     */
+    public void sendOnNext(@Nullable final T t) {
+        // This is a single producer process, so we optimistically increment and may maxOnNextQueueSize, but we can
+        // decrement after the fact if this is the case to prevent overflow on subsequent calls.
+        if (onNextQueueSizeUpdater.getAndIncrement(this) == maxOnNextQueueSize) {
+            onNextQueueSizeUpdater.decrementAndGet(this);
+            final QueueFullException e = new QueueFullException("signalQueue", maxOnNextQueueSize);
+            signalQueue.add(TerminalNotification.error(e));
+            drainQueue();
+            // The calling thread should be notified that the queue is full, and if this is in the context of another
+            // asynchronous source it will serve as a best effort to terminate that source.
+            throw e;
+        } else {
+            signalQueue.add(t == null ? NULL_TOKEN : t);
+            drainQueue();
+        }
+    }
+
+    /**
+     * Send an {@link PublisherSource.Subscriber#onError(Throwable)} signal to the subscriber of this {@link Publisher}.
+     *
+     * @param t The signals for {@link PublisherSource.Subscriber#onError(Throwable)}.
+     */
+    public void sendOnError(final Throwable t) {
+        signalQueue.add(TerminalNotification.error(t));
+        drainQueue();
+    }
+
+    /**
+     * Send an {@link PublisherSource.Subscriber#onComplete()} signal to the subscriber of this {@link Publisher}.
+     */
+    public void sendOnComplete() {
+        signalQueue.add(TerminalNotification.complete());
+        drainQueue();
+    }
+
+    private void drainQueue() {
+        for (;;) {
+            final Subscriber<? super T> subscriber = this.subscriber;
+            if (subscriber == null || subscriber == CALLING_ON_SUBSCRIBE || subscriber == DRAINING_SUBSCRIBER) {
+                if (subscriberUpdater.compareAndSet(this, subscriber, subscriber)) {
+                    break;
+                }
+            } else if (subscriber == TERMINATING_SUBSCRIBER) {
+                // forcing the state to TERMINATED_SUBSCRIBER either signals to the consumer thread that it needs to
+                // drain again, or we will take ownership of the consumer and drain if already terminated.
+                if (subscriberUpdater.getAndSet(this, TERMINATED_SUBSCRIBER) == TERMINATED_SUBSCRIBER) {
+                    signalQueue.clear();
+                }
+                break;
+            } else if (subscriber == TERMINATED_SUBSCRIBER) {
+                signalQueue.clear();
+                break;
+            } else {
+                for (;;) {
+                    if (!subscriberUpdater.compareAndSet(this, subscriber, DRAINING_SUBSCRIBER)) {
+                        return;
+                    }
+                    Object signal;
+                    long previousRequested;
+                    // getAndAccumulate because we want to know if before the decrement, the value was positive.
+                    while ((previousRequested = requestedUpdater.getAndAccumulate(this, 1,
+                            FlowControlUtil::subtractIfPositive)) > 0) {
+                        signal = signalQueue.poll();
+                        if (signal == null) {
+                            previousRequested = requestedUpdater.accumulateAndGet(this, 1,
+                                    FlowControlUtil::addWithOverflowProtectionIfNotNegative);
+                            break;
+                        } else if (signal instanceof TerminalNotification) {
+                            clearQueueAndTerminate();
+                            ((TerminalNotification) signal).terminate(subscriber);
+                            return;
+                        } else {
+                            try {
+                                onNextQueueSizeUpdater.decrementAndGet(this);
+                                @SuppressWarnings("unchecked")
+                                final T tSignal = signal == NULL_TOKEN ? null : (T) signal;
+                                subscriber.onNext(tSignal);
+                            } catch (Throwable cause) {
+                                clearQueueAndTerminate();
+                                subscriber.onError(cause);
+                                return;
+                            }
+                        }
+                    }
+                    if (previousRequested < 0) {
+                        clearQueueAndTerminate();
+                        if (previousRequested != CANCELLED) {
+                            subscriber.onError(newExceptionForInvalidRequestN(previousRequested));
+                        }
+                        return;
+                    } else if ((signal = signalQueue.peek()) instanceof TerminalNotification) {
+                        clearQueueAndTerminate();
+                        ((TerminalNotification) signal).terminate(subscriber);
+                        return;
+                    }
+
+                    // "unlock" the subscriber.
+                    this.subscriber = subscriber;
+
+                    final boolean empty = signalQueue.isEmpty();
+                    previousRequested = requested;
+                    if (!empty && previousRequested == 0 || empty && previousRequested >= 0) {
+                        break;
+                    }
+                }
+                break;
+            }
+        }
+    }
+
+    private void clearQueueAndTerminate() {
+        do {
+            subscriber = terminatingSubscriber();
+            signalQueue.clear();
+        } while (!subscriberUpdater.compareAndSet(this, TERMINATING_SUBSCRIBER, TERMINATED_SUBSCRIBER));
+    }
+
+    private static <T> Subscriber<T> newErrorSubscriber() {
+        return new Subscriber<T>() {
+            @Override
+            public void onSubscribe(final Subscription subscription) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void onNext(@Nullable final T o) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void onError(final Throwable t) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void onComplete() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Subscriber<T> terminatingSubscriber() {
+        return (Subscriber<T>) TERMINATING_SUBSCRIBER;
+    }
+}

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/SpScPublisherProcessorTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/SpScPublisherProcessorTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api.internal;
+
+import io.servicetalk.concurrent.api.TestPublisherSubscriber;
+import io.servicetalk.concurrent.internal.QueueFullException;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class SpScPublisherProcessorTest {
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+    private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
+    private SpScPublisherProcessor<Integer> publisher = new SpScPublisherProcessor<>(4);
+
+    @Test
+    public void signalsDeliveredSynchronouslyIfSufficientDemand() {
+        publisher = new SpScPublisherProcessor<>(4);
+        publisher.subscribe(subscriber);
+        subscriber.request(4);
+        publisher.sendOnNext(1);
+        assertEquals(singletonList(1), subscriber.takeItems());
+        publisher.sendOnNext(2);
+        assertEquals(singletonList(2), subscriber.takeItems());
+        publisher.sendOnNext(3);
+        assertEquals(singletonList(3), subscriber.takeItems());
+        publisher.sendOnNext(4);
+        assertEquals(singletonList(4), subscriber.takeItems());
+        publisher.sendOnComplete();
+        assertThat(subscriber.takeTerminal(), is(complete()));
+    }
+
+    @Test
+    public void onNextQueueCanHoldMaxSignals() {
+        publisher = new SpScPublisherProcessor<>(4);
+        publisher.subscribe(subscriber);
+        publisher.sendOnNext(1);
+        publisher.sendOnNext(2);
+        publisher.sendOnNext(3);
+        publisher.sendOnNext(4);
+        publisher.sendOnComplete();
+        assertThat(subscriber.takeItems(), is(empty()));
+        subscriber.request(4);
+        assertEquals(asList(1, 2, 3, 4), subscriber.takeItems());
+        assertThat(subscriber.takeTerminal(), is(complete()));
+    }
+
+    @Test
+    public void completeDeliveredWithExcessDemand() {
+        publisher = new SpScPublisherProcessor<>(4);
+        publisher.subscribe(subscriber);
+        subscriber.request(4);
+        publisher.sendOnNext(1);
+        publisher.sendOnComplete();
+        assertEquals(singletonList(1), subscriber.takeItems());
+        assertThat(subscriber.takeTerminal(), is(complete()));
+    }
+
+    @Test
+    public void errorDeliveredWithExcessDemand() {
+        publisher = new SpScPublisherProcessor<>(4);
+        publisher.subscribe(subscriber);
+        subscriber.request(4);
+        publisher.sendOnNext(1);
+        publisher.sendOnError(DELIBERATE_EXCEPTION);
+        assertEquals(singletonList(1), subscriber.takeItems());
+        assertThat(subscriber.takeError(), sameInstance(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    public void onNextQueueOverflowTerminatesAndThrows() {
+        publisher = new SpScPublisherProcessor<>(1);
+        publisher.subscribe(subscriber);
+        publisher.sendOnNext(1);
+        assertThat(subscriber.takeItems(), is(empty()));
+        QueueFullException expectedException = null;
+        try {
+            publisher.sendOnNext(2);
+            fail();
+        } catch (QueueFullException e) {
+            expectedException = e;
+        }
+
+        assertThat(subscriber.takeItems(), is(empty()));
+        subscriber.request(1);
+        assertEquals(singletonList(1), subscriber.takeItems());
+        assertThat(subscriber.takeError(), sameInstance(expectedException));
+    }
+
+    @Test
+    public void onNextThrows() {
+        toSource(publisher.doOnNext(i -> {
+            throw DELIBERATE_EXCEPTION;
+        })).subscribe(subscriber);
+        subscriber.request(1);
+        publisher.sendOnNext(1);
+        publisher.sendOnNext(2);
+        publisher.sendOnComplete();
+
+        assertEquals(singletonList(1), subscriber.takeItems());
+        assertThat(subscriber.takeError(), sameInstance(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    public void invalidRequestN() {
+        publisher.subscribe(subscriber);
+        subscriber.request(-1);
+        assertThat(subscriber.takeItems(), is(empty()));
+        assertThat(subscriber.takeError(), instanceOf(IllegalArgumentException.class));
+    }
+
+    @Test
+    public void cancelStopsOnNextDelivery() {
+        publisher.subscribe(subscriber);
+        subscriber.request(4);
+        publisher.sendOnNext(1);
+        publisher.sendOnNext(2);
+        subscriber.cancel();
+        publisher.sendOnNext(3);
+        publisher.sendOnComplete();
+        assertEquals(asList(1, 2), subscriber.takeItems());
+        assertFalse(subscriber.isTerminated());
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPublisherGroupBy.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPublisherGroupBy.java
@@ -39,10 +39,10 @@ import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.MulticastUtils.drainToSubscriber;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.SUBSCRIBER_STATE_IDLE;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.SUBSCRIBER_STATE_ON_NEXT;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.SUBSCRIBER_STATE_TERMINATED;
 import static io.servicetalk.concurrent.internal.EmptySubscription.EMPTY_SUBSCRIPTION;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.SUBSCRIBER_STATE_IDLE;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.SUBSCRIBER_STATE_ON_NEXT;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.SUBSCRIBER_STATE_TERMINATED;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateSubscription;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextProvider.java
@@ -163,16 +163,6 @@ interface AsyncContextProvider {
     <T> Consumer<T> wrapConsumer(Consumer<T> consumer, AsyncContextMap contextMap);
 
     /**
-     * Wrap a {@link Consumer} to ensure it is able to track {@link AsyncContext} correctly.
-     * @param consumer The consumer to wrap.
-     * @param <T> The type of data consumed by {@code consumer}.
-     * @return The wrapped {@link Consumer}.
-     */
-    default <T> Consumer<T> wrapConsumer(Consumer<T> consumer) {
-        return wrapConsumer(consumer, contextMap());
-    }
-
-    /**
      * Wrap a {@link Function} to ensure it is able to track {@link AsyncContext} correctly.
      * @param func The function to wrap.
      * @param contextMap The {@link AsyncContext}.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MulticastPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MulticastPublisher.java
@@ -35,9 +35,9 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.PublishAndSubscribeOnPublishers.deliverOnSubscribeAndOnError;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.NULL_TOKEN;
 import static io.servicetalk.concurrent.internal.ConcurrentSubscription.wrap;
 import static io.servicetalk.concurrent.internal.PlatformDependent.throwException;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.NULL_TOKEN;
 import static java.lang.Math.min;
 
 final class MulticastPublisher<T> extends AbstractNoHandleSubscribePublisher<T> implements Subscriber<T> {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MulticastUtils.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MulticastUtils.java
@@ -32,10 +32,10 @@ import java.util.function.IntConsumer;
 import java.util.function.LongSupplier;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.NULL_TOKEN;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.SUBSCRIBER_STATE_IDLE;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.SUBSCRIBER_STATE_ON_NEXT;
 import static io.servicetalk.concurrent.internal.PlatformDependent.newUnboundedSpscQueue;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.NULL_TOKEN;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.SUBSCRIBER_STATE_IDLE;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.SUBSCRIBER_STATE_ON_NEXT;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.calculateSourceRequested;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static java.util.Objects.requireNonNull;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
@@ -32,9 +32,9 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.NULL_TOKEN;
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.drainSingleConsumerQueue;
 import static io.servicetalk.concurrent.internal.PlatformDependent.newUnboundedMpscQueue;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.NULL_TOKEN;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.calculateSourceRequested;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateSubscription;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SubscriberApiUtils.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SubscriberApiUtils.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+final class SubscriberApiUtils {
+    static final Object NULL_TOKEN = new Object();
+    static final int SUBSCRIBER_STATE_IDLE = 0;
+    static final int SUBSCRIBER_STATE_ON_NEXT = 1;
+    static final int SUBSCRIBER_STATE_TERMINATED = 2;
+
+    private SubscriberApiUtils() {
+        // no instances
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutCompletable.java
@@ -21,10 +21,12 @@ import io.servicetalk.concurrent.internal.SignalOffloader;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.PublishAndSubscribeOnCompletables.deliverOnSubscribeAndOnError;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
@@ -66,23 +68,34 @@ final class TimeoutCompletable extends AbstractNoHandleSubscribeCompletable {
          * Create a local instance because the instance is used as part of the local state machine.
          */
         private static final Cancellable LOCAL_IGNORE_CANCEL = () -> { };
+        private static final int STATE_ON_WAITING_FOR_SUBSCRIBE = 0;
+        private static final int STATE_ON_SUBSCRIBE_DONE = 1;
+        private static final int STATE_TIMED_OUT_ERROR = 2;
         private static final AtomicReferenceFieldUpdater<TimeoutSubscriber, Cancellable>
                 cancellableUpdater = newUpdater(TimeoutSubscriber.class, Cancellable.class, "cancellable");
+        private static final AtomicIntegerFieldUpdater<TimeoutSubscriber> subscriberStateUpdater =
+                AtomicIntegerFieldUpdater.newUpdater(TimeoutSubscriber.class, "subscriberState");
         @Nullable
         private volatile Cancellable cancellable;
+        private volatile int subscriberState;
         private final TimeoutCompletable parent;
         private final Subscriber target;
+        private final SignalOffloader offloader;
+        private final AsyncContextProvider contextProvider;
         @Nullable
         private Cancellable timerCancellable;
 
-        private TimeoutSubscriber(TimeoutCompletable parent, Subscriber target) {
+        private TimeoutSubscriber(TimeoutCompletable parent, Subscriber target, SignalOffloader offloader,
+                                  AsyncContextProvider contextProvider) {
             this.parent = parent;
             this.target = target;
+            this.offloader = offloader;
+            this.contextProvider = contextProvider;
         }
 
         static TimeoutSubscriber newInstance(TimeoutCompletable parent, Subscriber target, SignalOffloader offloader,
                                              AsyncContextMap contextMap, AsyncContextProvider contextProvider) {
-            TimeoutSubscriber s = new TimeoutSubscriber(parent, target);
+            TimeoutSubscriber s = new TimeoutSubscriber(parent, target, offloader, contextProvider);
             Cancellable localTimerCancellable;
             try {
                 // We rely upon the timeoutExecutor to save/restore the current context when notifying when the timer
@@ -107,6 +120,13 @@ final class TimeoutCompletable extends AbstractNoHandleSubscribeCompletable {
         public void onSubscribe(final Cancellable cancellable) {
             if (cancellableUpdater.compareAndSet(this, null, cancellable)) {
                 target.onSubscribe(this);
+
+                if (!subscriberStateUpdater.compareAndSet(this, STATE_ON_WAITING_FOR_SUBSCRIBE,
+                        STATE_ON_SUBSCRIBE_DONE)) {
+                    // subscriberState will be STATE_TIMED_OUT_ERROR, but the timeout occurred while we were invoking
+                    // onSubscribe so terminating the target is handed off to this thread.
+                    target.onError(newTimeoutException());
+                }
             } else {
                 cancellable.cancel();
             }
@@ -152,14 +172,34 @@ final class TimeoutCompletable extends AbstractNoHandleSubscribeCompletable {
         public void run() {
             Cancellable oldCancellable = cancellableUpdater.getAndSet(this, LOCAL_IGNORE_CANCEL);
             if (oldCancellable != LOCAL_IGNORE_CANCEL) {
+                // The timeout may be running on a different Executor than the original async source. If that is the
+                // case we should offload to the correct Executor.
+                // We rely upon the timeout Executor to save/restore the context. so we just use
+                // contextProvider.contextMap() here.
+                final Subscriber offloadedTarget = parent.timeoutExecutor == parent.executor() ? target :
+                        offloader.offloadSubscriber(contextProvider.wrapCompletableSubscriber(target,
+                                contextProvider.contextMap()));
                 // The timer is started before onSubscribe so the oldCancellable may actually be null at this time.
                 if (oldCancellable != null) {
                     oldCancellable.cancel();
+
+                    // We already know that this.onSubscribe was called because we have a valid Cancellable. We need to
+                    // know that the call to target.onSubscribe completed so we don't interact with the Subscriber
+                    // concurrently.
+                    if (subscriberStateUpdater.getAndSet(this, STATE_TIMED_OUT_ERROR) == STATE_ON_SUBSCRIBE_DONE) {
+                        offloadedTarget.onError(newTimeoutException());
+                    }
                 } else {
-                    target.onSubscribe(IGNORE_CANCEL);
+                    // If there is no Cancellable, that means this.onSubscribe wasn't called before the timeout. In this
+                    // case there is no risk of concurrent invocation on target because we won't invoke
+                    // target.onSubscribe from this.onSubscribe.
+                    deliverTerminalFromSource(offloadedTarget, newTimeoutException());
                 }
-                target.onError(new TimeoutException("timeout after " + NANOSECONDS.toMillis(parent.durationNs) + "ms"));
             }
+        }
+
+        private TimeoutException newTimeoutException() {
+            return new TimeoutException("timeout after " + NANOSECONDS.toMillis(parent.durationNs) + "ms");
         }
 
         private void stopTimer() {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultAsyncContextProviderTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultAsyncContextProviderTest.java
@@ -409,7 +409,8 @@ public class DefaultAsyncContextProviderTest {
 
         new ContextCapturer()
                 .runAndWait(collector -> {
-                    Consumer<Void> c = INSTANCE.wrapConsumer(v -> collector.complete(AsyncContext.current()));
+                    Consumer<Void> c = INSTANCE.wrapConsumer(v -> collector.complete(AsyncContext.current()),
+                            AsyncContext.current());
                     executor.execute(() -> c.accept(null));
                 })
                 .verifyContext(verifier);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentTerminalSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentTerminalSubscriberTest.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.internal;
+
+import io.servicetalk.concurrent.PublisherSource.Subscriber;
+import io.servicetalk.concurrent.PublisherSource.Subscription;
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.ExecutorRule;
+import io.servicetalk.concurrent.api.TestPublisher;
+import io.servicetalk.concurrent.api.TestSubscription;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class ConcurrentTerminalSubscriberTest {
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+    @Rule
+    public final ExecutorRule<Executor> executorRule = ExecutorRule.newRule();
+
+    private final TestPublisher<Integer> publisher =
+            new TestPublisher.Builder<Integer>().disableAutoOnSubscribe().build();
+    private final TestSubscription subscription = new TestSubscription();
+
+    @Test
+    public void concurrentOnSubscribeWithOnNextAndOnComplete() throws Exception {
+        concurrentOnSubscribe(true, true);
+    }
+
+    @Test
+    public void concurrentOnSubscribeWithOnComplete() throws Exception {
+        concurrentOnSubscribe(true, false);
+    }
+
+    @Test
+    public void concurrentOnSubscribeWithOnNextAndOnError() throws Exception {
+        concurrentOnSubscribe(false, true);
+    }
+
+    @Test
+    public void concurrentOnSubscribeWithOnError() throws Exception {
+        concurrentOnSubscribe(false, false);
+    }
+
+    @Test
+    public void concurrentOnNextWithOnComplete() throws Exception {
+        concurrentOnNext(true);
+    }
+
+    @Test
+    public void concurrentOnNextWithOnError() throws Exception {
+        concurrentOnNext(false);
+    }
+
+    @Test
+    public void concurrentOnCompleteWithOnComplete() throws Exception {
+        concurrentOnComplete(true, true);
+    }
+
+    @Test
+    public void concurrentOnCompleteWithOnError() throws Exception {
+        concurrentOnComplete(true, false);
+    }
+
+    @Test
+    public void concurrentOnErrorWithOnComplete() throws Exception {
+        concurrentOnComplete(false, true);
+    }
+
+    @Test
+    public void concurrentOnErrorWithOnError() throws Exception {
+        concurrentOnComplete(false, false);
+    }
+
+    @Test
+    public void reentrySynchronousOnNextAllowedOnComplete() {
+        reentrySynchronousOnNextAllowed(true);
+    }
+
+    @Test
+    public void reentrySynchronousOnNextAllowedOnError() {
+        reentrySynchronousOnNextAllowed(false);
+    }
+
+    private void reentrySynchronousOnNextAllowed(boolean onComplete) {
+        AtomicReference<Subscription> subscriptionRef = new AtomicReference<>();
+        @SuppressWarnings("unchecked")
+        Subscriber<Integer> mockSubscriber = (Subscriber<Integer>) mock(Subscriber.class);
+        doAnswer((Answer<Void>) invocation -> {
+            Subscription s = invocation.getArgument(0);
+            subscriptionRef.set(s);
+            s.request(1);
+            return null;
+        }).when(mockSubscriber).onSubscribe(any());
+        doAnswer((Answer<Void>) invocation -> {
+            subscriptionRef.get().request(1);
+            return null;
+        }).when(mockSubscriber).onNext(any());
+
+        ConcurrentTerminalSubscriber<Integer> subscriber = new ConcurrentTerminalSubscriber<>(mockSubscriber);
+        publisher.subscribe(subscriber);
+        publisher.onSubscribe(new Subscription() {
+            private int i;
+            @Override
+            public void request(final long n) {
+                if (i < 5) {
+                    publisher.onNext(++i);
+                } else if (i == 5) {
+                    ++i;
+                    if (onComplete) {
+                        publisher.onComplete();
+                    } else {
+                        publisher.onError(DELIBERATE_EXCEPTION);
+                    }
+                    // This should be filtered, because we need to protect against concurrent termination this may
+                    // happen concurrently.
+                    publisher.onNext(i);
+                }
+            }
+
+            @Override
+            public void cancel() {
+            }
+        });
+
+        ArgumentCaptor<Integer> onNextArgs = ArgumentCaptor.forClass(Integer.class);
+        verify(mockSubscriber, times(5)).onNext(onNextArgs.capture());
+        assertEquals(asList(1, 2, 3, 4, 5), onNextArgs.getAllValues());
+        if (onComplete) {
+            verify(mockSubscriber).onComplete();
+        } else {
+            verify(mockSubscriber).onError(same(DELIBERATE_EXCEPTION));
+        }
+    }
+
+    private void concurrentOnComplete(boolean firstOnComplete, boolean secondOnComplete) throws Exception {
+        CyclicBarrier terminalEnterBarrier = new CyclicBarrier(2);
+        CountDownLatch terminatedLatch = new CountDownLatch(1);
+
+        @SuppressWarnings("unchecked")
+        Subscriber<Integer> mockSubscriber = (Subscriber<Integer>) mock(Subscriber.class);
+        doAnswer((Answer<Void>) invocation -> {
+            Subscription s = invocation.getArgument(0);
+            s.request(1);
+            return null;
+        }).when(mockSubscriber).onSubscribe(any());
+        doAnswer((Answer<Void>) invocation -> {
+            terminalEnterBarrier.await();
+            terminatedLatch.countDown();
+            return null;
+        }).when(mockSubscriber).onComplete();
+        doAnswer((Answer<Void>) invocation -> {
+            terminalEnterBarrier.await();
+            terminatedLatch.countDown();
+            return null;
+        }).when(mockSubscriber).onError(any());
+
+        ConcurrentTerminalSubscriber<Integer> subscriber = new ConcurrentTerminalSubscriber<>(mockSubscriber);
+        publisher.subscribe(subscriber);
+        publisher.onSubscribe(subscription);
+        executorRule.executor().execute(() -> {
+            if (firstOnComplete) {
+                publisher.onComplete();
+            } else {
+                publisher.onError(DELIBERATE_EXCEPTION);
+            }
+        });
+        terminalEnterBarrier.await();
+        if (secondOnComplete) {
+            publisher.onComplete();
+        } else {
+            publisher.onError(DELIBERATE_EXCEPTION);
+        }
+
+        terminatedLatch.await();
+
+        if (firstOnComplete && secondOnComplete) {
+            verify(mockSubscriber).onComplete();
+        } else if (!firstOnComplete && !secondOnComplete) {
+            verify(mockSubscriber).onError(same(DELIBERATE_EXCEPTION));
+        } else {
+            try {
+                verify(mockSubscriber).onComplete();
+            } catch (AssertionError e) {
+                verify(mockSubscriber).onError(same(DELIBERATE_EXCEPTION));
+            }
+        }
+    }
+
+    private void concurrentOnNext(boolean onComplete) throws Exception {
+        CountDownLatch onNextLatch = new CountDownLatch(1);
+        CyclicBarrier onNextEnterBarrier = new CyclicBarrier(2);
+        CountDownLatch terminatedLatch = new CountDownLatch(1);
+
+        @SuppressWarnings("unchecked")
+        Subscriber<Integer> mockSubscriber = (Subscriber<Integer>) mock(Subscriber.class);
+        doAnswer((Answer<Void>) invocation -> {
+            Subscription s = invocation.getArgument(0);
+            s.request(1);
+            return null;
+        }).when(mockSubscriber).onSubscribe(any());
+        doAnswer((Answer<Void>) invocation -> {
+            try {
+                onNextEnterBarrier.await();
+                onNextLatch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            return null;
+        }).when(mockSubscriber).onNext(any());
+        doAnswer((Answer<Void>) invocation -> {
+            terminatedLatch.countDown();
+            return null;
+        }).when(mockSubscriber).onComplete();
+        doAnswer((Answer<Void>) invocation -> {
+            terminatedLatch.countDown();
+            return null;
+        }).when(mockSubscriber).onError(any());
+
+        ConcurrentTerminalSubscriber<Integer> subscriber = new ConcurrentTerminalSubscriber<>(mockSubscriber);
+        publisher.subscribe(subscriber);
+        publisher.onSubscribe(subscription);
+        subscription.awaitRequestN(1);
+        executorRule.executor().execute(() -> publisher.onNext(1));
+        onNextEnterBarrier.await();
+        if (onComplete) {
+            publisher.onComplete();
+        } else {
+            publisher.onError(DELIBERATE_EXCEPTION);
+        }
+        onNextLatch.countDown();
+
+        terminatedLatch.await();
+        verify(mockSubscriber).onNext(eq(1));
+
+        if (onComplete) {
+            verify(mockSubscriber).onComplete();
+        } else {
+            verify(mockSubscriber).onError(same(DELIBERATE_EXCEPTION));
+        }
+    }
+
+    private void concurrentOnSubscribe(boolean onComplete, boolean onNext) throws Exception {
+        CountDownLatch onSubscribeLatch = new CountDownLatch(1);
+        CountDownLatch terminatedLatch = new CountDownLatch(1);
+
+        @SuppressWarnings("unchecked")
+        Subscriber<Integer> mockSubscriber = (Subscriber<Integer>) mock(Subscriber.class);
+        doAnswer((Answer<Void>) invocation -> {
+            Subscription s = invocation.getArgument(0);
+            s.request(1);
+            try {
+                onSubscribeLatch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            return null;
+        }).when(mockSubscriber).onSubscribe(any());
+        doAnswer((Answer<Void>) invocation -> {
+            terminatedLatch.countDown();
+            return null;
+        }).when(mockSubscriber).onComplete();
+        doAnswer((Answer<Void>) invocation -> {
+            terminatedLatch.countDown();
+            return null;
+        }).when(mockSubscriber).onError(any());
+
+        ConcurrentTerminalSubscriber<Integer> subscriber = new ConcurrentTerminalSubscriber<>(mockSubscriber);
+        publisher.subscribe(subscriber);
+        executorRule.executor().execute(() -> publisher.onSubscribe(subscription));
+        subscription.awaitRequestN(1);
+        if (onNext) {
+            publisher.onNext(1);
+        }
+        if (onComplete) {
+            publisher.onComplete();
+        } else {
+            publisher.onError(DELIBERATE_EXCEPTION);
+        }
+        onSubscribeLatch.countDown();
+
+        terminatedLatch.await();
+        if (onNext) {
+            verify(mockSubscriber).onNext(eq(1));
+        } else {
+            verify(mockSubscriber, never()).onNext(any());
+        }
+
+        if (onComplete) {
+            verify(mockSubscriber).onComplete();
+        } else {
+            verify(mockSubscriber).onError(same(DELIBERATE_EXCEPTION));
+        }
+    }
+}

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ConcurrentTerminalSubscriber.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ConcurrentTerminalSubscriber.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.internal;
+
+import io.servicetalk.concurrent.PublisherSource;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.PublisherSource.Subscriber;
+import static io.servicetalk.concurrent.PublisherSource.Subscription;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A {@link Subscriber} that allows for concurrent delivery of terminal events.
+ *
+ * @param <T> The type of {@link Subscriber}.
+ */
+public final class ConcurrentTerminalSubscriber<T> implements Subscriber<T> {
+    private static final int SUBSCRIBER_STATE_INVALID = Integer.MIN_VALUE;
+    private static final int SUBSCRIBER_STATE_WAITING_ON_SUBSCRIBE = -1;
+    private static final int SUBSCRIBER_STATE_IDLE = 0;
+    private static final int SUBSCRIBER_STATE_ON_NEXT = 1;
+    private static final int SUBSCRIBER_STATE_TERMINATING = 2;
+    private static final int SUBSCRIBER_STATE_TERMINATED = 3;
+
+    private static final AtomicIntegerFieldUpdater<ConcurrentTerminalSubscriber> stateUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(ConcurrentTerminalSubscriber.class, "state");
+
+    private final Subscriber<T> delegate;
+    @Nullable
+    private TerminalNotification terminalNotification;
+    private volatile int state;
+
+    /**
+     * Create a new instance.
+     *
+     * @param delegate The {@link Subscriber} to delegate all signals to.
+     */
+    public ConcurrentTerminalSubscriber(Subscriber<T> delegate) {
+        this(delegate, true);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param delegate The {@link Subscriber} to delegate all signals to.
+     * @param concurrentOnSubscribe {@code false} to not guard for concurrency on
+     * {@link Subscriber#onSubscribe(PublisherSource.Subscription)}. {@code true} means that
+     * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be protected against concurrent invocation with
+     * terminal methods.
+     */
+    public ConcurrentTerminalSubscriber(Subscriber<T> delegate, boolean concurrentOnSubscribe) {
+        this.delegate = requireNonNull(delegate);
+        state = concurrentOnSubscribe ? SUBSCRIBER_STATE_WAITING_ON_SUBSCRIBE : SUBSCRIBER_STATE_IDLE;
+    }
+
+    @Override
+    public void onSubscribe(final Subscription subscription) {
+        final boolean wasWaiting = state == SUBSCRIBER_STATE_WAITING_ON_SUBSCRIBE;
+
+        try {
+            delegate.onSubscribe(subscription);
+        } finally {
+            if (wasWaiting) {
+                for (;;) {
+                    final int localState = state;
+                    if (localState == SUBSCRIBER_STATE_WAITING_ON_SUBSCRIBE) {
+                        if (stateUpdater.compareAndSet(this, SUBSCRIBER_STATE_WAITING_ON_SUBSCRIBE,
+                                SUBSCRIBER_STATE_IDLE)) {
+                            break;
+                        }
+                    } else if (localState == SUBSCRIBER_STATE_TERMINATING) {
+                        if (stateUpdater.compareAndSet(this, SUBSCRIBER_STATE_TERMINATING,
+                                SUBSCRIBER_STATE_TERMINATED)) {
+                            assert terminalNotification != null;
+                            terminalNotification.terminate(delegate);
+                            break;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onNext(@Nullable final T t) {
+        int originalState = SUBSCRIBER_STATE_INVALID;
+        for (;;) {
+            final int localState = state;
+            if (localState == SUBSCRIBER_STATE_IDLE || localState == SUBSCRIBER_STATE_WAITING_ON_SUBSCRIBE) {
+                if (stateUpdater.compareAndSet(this, localState, SUBSCRIBER_STATE_ON_NEXT)) {
+                    originalState = localState;
+                    break;
+                }
+            } else if (localState == SUBSCRIBER_STATE_ON_NEXT) {
+                // Allow reentry because we don't want to drop data.
+                break;
+            } else {
+                // The only possible state is TERMINATED. We don't have to worry about concurrency for
+                // Subscriber#onNext.
+                return;
+            }
+        }
+        try {
+            delegate.onNext(t);
+        } finally {
+            if (originalState != SUBSCRIBER_STATE_INVALID) {
+                for (;;) {
+                    final int localState = state;
+                    if (localState == SUBSCRIBER_STATE_ON_NEXT) {
+                        if (stateUpdater.compareAndSet(this, SUBSCRIBER_STATE_ON_NEXT, originalState)) {
+                            break;
+                        }
+                    } else if (localState == SUBSCRIBER_STATE_TERMINATING) {
+                        if (stateUpdater.compareAndSet(this, SUBSCRIBER_STATE_TERMINATING,
+                                SUBSCRIBER_STATE_TERMINATED)) {
+                            assert terminalNotification != null;
+                            terminalNotification.terminate(delegate);
+                            break;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onError(final Throwable t) {
+        processOnError(t);
+    }
+
+    /**
+     * Attempt to process {@link #onError(Throwable)}.
+     *
+     * @param t The error to process.
+     * @return {@code true} if the terminal signal was propagated to the delegate {@link Subscriber}.
+     */
+    public boolean processOnError(final Throwable t) {
+        for (;;) {
+            final int localState = state;
+            if (localState == SUBSCRIBER_STATE_TERMINATED || localState == SUBSCRIBER_STATE_TERMINATING) {
+                return false;
+            } else {
+                // We may overwrite the terminalNotification if there is concurrency on this method, but there is no
+                // guarantee about what terminal notification will be propagated in the event of concurrency anyways.
+                terminalNotification = TerminalNotification.error(t);
+                if (stateUpdater.compareAndSet(this, localState, SUBSCRIBER_STATE_TERMINATING)) {
+                    // We only propagate the terminal event here if the localState was SUBSCRIBER_STATE_IDLE, because
+                    // otherwise this means we maybe interacting with the Subscriber on another thread.
+                    if (localState == SUBSCRIBER_STATE_IDLE &&
+                            stateUpdater.compareAndSet(this, SUBSCRIBER_STATE_TERMINATING,
+                                    SUBSCRIBER_STATE_TERMINATED)) {
+                        delegate.onError(t);
+                        return true;
+                    }
+                    return false;
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onComplete() {
+        processOnComplete();
+    }
+
+    /**
+     * Attempt to process {@link #onComplete()}.
+     *
+     * @return {@code true} if the terminal signal was propagated to the delegate {@link Subscriber}.
+     */
+    public boolean processOnComplete() {
+        for (;;) {
+            final int localState = state;
+            if (localState == SUBSCRIBER_STATE_TERMINATED || localState == SUBSCRIBER_STATE_TERMINATING) {
+                return false;
+            } else {
+                // We may overwrite the terminalNotification if there is concurrency on this method, but there is no
+                // guarantee about what terminal notification will be propagated in the event of concurrency anyways.
+                terminalNotification = TerminalNotification.complete();
+                if (stateUpdater.compareAndSet(this, localState, SUBSCRIBER_STATE_TERMINATING)) {
+                    // We only propagate the terminal event here if the localState was SUBSCRIBER_STATE_IDLE, because
+                    // otherwise this means we maybe interacting with the Subscriber on another thread.
+                    if (localState == SUBSCRIBER_STATE_IDLE &&
+                            stateUpdater.compareAndSet(this, SUBSCRIBER_STATE_TERMINATING,
+                                    SUBSCRIBER_STATE_TERMINATED)) {
+                        delegate.onComplete();
+                        return true;
+                    }
+                    return false;
+                }
+            }
+        }
+    }
+}

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FlowControlUtil.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FlowControlUtil.java
@@ -28,34 +28,6 @@ public final class FlowControlUtil {
     }
 
     /**
-     * Adds two integer and saturate to {@code Integer.MAX_VALUE} / {@code Integer.MIN_VALUE} if overflow happens.
-     * @param x first value
-     * @param y second value
-     * @return sum of two values or {@code Integer.MAX_VALUE} / {@code Integer.MIN_VALUE} if overflow happens.
-     */
-    public static int addSaturated(final int x, final int y) {
-        int r = x + y;
-        if (((x ^ r) & (y ^ r)) < 0) {
-            return x >= 0 ? Integer.MAX_VALUE : Integer.MIN_VALUE;
-        }
-        return r;
-    }
-
-    /**
-     * Adds two longs and saturate to {@code Long.MAX_VALUE} / {@code Long.MIN_VALUE} if overflow happens.
-     * @param x first value
-     * @param y second value
-     * @return sum of two values or {@code Long.MAX_VALUE} / {@code Long.MIN_VALUE} if overflow happens.
-     */
-    public static long addSaturated(final long x, final long y) {
-        long r = x + y;
-        if (((x ^ r) & (y ^ r)) < 0) {
-            return x >= 0 ? Long.MAX_VALUE : Long.MIN_VALUE;
-        }
-        return r;
-    }
-
-    /**
      * If {@code x} is non-negative this method behaves the same as {@link #addWithOverflowProtection(long, long)}.
      * If {@code x} is negative then {@code x} is returned.
      * @param x first value (may be negative).
@@ -101,6 +73,16 @@ public final class FlowControlUtil {
      */
     public static long addWithOverflowProtectionIfPositive(long x, long y) {
         return x <= 0 ? x : addWithOverflowProtection(x, y);
+    }
+
+    /**
+     * Subtract {@code y} from {@code x} if {@code x} is positive.
+     * @param x first value (may be negative).
+     * @param y second value (should be positive).
+     * @return the result of {@code x-y} if {@code x>0}, or {@code x}.
+     */
+    public static long subtractIfPositive(long x, long y) {
+        return x <= 0 ? x : x - y;
     }
 
     /**

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/TaskBasedSignalOffloader.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/TaskBasedSignalOffloader.java
@@ -281,8 +281,7 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
         private static final int STATE_ENQUEUED = 1;
         private static final int STATE_EXECUTING = 2;
         private static final int STATE_TERMINATING = 3;
-        private static final int STATE_TERMINATING_INTERRUPTED = 4;
-        private static final int STATE_TERMINATED = 5;
+        private static final int STATE_TERMINATED = 4;
         private static final AtomicIntegerFieldUpdater<OffloadedSubscriber> stateUpdater =
                 newUpdater(OffloadedSubscriber.class, "state");
 
@@ -417,11 +416,10 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
                     signals.clear();
                     return;
                 } else if (cState == STATE_TERMINATING) {
-                    if (!stateUpdater.compareAndSet(this, STATE_TERMINATING, STATE_TERMINATING_INTERRUPTED)) {
+                    if (stateUpdater.getAndSet(this, STATE_TERMINATED) == STATE_TERMINATED) {
                         // If another thread was draining the queue, and is no longer training the queue then the only
                         // state we can be in is STATE_TERMINATED. This means no other thread is consuming from the
                         // queue and we are safe to consume/clear it.
-                        // assert state == STATE_TERMINATED;
                         signals.clear();
                     }
                     return;

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -29,8 +29,7 @@ import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.concurrent.api.internal.SubscribablePublisher;
-import io.servicetalk.concurrent.internal.DuplicateSubscribeException;
+import io.servicetalk.concurrent.api.internal.SpScPublisherProcessor;
 import io.servicetalk.concurrent.internal.SequentialCancellable;
 
 import org.slf4j.Logger;
@@ -58,13 +57,6 @@ import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.error;
 import static io.servicetalk.concurrent.api.Single.success;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
-import static io.servicetalk.concurrent.internal.EmptySubscription.EMPTY_SUBSCRIPTION;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.SUBSCRIBER_STATE_TERMINATED;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.checkTerminationValidWithConcurrentOnNextCheck;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.sendOnNextWithConcurrentTerminationCheck;
-import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.ThrowableUtil.unknownStackTrace;
 import static java.util.Collections.binarySearch;
 import static java.util.Collections.emptyList;
@@ -112,7 +104,7 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends ListenableA
     private volatile int index;
     private volatile List<Host<ResolvedAddress, C>> activeHosts = emptyList();
 
-    private final PublisherProcessorSingle<Object> eventStream = new PublisherProcessorSingle<>();
+    private final SpScPublisherProcessor<Object> eventStream = new SpScPublisherProcessor<>(32);
     private final SequentialCancellable discoveryCancellable = new SequentialCancellable();
     private final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory;
     private final ListenableAsyncCloseable asyncCloseable;
@@ -190,6 +182,7 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends ListenableA
             @Override
             public void onError(final Throwable t) {
                 List<Host<ResolvedAddress, C>> hosts = activeHosts;
+                eventStream.sendOnError(t);
                 LOGGER.error(
                         "Load balancer {}. Service discoverer {} emitted an error. Last seen addresses (size {}) {}",
                         RoundRobinLoadBalancer.this, eventPublisher, hosts.size(), hosts, t);
@@ -198,6 +191,7 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends ListenableA
             @Override
             public void onComplete() {
                 List<Host<ResolvedAddress, C>> hosts = activeHosts;
+                eventStream.sendOnComplete();
                 LOGGER.error("Load balancer {}. Service discoverer {} completed. Last seen addresses (size {}) {}",
                         RoundRobinLoadBalancer.this, eventPublisher, hosts.size(), hosts);
             }
@@ -387,156 +381,5 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends ListenableA
     private static final class MutableAddressHost<Addr, C extends ListenableAsyncCloseable> extends Host<Addr, C> {
         @Nullable
         Addr mutableAddress;
-    }
-
-    /**
-     * Eventually this will be replaced by a PublisherProcessor which is backed by a queue and allows for
-     * arbitrary events being published.
-     * @param <T> The type of data delivered to {@link Subscriber}s.
-     */
-    private static final class PublisherProcessorSingle<T> extends SubscribablePublisher<T> {
-        private static final AtomicIntegerFieldUpdater<PublisherProcessorSingle> subscriberStateUpdater =
-                newUpdater(PublisherProcessorSingle.class, "subscriberState");
-        private static final AtomicReferenceFieldUpdater<PublisherProcessorSingle, Object> terminalNotificationUpdater =
-                newUpdater(PublisherProcessorSingle.class, Object.class, "terminalNotification");
-        private static final AtomicReferenceFieldUpdater<PublisherProcessorSingle, Object> eventUpdater =
-                newUpdater(PublisherProcessorSingle.class, Object.class, "event");
-        private static final Object REQUESTED = new Object();
-        private static final Object DELIVERED = new Object();
-        private static final Object COMPLETED = new Object();
-        @Nullable
-        private volatile Subscriber<? super T> subscriber;
-        @Nullable
-        private volatile Object event;
-        @SuppressWarnings("unused")
-        private volatile int subscriberState;
-        @SuppressWarnings("unused")
-        @Nullable
-        private volatile Object terminalNotification;
-
-        @Override
-        protected void handleSubscribe(final Subscriber<? super T> subscriber) {
-            Subscriber<? super T> thisSubscriber = this.subscriber;
-            if (thisSubscriber == null) {
-                this.subscriber = subscriber;
-                subscriber.onSubscribe(new Subscription() {
-                    @Override
-                    public void request(final long n) {
-                        if (isRequestNValid(n)) {
-                            for (;;) {
-                                Object event = PublisherProcessorSingle.this.event;
-                                if (event == REQUESTED || event == DELIVERED || event == COMPLETED) {
-                                    break;
-                                } else if (event != null) {
-                                    if (eventUpdater.compareAndSet(PublisherProcessorSingle.this, event, DELIVERED)) {
-                                        @SuppressWarnings("unchecked")
-                                        final T finalT = (T) event;
-                                        deliverOnNext(finalT, subscriber);
-                                        break;
-                                    }
-                                } else if (eventUpdater.compareAndSet(PublisherProcessorSingle.this, null, REQUESTED)) {
-                                    // Check if sendOnComplete was called but the Subscriber was not visible, and then
-                                    // deliver the terminal notification if we change the event to COMPLETED.
-                                    if (subscriberState == SUBSCRIBER_STATE_TERMINATED &&
-                                        eventUpdater.compareAndSet(PublisherProcessorSingle.this, REQUESTED,
-                                                COMPLETED)) {
-                                        subscriber.onComplete();
-                                    }
-                                    break;
-                                }
-                            }
-                        } else {
-                            Throwable cause = newExceptionForInvalidRequestN(n);
-                            if (checkTerminationValidWithConcurrentOnNextCheck(null, cause, subscriberStateUpdater,
-                                    terminalNotificationUpdater, PublisherProcessorSingle.this)) {
-                                for (;;) {
-                                    Object event = PublisherProcessorSingle.this.event;
-                                    if (event == null || event == REQUESTED || event == DELIVERED) {
-                                        if (eventUpdater.compareAndSet(PublisherProcessorSingle.this, event,
-                                                COMPLETED)) {
-                                            subscriber.onError(cause);
-                                            break;
-                                        }
-                                    } else {
-                                        // If there is data pending we will deliver the error after the data.
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    @Override
-                    public void cancel() {
-                        // This will ensure the event is GCed (if it exists) and will swallow any terminal events which
-                        // also maybe pending.
-                        event = COMPLETED;
-                    }
-                });
-            } else {
-                subscriber.onSubscribe(EMPTY_SUBSCRIPTION);
-                subscriber.onError(new DuplicateSubscribeException(thisSubscriber, subscriber));
-            }
-        }
-
-        void sendOnNext(T next) {
-            for (;;) {
-                Object event = this.event;
-                if (event == null) {
-                    if (eventUpdater.compareAndSet(this, null, next)) {
-                        break;
-                    }
-                } else if (event == REQUESTED) {
-                    if (eventUpdater.compareAndSet(this, REQUESTED, DELIVERED)) {
-                        Subscriber<? super T> subscriber = this.subscriber;
-                        assert subscriber != null;
-                        deliverOnNext(next, subscriber);
-                        break;
-                    }
-                } else {
-                    break;
-                }
-            }
-        }
-
-        void sendOnComplete() {
-            if (checkTerminationValidWithConcurrentOnNextCheck(null, complete(),
-                    subscriberStateUpdater, terminalNotificationUpdater, this)) {
-                Subscriber<? super T> subscriber = this.subscriber;
-                // If the subscriber is not null, deliver the event now, otherwise we deliver in the Subscription.
-                if (subscriber != null) {
-                    // Make a best effort to terminate early, if there is data pending we will let the Subscription
-                    // deliver the terminal event after it delivers the data.
-                    for (;;) {
-                        Object event = this.event;
-                        if (event == null || event == REQUESTED || event == DELIVERED) {
-                            if (eventUpdater.compareAndSet(this, event, COMPLETED)) {
-                                subscriber.onComplete();
-                                break;
-                            }
-                        } else {
-                            // Note that the Subscription may have requested data in the mean time, but we let the
-                            // Subscription handle that.
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-
-        private void deliverOnNext(T next, Subscriber<? super T> subscriber) {
-            sendOnNextWithConcurrentTerminationCheck(subscriber, next, this::terminate,
-                    subscriberStateUpdater, terminalNotificationUpdater, this);
-        }
-
-        private void terminate(Object terminalNotification) {
-            Subscriber<? super T> subscriber = this.subscriber;
-            assert subscriber != null;
-            if (terminalNotification instanceof Throwable) {
-                subscriber.onError((Throwable) terminalNotification);
-            } else {
-                subscriber.onComplete();
-            }
-        }
     }
 }


### PR DESCRIPTION
Motivation:
The timeout operator for Completable, Single, and Publisher all set the timeout
when subscribe(..) is called. When the timeout fires we try to terminate the
corresponding Subscriber. However this may occur concurrently with calling
onSubscribe(..) on that Subscriber. Concurrent invocation of the Subscriber is
not allowed by the ReactiveStreams specification.

Modifications:
- Add protections between the timer terminating the Subscriber and invoking
  onSubscribe.
- Avoid offloading for timer notification if the timeout Executor is the same as
  the asynchronous source's Executor.
- Single and Completable timeout is also not respecting the offloading of the
  asynchronous source, and it now does.
- Remove the SubscriberUtil methods that leak state because the state now has to
  change to accomidate the onSubscribe protection. This functionality can be
encapsulated in its own class (e.g. ConcurrentTerminalSubscriber) at the cost of
an additional object allocation and wrapping layer. This also involves removing
the single item publisher processor from RoundRobinLoadBalancer. This single
item publisher doesn't lend itself nicely to the new tools so the intended logic
will be generalized.

Result:
No more concurrent invocation of the Subscriber from timeout operators.