### PR TITLE
Rename `onErrorResume` to `recoverWith`

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -98,7 +98,8 @@ public abstract class Completable {
     //
 
     /**
-     * Ignores any error returned by this {@link Completable} and resume to a new {@link Completable}.
+     * Recover from any error emitted by this {@link Completable} by using another {@link Completable} provided by the
+     * passed {@code nextFactory}.
      * <p>
      * This method provides similar capabilities to a try/catch block in sequential programming:
      * <pre>{@code
@@ -111,7 +112,8 @@ public abstract class Completable {
      * }</pre>
      *
      * @param nextFactory Returns the next {@link Completable}, if this {@link Completable} emits an error.
-     * @return The new {@link Completable}.
+     * @return A {@link Completable} that recovers from an error from this {@code Completable} by using another
+     * {@link Completable} provided by the passed {@code nextFactory}.
      */
     public final Completable onErrorResume(Function<Throwable, ? extends Completable> nextFactory) {
         return new ResumeCompletable(this, nextFactory, executor);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -162,7 +162,8 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Ignores any error returned by this {@link Publisher} and resume to a new {@link Publisher}.
+     * Recover from any error emitted by this {@link Publisher} by using another {@link Publisher} provided by the
+     * passed {@code nextFactory}.
      * <p>
      * This method provides similar capabilities to a try/catch block in sequential programming:
      * <pre>{@code
@@ -177,11 +178,11 @@ public abstract class Publisher<T> {
      * }</pre>
      *
      * @param nextFactory Returns the next {@link Publisher}, when this {@link Publisher} emits an error.
-     * @return A {@link Publisher} that ignores error from this {@code Publisher} and resume with the {@link Publisher}
-     * produced by {@code nextFactory}.
+     * @return A {@link Publisher} that recovers from an error from this {@code Publisher} by using another
+     * {@link Publisher} provided by the passed {@code nextFactory}.
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX catch operator.</a>
      */
-    public final Publisher<T> onErrorResume(Function<Throwable, ? extends Publisher<? extends T>> nextFactory) {
+    public final Publisher<T> recoverWith(Function<Throwable, ? extends Publisher<? extends T>> nextFactory) {
         return new ResumePublisher<>(this, nextFactory, executor);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ResumePublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ResumePublisher.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
 import static java.util.Objects.requireNonNull;
 
 /**
- * As returned by {@link Publisher#onErrorResume(Function)}.
+ * As returned by {@link Publisher#recoverWith(Function)}.
  *
  * @param <T> Type of items emitted by this {@link Publisher}.
  */

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ResumeSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ResumeSingle.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 import static java.util.Objects.requireNonNull;
 
 /**
- * {@link Single} as returned by {@link Single#onErrorResume(Function)}.
+ * {@link Single} as returned by {@link Single#recoverWith(Function)}.
  */
 final class ResumeSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -120,7 +120,8 @@ public abstract class Single<T> {
     }
 
     /**
-     * Ignores any error returned by this {@link Single} and resume to a new {@link Single}.
+     * Recover from any error emitted by this {@link Single} by using another {@link Single} provided by the
+     * passed {@code nextFactory}.
      * <p>
      * This method provides similar capabilities to a try/catch block in sequential programming:
      * <pre>{@code
@@ -134,10 +135,10 @@ public abstract class Single<T> {
      *     return result;
      * }</pre>
      * @param nextFactory Returns the next {@link Single}, when this {@link Single} emits an error.
-     * @return A {@link Single} that ignores error from this {@code Single} and resume with the {@link Single} produced
-     * by {@code nextFactory}.
+     * @return A {@link Single} that recovers from an error from this {@code Single} by using another
+     * {@link Single} provided by the passed {@code nextFactory}.
      */
-    public final Single<T> onErrorResume(Function<Throwable, ? extends Single<? extends T>> nextFactory) {
+    public final Single<T> recoverWith(Function<Throwable, ? extends Single<? extends T>> nextFactory) {
         return new ResumeSingle<>(this, nextFactory, executor);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
@@ -107,7 +107,7 @@ public class PublisherFlatMapSingleTest {
                 return x;
             }
             throw new DeliberateException();
-        }), 1024).onErrorResume(t -> {
+        }), 1024).recoverWith(t -> {
             error.set(t);
             return Publisher.empty();
         }).reduce(ArrayList::new, (ints, s) -> {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ResumePublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ResumePublisherTest.java
@@ -41,7 +41,7 @@ public final class ResumePublisherTest {
 
     @Test
     public void testFirstComplete() {
-        toSource(first.onErrorResume(throwable -> second)).subscribe(subscriber);
+        toSource(first.recoverWith(throwable -> second)).subscribe(subscriber);
         subscriber.request(1);
         first.onNext(1);
         first.onComplete();
@@ -51,7 +51,7 @@ public final class ResumePublisherTest {
 
     @Test
     public void testFirstErrorSecondComplete() {
-        toSource(first.onErrorResume(throwable -> second)).subscribe(subscriber);
+        toSource(first.recoverWith(throwable -> second)).subscribe(subscriber);
         subscriber.request(1);
         first.onError(DELIBERATE_EXCEPTION);
         assertTrue(subscriber.subscriptionReceived());
@@ -65,7 +65,7 @@ public final class ResumePublisherTest {
 
     @Test
     public void testFirstErrorSecondError() {
-        toSource(first.onErrorResume(throwable -> second)).subscribe(subscriber);
+        toSource(first.recoverWith(throwable -> second)).subscribe(subscriber);
         subscriber.request(1);
         first.onError(new DeliberateException());
         assertTrue(subscriber.subscriptionReceived());
@@ -77,7 +77,7 @@ public final class ResumePublisherTest {
 
     @Test
     public void testCancelFirstActive() {
-        toSource(first.onErrorResume(throwable -> second)).subscribe(subscriber);
+        toSource(first.recoverWith(throwable -> second)).subscribe(subscriber);
         final TestSubscription subscription = new TestSubscription();
         first.onSubscribe(subscription);
         subscriber.request(1);
@@ -90,7 +90,7 @@ public final class ResumePublisherTest {
 
     @Test
     public void testCancelSecondActive() {
-        toSource(first.onErrorResume(throwable -> second)).subscribe(subscriber);
+        toSource(first.recoverWith(throwable -> second)).subscribe(subscriber);
         final TestSubscription subscription = new TestSubscription();
         subscriber.request(1);
         first.onError(DELIBERATE_EXCEPTION);
@@ -105,7 +105,7 @@ public final class ResumePublisherTest {
 
     @Test
     public void testDemandAcrossPublishers() {
-        toSource(first.onErrorResume(throwable -> second)).subscribe(subscriber);
+        toSource(first.recoverWith(throwable -> second)).subscribe(subscriber);
         subscriber.request(2);
         first.onNext(1);
         first.onError(DELIBERATE_EXCEPTION);
@@ -119,7 +119,7 @@ public final class ResumePublisherTest {
 
     @Test
     public void testDuplicateOnError() {
-        toSource(first.onErrorResume(throwable -> second)).subscribe(subscriber);
+        toSource(first.recoverWith(throwable -> second)).subscribe(subscriber);
         subscriber.request(1);
         first.onError(DELIBERATE_EXCEPTION);
         assertTrue(subscriber.subscriptionReceived());
@@ -134,7 +134,7 @@ public final class ResumePublisherTest {
     @Test
     public void exceptionInTerminalCallsOnError() {
         DeliberateException ex = new DeliberateException();
-        toSource(first.onErrorResume(throwable -> {
+        toSource(first.recoverWith(throwable -> {
             throw ex;
         })).subscribe(subscriber);
         subscriber.request(1);
@@ -146,7 +146,7 @@ public final class ResumePublisherTest {
 
     @Test
     public void nullInTerminalCallsOnError() {
-        toSource(first.onErrorResume(throwable -> null)).subscribe(subscriber);
+        toSource(first.recoverWith(throwable -> null)).subscribe(subscriber);
         subscriber.request(1);
         first.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.takeError(), instanceOf(NullPointerException.class));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ResumeSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ResumeSingleTest.java
@@ -42,7 +42,7 @@ public final class ResumeSingleTest {
         subscriber = new TestSingleSubscriber<>();
         first = new TestSingle<>();
         second = new TestSingle<>();
-        toSource(first.onErrorResume(throwable -> second)).subscribe(subscriber);
+        toSource(first.recoverWith(throwable -> second)).subscribe(subscriber);
     }
 
     @Test
@@ -98,7 +98,7 @@ public final class ResumeSingleTest {
         first = new TestSingle<>();
         subscriber = new TestSingleSubscriber<>();
         DeliberateException ex = new DeliberateException();
-        toSource(first.onErrorResume(throwable -> {
+        toSource(first.recoverWith(throwable -> {
             throw ex;
         })).subscribe(subscriber);
 

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherOnErrorResumeTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherOnErrorResumeTckTest.java
@@ -27,7 +27,7 @@ public class PublisherOnErrorResumeTckTest extends AbstractPublisherTckTest<Inte
         int numElements = TckUtils.requestNToInt(elements);
 
         return TckUtils.<Integer>newFailedPublisher()
-                .onErrorResume(cause -> TckUtils.newPublisher(numElements));
+                .recoverWith(cause -> TckUtils.newPublisher(numElements));
     }
 
     @Override

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleOnErrorResumeTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleOnErrorResumeTckTest.java
@@ -27,6 +27,6 @@ public class SingleOnErrorResumeTckTest extends AbstractSingleTckTest<Integer> {
     @Override
     public Publisher<Integer> createServiceTalkPublisher(long elements) {
         return Single.<Integer>error(DeliberateException.DELIBERATE_EXCEPTION)
-                .onErrorResume(cause -> Single.success(1)).toPublisher();
+                .recoverWith(cause -> Single.success(1)).toPublisher();
     }
 }

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/GatewayService.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/GatewayService.java
@@ -106,7 +106,7 @@ final class GatewayService extends HttpService {
                                     // response with a static "unavailable" rating when the rating service is
                                     // unavailable or provides a bad response. This is typically referred to as a
                                     // "fallback".
-                                    .onErrorResume(cause -> success(new Rating(reco.getEntityId(), -1)));
+                                    .recoverWith(cause -> success(new Rating(reco.getEntityId(), -1)));
 
                     // The below asynchronously queries metadata, user and rating backends and zips them into a single
                     // FullRecommendation instance.

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/StreamingGatewayService.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/StreamingGatewayService.java
@@ -96,7 +96,7 @@ final class StreamingGatewayService extends StreamingHttpService {
                             // We consider ratings to be a non-critical data and hence we substitute the response
                             // with a static "unavailable" rating when the rating service is unavailable or provides
                             // a bad response. This is typically referred to as a "fallback".
-                            .onErrorResume(cause -> {
+                            .recoverWith(cause -> {
                                 LOGGER.error("Error querying ratings service. Ignoring and providing a fallback.",
                                         cause);
                                 return success(new Rating(recommendation.getEntityId(), -1));

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpExecutionStrategy.java
@@ -99,7 +99,7 @@ final class DefaultHttpExecutionStrategy implements HttpExecutionStrategy {
         } else {
             responseSingle = service.apply(request);
         }
-        Publisher<Object> resp = responseSingle.onErrorResume(t -> errorHandler.apply(t, e))
+        Publisher<Object> resp = responseSingle.recoverWith(t -> errorHandler.apply(t, e))
                 .flatMapPublisher(response -> flatten(response, response.payloadBodyAndTrailers()));
         if (offloaded(OFFLOAD_SEND)) {
             resp = resp.subscribeOn(e);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/NoOffloadsHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/NoOffloadsHttpExecutionStrategy.java
@@ -62,7 +62,7 @@ final class NoOffloadsHttpExecutionStrategy implements HttpExecutionStrategy {
             final BiFunction<Throwable, Executor, Single<StreamingHttpResponse>> errorHandler) {
         request = request.transformRawPayloadBody(payload -> payload.publishOnOverride(immediate()));
         return service.apply(request)
-                .onErrorResume(t -> errorHandler.apply(t, immediate()))
+                .recoverWith(t -> errorHandler.apply(t, immediate()))
                 .flatMapPublisher(response -> flatten(response, response.payloadBodyAndTrailers()))
                 .subscribeOnOverride(immediate());
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConcurrentRequestsHttpConnectionFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConcurrentRequestsHttpConnectionFilterTest.java
@@ -245,7 +245,7 @@ public class ConcurrentRequestsHttpConnectionFilterTest {
             final AtomicReference<Throwable> ioEx = new AtomicReference<>();
 
             Publisher.empty()
-                    .concatWith(resp1).onErrorResume(reset -> {
+                    .concatWith(resp1).recoverWith(reset -> {
                         ioEx.set(reset); // Capture connection reset
                         return Publisher.empty();
                     })

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
@@ -117,7 +117,7 @@ public class HttpAuthConnectionFactoryClientTest {
                 final ResolvedAddress resolvedAddress) {
             return delegate.newConnection(resolvedAddress).flatMap(cnx ->
                     cnx.request(defaultStrategy(), newTestRequest(cnx, "/auth"))
-                            .onErrorResume(cause -> {
+                            .recoverWith(cause -> {
                                 cnx.closeAsync().subscribe();
                                 return error(new IllegalStateException("failed auth"));
                             })

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/auth/BasicAuthHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/auth/BasicAuthHttpServiceFilter.java
@@ -309,7 +309,7 @@ public final class BasicAuthHttpServiceFilter<UserInfo> implements HttpServiceFi
 
             return config.credentialsVerifier.apply(userId, password)
                     .flatMap(userInfo -> onAuthenticated(ctx, request, factory, userInfo))
-                    .onErrorResume(t -> {
+                    .recoverWith(t -> {
                         if (t instanceof AuthenticationException) {
                             return onAccessDenied(request, factory);
                         }

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/CommanderUtils.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/CommanderUtils.java
@@ -183,7 +183,7 @@ final class CommanderUtils {
             }
             Single<String> discardSingle = abortSingles(queued, singles);
             if (releaseAfterDone) {
-                discardSingle = discardSingle.onErrorResume(discardThrowable -> reservedCnx.releaseAsync()
+                discardSingle = discardSingle.recoverWith(discardThrowable -> reservedCnx.releaseAsync()
                         // If releaseAsync() fails then add as a suppressed exception.
                         .onErrorResume(releaseThrowable -> {
                             discardThrowable.addSuppressed(releaseThrowable);

--- a/servicetalk-redis-utils/src/main/java/io/servicetalk/redis/utils/RedisAuthConnectionFactory.java
+++ b/servicetalk-redis-utils/src/main/java/io/servicetalk/redis/utils/RedisAuthConnectionFactory.java
@@ -58,7 +58,7 @@ public class RedisAuthConnectionFactory<ResolvedAddress>
     public Single<RedisConnection> newConnection(ResolvedAddress resolvedAddress) {
         return delegate.newConnection(resolvedAddress)
                 .flatMap(cnx -> cnx.asBufferCommander().auth(addressToPassword.apply(cnx.connectionContext()))
-                        .onErrorResume(cause -> {
+                        .recoverWith(cause -> {
                             cnx.closeAsync().subscribe();
                             return error(new RedisAuthorizationException("Failed to authenticate on connection " + cnx +
                                     " to address " + resolvedAddress, cause));

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -131,7 +131,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
                                    FlushStrategy flushStrategy) {
         super(channel, executor);
         nettyChannelPublisher = new NettyChannelPublisher<>(channel, terminalMsgPredicate, closeHandler);
-        this.readPublisher = nettyChannelPublisher.onErrorResume(this::enrichErrorPublisher);
+        this.readPublisher = nettyChannelPublisher.recoverWith(this::enrichErrorPublisher);
         this.terminalMsgPredicate = requireNonNull(terminalMsgPredicate);
         this.executionContext = new DefaultExecutionContext(allocator, fromNettyEventLoop(channel.eventLoop()),
                 executor);


### PR DESCRIPTION
__Motivation__

`onErrorResume` has some conflicts in the name with operators that provide callbacks for certain `Subscriber`/`Subscription` and contains `on`.
`recoverWith` can be a better name to indicate intent here that we are trying to recover from an error with another source.

__Modification__

Rename `onErroResume` on all sources to `recoverWith`.

__Result__

Better operator naming.