### PR TITLE
Enable checkstyle 120 char line limit and fix violations.

### DIFF
--- a/servicetalk-client-api/src/test/java/io/servicetalk/client/api/LimitingActiveConnectionFactoryFilterTest.java
+++ b/servicetalk-client-api/src/test/java/io/servicetalk/client/api/LimitingActiveConnectionFactoryFilterTest.java
@@ -47,7 +47,8 @@ public class LimitingActiveConnectionFactoryFilterTest {
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();
     @Rule
-    public final LegacyMockedSingleListenerRule<ListenableAsyncCloseable> connectlistener = new LegacyMockedSingleListenerRule<>();
+    public final LegacyMockedSingleListenerRule<ListenableAsyncCloseable> connectlistener =
+            new LegacyMockedSingleListenerRule<>();
 
     private ConnectionFactory<String, ListenableAsyncCloseable> original;
     private BlockingQueue<CompletableProcessor> connectionOnClose;

--- a/servicetalk-client-internal/src/test/java/io/servicetalk/client/internal/partition/PowerSetPartitionMapTest.java
+++ b/servicetalk-client-internal/src/test/java/io/servicetalk/client/internal/partition/PowerSetPartitionMapTest.java
@@ -241,7 +241,8 @@ public class PowerSetPartitionMapTest {
     public void testAddDuplicationPartitions() {
         PowerSetPartitionMap<ListenableAsyncCloseable> map = new PowerSetPartitionMap<>(address -> VALUE);
         assertTrue("New map is not empty.", map.isEmpty());
-        PartitionAttributes partition = new DefaultPartitionAttributesBuilder(1).add(IS_MASTER, true).add(SHARD_ID, 1).build();
+        PartitionAttributes partition = new DefaultPartitionAttributesBuilder(1).add(IS_MASTER, true).add(SHARD_ID, 1)
+                .build();
         List<ListenableAsyncCloseable> added1 = map.add(partition);
         List<ListenableAsyncCloseable> added2 = map.add(partition);
         assertEquals("Added partitions are not equal.", added1, added2);

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/PublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/PublishAndSubscribeOnTest.java
@@ -56,7 +56,8 @@ public class PublishAndSubscribeOnTest extends AbstractPublishAndSubscribeOnTest
                 setupAndSubscribe(Publisher::publishOnOverride, executorRule.executor());
 
         assertThat("Unexpected threads for subscription and subscriber for original source.",
-                capturedThreads.get(ORIGINAL_SUBSCRIBER_THREAD), not(capturedThreads.get(ORIGINAL_SUBSCRIPTION_THREAD)));
+                capturedThreads.get(ORIGINAL_SUBSCRIBER_THREAD),
+                not(capturedThreads.get(ORIGINAL_SUBSCRIPTION_THREAD)));
         assertThat("Unexpected threads for subscription and subscriber for offloaded source.",
                 capturedThreads.get(OFFLOADED_SUBSCRIBER_THREAD),
                 not(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD)));

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RedoPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RedoPublisher.java
@@ -45,8 +45,8 @@ final class RedoPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
                          AsyncContextProvider contextProvider) {
         // For the current subscribe operation we want to use contextMap directly, but in the event a re-subscribe
         // operation occurs we want to restore the original state of the AsyncContext map, so we save a copy upfront.
-        original.delegateSubscribe(new RedoSubscriber<>(new SequentialSubscription(), 0, subscriber,
-                contextMap.copy(), contextProvider, this, signalOffloader), signalOffloader, contextMap, contextProvider);
+        original.delegateSubscribe(new RedoSubscriber<>(new SequentialSubscription(), 0, subscriber, contextMap.copy(),
+                contextProvider, this, signalOffloader), signalOffloader, contextMap, contextProvider);
     }
 
     abstract static class AbstractRedoSubscriber<T> implements Subscriber<T> {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletionStageTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletionStageTest.java
@@ -243,7 +243,8 @@ public class SingleToCompletionStageTest {
     @Test
     public void thenAcceptAsync() throws Exception {
         AtomicReference<String> stringRef = new AtomicReference<>();
-        thenAccept(source.toCompletionStage().thenAcceptAsync(jdkForkJoinThread(stringRef)), stringRef, "thenAcceptAsync");
+        thenAccept(source.toCompletionStage().thenAcceptAsync(jdkForkJoinThread(stringRef)), stringRef,
+                "thenAcceptAsync");
     }
 
     @Test

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThreadBasedSignalOffloader.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThreadBasedSignalOffloader.java
@@ -134,7 +134,8 @@ final class ThreadBasedSignalOffloader implements SignalOffloader, Runnable {
     }
 
     @Override
-    public <T> void offloadSubscribe(Subscriber<? super T> subscriber, Consumer<Subscriber<? super T>> handleSubscribe) {
+    public <T> void offloadSubscribe(
+            Subscriber<? super T> subscriber, Consumer<Subscriber<? super T>> handleSubscribe) {
         try {
             addOffloadedEntity(new OffloadedSignalEntity<>(handleSubscribe, subscriber), true);
         } catch (EnqueueForOffloadingFailed e) {

--- a/servicetalk-data-jackson/src/test/java/io/servicetalk/data/jackson/JacksonSerializationProviderTest.java
+++ b/servicetalk-data-jackson/src/test/java/io/servicetalk/data/jackson/JacksonSerializationProviderTest.java
@@ -56,7 +56,8 @@ public class JacksonSerializationProviderTest {
 
         final Buffer serialized = DEFAULT_ALLOCATOR.newBuffer();
         serializationProvider.getSerializer(TestPojo.class).serialize(expected, serialized);
-        final Iterator<TestPojo> iterator = serializationProvider.getDeserializer(TestPojo.class).deserialize(serialized).iterator();
+        final Iterator<TestPojo> iterator = serializationProvider.getDeserializer(TestPojo.class)
+                .deserialize(serialized).iterator();
         assertTrue(iterator.hasNext());
         assertEquals(expected, iterator.next());
         assertFalse(iterator.hasNext());
@@ -73,7 +74,8 @@ public class JacksonSerializationProviderTest {
 
         final Buffer serialized = DEFAULT_ALLOCATOR.newBuffer();
         serializationProvider.getSerializer(listTypeHolder).serialize(pojos, serialized);
-        final Iterator<List<TestPojo>> iterator = serializationProvider.getDeserializer(listTypeHolder).deserialize(serialized).iterator();
+        final Iterator<List<TestPojo>> iterator = serializationProvider.getDeserializer(listTypeHolder)
+                .deserialize(serialized).iterator();
         assertTrue(iterator.hasNext());
         assertEquals(pojos, iterator.next());
         assertFalse(iterator.hasNext());

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererTest.java
@@ -405,7 +405,8 @@ public class DefaultDnsServiceDiscovererTest {
         ServiceDiscoverer<String, InetAddress, ServiceDiscovererEvent<InetAddress>> discoverer =
                 serviceDiscovererBuilder()
                         .queryTimeout(Duration.ofMillis(100))
-                        .appendFilter(client -> new ServiceDiscovererFilter<String, InetAddress, ServiceDiscovererEvent<InetAddress>>(client) {
+                        .appendFilter(client -> new ServiceDiscovererFilter<String, InetAddress,
+                                ServiceDiscovererEvent<InetAddress>>(client) {
                             @Override
                             public Publisher<ServiceDiscovererEvent<InetAddress>> discover(final String s) {
                                 return super.discover(s).doOnError(t -> {

--- a/servicetalk-gradle-plugin-internal/src/main/resources/io/servicetalk/gradle/plugin/internal/checkstyle/checkstyle.xml
+++ b/servicetalk-gradle-plugin-internal/src/main/resources/io/servicetalk/gradle/plugin/internal/checkstyle/checkstyle.xml
@@ -95,6 +95,7 @@
     <property name="lineSeparator" value="lf"/>
   </module>
   <module name="UniqueProperties"/>
+
   <module name="TreeWalker">
     <!-- Prohibit calls to print to the console -->
     <module name="RegexpSinglelineJava">
@@ -244,10 +245,9 @@
     <module name="OuterTypeFilename"/>
     <module name="UncommentedMain"/>
     <module name="UpperEll"/>
-    <!-- To be turned on in the future. Uncomment to incrementally improve things. -->
-    <!--<module name="LineLength">-->
-      <!--<property name="max" value="120"/>-->
-    <!--</module>-->
+    <module name="LineLength">
+      <property name="max" value="120"/>
+    </module>
 
     <!-- Coding -->
     <module name="ArrayTrailingComma"/>

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClient.java
@@ -45,7 +45,8 @@ public abstract class BlockingStreamingHttpClient extends BlockingStreamingHttpR
      * @return a {@link ReservedBlockingStreamingHttpConnection}.
      * @throws Exception if a exception occurs during the reservation process.
      */
-    public final ReservedBlockingStreamingHttpConnection reserveConnection(HttpRequestMetaData metaData) throws Exception {
+    public final ReservedBlockingStreamingHttpConnection reserveConnection(HttpRequestMetaData metaData)
+            throws Exception {
         return reserveConnection(executionStrategy(), metaData);
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilter.java
@@ -74,8 +74,8 @@ public class StreamingHttpClientFilter implements StreamingHttpRequestFactory,
     }
 
     /**
-     * Called when the filter needs to delegate the request using the provided {@link StreamingHttpRequestFunction} on which
-     * to call {@link StreamingHttpRequestFunction#request(HttpExecutionStrategy, StreamingHttpRequest)}.
+     * Called when the filter needs to delegate the request using the provided {@link StreamingHttpRequestFunction} on
+     * which to call {@link StreamingHttpRequestFunction#request(HttpExecutionStrategy, StreamingHttpRequest)}.
      *
      * @param delegate The {@link StreamingHttpRequestFunction} to delegate requests to.
      * @param strategy The {@link HttpExecutionStrategy} to use for executing the request.

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractBlockingStreamingHttpRequesterTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractBlockingStreamingHttpRequesterTest.java
@@ -225,7 +225,8 @@ public abstract class AbstractBlockingStreamingHttpRequesterTest {
         String expectedPayload = "hello";
         byte[] expectedPayloadBytes = expectedPayload.getBytes(US_ASCII);
         TestStreamingHttpRequester asyncRequester = newAsyncRequester(reqRespFactory, mockExecutionCtx,
-                (strategy, req) -> success(reqRespFactory.ok().payloadBody(just(allocator.fromAscii(expectedPayload)))));
+                (strategy, req) -> success(reqRespFactory.ok().payloadBody(
+                        just(allocator.fromAscii(expectedPayload)))));
         BlockingStreamingHttpRequester syncRequester = asyncRequester.asBlockingStreaming();
         BlockingStreamingHttpResponse syncResponse = syncRequester.request(
                 syncRequester.get("/"));

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpServiceTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpServiceTest.java
@@ -220,7 +220,8 @@ public class BlockingStreamingHttpServiceTest {
             }
         };
         StreamingHttpService asyncService = syncService.asStreamingService();
-        StreamingHttpResponse asyncResponse = asyncService.handle(mockCtx, reqRespFactory.get("/"), reqRespFactory).toFuture().get();
+        StreamingHttpResponse asyncResponse = asyncService.handle(mockCtx, reqRespFactory.get("/"), reqRespFactory)
+                .toFuture().get();
         assertNotNull(asyncResponse);
         assertEquals(HTTP_1_1, asyncResponse.version());
         assertEquals(OK, asyncResponse.status());

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpCookiesTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpCookiesTest.java
@@ -226,8 +226,8 @@ public class DefaultHttpCookiesTest {
     private static void getCookiesNameDomainPath(final HttpHeaders headers) {
         final Iterator<? extends HttpCookie> cookieItr = headers.getSetCookies("qwerty", "somecompany2.co.uk", "/2");
         assertTrue(cookieItr.hasNext());
-        assertTrue(areCookiesEqual(new TestCookie("qwerty", "abcd", "/2", "somecompany2.co.uk", "Wed, 30 Aug 2019 00:00:00 GMT",
-                null, false, false, false), cookieItr.next()));
+        assertTrue(areCookiesEqual(new TestCookie("qwerty", "abcd", "/2", "somecompany2.co.uk",
+                "Wed, 30 Aug 2019 00:00:00 GMT", null, false, false, false), cookieItr.next()));
         assertFalse(cookieItr.hasNext());
     }
 
@@ -448,8 +448,8 @@ public class DefaultHttpCookiesTest {
         // Encode again
         final Iterator<? extends HttpCookie> cookieItr = headers.getSetCookies("qwerty");
         assertTrue(cookieItr.hasNext());
-        assertTrue(areCookiesEqual(new TestCookie("qwerty", "12345", "/", "somecompany.co.uk", "Wed, 30 Aug 2019 00:00:00 GMT",
-                null, true, false, false), cookieItr.next()));
+        assertTrue(areCookiesEqual(new TestCookie("qwerty", "12345", "/", "somecompany.co.uk",
+                "Wed, 30 Aug 2019 00:00:00 GMT", null, true, false, false), cookieItr.next()));
         assertFalse(cookieItr.hasNext());
 
         final CharSequence value = headers.get("set-cookie");
@@ -493,8 +493,10 @@ public class DefaultHttpCookiesTest {
     public void overallIteratorRemoveFirstAndLast() {
         final HttpHeaders headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders();
         headers.add("set-cookie", "foo=bar");
-        headers.add("set-cookie", "qwerty=12345; Domain=somecompany.co.uk; Path=/; Expires=Wed, 30 Aug 2019 00:00:00 GMT");
-        headers.add("set-cookie", "qwerty=abcd; Domain=somecompany2.co.uk; Path=/2; Expires=Wed, 30 Aug 2019 00:00:00 GMT");
+        headers.add("set-cookie", "qwerty=12345; Domain=somecompany.co.uk; Path=/; " +
+                "Expires=Wed, 30 Aug 2019 00:00:00 GMT");
+        headers.add("set-cookie", "qwerty=abcd; Domain=somecompany2.co.uk; Path=/2; " +
+                "Expires=Wed, 30 Aug 2019 00:00:00 GMT");
         headers.add("set-cookie", "baz=xxx");
 
         // Overall iteration order isn't defined, so track which elements we don't expect to be present after removal.
@@ -584,8 +586,10 @@ public class DefaultHttpCookiesTest {
     public void overallIteratorRemoveAll() {
         final HttpHeaders headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders();
         headers.add("set-cookie", "foo=bar");
-        headers.add("set-cookie", "qwerty=12345; Domain=somecompany.co.uk; Path=/; Expires=Wed, 30 Aug 2019 00:00:00 GMT");
-        headers.add("set-cookie", "qwerty=abcd; Domain=somecompany2.co.uk; Path=/2; Expires=Wed, 30 Aug 2019 00:00:00 GMT");
+        headers.add("set-cookie", "qwerty=12345; Domain=somecompany.co.uk; Path=/; " +
+                "Expires=Wed, 30 Aug 2019 00:00:00 GMT");
+        headers.add("set-cookie", "qwerty=abcd; Domain=somecompany2.co.uk; Path=/2; " +
+                "Expires=Wed, 30 Aug 2019 00:00:00 GMT");
         headers.add("set-cookie", "baz=xxx");
 
         Iterator<Entry<CharSequence, CharSequence>> cookieItr = headers.iterator();
@@ -764,7 +768,8 @@ public class DefaultHttpCookiesTest {
 
         TestCookie(final String name, final String value, @Nullable final String path,
                    @Nullable final String domain, @Nullable final String expires,
-                   @Nullable final Long maxAge, final boolean isWrapped, final boolean isSecure, final boolean isHttpOnly) {
+                   @Nullable final Long maxAge, final boolean isWrapped, final boolean isSecure,
+                   final boolean isHttpOnly) {
             this.name = name;
             this.value = value;
             this.path = path;

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpUriTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpUriTest.java
@@ -741,7 +741,8 @@ public class HttpUriTest {
         new HttpUri("/path?param=value", () -> ":8080");
     }
 
-    private static void verifyAppleString(final HttpUri hp, final boolean isSsl, final int port, @Nullable final String userInfo) {
+    private static void verifyAppleString(final HttpUri hp, final boolean isSsl, final int port,
+                                          @Nullable final String userInfo) {
         assertEquals(isSsl ? HTTPS_SCHEME : HTTP_SCHEME, hp.scheme());
         assertEquals(userInfo, hp.userInfo());
         assertEquals("apple.com:8080", hp.hostHeader());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -128,8 +128,9 @@ final class DefaultMultiAddressUrlHttpClientBuilder extends MultiAddressHttpClie
             filterChain = maxRedirects <= 0 ? filterChain :
                     new RedirectingHttpRequesterFilter(false, maxRedirects).create(filterChain);
 
-            return StreamingHttpClient.newStreamingClientWorkAroundToBeFixed(new StreamingHttpClientWithDependencies(filterChain,
-                    toListenableAsyncCloseable(closeables)), clientFactory.builderTemplate.executionStrategy());
+            return StreamingHttpClient.newStreamingClientWorkAroundToBeFixed(new StreamingHttpClientWithDependencies(
+                            filterChain, toListenableAsyncCloseable(closeables)),
+                    clientFactory.builderTemplate.executionStrategy());
         } catch (final Throwable t) {
             if (keyFactory != null) {
                 keyFactory.closeAsync().subscribe();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -108,7 +108,8 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
                 new DefaultPartitionedStreamingHttpClient<>(psdEvents, serviceDiscoveryMaxQueueSize, clientFactory,
                         partitionAttributesBuilderFactory, reqRespFactory, exec, partitionMapFactory);
 
-        return StreamingHttpClient.newStreamingClientWorkAroundToBeFixed(partitionedFilterChain, copy.executionStrategy());
+        return StreamingHttpClient.newStreamingClientWorkAroundToBeFixed(partitionedFilterChain,
+                copy.executionStrategy());
     }
 
     private static final class DefaultPartitionedStreamingHttpClient<U, R> extends StreamingHttpClientFilter {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultStreamingHttpClientFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultStreamingHttpClientFilter.java
@@ -45,7 +45,8 @@ final class DefaultStreamingHttpClientFilter extends StreamingHttpClientFilter {
     private final ExecutionContext executionContext;
     private final LoadBalancer<LoadBalancedStreamingHttpConnectionFilter> loadBalancer;
 
-    DefaultStreamingHttpClientFilter(final ExecutionContext executionContext, final HttpExecutionStrategy executionStrategy,
+    DefaultStreamingHttpClientFilter(final ExecutionContext executionContext,
+                                     final HttpExecutionStrategy executionStrategy,
                                      final LoadBalancer<LoadBalancedStreamingHttpConnectionFilter> loadBalancer,
                                      final StreamingHttpRequestResponseFactory reqRespFactory) {
         super(terminal(reqRespFactory));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpConnectionTest.java
@@ -84,7 +84,8 @@ public final class AbstractHttpConnectionTest {
     private final StreamingHttpRequestResponseFactory reqRespFactory =
             new DefaultStreamingHttpRequestResponseFactory(allocator, headersFactory);
 
-    private class MockStreamingHttpConnectionFilter extends AbstractStreamingHttpConnectionFilter<NettyConnection<Object, Object>> {
+    private class MockStreamingHttpConnectionFilter
+            extends AbstractStreamingHttpConnectionFilter<NettyConnection<Object, Object>> {
         protected MockStreamingHttpConnectionFilter(final NettyConnection<Object, Object> connection,
                                                     final ReadOnlyHttpClientConfig config) {
             super(connection, config, ctx, reqRespFactory);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOverrideTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOverrideTest.java
@@ -180,7 +180,8 @@ public class FlushStrategyOverrideTest {
         }
 
         @Override
-        public Publisher<ServiceDiscovererEvent<InetSocketAddress>> discover(final InetSocketAddress inetSocketAddress) {
+        public Publisher<ServiceDiscovererEvent<InetSocketAddress>> discover(
+                final InetSocketAddress inetSocketAddress) {
             return from(new ServiceDiscovererEvent<InetSocketAddress>() {
                 @Override
                 public InetSocketAddress address() {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientBuilderTest.java
@@ -99,7 +99,8 @@ public class HttpClientBuilderTest extends AbstractEchoServerBasedHttpRequesterT
 
     @SuppressWarnings("unchecked")
     private static ConnectionFactory<InetSocketAddress, ? extends StreamingHttpConnectionFilter> newFilter() {
-        ConnectionFactory<InetSocketAddress, ? extends StreamingHttpConnectionFilter> factory = mock(ConnectionFactory.class);
+        ConnectionFactory<InetSocketAddress, ? extends StreamingHttpConnectionFilter> factory =
+                mock(ConnectionFactory.class);
         when(factory.closeAsyncGracefully()).thenReturn(completed());
         when(factory.closeAsync()).thenReturn(completed());
         return factory;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionEmptyPayloadTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionEmptyPayloadTest.java
@@ -70,13 +70,14 @@ public class HttpConnectionEmptyPayloadTest {
                     .listenStreamingAndAwait(
                             new StreamingHttpService() {
                                 @Override
-                                public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
-                                                                            final StreamingHttpRequest req,
-                                                                            final StreamingHttpResponseFactory factory) {
+                                public Single<StreamingHttpResponse> handle(
+                                        final HttpServiceContext ctx, final StreamingHttpRequest req,
+                                        final StreamingHttpResponseFactory factory) {
                                     StreamingHttpResponse resp = factory.ok().payloadBody(just(
                                             HEAD.equals(req.method()) ? EMPTY_BUFFER :
                                                     ctx.executionContext().bufferAllocator()
-                                                    .newBuffer(expectedContentLength).writeBytes(expectedPayload)));
+                                                            .newBuffer(expectedContentLength)
+                                                            .writeBytes(expectedPayload)));
                                     resp.addHeader(CONTENT_LENGTH, String.valueOf(expectedContentLength));
                                     return success(resp);
                                 }
@@ -87,11 +88,12 @@ public class HttpConnectionEmptyPayloadTest {
                                 }
                             }));
 
-            StreamingHttpConnection connection = closeable.merge(awaitIndefinitelyNonNull(new DefaultHttpConnectionBuilder<>()
-                    .ioExecutor(executionContextRule.ioExecutor())
-                    .maxPipelinedRequests(3)
-                    .executionStrategy(defaultStrategy(executionContextRule.executor()))
-                    .buildStreaming(serverContext.listenAddress())));
+            StreamingHttpConnection connection = closeable.merge(awaitIndefinitelyNonNull(
+                    new DefaultHttpConnectionBuilder<>()
+                            .ioExecutor(executionContextRule.ioExecutor())
+                            .maxPipelinedRequests(3)
+                            .executionStrategy(defaultStrategy(executionContextRule.executor()))
+                            .buildStreaming(serverContext.listenAddress())));
 
             // Request HEAD, GET, HEAD to verify that we can keep reading data despite a HEAD request providing a hint
             // about content-length (and not actually providing the content).

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseEncoderTest.java
@@ -104,9 +104,12 @@ public class HttpResponseEncoderTest {
         String actualMetaData = byteBuf.toString(US_ASCII);
         byteBuf.release();
         assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains("HTTP/1.1 200 OK" + "\r\n"));
-        assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains(" " + CONNECTION + " :  " + KEEP_ALIVE + "\r\n"));
-        assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains("  " + SERVER + "   :     unit-test   " + "\r\n"));
-        assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains(CONTENT_LENGTH + ": " + valueOf(buffer.readableBytes()) + "\r\n"));
+        assertTrue("unexpected metadata: " + actualMetaData,
+                actualMetaData.contains(" " + CONNECTION + " :  " + KEEP_ALIVE + "\r\n"));
+        assertTrue("unexpected metadata: " + actualMetaData,
+                actualMetaData.contains("  " + SERVER + "   :     unit-test   " + "\r\n"));
+        assertTrue("unexpected metadata: " + actualMetaData,
+                actualMetaData.contains(CONTENT_LENGTH + ": " + valueOf(buffer.readableBytes()) + "\r\n"));
         assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.endsWith("\r\n" + "\r\n"));
         byteBuf = channel.readOutbound();
         assertEquals(buffer.toNioBuffer(), byteBuf.nioBuffer());
@@ -249,12 +252,14 @@ public class HttpResponseEncoderTest {
         String actualMetaData = byteBuf.toString(US_ASCII);
         byteBuf.release();
         assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains("HTTP/1.1 200 OK" + "\r\n"));
-        assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains(CONNECTION + ": " + KEEP_ALIVE + "\r\n"));
+        assertTrue("unexpected metadata: " + actualMetaData,
+                actualMetaData.contains(CONNECTION + ": " + KEEP_ALIVE + "\r\n"));
         assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains(SERVER + ": unit-test" + "\r\n"));
         assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.endsWith("\r\n" + "\r\n"));
         switch (encoding) {
             case Chunked:
-                assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains(TRANSFER_ENCODING + ": " + CHUNKED + "\r\n"));
+                assertTrue("unexpected metadata: " + actualMetaData,
+                        actualMetaData.contains(TRANSFER_ENCODING + ": " + CHUNKED + "\r\n"));
                 if (buffer.readableBytes() != 0) {
                     byteBuf = channel.readOutbound();
                     assertEquals(toHexString(buffer.readableBytes()) + "\r\n", byteBuf.toString(US_ASCII));
@@ -284,7 +289,8 @@ public class HttpResponseEncoderTest {
                 }
                 break;
             case ContentLength:
-                assertTrue("unexpected metadata: " + actualMetaData, actualMetaData.contains(CONTENT_LENGTH + ": " + valueOf(buffer.readableBytes()) + "\r\n"));
+                assertTrue("unexpected metadata: " + actualMetaData,
+                        actualMetaData.contains(CONTENT_LENGTH + ": " + valueOf(buffer.readableBytes()) + "\r\n"));
                 byteBuf = channel.readOutbound();
                 assertEquals(buffer.toNioBuffer(), byteBuf.nioBuffer());
                 consumeEmptyBufferFromTrailers(channel);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpStreamingClientOverrideOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpStreamingClientOverrideOffloadingTest.java
@@ -69,7 +69,8 @@ public class HttpStreamingClientOverrideOffloadingTest {
     public HttpStreamingClientOverrideOffloadingTest(@SuppressWarnings("unused") final String description,
                                                      final Predicate<Thread> isInvalidThread,
                                                      @Nullable final HttpExecutionStrategy overridingStrategy,
-                                                     @Nullable final HttpExecutionStrategy defaultStrategy) throws Exception {
+                                                     @Nullable final HttpExecutionStrategy defaultStrategy)
+            throws Exception {
         this.ioExecutor = createIoExecutor(new DefaultThreadFactory(IO_EXECUTOR_THREAD_NAME_PREFIX, true,
                 NORM_PRIORITY));
         this.executor = newCachedThreadExecutor();
@@ -89,7 +90,8 @@ public class HttpStreamingClientOverrideOffloadingTest {
         params.add(newParam("Override no offload", th -> !isInClientEventLoop(th), noOffloadsStrategy(), null));
         params.add(newParam("Default no offload", HttpStreamingClientOverrideOffloadingTest::isInClientEventLoop,
                 null, noOffloadsStrategy()));
-        params.add(newParam("Both offloads", HttpStreamingClientOverrideOffloadingTest::isInClientEventLoop, null, null));
+        params.add(newParam("Both offloads", HttpStreamingClientOverrideOffloadingTest::isInClientEventLoop, null,
+                null));
         return params;
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
@@ -89,7 +89,8 @@ public class MultiAddressUrlHttpClientTest {
     public final Timeout timeout = new ServiceTalkTestTimeout();
 
     @Rule
-    public final LegacyMockedSingleListenerRule<StreamingHttpResponse> listener = new LegacyMockedSingleListenerRule<>();
+    public final LegacyMockedSingleListenerRule<StreamingHttpResponse> listener =
+            new LegacyMockedSingleListenerRule<>();
 
     private static CompositeCloseable afterClassCloseables;
     private static StreamingHttpService httpService;
@@ -278,7 +279,8 @@ public class MultiAddressUrlHttpClientTest {
         }
     }
 
-    private static void makeGetRequestAndValidate(final String hostHeader, final HttpResponseStatus status) throws Exception {
+    private static void makeGetRequestAndValidate(final String hostHeader, final HttpResponseStatus status)
+            throws Exception {
         final StreamingHttpRequest request =
                 requester.get(format("http://%s/%d?param=value#tag", hostHeader, status.code()));
         requestAndValidate(request, status);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerTest.java
@@ -92,7 +92,8 @@ public class NettyHttpServerTest extends AbstractNettyHttpServerTest {
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
     @Rule
-    public final LegacyMockedCompletableListenerRule completableListenerRule = new LegacyMockedCompletableListenerRule();
+    public final LegacyMockedCompletableListenerRule completableListenerRule =
+            new LegacyMockedCompletableListenerRule();
     private final StreamingHttpRequestResponseFactory reqRespFactory =
             new DefaultStreamingHttpRequestResponseFactory(DEFAULT_ALLOCATOR, INSTANCE);
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PipelinedHttpConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PipelinedHttpConnectionTest.java
@@ -96,8 +96,9 @@ public class PipelinedHttpConnectionTest {
             return publisher.ignoreElements(); // simulate write consuming all
         });
         when(connection.read()).thenReturn(readPublisher1, readPublisher2);
-        pipe = StreamingHttpConnection.newStreamingConnectionWorkAroundToBeFixed(new PipelinedStreamingHttpConnectionFilter(
-                connection, config.asReadOnly(), ctx, reqRespFactory), defaultStrategy());
+        pipe = StreamingHttpConnection.newStreamingConnectionWorkAroundToBeFixed(
+                new PipelinedStreamingHttpConnectionFilter(connection, config.asReadOnly(), ctx, reqRespFactory),
+                defaultStrategy());
     }
 
     @Test
@@ -141,10 +142,12 @@ public class PipelinedHttpConnectionTest {
         assertFalse(writePublisher2.isSubscribed());
 
         writePublisher1.onComplete();
-        assertTrue(readPublisher1.isSubscribed()); // read after write completes, pipelining will be full-duplex in follow-up PR
+        // read after write completes, pipelining will be full-duplex in follow-up PR
+        assertTrue(readPublisher1.isSubscribed());
         readPublisher1.onNext(mockResp);
 
-        assertTrue(writePublisher2.isSubscribed()); // pipelining in action – 2nd req writing while 1st req still reading
+        // pipelining in action – 2nd req writing while 1st req still reading
+        assertTrue(writePublisher2.isSubscribed());
         writePublisher2.onComplete();
 
         readPublisher1.onComplete();

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/SynchronousResourceTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/SynchronousResourceTest.java
@@ -67,12 +67,14 @@ public class SynchronousResourceTest extends AbstractResourceTest {
 
     @Test
     public void http10Support() {
-        sendAndAssertResponse(get("/text").version(HTTP_1_0), HTTP_1_0, OK, TEXT_PLAIN, is("GOT: null & null"), __ -> 16);
+        sendAndAssertResponse(get("/text").version(HTTP_1_0), HTTP_1_0, OK, TEXT_PLAIN, is("GOT: null & null"),
+                __ -> 16);
     }
 
     @Test
     public void postTextStrInPubOut() {
-        sendAndAssertResponse(post("/text-strin-pubout", "bar2", TEXT_PLAIN), OK, TEXT_PLAIN, is("GOT: bar2"), __ -> null);
+        sendAndAssertResponse(post("/text-strin-pubout", "bar2", TEXT_PLAIN), OK, TEXT_PLAIN, is("GOT: bar2"),
+                __ -> null);
     }
 
     @Test
@@ -82,7 +84,8 @@ public class SynchronousResourceTest extends AbstractResourceTest {
 
     @Test
     public void postTextPubInPubOut() {
-        sendAndAssertResponse(post("/text-pubin-pubout", "bar23", TEXT_PLAIN), OK, TEXT_PLAIN, is("GOT: bar23"), __ -> null);
+        sendAndAssertResponse(post("/text-pubin-pubout", "bar23", TEXT_PLAIN), OK, TEXT_PLAIN, is("GOT: bar23"),
+                __ -> null);
     }
 
     @Test

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/BaseHttpPredicateRouterBuilderTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/BaseHttpPredicateRouterBuilderTest.java
@@ -86,10 +86,11 @@ public abstract class BaseHttpPredicateRouterBuilderTest {
         when(executionCtx.executor()).thenReturn(immediate());
         when(request.version()).thenReturn(HTTP_1_1);
         when(request.headers()).thenReturn(headers);
-        when(factory.newResponse(any(HttpResponseStatus.class))).thenAnswer((Answer<StreamingHttpResponse>) invocation -> {
-            HttpResponseStatus status = invocation.getArgument(0);
-            return reqRespFactory.newResponse(status);
-        });
+        when(factory.newResponse(any(HttpResponseStatus.class))).thenAnswer(
+                (Answer<StreamingHttpResponse>) invocation -> {
+                    HttpResponseStatus status = invocation.getArgument(0);
+                    return reqRespFactory.newResponse(status);
+                });
 
         when(strategy.offloadService(any(), any())).then(invocation -> invocation.getArgument(1));
         when(serviceA.executionStrategy()).thenReturn(strategy);

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilderHeaderTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilderHeaderTest.java
@@ -91,7 +91,8 @@ public class HttpPredicateRouterBuilderHeaderTest extends BaseHttpPredicateRoute
     @Test
     public void testWhenHeaderFirstValueMatchesPattern() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
-                .whenHeader("host").firstValueMatches(Pattern.compile("127\\..*", CASE_INSENSITIVE)).thenRouteTo(serviceA)
+                .whenHeader("host").firstValueMatches(Pattern.compile("127\\..*", CASE_INSENSITIVE))
+                .thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
                 .buildStreaming();
 

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilderQueryTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilderQueryTest.java
@@ -91,7 +91,8 @@ public class HttpPredicateRouterBuilderQueryTest extends BaseHttpPredicateRouter
     @Test
     public void testWhenQueryParamFirstValueMatchesPattern() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
-                .whenQueryParam("page").firstValueMatches(Pattern.compile("sign.*", CASE_INSENSITIVE)).thenRouteTo(serviceA)
+                .whenQueryParam("page").firstValueMatches(Pattern.compile("sign.*", CASE_INSENSITIVE))
+                .thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
                 .buildStreaming();
 

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -91,7 +91,8 @@ public class RoundRobinLoadBalancerTest {
     public final ExpectedException thrown = ExpectedException.none();
 
     @Rule
-    public final LegacyMockedSingleListenerRule<TestLoadBalancedConnection> selectConnectionListener = new LegacyMockedSingleListenerRule<>();
+    public final LegacyMockedSingleListenerRule<TestLoadBalancedConnection> selectConnectionListener =
+            new LegacyMockedSingleListenerRule<>();
 
     private final TestPublisher<ServiceDiscovererEvent<String>> serviceDiscoveryPublisher = new TestPublisher<>();
     private final List<TestLoadBalancedConnection> connectionsCreated = new CopyOnWriteArrayList<>();
@@ -241,7 +242,8 @@ public class RoundRobinLoadBalancerTest {
         testSelectStampede(newSaturableConnectionFilter());
     }
 
-    private void testSelectStampede(final Function<TestLoadBalancedConnection, TestLoadBalancedConnection> selectionFilter) throws Exception {
+    private void testSelectStampede(
+            final Function<TestLoadBalancedConnection, TestLoadBalancedConnection> selectionFilter) throws Exception {
         connectionFactory = new DelegatingConnectionFactory(this::newUnrealizedConnectionSingle);
         lb = newTestLoadBalancer(connectionFactory);
 
@@ -295,7 +297,8 @@ public class RoundRobinLoadBalancerTest {
 
         assertThat(exceptions, is(empty()));
         assertThat(selectedConnections, hasSize(100));
-        assertThat(selectedConnections.stream().map(TestLoadBalancedConnection::address).collect(toSet()), contains("address-1"));
+        assertThat(selectedConnections.stream().map(TestLoadBalancedConnection::address).collect(toSet()),
+                contains("address-1"));
         assertThat(connectionsCreated, hasSize(both(greaterThan(0)).and(lessThanOrEqualTo(100))));
     }
 

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BlockingBufferRedisCommanderTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BlockingBufferRedisCommanderTest.java
@@ -116,9 +116,11 @@ public class BlockingBufferRedisCommanderTest extends BaseRedisClientTest {
         assertThat(commandClient.set(key("a-key"), buf("a-value2"), new ExpireDuration(EX, 10L), null), is("OK"));
         assertThat(commandClient.get(key("a-key")), is(buf("a-value2")));
 
-        assertThat(commandClient.set(key("exp-key"), buf("exp-value"), null, NX), is(anyOf(nullValue(), equalTo("OK"))));
+        assertThat(commandClient.set(key("exp-key"), buf("exp-value"), null, NX),
+                is(anyOf(nullValue(), equalTo("OK"))));
 
-        assertThat(commandClient.zadd(key("a-zset"), null, null, 1, buf("one")), is(either(equalTo(0L)).or(equalTo(1L))));
+        assertThat(commandClient.zadd(key("a-zset"), null, null, 1, buf("one")),
+                is(either(equalTo(0L)).or(equalTo(1L))));
         assertThat(commandClient.zrank(key("a-zset"), buf("one")), is(0L));
         assertThat(commandClient.zrank(key("missing"), buf("missing-member")), is(nullValue()));
         if (getEnv().serverVersion[0] >= 3) {
@@ -132,7 +134,8 @@ public class BlockingBufferRedisCommanderTest extends BaseRedisClientTest {
 
         assertThat(commandClient.sadd(key("a-set-1"), buf("a"), buf("b"), buf("c")), greaterThanOrEqualTo(0L));
         assertThat(commandClient.sadd(key("a-set-2"), buf("c"), buf("d"), buf("e")), greaterThanOrEqualTo(0L));
-        assertThat(commandClient.sdiff(key("a-set-1"), key("a-set-2"), buf("missing-key")), containsInAnyOrder(buf("a"), buf("b")));
+        assertThat(commandClient.sdiff(key("a-set-1"), key("a-set-2"), buf("missing-key")),
+                containsInAnyOrder(buf("a"), buf("b")));
         assertThat(commandClient.sdiffstore(key("diff"), key("a-set-1"), key("a-set-2"), buf("missing-key")), is(2L));
     }
 
@@ -156,7 +159,8 @@ public class BlockingBufferRedisCommanderTest extends BaseRedisClientTest {
     @Test
     public void argumentVariants() throws Exception {
         assertThat(commandClient.mset(key("key0"), buf("val0")), is("OK"));
-        assertThat(commandClient.mset(key("key1"), buf("val1"), key("key2"), buf("val2"), key("key3"), buf("val3")), is("OK"));
+        assertThat(commandClient.mset(key("key1"), buf("val1"), key("key2"), buf("val2"), key("key3"), buf("val3")),
+                is("OK"));
 
         final List<BufferKeyValue> keyValues = IntStream.range(4, 10)
                 .mapToObj(i -> new BufferKeyValue(key("key" + i), buf("val" + i)))
@@ -164,7 +168,8 @@ public class BlockingBufferRedisCommanderTest extends BaseRedisClientTest {
         assertThat(commandClient.mset(keyValues), is("OK"));
 
         assertThat(commandClient.mget(key("key0")), contains(buf("val0")));
-        assertThat(commandClient.mget(key("key1"), key("key2"), key("key3")), contains(buf("val1"), buf("val2"), buf("val3")));
+        assertThat(commandClient.mget(key("key1"), key("key2"), key("key3")),
+                contains(buf("val1"), buf("val2"), buf("val3")));
 
         final List<Buffer> keys = keyValues.stream().map(kv -> kv.key).collect(toList());
         final List<Buffer> expectedValues = keyValues.stream().map(kv -> kv.value).collect(toList());
@@ -234,7 +239,8 @@ public class BlockingBufferRedisCommanderTest extends BaseRedisClientTest {
         // Disable these tests for Redis 2 and below
         assumeThat(getEnv().serverVersion[0], is(greaterThanOrEqualTo(3)));
 
-        assertThat(commandClient.zrem(key("Sicily"), asList(buf("Palermo"), buf("Catania"))), is(lessThanOrEqualTo(2L)));
+        assertThat(commandClient.zrem(key("Sicily"), asList(buf("Palermo"), buf("Catania"))),
+                is(lessThanOrEqualTo(2L)));
 
         final Long geoaddLong = commandClient.geoadd(key("Sicily"),
                 asList(new BufferLongitudeLatitudeMember(13.361389d, 38.115556d, buf("Palermo")),
@@ -244,17 +250,21 @@ public class BlockingBufferRedisCommanderTest extends BaseRedisClientTest {
         final List<Buffer> georadiusBuffers = commandClient.georadius(key("Sicily"), 15d, 37d, 200d, KM);
         assertThat(georadiusBuffers, contains(buf("Palermo"), buf("Catania")));
 
-        final List<?> georadiusMixedList = commandClient.georadius(key("Sicily"), 15d, 37d, 200d, KM, WITHCOORD, WITHDIST, null, 5L, ASC, null, null);
+        final List<?> georadiusMixedList = commandClient.georadius(key("Sicily"), 15d, 37d, 200d, KM, WITHCOORD,
+                WITHDIST, null, 5L, ASC, null, null);
         final Matcher georadiusResponseMatcher = contains(
-                contains(is(buf("Catania")), bufStartingWith(buf("56.")), contains(bufStartingWith(buf("15.")), bufStartingWith(buf("37.")))),
-                contains(is(buf("Palermo")), bufStartingWith(buf("190.")), contains(bufStartingWith(buf("13.")), bufStartingWith(buf("38.")))));
+                contains(is(buf("Catania")), bufStartingWith(buf("56.")), contains(bufStartingWith(buf("15.")),
+                        bufStartingWith(buf("37.")))),
+                contains(is(buf("Palermo")), bufStartingWith(buf("190.")), contains(bufStartingWith(buf("13.")),
+                        bufStartingWith(buf("38.")))));
         assertThat(georadiusMixedList, georadiusResponseMatcher);
 
         assertThat(commandClient.geodist(key("Sicily"), buf("Palermo"), buf("Catania")), is(greaterThan(0d)));
         assertThat(commandClient.geodist(key("Sicily"), buf("foo"), buf("bar")), is(nullValue()));
 
         assertThat(commandClient.geopos(key("Sicily"), buf("Palermo"), buf("NonExisting"), buf("Catania")), contains(
-                contains(bufStartingWith(buf("13.")), bufStartingWith(buf("38."))), is(nullValue()), contains(bufStartingWith(buf("15.")), bufStartingWith(buf("37.")))));
+                contains(bufStartingWith(buf("13.")), bufStartingWith(buf("38."))), is(nullValue()),
+                contains(bufStartingWith(buf("15.")), bufStartingWith(buf("37.")))));
 
         final List<Buffer> evalBuffers = commandClient.evalList(buf("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}"),
                 2L, asList(buf("key1"), buf("key2")), asList(buf("first"), buf("second")));
@@ -267,7 +277,8 @@ public class BlockingBufferRedisCommanderTest extends BaseRedisClientTest {
         final Long evalLong = commandClient.evalLong(buf("return 10"), 0L, emptyList(), emptyList());
         assertThat(evalLong, is(10L));
 
-        final List<?> evalMixedList = commandClient.evalList(buf("return {1,2,{3,'four'}}"), 0L, emptyList(), emptyList());
+        final List<?> evalMixedList = commandClient.evalList(buf("return {1,2,{3,'four'}}"), 0L, emptyList(),
+                emptyList());
         assertThat(evalMixedList, contains(1L, 2L, asList(3L, buf("four"))));
     }
 
@@ -303,7 +314,8 @@ public class BlockingBufferRedisCommanderTest extends BaseRedisClientTest {
         fields.add(new BufferFieldValue(buf("f9"), buf("v9")));
         fields.add(new BufferFieldValue(buf("f10"), buf("v10")));
         commandClient.hmset(buf(testKey), fields);
-        final List<Buffer> values = commandClient.hmget(buf(testKey), asList(buf("f"), buf("f1"), buf("f2"), buf("f3"), buf("f4"), buf("f5"), buf("f6"), buf("f7"), buf("f8"), buf("f9"), buf("f10")));
+        final List<Buffer> values = commandClient.hmget(buf(testKey), asList(buf("f"), buf("f1"), buf("f2"), buf("f3"),
+                buf("f4"), buf("f5"), buf("f6"), buf("f7"), buf("f8"), buf("f9"), buf("f10")));
         assertThat(values, is(fields.stream().map(fv -> fv.value).collect(toList())));
     }
 
@@ -315,12 +327,12 @@ public class BlockingBufferRedisCommanderTest extends BaseRedisClientTest {
         commandClient.set(buf("1-score"), buf("1"));
         commandClient.set(buf("1-ᕈгø⨯у"), buf("proxy"));
 
-        assertThat(commandClient.sort(buf(testKey), buf("*-score"), new OffsetCount(0, 1), singletonList(buf("*-ᕈгø⨯у")), SortOrder.ASC, SortSorting.ALPHA),
-                is(singletonList(buf("proxy"))));
-        assertThat(commandClient.sort(buf(testKey), null, new OffsetCount(0, 1), singletonList(buf("*-ᕈгø⨯у")), SortOrder.ASC, SortSorting.ALPHA),
-                is(singletonList(buf("proxy"))));
-        assertThat(commandClient.sort(buf(testKey), null, null, singletonList(buf("*-ᕈгø⨯у")), SortOrder.ASC, SortSorting.ALPHA),
-                is(singletonList(buf("proxy"))));
+        assertThat(commandClient.sort(buf(testKey), buf("*-score"), new OffsetCount(0, 1),
+                singletonList(buf("*-ᕈгø⨯у")), SortOrder.ASC, SortSorting.ALPHA), is(singletonList(buf("proxy"))));
+        assertThat(commandClient.sort(buf(testKey), null, new OffsetCount(0, 1), singletonList(buf("*-ᕈгø⨯у")),
+                SortOrder.ASC, SortSorting.ALPHA), is(singletonList(buf("proxy"))));
+        assertThat(commandClient.sort(buf(testKey), null, null, singletonList(buf("*-ᕈгø⨯у")), SortOrder.ASC,
+                SortSorting.ALPHA), is(singletonList(buf("proxy"))));
         assertThat(commandClient.sort(buf(testKey), null, null, singletonList(buf("*-ᕈгø⨯у")), null, SortSorting.ALPHA),
                 is(singletonList(buf("proxy"))));
         assertThat(commandClient.sort(buf(testKey), null, null, singletonList(buf("*-ᕈгø⨯у")), null, null),

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BlockingPartitionedRedisClientTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BlockingPartitionedRedisClientTest.java
@@ -148,7 +148,8 @@ public class BlockingPartitionedRedisClientTest extends AbstractPartitionedRedis
             @Override
             public Completable closeAsync() {
                 closedLatch.countDown();
-                // Don't actually close the client connection for this unit test ... because it is used in a static fashion.
+                // Don't actually close the client connection for this unit test ... because it is used in a static
+                // fashion.
                 return delegate.onClose();
             }
         };

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BlockingRedisCommanderTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BlockingRedisCommanderTest.java
@@ -242,7 +242,8 @@ public class BlockingRedisCommanderTest extends BaseRedisClientTest {
         final List<String> georadiusBuffers = commandClient.georadius(key("Sicily"), 15d, 37d, 200d, KM);
         assertThat(georadiusBuffers, contains("Palermo", "Catania"));
 
-        final List georadiusMixedList = commandClient.georadius(key("Sicily"), 15d, 37d, 200d, KM, WITHCOORD, WITHDIST, null, 5L, ASC, null, null);
+        final List georadiusMixedList = commandClient.georadius(key("Sicily"), 15d, 37d, 200d, KM, WITHCOORD, WITHDIST,
+                null, 5L, ASC, null, null);
         final Matcher georadiusResponseMatcher = contains(
                 contains(is("Catania"), startsWith("56."), contains(startsWith("15."), startsWith("37."))),
                 contains(is("Palermo"), startsWith("190."), contains(startsWith("13."), startsWith("38."))));
@@ -252,7 +253,8 @@ public class BlockingRedisCommanderTest extends BaseRedisClientTest {
         assertThat(commandClient.geodist(key("Sicily"), "foo", "bar"), is(nullValue()));
 
         assertThat(commandClient.geopos(key("Sicily"), "Palermo", "NonExisting", "Catania"), contains(
-                contains(startsWith("13."), startsWith("38.")), is(nullValue()), contains(startsWith("15."), startsWith("37."))));
+                contains(startsWith("13."), startsWith("38.")), is(nullValue()), contains(startsWith("15."),
+                        startsWith("37."))));
 
         final List<String> evalBuffers = commandClient.evalList("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}",
                 2L, asList("key1", "key2"), asList("first", "second"));
@@ -301,7 +303,8 @@ public class BlockingRedisCommanderTest extends BaseRedisClientTest {
         fields.add(new FieldValue("f9", "v9"));
         fields.add(new FieldValue("f10", "v10"));
         commandClient.hmset(testKey, fields);
-        final List<String> values = commandClient.hmget(testKey, asList("f", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10"));
+        final List<String> values = commandClient.hmget(testKey, asList("f", "f1", "f2", "f3", "f4", "f5", "f6", "f7",
+                "f8", "f9", "f10"));
         assertThat(values, is(fields.stream().map(fv -> fv.value).collect(toList())));
     }
 
@@ -313,10 +316,10 @@ public class BlockingRedisCommanderTest extends BaseRedisClientTest {
         commandClient.set("1-score", "1");
         commandClient.set("1-ᕈгø⨯у", "proxy");
 
-        assertThat(commandClient.sort(testKey, "*-score", new OffsetCount(0, 1), singletonList("*-ᕈгø⨯у"), SortOrder.ASC, SortSorting.ALPHA),
-                is(singletonList("proxy")));
-        assertThat(commandClient.sort(testKey, null, new OffsetCount(0, 1), singletonList("*-ᕈгø⨯у"), SortOrder.ASC, SortSorting.ALPHA),
-                is(singletonList("proxy")));
+        assertThat(commandClient.sort(testKey, "*-score", new OffsetCount(0, 1), singletonList("*-ᕈгø⨯у"),
+                SortOrder.ASC, SortSorting.ALPHA), is(singletonList("proxy")));
+        assertThat(commandClient.sort(testKey, null, new OffsetCount(0, 1), singletonList("*-ᕈгø⨯у"), SortOrder.ASC,
+                SortSorting.ALPHA), is(singletonList("proxy")));
         assertThat(commandClient.sort(testKey, null, null, singletonList("*-ᕈгø⨯у"), SortOrder.ASC, SortSorting.ALPHA),
                 is(singletonList("proxy")));
         assertThat(commandClient.sort(testKey, null, null, singletonList("*-ᕈгø⨯у"), null, SortSorting.ALPHA),

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BufferRedisCommanderTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/BufferRedisCommanderTest.java
@@ -114,12 +114,15 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
         assertThat(awaitIndefinitely(commandClient.get(buf("missing-key"))), is(nullValue()));
         assertThat(awaitIndefinitely(commandClient.set(key("a-key"), buf("a-value1"))), is("OK"));
         assertThat(awaitIndefinitely(commandClient.get(key("a-key"))), is(buf("a-value1")));
-        assertThat(awaitIndefinitely(commandClient.set(key("a-key"), buf("a-value2"), new ExpireDuration(EX, 10L), null)), is("OK"));
+        assertThat(awaitIndefinitely(commandClient.set(key("a-key"), buf("a-value2"),
+                new ExpireDuration(EX, 10L), null)), is("OK"));
         assertThat(awaitIndefinitely(commandClient.get(key("a-key"))), is(buf("a-value2")));
 
-        assertThat(awaitIndefinitely(commandClient.set(key("exp-key"), buf("exp-value"), null, NX)), is(anyOf(nullValue(), equalTo("OK"))));
+        assertThat(awaitIndefinitely(commandClient.set(key("exp-key"), buf("exp-value"), null, NX)),
+                is(anyOf(nullValue(), equalTo("OK"))));
 
-        assertThat(awaitIndefinitely(commandClient.zadd(key("a-zset"), null, null, 1, buf("one"))), is(either(equalTo(0L)).or(equalTo(1L))));
+        assertThat(awaitIndefinitely(commandClient.zadd(key("a-zset"), null, null, 1, buf("one"))),
+                is(either(equalTo(0L)).or(equalTo(1L))));
         assertThat(awaitIndefinitely(commandClient.zrank(key("a-zset"), buf("one"))), is(0L));
         assertThat(awaitIndefinitely(commandClient.zrank(key("missing"), buf("missing-member"))), is(nullValue()));
         if (getEnv().serverVersion[0] >= 3) {
@@ -134,8 +137,10 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
         assertThat(awaitIndefinitely(commandClient.sadd(key("a-set-1"), buf("a"), buf("b"), buf("c"))
                         .concatWith(commandClient.sadd(key("a-set-2"), buf("c"), buf("d"), buf("e")))),
                 contains(greaterThanOrEqualTo(0L), greaterThanOrEqualTo(0L)));
-        assertThat(awaitIndefinitely(commandClient.sdiff(key("a-set-1"), key("a-set-2"), buf("missing-key"))), containsInAnyOrder(buf("a"), buf("b")));
-        assertThat(awaitIndefinitely(commandClient.sdiffstore(key("diff"), key("a-set-1"), key("a-set-2"), buf("missing-key"))), is(2L));
+        assertThat(awaitIndefinitely(commandClient.sdiff(key("a-set-1"), key("a-set-2"), buf("missing-key"))),
+                containsInAnyOrder(buf("a"), buf("b")));
+        assertThat(awaitIndefinitely(commandClient.sdiffstore(key("diff"), key("a-set-1"), key("a-set-2"),
+                buf("missing-key"))), is(2L));
     }
 
     @Test
@@ -158,7 +163,8 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
     @Test
     public void argumentVariants() throws Exception {
         assertThat(awaitIndefinitely(commandClient.mset(key("key0"), buf("val0"))), is("OK"));
-        assertThat(awaitIndefinitely(commandClient.mset(key("key1"), buf("val1"), key("key2"), buf("val2"), key("key3"), buf("val3"))), is("OK"));
+        assertThat(awaitIndefinitely(commandClient.mset(key("key1"), buf("val1"), key("key2"), buf("val2"), key("key3"),
+                buf("val3"))), is("OK"));
 
         final List<BufferKeyValue> keyValues = IntStream.range(4, 10)
                 .mapToObj(i -> new BufferKeyValue(key("key" + i), buf("val" + i)))
@@ -166,7 +172,8 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
         assertThat(awaitIndefinitely(commandClient.mset(keyValues)), is("OK"));
 
         assertThat(awaitIndefinitely(commandClient.mget(key("key0"))), contains(buf("val0")));
-        assertThat(awaitIndefinitely(commandClient.mget(key("key1"), key("key2"), key("key3"))), contains(buf("val1"), buf("val2"), buf("val3")));
+        assertThat(awaitIndefinitely(commandClient.mget(key("key1"), key("key2"), key("key3"))), contains(buf("val1"),
+                buf("val2"), buf("val3")));
 
         final List<Buffer> keys = keyValues.stream().map(kv -> kv.key).collect(toList());
         final List<Buffer> expectedValues = keyValues.stream().map(kv -> kv.value).collect(toList());
@@ -186,7 +193,8 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
 
         awaitIndefinitely(commandClient.del(key("bf")));
 
-        List<Long> results = awaitIndefinitely(commandClient.bitfield(key("bf"), asList(new Incrby(I05, 100L, 1L), new Get(U04, 0L))));
+        List<Long> results = awaitIndefinitely(commandClient.bitfield(key("bf"), asList(new Incrby(I05, 100L, 1L),
+                new Get(U04, 0L))));
         assertThat(results, contains(1L, 0L));
 
         results.clear();
@@ -198,7 +206,8 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
         }
         assertThat(results, contains(1L, 1L, 2L, 2L, 3L, 3L, 0L, 3L));
 
-        results = awaitIndefinitely(commandClient.bitfield(key("bf"), asList(new Overflow(FAIL), new Incrby(U02, 102L, 1L))));
+        results = awaitIndefinitely(commandClient.bitfield(key("bf"), asList(new Overflow(FAIL),
+                new Incrby(U02, 102L, 1L))));
         assertThat(results, contains(nullValue()));
 
         awaitIndefinitely(commandClient.del(key("bf")));
@@ -236,29 +245,37 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
         // Disable these tests for Redis 2 and below
         assumeThat(getEnv().serverVersion[0], is(greaterThanOrEqualTo(3)));
 
-        assertThat(awaitIndefinitely(commandClient.zrem(key("Sicily"), asList(buf("Palermo"), buf("Catania")))), is(lessThanOrEqualTo(2L)));
+        assertThat(awaitIndefinitely(commandClient.zrem(key("Sicily"), asList(buf("Palermo"), buf("Catania")))),
+                is(lessThanOrEqualTo(2L)));
 
         final Long geoaddLong = awaitIndefinitely(commandClient.geoadd(key("Sicily"),
                 asList(new BufferLongitudeLatitudeMember(13.361389d, 38.115556d, buf("Palermo")),
                         new BufferLongitudeLatitudeMember(15.087269d, 37.502669d, buf("Catania")))));
         assertThat(geoaddLong, is(2L));
 
-        final List<Buffer> georadiusBuffers = awaitIndefinitely(commandClient.georadius(key("Sicily"), 15d, 37d, 200d, KM));
+        final List<Buffer> georadiusBuffers = awaitIndefinitely(commandClient.georadius(key("Sicily"), 15d, 37d, 200d,
+                KM));
         assertThat(georadiusBuffers, contains(buf("Palermo"), buf("Catania")));
 
-        final List<?> georadiusMixedList = awaitIndefinitely(commandClient.georadius(key("Sicily"), 15d, 37d, 200d, KM, WITHCOORD, WITHDIST, null, 5L, GeoradiusOrder.ASC, null, null));
+        final List<?> georadiusMixedList = awaitIndefinitely(commandClient.georadius(key("Sicily"), 15d, 37d, 200d, KM,
+                WITHCOORD, WITHDIST, null, 5L, GeoradiusOrder.ASC, null, null));
         final Matcher georadiusResponseMatcher = contains(
-                contains(is(buf("Catania")), bufStartingWith(buf("56.")), contains(bufStartingWith(buf("15.")), bufStartingWith(buf("37.")))),
-                contains(is(buf("Palermo")), bufStartingWith(buf("190.")), contains(bufStartingWith(buf("13.")), bufStartingWith(buf("38.")))));
+                contains(is(buf("Catania")), bufStartingWith(buf("56.")), contains(bufStartingWith(buf("15.")),
+                        bufStartingWith(buf("37.")))),
+                contains(is(buf("Palermo")), bufStartingWith(buf("190.")), contains(bufStartingWith(buf("13.")),
+                        bufStartingWith(buf("38.")))));
         assertThat(georadiusMixedList, georadiusResponseMatcher);
 
-        assertThat(awaitIndefinitely(commandClient.geodist(key("Sicily"), buf("Palermo"), buf("Catania"))), is(greaterThan(0d)));
+        assertThat(awaitIndefinitely(commandClient.geodist(key("Sicily"), buf("Palermo"), buf("Catania"))),
+                is(greaterThan(0d)));
         assertThat(awaitIndefinitely(commandClient.geodist(key("Sicily"), buf("foo"), buf("bar"))), is(nullValue()));
 
-        assertThat(awaitIndefinitely(commandClient.geopos(key("Sicily"), buf("Palermo"), buf("NonExisting"), buf("Catania"))), contains(
-                contains(bufStartingWith(buf("13.")), bufStartingWith(buf("38."))), is(nullValue()), contains(bufStartingWith(buf("15.")), bufStartingWith(buf("37.")))));
+        assertThat(awaitIndefinitely(commandClient.geopos(key("Sicily"), buf("Palermo"), buf("NonExisting"),
+                buf("Catania"))), contains(contains(bufStartingWith(buf("13.")), bufStartingWith(buf("38."))),
+                is(nullValue()), contains(bufStartingWith(buf("15.")), bufStartingWith(buf("37.")))));
 
-        final List<Buffer> evalBuffers = awaitIndefinitely(commandClient.evalList(buf("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}"),
+        final List<Buffer> evalBuffers = awaitIndefinitely(commandClient.evalList(
+                buf("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}"),
                 2L, asList(buf("key1"), buf("key2")), asList(buf("first"), buf("second"))));
         assertThat(evalBuffers, contains(buf("key1"), buf("key2"), buf("first"), buf("second")));
 
@@ -269,7 +286,8 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
         final Long evalLong = awaitIndefinitely(commandClient.evalLong(buf("return 10"), 0L, emptyList(), emptyList()));
         assertThat(evalLong, is(10L));
 
-        final List<?> evalMixedList = awaitIndefinitely(commandClient.evalList(buf("return {1,2,{3,'four'}}"), 0L, emptyList(), emptyList()));
+        final List<?> evalMixedList = awaitIndefinitely(commandClient.evalList(buf("return {1,2,{3,'four'}}"), 0L,
+                emptyList(), emptyList()));
         assertThat(evalMixedList, contains(1L, 2L, asList(3L, buf("four"))));
     }
 
@@ -284,7 +302,8 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
         awaitIndefinitelyNonNull(commandClient.hmset(buf(testKey), fields));
         final List<Buffer> result = awaitIndefinitelyNonNull(commandClient.hgetall(buf(testKey)));
         assertThat(new HashSet<>(toBufferFieldValues(result)), is(new HashSet<>(fields)));
-        final List<Buffer> values = awaitIndefinitelyNonNull(commandClient.hmget(buf(testKey), buf("f"), buf("f1"), buf("f2")));
+        final List<Buffer> values = awaitIndefinitelyNonNull(commandClient.hmget(buf(testKey), buf("f"), buf("f1"),
+                buf("f2")));
         assertThat(values, is(asList(buf("v"), buf("v1"), buf("v2"))));
     }
 
@@ -305,7 +324,9 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
         fields.add(new BufferFieldValue(buf("f9"), buf("v9")));
         fields.add(new BufferFieldValue(buf("f10"), buf("v10")));
         awaitIndefinitelyNonNull(commandClient.hmset(buf(testKey), fields));
-        final List<Buffer> values = awaitIndefinitelyNonNull(commandClient.hmget(buf(testKey), asList(buf("f"), buf("f1"), buf("f2"), buf("f3"), buf("f4"), buf("f5"), buf("f6"), buf("f7"), buf("f8"), buf("f9"), buf("f10"))));
+        final List<Buffer> values = awaitIndefinitelyNonNull(commandClient.hmget(buf(testKey), asList(buf("f"),
+                buf("f1"), buf("f2"), buf("f3"), buf("f4"), buf("f5"), buf("f6"), buf("f7"), buf("f8"), buf("f9"),
+                buf("f10"))));
         assertThat(values, is(fields.stream().map(fv -> fv.value).collect(toList())));
     }
 
@@ -317,16 +338,16 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
         awaitIndefinitelyNonNull(commandClient.set(buf("1-score"), buf("1")));
         awaitIndefinitelyNonNull(commandClient.set(buf("1-ᕈгø⨯у"), buf("proxy")));
 
-        assertThat(awaitIndefinitelyNonNull(commandClient.sort(buf(testKey), buf("*-score"), new OffsetCount(0, 1), singletonList(buf("*-ᕈгø⨯у")), SortOrder.ASC, SortSorting.ALPHA)),
-                is(singletonList(buf("proxy"))));
-        assertThat(awaitIndefinitelyNonNull(commandClient.sort(buf(testKey), null, new OffsetCount(0, 1), singletonList(buf("*-ᕈгø⨯у")), SortOrder.ASC, SortSorting.ALPHA)),
-                is(singletonList(buf("proxy"))));
-        assertThat(awaitIndefinitelyNonNull(commandClient.sort(buf(testKey), null, null, singletonList(buf("*-ᕈгø⨯у")), SortOrder.ASC, SortSorting.ALPHA)),
-                is(singletonList(buf("proxy"))));
-        assertThat(awaitIndefinitelyNonNull(commandClient.sort(buf(testKey), null, null, singletonList(buf("*-ᕈгø⨯у")), null, SortSorting.ALPHA)),
-                is(singletonList(buf("proxy"))));
-        assertThat(awaitIndefinitelyNonNull(commandClient.sort(buf(testKey), null, null, singletonList(buf("*-ᕈгø⨯у")), null, null)),
-                is(singletonList(buf("proxy"))));
+        assertThat(awaitIndefinitelyNonNull(commandClient.sort(buf(testKey), buf("*-score"), new OffsetCount(0, 1),
+                singletonList(buf("*-ᕈгø⨯у")), SortOrder.ASC, SortSorting.ALPHA)), is(singletonList(buf("proxy"))));
+        assertThat(awaitIndefinitelyNonNull(commandClient.sort(buf(testKey), null, new OffsetCount(0, 1),
+                singletonList(buf("*-ᕈгø⨯у")), SortOrder.ASC, SortSorting.ALPHA)), is(singletonList(buf("proxy"))));
+        assertThat(awaitIndefinitelyNonNull(commandClient.sort(buf(testKey), null, null, singletonList(buf("*-ᕈгø⨯у")),
+                SortOrder.ASC, SortSorting.ALPHA)), is(singletonList(buf("proxy"))));
+        assertThat(awaitIndefinitelyNonNull(commandClient.sort(buf(testKey), null, null, singletonList(buf("*-ᕈгø⨯у")),
+                null, SortSorting.ALPHA)), is(singletonList(buf("proxy"))));
+        assertThat(awaitIndefinitelyNonNull(commandClient.sort(buf(testKey), null, null, singletonList(buf("*-ᕈгø⨯у")),
+                null, null)), is(singletonList(buf("proxy"))));
     }
 
     @Test
@@ -520,12 +541,14 @@ public class BufferRedisCommanderTest extends BaseRedisClientTest {
         assertThat(awaitIndefinitely(pubSubClient1.ping()).bufferValue(), is(EMPTY_BUFFER));
 
         // Subscribe to a pattern on the same connection
-        final PubSubBufferRedisConnection pubSubClient2 = awaitIndefinitely(pubSubClient1.psubscribe(key("channel-2*")));
+        final PubSubBufferRedisConnection pubSubClient2 = awaitIndefinitely(pubSubClient1.psubscribe(
+                key("channel-2*")));
         final AccumulatingSubscriber<PubSubRedisMessage> subscriber2 = new AccumulatingSubscriber<>();
         subscriber2.subscribe(pubSubClient2.messages());
 
         // Let's throw a wrench and psubscribe a second time to the same pattern
-        final PubSubBufferRedisConnection pubSubClient3 = awaitIndefinitely(pubSubClient1.psubscribe(key("channel-2*")));
+        final PubSubBufferRedisConnection pubSubClient3 = awaitIndefinitely(pubSubClient1.psubscribe(
+                key("channel-2*")));
         final AccumulatingSubscriber<PubSubRedisMessage> subscriber3 =
                 new AccumulatingSubscriber<PubSubRedisMessage>().subscribe(pubSubClient3.messages());
         assertThat(subscriber3.awaitTerminal(DEFAULT_TIMEOUT_SECONDS, SECONDS), is(true));

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/PartitionedRedisClientTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/PartitionedRedisClientTest.java
@@ -151,7 +151,8 @@ public class PartitionedRedisClientTest extends AbstractPartitionedRedisClientTe
             @Override
             public Completable closeAsync() {
                 closeCalled.set(true);
-                // Don't actually close the client connection for this unit test, because it is used in a static fashion.
+                // Don't actually close the client connection for this unit test, because it is used in a static
+                // fashion.
                 return delegate.onClose();
             }
         };

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/PingerTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/PingerTest.java
@@ -214,7 +214,8 @@ public class PingerTest {
                 .andThen((channel, context) -> {
                     channel.pipeline().addFirst(new ChannelOutboundHandlerAdapter() {
                         @Override
-                        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+                        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
+                                throws Exception {
                             if (msg instanceof ByteBuf) {
                                 String cmd = ((ByteBuf) msg).toString(StandardCharsets.UTF_8);
                                 Command command = null;

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisAuthConnectionFactoryClientTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisAuthConnectionFactoryClientTest.java
@@ -147,7 +147,8 @@ public class RedisAuthConnectionFactoryClientTest {
                 .ioExecutor(ioExecutor)
                 .executionStrategy(noOffloadsStrategy())
                 .idleConnectionTimeout(ofSeconds(2))
-                .appendClientFilter(new RetryingRedisRequesterFilter.Builder().maxRetries(10).buildWithImmediateRetries())
+                .appendClientFilter(
+                        new RetryingRedisRequesterFilter.Builder().maxRetries(10).buildWithImmediateRetries())
                 .build();
         clientConsumer.accept(client);
     }

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisAuthConnectionFactoryConnectionTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisAuthConnectionFactoryConnectionTest.java
@@ -86,7 +86,7 @@ public class RedisAuthConnectionFactoryConnectionTest {
     }
 
     @Test
-    public void correctPasswordConnectionBuilder() throws Exception {
+    public void correctPasswordConnectionBuilder() {
         authTestConnection(System.getenv("REDIS_AUTH_PORT"), CORRECT_PASSWORD, connectionSingle -> {
             try {
                 RedisCommander commandClient = connectionSingle.toFuture().get().asCommander();
@@ -98,7 +98,7 @@ public class RedisAuthConnectionFactoryConnectionTest {
     }
 
     @Test
-    public void invalidPasswordConnectionBuilder() throws Exception {
+    public void invalidPasswordConnectionBuilder() {
         authTestConnection(System.getenv("REDIS_AUTH_PORT"), CORRECT_PASSWORD + "foo", connectionSingle -> {
             try {
                 RedisCommander commandClient = connectionSingle.toFuture().get().asCommander();
@@ -110,7 +110,8 @@ public class RedisAuthConnectionFactoryConnectionTest {
         });
     }
 
-    private void authTestConnection(String tmpRedisPort, String password, Consumer<Single<RedisConnection>> connectionConsumer) throws Exception {
+    private void authTestConnection(String tmpRedisPort, String password,
+                                    Consumer<Single<RedisConnection>> connectionConsumer) {
         int redisPort;
         String redisHost;
         assumeThat(tmpRedisPort, not(isEmptyOrNullString()));

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisClientTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisClientTest.java
@@ -253,7 +253,8 @@ public class RedisClientTest extends BaseRedisClientTest {
         Buffer reqBuf = getEnv().client.executionContext().bufferAllocator().newBuffer(33);
         reqBuf.writeAscii("*2\r\n$6\r\nFOOBAR\r\n$12\r\nbufreq-pong1\r\n");
 
-        // We use PING to build the request object, which doesn't matter here: FOOBAR is the actual command sent on the wire
+        // We use PING to build the request object, which doesn't matter here: FOOBAR is the actual command sent on the
+        // wire
         assertThat(awaitIndefinitely(getEnv().client.request(newRequest(PING, reqBuf)).firstOrError()),
                 is(redisError(startsWith("ERR"))));
     }

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisCommanderTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisCommanderTest.java
@@ -112,12 +112,15 @@ public class RedisCommanderTest extends BaseRedisClientTest {
         assertThat(awaitIndefinitely(commandClient.get("missing-key")), is(nullValue()));
         assertThat(awaitIndefinitely(commandClient.set(key("a-key"), "a-value1")), is("OK"));
         assertThat(awaitIndefinitely(commandClient.get(key("a-key"))), is("a-value1"));
-        assertThat(awaitIndefinitely(commandClient.set(key("a-key"), "a-value2", new ExpireDuration(EX, 10L), null)), is("OK"));
+        assertThat(awaitIndefinitely(commandClient.set(key("a-key"), "a-value2", new ExpireDuration(EX, 10L), null)),
+                is("OK"));
         assertThat(awaitIndefinitely(commandClient.get(key("a-key"))), is("a-value2"));
 
-        assertThat(awaitIndefinitely(commandClient.set(key("exp-key"), "exp-value", null, NX)), is(anyOf(nullValue(), equalTo("OK"))));
+        assertThat(awaitIndefinitely(commandClient.set(key("exp-key"), "exp-value", null, NX)), is(anyOf(nullValue(),
+                equalTo("OK"))));
 
-        assertThat(awaitIndefinitely(commandClient.zadd(key("a-zset"), null, null, 1, "one")), is(either(equalTo(0L)).or(equalTo(1L))));
+        assertThat(awaitIndefinitely(commandClient.zadd(key("a-zset"), null, null, 1, "one")),
+                is(either(equalTo(0L)).or(equalTo(1L))));
         assertThat(awaitIndefinitely(commandClient.zrank(key("a-zset"), "one")), is(0L));
         assertThat(awaitIndefinitely(commandClient.zrank("missing-key", "missing-member")), is(nullValue()));
         if (getEnv().serverVersion[0] >= 3) {
@@ -129,10 +132,12 @@ public class RedisCommanderTest extends BaseRedisClientTest {
 
         assertThat(awaitIndefinitely(commandClient.blpop(singletonList("missing-key"), 1)), is(nullValue()));
 
-        assertThat(awaitIndefinitely(commandClient.sadd(key("a-set-1"), "a", "b", "c").concatWith(commandClient.sadd(key("a-set-2"), "c", "d", "e"))),
-                contains(greaterThanOrEqualTo(0L), greaterThanOrEqualTo(0L)));
-        assertThat(awaitIndefinitely(commandClient.sdiff(key("a-set-1"), key("a-set-2"), "missing-key")), containsInAnyOrder("a", "b"));
-        assertThat(awaitIndefinitely(commandClient.sdiffstore(key("diff"), key("a-set-1"), key("a-set-2"), "missing-key")), is(2L));
+        assertThat(awaitIndefinitely(commandClient.sadd(key("a-set-1"), "a", "b", "c").concatWith(commandClient.sadd(
+                key("a-set-2"), "c", "d", "e"))), contains(greaterThanOrEqualTo(0L), greaterThanOrEqualTo(0L)));
+        assertThat(awaitIndefinitely(commandClient.sdiff(key("a-set-1"), key("a-set-2"), "missing-key")),
+                containsInAnyOrder("a", "b"));
+        assertThat(awaitIndefinitely(commandClient.sdiffstore(key("diff"), key("a-set-1"), key("a-set-2"),
+                "missing-key")), is(2L));
     }
 
     @Test
@@ -155,7 +160,8 @@ public class RedisCommanderTest extends BaseRedisClientTest {
     @Test
     public void argumentVariants() throws Exception {
         assertThat(awaitIndefinitely(commandClient.mset(key("key0"), "val0")), is("OK"));
-        assertThat(awaitIndefinitely(commandClient.mset(key("key1"), "val1", key("key2"), "val2", key("key3"), "val3")), is("OK"));
+        assertThat(awaitIndefinitely(commandClient.mset(key("key1"), "val1", key("key2"), "val2", key("key3"), "val3")),
+                is("OK"));
 
         final List<KeyValue> keyValues = IntStream.range(4, 10)
                 .mapToObj(i -> new KeyValue(key("key" + i), "val" + i))
@@ -163,7 +169,8 @@ public class RedisCommanderTest extends BaseRedisClientTest {
         assertThat(awaitIndefinitely(commandClient.mset(keyValues)), is("OK"));
 
         assertThat(awaitIndefinitely(commandClient.mget(key("key0"))), contains("val0"));
-        assertThat(awaitIndefinitely(commandClient.mget(key("key1"), key("key2"), key("key3"))), contains("val1", "val2", "val3"));
+        assertThat(awaitIndefinitely(commandClient.mget(key("key1"), key("key2"), key("key3"))),
+                contains("val1", "val2", "val3"));
 
         final List<String> keys = keyValues.stream().map(kv -> kv.key.toString()).collect(toList());
         final List<String> expectedValues = keyValues.stream().map(kv -> kv.value.toString()).collect(toList());
@@ -183,7 +190,8 @@ public class RedisCommanderTest extends BaseRedisClientTest {
 
         awaitIndefinitely(commandClient.del(key("bf")));
 
-        List<Long> results = awaitIndefinitely(commandClient.bitfield(key("bf"), asList(new Incrby(I05, 100L, 1L), new Get(U04, 0L))));
+        List<Long> results = awaitIndefinitely(commandClient.bitfield(key("bf"), asList(new Incrby(I05, 100L, 1L),
+                new Get(U04, 0L))));
         assertThat(results, contains(1L, 0L));
 
         results.clear();
@@ -195,7 +203,8 @@ public class RedisCommanderTest extends BaseRedisClientTest {
         }
         assertThat(results, contains(1L, 1L, 2L, 2L, 3L, 3L, 0L, 3L));
 
-        results = awaitIndefinitely(commandClient.bitfield(key("bf"), asList(new Overflow(FAIL), new Incrby(U02, 102L, 1L))));
+        results = awaitIndefinitely(commandClient.bitfield(key("bf"), asList(new Overflow(FAIL),
+                new Incrby(U02, 102L, 1L))));
         assertThat(results, contains(nullValue()));
 
         awaitIndefinitely(commandClient.del(key("bf")));
@@ -233,17 +242,20 @@ public class RedisCommanderTest extends BaseRedisClientTest {
         // Disable these tests for Redis 2 and below
         assumeThat(getEnv().serverVersion[0], is(greaterThanOrEqualTo(3)));
 
-        assertThat(awaitIndefinitely(commandClient.zrem(key("Sicily"), asList("Palermo", "Catania"))), is(lessThanOrEqualTo(2L)));
+        assertThat(awaitIndefinitely(commandClient.zrem(key("Sicily"), asList("Palermo", "Catania"))),
+                is(lessThanOrEqualTo(2L)));
 
         final Long geoaddLong = awaitIndefinitely(commandClient.geoadd(key("Sicily"),
                 asList(new LongitudeLatitudeMember(13.361389d, 38.115556d, "Palermo"),
                         new LongitudeLatitudeMember(15.087269d, 37.502669d, "Catania"))));
         assertThat(geoaddLong, is(2L));
 
-        final List<String> georadiusBuffers = awaitIndefinitely(commandClient.georadius(key("Sicily"), 15d, 37d, 200d, KM));
+        final List<String> georadiusBuffers = awaitIndefinitely(commandClient.georadius(key("Sicily"), 15d, 37d, 200d,
+                KM));
         assertThat(georadiusBuffers, contains("Palermo", "Catania"));
 
-        final List georadiusMixedList = awaitIndefinitely(commandClient.georadius(key("Sicily"), 15d, 37d, 200d, KM, WITHCOORD, WITHDIST, null, 5L, ASC, null, null));
+        final List georadiusMixedList = awaitIndefinitely(commandClient.georadius(key("Sicily"), 15d, 37d, 200d, KM,
+                WITHCOORD, WITHDIST, null, 5L, ASC, null, null));
         final Matcher georadiusResponseMatcher = contains(
                 contains(is("Catania"), startsWith("56."), contains(startsWith("15."), startsWith("37."))),
                 contains(is("Palermo"), startsWith("190."), contains(startsWith("13."), startsWith("38."))));
@@ -252,11 +264,12 @@ public class RedisCommanderTest extends BaseRedisClientTest {
         assertThat(awaitIndefinitely(commandClient.geodist(key("Sicily"), "Palermo", "Catania")), is(greaterThan(0d)));
         assertThat(awaitIndefinitely(commandClient.geodist(key("Sicily"), "foo", "bar")), is(nullValue()));
 
-        assertThat(awaitIndefinitely(commandClient.geopos(key("Sicily"), "Palermo", "NonExisting", "Catania")), contains(
-                contains(startsWith("13."), startsWith("38.")), is(nullValue()), contains(startsWith("15."), startsWith("37."))));
+        assertThat(awaitIndefinitely(commandClient.geopos(key("Sicily"), "Palermo", "NonExisting", "Catania")),
+                contains(contains(startsWith("13."), startsWith("38.")), is(nullValue()), contains(startsWith("15."),
+                        startsWith("37."))));
 
-        final List<String> evalBuffers = awaitIndefinitely(commandClient.evalList("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}",
-                2L, asList("key1", "key2"), asList("first", "second")));
+        final List<String> evalBuffers = awaitIndefinitely(commandClient.evalList(
+                "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}", 2L, asList("key1", "key2"), asList("first", "second")));
         assertThat(evalBuffers, contains("key1", "key2", "first", "second"));
 
         final String evalChars = awaitIndefinitely(commandClient.eval("return redis.call('set','foo','bar')",
@@ -266,7 +279,8 @@ public class RedisCommanderTest extends BaseRedisClientTest {
         final Long evalLong = awaitIndefinitely(commandClient.evalLong("return 10", 0L, emptyList(), emptyList()));
         assertThat(evalLong, is(10L));
 
-        final List<?> evalMixedList = awaitIndefinitely(commandClient.evalList("return {1,2,{3,'four'}}", 0L, emptyList(), emptyList()));
+        final List<?> evalMixedList = awaitIndefinitely(commandClient.evalList("return {1,2,{3,'four'}}", 0L,
+                emptyList(), emptyList()));
         assertThat(evalMixedList, contains(1L, 2L, asList(3L, "four")));
     }
 
@@ -302,7 +316,8 @@ public class RedisCommanderTest extends BaseRedisClientTest {
         fields.add(new FieldValue("f9", "v9"));
         fields.add(new FieldValue("f10", "v10"));
         awaitIndefinitelyNonNull(commandClient.hmset(testKey, fields));
-        final List<String> values = awaitIndefinitelyNonNull(commandClient.hmget(testKey, asList("f", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10")));
+        final List<String> values = awaitIndefinitelyNonNull(commandClient.hmget(testKey, asList("f", "f1", "f2", "f3",
+                "f4", "f5", "f6", "f7", "f8", "f9", "f10")));
         assertThat(values, is(fields.stream().map(fv -> fv.value).collect(toList())));
     }
 
@@ -314,16 +329,16 @@ public class RedisCommanderTest extends BaseRedisClientTest {
         awaitIndefinitelyNonNull(commandClient.set("1-score", "1"));
         awaitIndefinitelyNonNull(commandClient.set("1-ᕈгø⨯у", "proxy"));
 
-        assertThat(awaitIndefinitelyNonNull(commandClient.sort(testKey, "*-score", new OffsetCount(0, 1), singletonList("*-ᕈгø⨯у"), SortOrder.ASC, SortSorting.ALPHA)),
-                is(singletonList("proxy")));
-        assertThat(awaitIndefinitelyNonNull(commandClient.sort(testKey, null, new OffsetCount(0, 1), singletonList("*-ᕈгø⨯у"), SortOrder.ASC, SortSorting.ALPHA)),
-                is(singletonList("proxy")));
-        assertThat(awaitIndefinitelyNonNull(commandClient.sort(testKey, null, null, singletonList("*-ᕈгø⨯у"), SortOrder.ASC, SortSorting.ALPHA)),
-                is(singletonList("proxy")));
-        assertThat(awaitIndefinitelyNonNull(commandClient.sort(testKey, null, null, singletonList("*-ᕈгø⨯у"), null, SortSorting.ALPHA)),
-                is(singletonList("proxy")));
-        assertThat(awaitIndefinitelyNonNull(commandClient.sort(testKey, null, null, singletonList("*-ᕈгø⨯у"), null, null)),
-                is(singletonList("proxy")));
+        assertThat(awaitIndefinitelyNonNull(commandClient.sort(testKey, "*-score", new OffsetCount(0, 1),
+                singletonList("*-ᕈгø⨯у"), SortOrder.ASC, SortSorting.ALPHA)), is(singletonList("proxy")));
+        assertThat(awaitIndefinitelyNonNull(commandClient.sort(testKey, null, new OffsetCount(0, 1),
+                singletonList("*-ᕈгø⨯у"), SortOrder.ASC, SortSorting.ALPHA)), is(singletonList("proxy")));
+        assertThat(awaitIndefinitelyNonNull(commandClient.sort(testKey, null, null, singletonList("*-ᕈгø⨯у"),
+                SortOrder.ASC, SortSorting.ALPHA)), is(singletonList("proxy")));
+        assertThat(awaitIndefinitelyNonNull(commandClient.sort(testKey, null, null, singletonList("*-ᕈгø⨯у"),
+                null, SortSorting.ALPHA)), is(singletonList("proxy")));
+        assertThat(awaitIndefinitelyNonNull(commandClient.sort(testKey, null, null, singletonList("*-ᕈгø⨯у"),
+                null, null)), is(singletonList("proxy")));
     }
 
     @Test
@@ -543,7 +558,8 @@ public class RedisCommanderTest extends BaseRedisClientTest {
         assertThat(subscriber2.awaitUntilAtLeastNReceived(1, DEFAULT_TIMEOUT_SECONDS, SECONDS), is(true));
         final PubSubRedisMessage next2 = subscriber2.received().poll();
         assertThat(next2, instanceOf(PubSubRedisMessage.PatternPubSubRedisMessage.class));
-        final PubSubRedisMessage.PatternPubSubRedisMessage patternMessage = (PubSubRedisMessage.PatternPubSubRedisMessage) next2;
+        final PubSubRedisMessage.PatternPubSubRedisMessage patternMessage =
+                (PubSubRedisMessage.PatternPubSubRedisMessage) next2;
         assertThat(patternMessage.channel(), equalTo(key("channel-202")));
         assertThat(patternMessage.pattern(), equalTo(key("channel-2*")));
         assertThat(patternMessage.charSequenceValue(), equalTo("test-message"));

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisDataMatcher.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisDataMatcher.java
@@ -40,7 +40,8 @@ final class RedisDataMatcher extends BaseMatcher<RedisData> {
     private final Class<? extends RedisData> expectedClass;
     private final MatcherHolder matcherHolder;
 
-    private <T> RedisDataMatcher(final Class<? extends RedisData> expectedClass, final Function<RedisData, T> extractor, final Matcher<T> contentMatcher) {
+    private <T> RedisDataMatcher(final Class<? extends RedisData> expectedClass, final Function<RedisData, T> extractor,
+                                 final Matcher<T> contentMatcher) {
         this.expectedClass = requireNonNull(expectedClass);
         this.matcherHolder = new MatcherHolder(contentMatcher, extractor);
     }
@@ -82,7 +83,8 @@ final class RedisDataMatcher extends BaseMatcher<RedisData> {
     }
 
     static RedisDataMatcher redisFirstBulkStringChunkSize(final Matcher<Integer> sizeMatcher) {
-        return new RedisDataMatcher(DefaultFirstBulkStringChunk.class, rd -> rd.bufferValue().readableBytes(), sizeMatcher);
+        return new RedisDataMatcher(DefaultFirstBulkStringChunk.class, rd -> rd.bufferValue().readableBytes(),
+                sizeMatcher);
     }
 
     static RedisDataMatcher redisCompleteBulkString(final Buffer buf) {

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisTestEnvironment.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisTestEnvironment.java
@@ -75,7 +75,8 @@ final class RedisTestEnvironment implements AutoCloseable {
                 .executionStrategy(defaultStrategy(executor))
                 .maxPipelinedRequests(10)
                 .pingPeriod(ofSeconds(PING_PERIOD_SECONDS))
-                .appendClientFilter(new RetryingRedisRequesterFilter.Builder().maxRetries(10).buildWithImmediateRetries())
+                .appendClientFilter(
+                        new RetryingRedisRequesterFilter.Builder().maxRetries(10).buildWithImmediateRetries())
                 .build();
 
         final String serverInfo = awaitIndefinitelyNonNull(

--- a/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisUtilsTest.java
+++ b/servicetalk-redis-netty/src/test/java/io/servicetalk/redis/netty/RedisUtilsTest.java
@@ -101,7 +101,8 @@ public class RedisUtilsTest {
             }
 
             @Override
-            public RedisRequest transformContent(final Function<Publisher<RequestRedisData>, Publisher<RequestRedisData>> transformer) {
+            public RedisRequest transformContent(
+                    final Function<Publisher<RequestRedisData>, Publisher<RequestRedisData>> transformer) {
                 throw new UnsupportedOperationException();
             }
         };

--- a/servicetalk-serialization-api/src/test/java/io/servicetalk/serialization/api/DefaultSerializerSerializationTest.java
+++ b/servicetalk-serialization-api/src/test/java/io/servicetalk/serialization/api/DefaultSerializerSerializationTest.java
@@ -172,8 +172,8 @@ public class DefaultSerializerSerializationTest {
 
     @Test
     public void applySerializationForIterableWithTypeAndEstimator() {
-        final Iterable<Buffer> buffers = factory.serialize(asList("Hello1", "Hello2"), allocator, String.class, sizeEstimator
-        );
+        final Iterable<Buffer> buffers = factory.serialize(asList("Hello1", "Hello2"), allocator, String.class,
+                sizeEstimator);
         verify(provider).getSerializer(String.class);
         assertThat("Unexpected created buffers.", createdBuffers, hasSize(2));
         verify(serializer).serialize("Hello1", createdBuffers.get(0));

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
@@ -100,7 +100,8 @@ public final class TcpClient {
      * @throws ExecutionException If connect failed.
      * @throws InterruptedException If interrupted while waiting for connect to complete.
      */
-    public NettyConnection<Buffer, Buffer> connectWithFdBlocking(ExecutionContext executionContext, SocketAddress address)
+    public NettyConnection<Buffer, Buffer> connectWithFdBlocking(ExecutionContext executionContext,
+                                                                 SocketAddress address)
             throws ExecutionException, InterruptedException {
         assumeTrue(executionContext.ioExecutor().isFileDescriptorSocketAddressSupported());
         assumeTrue(Epoll.isAvailable() || KQueue.isAvailable());

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
@@ -86,8 +86,8 @@ public class TcpServer {
      *
      * @param executionContext {@link ExecutionContext} to use for incoming connections.
      * @param port Port for the server.
-     * @param connectionAcceptor to use for filtering accepted connections. The returned {@link ServerContext} manages the
-     * lifecycle of the {@code connectionAcceptor}, ensuring it is closed when the {@link ServerContext} is closed.
+     * @param connectionAcceptor to use for filtering accepted connections. The returned {@link ServerContext} manages
+     * the lifecycle of the {@code connectionAcceptor}, ensuring it is closed when the {@link ServerContext} is closed.
      * @param service {@link Function} that is invoked for each accepted connection.
      * @return {@link ServerContext} for the started server.
      * @throws ExecutionException If the server start failed.

--- a/servicetalk-transport-netty-internal/gradle/checkstyle/suppressions.xml
+++ b/servicetalk-transport-netty-internal/gradle/checkstyle/suppressions.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  <!-- The list of test cases must be kept single-line each. -->
+  <suppress checks="LineLength" files="io/servicetalk/transport/netty/internal/RequestResponseCloseHandlerTest.java"/>
+</suppressions>

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
@@ -464,7 +464,8 @@ public class DefaultNettyConnectionTest {
         // Exception should NOT be of type CloseEventObservedException
         assertThat(exCaptor.getValue(), instanceOf(ClosedChannelException.class));
         assertThat(exCaptor.getValue().getCause(), nullValue());
-        assertThat(exCaptor.getValue().getStackTrace()[0].getClassName(), equalTo(DefaultNettyConnection.class.getName()));
+        assertThat(exCaptor.getValue().getStackTrace()[0].getClassName(),
+                equalTo(DefaultNettyConnection.class.getName()));
     }
 
     @Test

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/OverlappingCapacityAwareSupplierTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/OverlappingCapacityAwareSupplierTest.java
@@ -149,13 +149,15 @@ public class OverlappingCapacityAwareSupplierTest {
         verifyNoMoreInteractions(supplier);
     }
 
-    private static void requestNAndVerify(OverlappingCapacityAwareSupplier supplier, int writeBufferCapacityInBytes, long expectedRequestN) {
+    private static void requestNAndVerify(OverlappingCapacityAwareSupplier supplier, int writeBufferCapacityInBytes,
+                                          long expectedRequestN) {
         long requestN = supplier.requestNFor(writeBufferCapacityInBytes);
         assertThat("Unexpected requestN", requestN, is(expectedRequestN));
     }
 
     private static OverlappingCapacityAwareSupplier newSupplier(LongSupplier requestNSupplier) {
-        OverlappingCapacityAwareSupplier mock = mock(OverlappingCapacityAwareSupplier.class, withSettings().useConstructor());
+        OverlappingCapacityAwareSupplier mock = mock(OverlappingCapacityAwareSupplier.class,
+                withSettings().useConstructor());
         when(mock.getRequestNForCapacity(anyLong())).thenAnswer(invocation -> requestNSupplier.getAsLong());
         return mock;
     }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberOutOfEventloopTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberOutOfEventloopTest.java
@@ -93,7 +93,8 @@ public class WriteStreamSubscriberOutOfEventloopTest extends AbstractOutOfEventl
                 if (pendingFlush.contains(1)) {
                     subject.onError(t);
                 } else {
-                    subject.onError(new IllegalStateException("The expected object wasn't written before termination!", t));
+                    subject.onError(
+                            new IllegalStateException("The expected object wasn't written before termination!", t));
                 }
             }
         };


### PR DESCRIPTION
Motivation:

To help with readability, we'd like our code to fit within 120 chars.
Addressing all the violations allows us to enable the checkstyle rule
for this.

Modifications:

Add a checkstyle rule for 120 char lines.
Address remaining 120 char lines across all code.

Results:

The 120 char limit is now enforced by checkstyle.