### PR TITLE
StreamingHttpClientFilter StreamingHttpConnectionFilter implement Lis…

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilter.java
@@ -16,7 +16,6 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.api.Completable;
-import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ExecutionContext;
 
@@ -28,8 +27,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * A {@link StreamingHttpClient} that delegates all methods to a different {@link StreamingHttpClient}.
  */
-public class StreamingHttpClientFilter implements StreamingHttpRequester,
-                                                  ListenableAsyncCloseable {
+public class StreamingHttpClientFilter implements StreamingHttpRequester {
     @Nullable
     private final StreamingHttpClientFilter delegate;
     final StreamingHttpRequestResponseFactory reqRespFactory;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionFilter.java
@@ -17,7 +17,6 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.api.Completable;
-import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.StreamingHttpConnection.SettingKey;
@@ -33,8 +32,7 @@ import static java.util.Objects.requireNonNull;
  * A {@link StreamingHttpConnectionFilter} that delegates all methods to a different {@link
  * StreamingHttpConnectionFilter}.
  */
-public class StreamingHttpConnectionFilter implements StreamingHttpRequester,
-                                                      ListenableAsyncCloseable {
+public class StreamingHttpConnectionFilter implements StreamingHttpRequester {
 
     @Nullable
     private final StreamingHttpConnectionFilter delegate;


### PR DESCRIPTION
…tenableAsyncCloseable twice

Motivation:
StreamingHttpClientFilter StreamingHttpConnectionFilter both implement ListenableAsyncCloseable and StreamingHttpRequester. However now StreamingHttpRequester also implements ListenableAsyncCloseable so the client/connection filters no longer need to implement this type directly.

Modifications:
- StreamingHttpClientFilter StreamingHttpConnectionFilter no longer directly implement ListenableAsyncCloseable

Result:
Less duplication in inheritance.