### PR TITLE
`Completable` when converted to a value containing source (`Single`, …

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -18,7 +18,6 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.CompletableSource.Subscriber;
-import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.internal.SignalOffloader;
 
 import org.slf4j.Logger;
@@ -622,14 +621,13 @@ public abstract class Completable {
      *
      * @param shouldRepeat {@link IntPredicate} that given the repeat count determines if the operation should be
      * repeated
-     * @param <T> Type of items provided by the passed {@link Supplier} and emitted by the returned {@link Publisher}.
      * @return A {@link Publisher} that emits the value returned by the passed {@link Supplier} everytime this
      * {@link Completable} completes.
      *
      * @see <a href="http://reactivex.io/documentation/operators/repeat.html">ReactiveX repeat operator.</a>
      */
-    public final <T> Publisher<T> repeat(IntPredicate shouldRepeat) {
-        return this.<T>toSingle().repeat(shouldRepeat);
+    public final Publisher<Void> repeat(IntPredicate shouldRepeat) {
+        return toSingle().repeat(shouldRepeat);
     }
 
     /**
@@ -654,13 +652,12 @@ public abstract class Completable {
      * @param repeatWhen {@link IntFunction} that given the repeat count returns a {@link Completable}.
      * If this {@link Completable} emits an error repeat is terminated, otherwise, original {@link Completable} is
      * re-subscribed when this {@link Completable} completes.
-     * @param <T> Type of items provided by the passed {@link Supplier} and emitted by the returned {@link Publisher}.
      * @return A {@link Completable} that completes after all re-subscriptions completes.
      *
      * @see <a href="http://reactivex.io/documentation/operators/retry.html">ReactiveX retry operator.</a>
      */
-    public final <T> Publisher<T> repeatWhen(IntFunction<? extends Completable> repeatWhen) {
-        return this.<T>toSingle().repeatWhen(repeatWhen);
+    public final Publisher<Void> repeatWhen(IntFunction<? extends Completable> repeatWhen) {
+        return toSingle().repeatWhen(repeatWhen);
     }
 
     /**
@@ -1095,36 +1092,29 @@ public abstract class Completable {
 
     /**
      * Converts this {@code Completable} to a {@link Single}.
-     * <p>
-     * The return value's {@link SingleSource.Subscriber#onSuccess(Object)} value is undefined. If you need a specific
-     * value you can also use {@link #concatWith(Single)} with a {@link Single#success(Object)}.
-     * @param <T> The value type of the resulting {@link Single}.
+     *
      * @return A {@link Single} that mirrors the terminal signal from this {@link Completable}.
      */
-    public final <T> Single<T> toSingle() {
+    public final Single<Void> toSingle() {
         return new CompletableToSingle<>(this, executor);
     }
 
     /**
      * Converts this {@code Completable} to a {@link CompletionStage}.
-     * <p>
-     * The {@link CompletionStage}'s value is undefined.
-     * @param <T> The value type of the resulting {@link Single}.
+     *
      * @return A {@link CompletionStage} that mirrors the terminal signal from this {@link Completable}.
      */
-    public final <T> CompletionStage<T> toCompletionStage() {
-        return this.<T>toSingle().toCompletionStage();
+    public final CompletionStage<Void> toCompletionStage() {
+        return toSingle().toCompletionStage();
     }
 
     /**
      * Converts this {@code Completable} to a {@link Future}.
-     * <p>
-     * The {@link Future}'s value is undefined.
-     * @param <T> The value type of the resulting {@link Single}.
+     *
      * @return A {@link Future} that mirrors the terminal signal from this {@link Completable}.
      */
-    public final <T> Future<T> toFuture() {
-        return this.<T>toSingle().toFuture();
+    public final Future<Void> toFuture() {
+        return toSingle().toFuture();
     }
 
     //

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SourceAdaptersTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SourceAdaptersTest.java
@@ -207,7 +207,7 @@ public class SourceAdaptersTest {
             s.onError(DELIBERATE_EXCEPTION);
         };
 
-        Future<Integer> future = fromSource(src).toFuture();
+        Future<Void> future = fromSource(src).toFuture();
         expectedException.expect(ExecutionException.class);
         expectedException.expectCause(sameInstance(DELIBERATE_EXCEPTION));
         future.get();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestExecutorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestExecutorTest.java
@@ -233,8 +233,8 @@ public class TestExecutorTest {
     @Test
     public void testCloseAsync() throws Exception {
         TestExecutor fixture = new TestExecutor();
-        Future<String> closeFuture = fixture.closeAsync().toFuture();
-        Future<String> onCloseFuture = fixture.onClose().toFuture();
+        Future<Void> closeFuture = fixture.closeAsync().toFuture();
+        Future<Void> onCloseFuture = fixture.onClose().toFuture();
 
         assertNull(closeFuture.get());
         assertTrue(closeFuture.isDone());

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToCompletionStageTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToCompletionStageTest.java
@@ -76,7 +76,7 @@ public class CompletableToCompletionStageTest {
 
     private void verifyComplete(boolean completeBeforeListen) throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(1);
-        CompletionStage<String> stage = source.toCompletionStage();
+        CompletionStage<Void> stage = source.toCompletionStage();
         if (completeBeforeListen) {
             source.onComplete();
             stage.thenRun(latch::countDown);
@@ -100,7 +100,7 @@ public class CompletableToCompletionStageTest {
     private void verifyError(boolean errorBeforeListen) throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(1);
         AtomicReference<Throwable> causeRef = new AtomicReference<>();
-        CompletionStage<String> stage = source.toCompletionStage();
+        CompletionStage<Void> stage = source.toCompletionStage();
         if (errorBeforeListen) {
             source.onError(DELIBERATE_EXCEPTION);
             stage.exceptionally(cause -> {
@@ -122,14 +122,14 @@ public class CompletableToCompletionStageTest {
 
     @Test
     public void futureComplete() throws Exception {
-        Future<String> f = source.toFuture();
+        Future<Void> f = source.toFuture();
         jdkExecutor.execute(source::onComplete);
         f.get();
     }
 
     @Test
     public void futureFail() throws Exception {
-        Future<String> f = source.toFuture();
+        Future<Void> f = source.toFuture();
         jdkExecutor.execute(() -> source.onError(DELIBERATE_EXCEPTION));
         thrown.expect(ExecutionException.class);
         thrown.expectCause(is(DELIBERATE_EXCEPTION));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToSingleTest.java
@@ -40,11 +40,11 @@ public class CompletableToSingleTest {
     @Rule
     public final ExecutorRule executorRule = ExecutorRule.newRule();
 
-    private TestSingleSubscriber<String> subscriber = new TestSingleSubscriber<>();
+    private TestSingleSubscriber<Void> subscriber = new TestSingleSubscriber<>();
 
     @Test
     public void noTerminalSucceeds() {
-        toSource(Completable.completed().<String>toSingle()).subscribe(subscriber);
+        toSource(Completable.completed().toSingle()).subscribe(subscriber);
         assertTrue(subscriber.hasResult());
         assertThat(subscriber.takeResult(), nullValue());
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/tck/SingleFlatMapCompletableTckTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/tck/SingleFlatMapCompletableTckTest.java
@@ -21,10 +21,10 @@ import io.servicetalk.concurrent.api.Single;
 import org.testng.annotations.Test;
 
 @Test
-public class SingleFlatMapCompletableTckTest extends AbstractSingleOperatorTckTest<Object> {
+public class SingleFlatMapCompletableTckTest extends AbstractSingleOperatorTckTest<Void> {
 
     @Override
-    protected Single<Object> composeSingle(Single<Integer> single) {
+    protected Single<Void> composeSingle(Single<Integer> single) {
         return single.flatMapCompletable(v -> Completable.completed()).toSingle();
     }
 


### PR DESCRIPTION
…`Future`, etc) should use `Void`

__Motivation__

Currently `Completable` methods to convert to `Future`, `CompletionStage` and `Single` return those types with the generic parameter as `T`.
The methods then emit `null` as the value. This is potentially confusing as we are forcing `null` and may introduce bugs when someone inadvertently uses the `null` value.

__Modification__

Converted these methods to now use `Void` as the generic parameter. `Void` is true to what we are emitting; `null`

__Result__

More intutitive and safer conversions.