### PR TITLE
Rename add/setTrailer(HttpHeaders) -> add/setTrailers(HttpHeaders)

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequest.java
@@ -165,8 +165,8 @@ public interface HttpRequest extends HttpRequestMetaData, TrailersHolder {
     }
 
     @Override
-    default HttpRequest addTrailer(final HttpHeaders trailers) {
-        TrailersHolder.super.addTrailer(trailers);
+    default HttpRequest addTrailers(final HttpHeaders trailers) {
+        TrailersHolder.super.addTrailers(trailers);
         return this;
     }
 
@@ -177,8 +177,8 @@ public interface HttpRequest extends HttpRequestMetaData, TrailersHolder {
     }
 
     @Override
-    default HttpRequest setTrailer(final HttpHeaders trailers) {
-        TrailersHolder.super.setTrailer(trailers);
+    default HttpRequest setTrailers(final HttpHeaders trailers) {
+        TrailersHolder.super.setTrailers(trailers);
         return this;
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponse.java
@@ -132,8 +132,8 @@ public interface HttpResponse extends HttpResponseMetaData, TrailersHolder {
     }
 
     @Override
-    default HttpResponse addTrailer(final HttpHeaders trailers) {
-        TrailersHolder.super.addTrailer(trailers);
+    default HttpResponse addTrailers(final HttpHeaders trailers) {
+        TrailersHolder.super.addTrailers(trailers);
         return this;
     }
 
@@ -144,8 +144,8 @@ public interface HttpResponse extends HttpResponseMetaData, TrailersHolder {
     }
 
     @Override
-    default HttpResponse setTrailer(final HttpHeaders trailers) {
-        TrailersHolder.super.setTrailer(trailers);
+    default HttpResponse setTrailers(final HttpHeaders trailers) {
+        TrailersHolder.super.setTrailers(trailers);
         return this;
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/TrailersHolder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/TrailersHolder.java
@@ -45,7 +45,7 @@ interface TrailersHolder {
      * @param trailers the trailers to add.
      * @return {@code this}.
      */
-    default TrailersHolder addTrailer(final HttpHeaders trailers) {
+    default TrailersHolder addTrailers(final HttpHeaders trailers) {
         trailers().add(trailers);
         return this;
     }
@@ -69,7 +69,7 @@ interface TrailersHolder {
      * @param trailers the trailers object which contains new values.
      * @return {@code this}.
      */
-    default TrailersHolder setTrailer(final HttpHeaders trailers) {
+    default TrailersHolder setTrailers(final HttpHeaders trailers) {
         trailers().set(trailers);
         return this;
     }


### PR DESCRIPTION
Motivation:

`addTrailer(HttpHeaders)` and `setTrailer(HttpHeaders)` take the whole
`HttpHeaders` object and should be named in the plural form.

Modifications:

- Rename: `addTrailer(HttpHeaders)` -> `addTrailers(HttpHeaders)`;
- Rename: `setTrailer(HttpHeaders)` -> `setTrailers(HttpHeaders)`;

Result:

Correct naming.