### PR TITLE
Qualify `flatMap` with "merge" where applicable

### DIFF
--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/HandleSubscribeOffloadedTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/HandleSubscribeOffloadedTest.java
@@ -59,14 +59,14 @@ public class HandleSubscribeOffloadedTest extends AbstractHandleSubscribeOffload
     @Test
     public void withAsyncOperatorsAddedAfter() throws Exception {
         awaitTermination(source.subscribeOn(newOffloadingAwareExecutor())
-                .flatMapSingle(t -> executorForTimerRule.executor().submit(() -> t)));
+                .flatMapMergeSingle(t -> executorForTimerRule.executor().submit(() -> t)));
         verifyHandleSubscribeInvoker();
         verifyPublisherOffloadCount();
     }
 
     @Test
     public void withAsyncOperatorsAddedBefore() throws Exception {
-        awaitTermination(source.flatMapSingle(t -> executorForTimerRule.executor().submit(() -> t))
+        awaitTermination(source.flatMapMergeSingle(t -> executorForTimerRule.executor().submit(() -> t))
                 .subscribeOn(newOffloadingAwareExecutor()));
         verifyHandleSubscribeInvoker();
         verifyPublisherOffloadCount();

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -189,7 +189,8 @@ public abstract class Publisher<T> {
      * Turns every item emitted by this {@link Publisher} into a {@link Single} and emits the items emitted by each of
      * those {@link Single}s.
      * <p>
-     * To control the amount of concurrent processing done by this operator see {@link #flatMapSingle(Function, int)}.
+     * To control the amount of concurrent processing done by this operator see
+     * {@link #flatMapMergeSingle(Function, int)}.
      * <p>
      * This method is similar to {@link #map(Function)} but the result is asynchronous, and provides a data
      * transformation in sequential programming similar to:
@@ -216,9 +217,9 @@ public abstract class Publisher<T> {
      * @return A new {@link Publisher} that emits all items emitted by each single produced by {@code mapper}.
      *
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX flatMap operator.</a>
-     * @see #flatMapSingle(Function, int)
+     * @see #flatMapMergeSingle(Function, int)
      */
-    public final <R> Publisher<R> flatMapSingle(Function<? super T, ? extends Single<? extends R>> mapper) {
+    public final <R> Publisher<R> flatMapMergeSingle(Function<? super T, ? extends Single<? extends R>> mapper) {
         return new PublisherFlatMapSingle<>(this, mapper, false, executor);
     }
 
@@ -255,21 +256,21 @@ public abstract class Publisher<T> {
      *
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX flatMap operator.</a>
      */
-    public final <R> Publisher<R> flatMapSingle(Function<? super T, ? extends Single<? extends R>> mapper,
-                                                int maxConcurrency) {
+    public final <R> Publisher<R> flatMapMergeSingle(Function<? super T, ? extends Single<? extends R>> mapper,
+                                                     int maxConcurrency) {
         return new PublisherFlatMapSingle<>(this, mapper, maxConcurrency, false, executor);
     }
 
     /**
      * Turns every item emitted by this {@link Publisher} into a {@link Single} and emits the items emitted by each of
-     * those {@link Single}s. This is the same as {@link #flatMapSingle(Function, int)} just that if any {@link Single}
-     * returned by {@code mapper}, terminates with an error, the returned {@link Publisher} will not immediately
-     * terminate. Instead, it will wait for this {@link Publisher} and all {@link Single}s to terminate and then
-     * terminate the returned {@link Publisher} with all errors emitted by the {@link Single}s produced by the
+     * those {@link Single}s. This is the same as {@link #flatMapMergeSingle(Function, int)} just that if any
+     * {@link Single} returned by {@code mapper}, terminates with an error, the returned {@link Publisher} will not
+     * immediately terminate. Instead, it will wait for this {@link Publisher} and all {@link Single}s to terminate and
+     * then terminate the returned {@link Publisher} with all errors emitted by the {@link Single}s produced by the
      * {@code mapper}.
      * <p>
      * To control the amount of concurrent processing done by this operator see
-     * {@link #flatMapSingleDelayError(Function, int)}.
+     * {@link #flatMapMergeSingleDelayError(Function, int)}.
      * <p>
      * This method is similar to {@link #map(Function)} but the result is asynchronous, and provides a data
      * transformation in sequential programming similar to:
@@ -304,18 +305,19 @@ public abstract class Publisher<T> {
      * @return A new {@link Publisher} that emits all items emitted by each single produced by {@code mapper}.
      *
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX merge operator.</a>
-     * @see #flatMapSingleDelayError(Function, int)
+     * @see #flatMapMergeSingleDelayError(Function, int)
      */
-    public final <R> Publisher<R> flatMapSingleDelayError(Function<? super T, ? extends Single<? extends R>> mapper) {
+    public final <R> Publisher<R> flatMapMergeSingleDelayError(
+            Function<? super T, ? extends Single<? extends R>> mapper) {
         return new PublisherFlatMapSingle<>(this, mapper, true, executor);
     }
 
     /**
      * Turns every item emitted by this {@link Publisher} into a {@link Single} and emits the items emitted by each of
-     * those {@link Single}s. This is the same as {@link #flatMapSingle(Function, int)} just that if any {@link Single}
-     * returned by {@code mapper}, terminates with an error, the returned {@link Publisher} will not immediately
-     * terminate. Instead, it will wait for this {@link Publisher} and all {@link Single}s to terminate and then
-     * terminate the returned {@link Publisher} with all errors emitted by the {@link Single}s produced by the
+     * those {@link Single}s. This is the same as {@link #flatMapMergeSingle(Function, int)} just that if any
+     * {@link Single} returned by {@code mapper}, terminates with an error, the returned {@link Publisher} will not
+     * immediately terminate. Instead, it will wait for this {@link Publisher} and all {@link Single}s to terminate and
+     * then terminate the returned {@link Publisher} with all errors emitted by the {@link Single}s produced by the
      * {@code mapper}.
      * <p>
      * This method is similar to {@link #map(Function)} but the result is asynchronous, and provides a data
@@ -355,8 +357,8 @@ public abstract class Publisher<T> {
      *
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX merge operator.</a>
      */
-    public final <R> Publisher<R> flatMapSingleDelayError(Function<? super T, ? extends Single<? extends R>> mapper,
-                                                          int maxConcurrency) {
+    public final <R> Publisher<R> flatMapMergeSingleDelayError(
+            Function<? super T, ? extends Single<? extends R>> mapper, int maxConcurrency) {
         return new PublisherFlatMapSingle<>(this, mapper, maxConcurrency, true, executor);
     }
 
@@ -396,7 +398,7 @@ public abstract class Publisher<T> {
      * @see #flatMapCompletableDelayError(Function)
      */
     public final Completable flatMapCompletable(Function<? super T, ? extends Completable> mapper) {
-        return flatMapSingle(t -> mapper.apply(t).toSingle()).ignoreElements();
+        return flatMapMergeSingle(t -> mapper.apply(t).toSingle()).ignoreElements();
     }
 
     /**
@@ -433,7 +435,7 @@ public abstract class Publisher<T> {
      * @see #flatMapCompletableDelayError(Function, int)
      */
     public final Completable flatMapCompletable(Function<? super T, ? extends Completable> mapper, int maxConcurrency) {
-        return flatMapSingle(t -> mapper.apply(t).toSingle(), maxConcurrency).ignoreElements();
+        return flatMapMergeSingle(t -> mapper.apply(t).toSingle(), maxConcurrency).ignoreElements();
     }
 
     /**
@@ -476,10 +478,10 @@ public abstract class Publisher<T> {
      * terminated successfully or any one of them has terminated with a failure.
      *
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX merge operator.</a>
-     * @see #flatMapSingleDelayError(Function, int)
+     * @see #flatMapMergeSingleDelayError(Function, int)
      */
     public final Completable flatMapCompletableDelayError(Function<? super T, ? extends Completable> mapper) {
-        return flatMapSingleDelayError(t -> mapper.apply(t).toSingle()).ignoreElements();
+        return flatMapMergeSingleDelayError(t -> mapper.apply(t).toSingle()).ignoreElements();
     }
 
     /**
@@ -520,54 +522,11 @@ public abstract class Publisher<T> {
      * terminated successfully or any one of them has terminated with a failure.
      *
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX merge operator.</a>
-     * @see #flatMapSingleDelayError(Function, int)
+     * @see #flatMapMergeSingleDelayError(Function, int)
      */
     public final Completable flatMapCompletableDelayError(Function<? super T, ? extends Completable> mapper,
                                                           int maxConcurrency) {
-        return flatMapSingleDelayError(t -> mapper.apply(t).toSingle(), maxConcurrency).ignoreElements();
-    }
-
-    /**
-     * Create a {@link Publisher} that flattens each element returned by the {@link Iterable#iterator()} from
-     * {@code mapper}.
-     * <p>
-     * Note that {@code flatMap} operators may process input in parallel, provide results as they become available, and
-     * may interleave results from multiple {@link Iterator}s. If ordering is required see
-     * {@link #concatMapIterable(Function)}.
-     * <p>
-     * This method provides similar capabilities as expanding each result into a collection and concatenating each
-     * collection concurrently in sequential programming:
-     * <pre>{@code
-     *     ExecutorService e = ...;
-     *     List<Future<List<R>> futures = ...; // assume this is thread safe
-     *     for (T t : resultOfThisPublisher()) {
-     *         // Note that flatMap process results in parallel.
-     *         futures.add(e.submit(() -> {
-     *             List<R> results = new ArrayList<>();
-     *             Iterable<? extends R> itr = mapper.apply(t);
-     *             itr.forEach(results::add);
-     *             return results;
-     *         }));
-     *     }
-     *     List<R> results = new ArrayList<>(futures.size());
-     *     // This is an approximation, this operator does not provide any ordering guarantees for the results.
-     *     for (Future<R> future : futures) {
-     *         R r = future.get(); // Throws if the processing for this item failed.
-     *         results.add(r);
-     *     }
-     *     return results;
-     * }</pre>
-     *
-     * @param mapper A {@link Function} that returns an {@link Iterable} for each element.
-     * @param <R> The elements returned by the {@link Iterable}.
-     * @return a {@link Publisher} that flattens each element returned by the {@link Iterable#iterator()} from
-     * {@code mapper}. Data is processed concurrently, the results are not necessarily ordered, and will depend upon
-     * completion order of the {@link Iterator}s.
-     * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX FlatMap operator.</a>
-     */
-    public final <R> Publisher<R> flatMapIterable(Function<? super T, ? extends Iterable<? extends R>> mapper) {
-        // TODO(scott): implement the flatMap variant.
-        return concatMapIterable(mapper);
+        return flatMapMergeSingleDelayError(t -> mapper.apply(t).toSingle(), maxConcurrency).ignoreElements();
     }
 
     /**
@@ -594,7 +553,7 @@ public abstract class Publisher<T> {
      * {@code mapper}. The results will be sequential for each {@link Iterator}, and overall for all calls to
      * {@link Iterable#iterator()}
      */
-    public final <R> Publisher<R> concatMapIterable(Function<? super T, ? extends Iterable<? extends R>> mapper) {
+    public final <R> Publisher<R> flatMapConcatIterable(Function<? super T, ? extends Iterable<? extends R>> mapper) {
         return new PublisherConcatMapIterable<>(this, mapper, executor);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
@@ -45,7 +45,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
 /**
- * As returned by {@link Publisher#flatMapSingle(Function, int)} and its variants.
+ * As returned by {@link Publisher#flatMapMergeSingle(Function, int)} and its variants.
  *
  * @param <R> Type of items emitted by this {@link Publisher}
  * @param <T> Type of items emitted by source {@link Publisher}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1164,7 +1164,7 @@ public abstract class Single<T> {
      * {@link Single}s passed to this method.
      */
     public static <T> Single<Collection<T>> collect(Iterable<? extends Single<? extends T>> singles) {
-        return Publisher.from(singles).flatMapSingle(identity()).reduce(ArrayList::new, (ts, t) -> {
+        return Publisher.from(singles).flatMapMergeSingle(identity()).reduce(ArrayList::new, (ts, t) -> {
             ts.add(t);
             return ts;
         });
@@ -1196,7 +1196,7 @@ public abstract class Single<T> {
      */
     @SafeVarargs
     public static <T> Single<Collection<T>> collect(Single<? extends T>... singles) {
-        return Publisher.from(singles).flatMapSingle(identity()).reduce(() -> new ArrayList<>(singles.length),
+        return Publisher.from(singles).flatMapMergeSingle(identity()).reduce(() -> new ArrayList<>(singles.length),
                 (ts, t) -> {
                     ts.add(t);
                     return ts;
@@ -1229,10 +1229,12 @@ public abstract class Single<T> {
      */
     public static <T> Single<Collection<T>> collect(Iterable<? extends Single<? extends T>> singles,
                                                     int maxConcurrency) {
-        return Publisher.from(singles).flatMapSingle(identity(), maxConcurrency).reduce(ArrayList::new, (ts, t) -> {
-            ts.add(t);
-            return ts;
-        });
+        return Publisher.from(singles)
+                .flatMapMergeSingle(identity(), maxConcurrency)
+                .reduce(ArrayList::new, (ts, t) -> {
+                    ts.add(t);
+                    return ts;
+                });
     }
 
     /**
@@ -1260,7 +1262,7 @@ public abstract class Single<T> {
      */
     @SafeVarargs
     public static <T> Single<Collection<T>> collect(int maxConcurrency, Single<? extends T>... singles) {
-        return Publisher.from(singles).flatMapSingle(identity(), maxConcurrency)
+        return Publisher.from(singles).flatMapMergeSingle(identity(), maxConcurrency)
                 .reduce(() -> new ArrayList<>(singles.length), (ts, t) -> {
                     ts.add(t);
                     return ts;
@@ -1301,7 +1303,7 @@ public abstract class Single<T> {
      * {@link Single}s passed to this method.
      */
     public static <T> Single<Collection<T>> collectDelayError(Iterable<? extends Single<? extends T>> singles) {
-        return Publisher.from(singles).flatMapSingleDelayError(identity()).reduce(ArrayList::new, (ts, t) -> {
+        return Publisher.from(singles).flatMapMergeSingleDelayError(identity()).reduce(ArrayList::new, (ts, t) -> {
             ts.add(t);
             return ts;
         });
@@ -1341,7 +1343,7 @@ public abstract class Single<T> {
      */
     @SafeVarargs
     public static <T> Single<Collection<T>> collectDelayError(Single<? extends T>... singles) {
-        return Publisher.from(singles).flatMapSingleDelayError(identity())
+        return Publisher.from(singles).flatMapMergeSingleDelayError(identity())
                 .reduce(() -> new ArrayList<>(singles.length), (ts, t) -> {
                     ts.add(t);
                     return ts;
@@ -1382,7 +1384,7 @@ public abstract class Single<T> {
      */
     public static <T> Single<Collection<T>> collectDelayError(Iterable<? extends Single<? extends T>> singles,
                                                               int maxConcurrency) {
-        return Publisher.from(singles).flatMapSingleDelayError(identity(), maxConcurrency)
+        return Publisher.from(singles).flatMapMergeSingleDelayError(identity(), maxConcurrency)
                 .reduce(ArrayList::new, (ts, t) -> {
                     ts.add(t);
                     return ts;
@@ -1422,7 +1424,7 @@ public abstract class Single<T> {
      */
     @SafeVarargs
     public static <T> Single<Collection<T>> collectDelayError(int maxConcurrency, Single<? extends T>... singles) {
-        return Publisher.from(singles).flatMapSingleDelayError(identity(), maxConcurrency)
+        return Publisher.from(singles).flatMapMergeSingleDelayError(identity(), maxConcurrency)
                 .reduce(() -> new ArrayList<>(singles.length), (ts, t) -> {
                     ts.add(t);
                     return ts;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherConcatMapIterableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherConcatMapIterableTest.java
@@ -50,7 +50,7 @@ public class PublisherConcatMapIterableTest {
 
     @Test
     public void cancellableIterableIsCancelled() {
-        toSource(cancellablePublisher.concatMapIterable(identity())).subscribe(subscriber);
+        toSource(cancellablePublisher.flatMapConcatIterable(identity())).subscribe(subscriber);
         cancellablePublisher.onSubscribe(subscription);
         assertTrue(subscriber.subscriptionReceived());
         subscriber.request(1);
@@ -67,7 +67,7 @@ public class PublisherConcatMapIterableTest {
 
     @Test
     public void justComplete() {
-        toSource(publisher.concatMapIterable(identity())).subscribe(subscriber);
+        toSource(publisher.flatMapConcatIterable(identity())).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         assertTrue(subscriber.subscriptionReceived());
         verifyTermination(true);
@@ -75,7 +75,7 @@ public class PublisherConcatMapIterableTest {
 
     @Test
     public void justFail() {
-        toSource(publisher.concatMapIterable(identity())).subscribe(subscriber);
+        toSource(publisher.flatMapConcatIterable(identity())).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         assertTrue(subscriber.subscriptionReceived());
         verifyTermination(false);
@@ -92,7 +92,7 @@ public class PublisherConcatMapIterableTest {
     }
 
     private void singleElementSingleValue(boolean success) {
-        toSource(publisher.concatMapIterable(identity())).subscribe(subscriber);
+        toSource(publisher.flatMapConcatIterable(identity())).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         assertTrue(subscriber.subscriptionReceived());
         subscriber.request(1);
@@ -116,7 +116,7 @@ public class PublisherConcatMapIterableTest {
     }
 
     private void singleElementMultipleValuesDelayedRequest(boolean success) {
-        toSource(publisher.concatMapIterable(identity())).subscribe(subscriber);
+        toSource(publisher.flatMapConcatIterable(identity())).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         assertTrue(subscriber.subscriptionReceived());
         subscriber.request(1);
@@ -151,7 +151,7 @@ public class PublisherConcatMapIterableTest {
     }
 
     private void multipleElementsSingleValue(boolean success) {
-        toSource(publisher.concatMapIterable(identity())).subscribe(subscriber);
+        toSource(publisher.flatMapConcatIterable(identity())).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         assertTrue(subscriber.subscriptionReceived());
         subscriber.request(1);
@@ -176,7 +176,7 @@ public class PublisherConcatMapIterableTest {
     }
 
     private void multipleElementsMultipleValues(boolean success) {
-        toSource(publisher.concatMapIterable(identity())).subscribe(subscriber);
+        toSource(publisher.flatMapConcatIterable(identity())).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         assertTrue(subscriber.subscriptionReceived());
         subscriber.request(1);
@@ -198,7 +198,7 @@ public class PublisherConcatMapIterableTest {
 
     @Test
     public void cancelIsPropagated() {
-        toSource(publisher.concatMapIterable(identity())).subscribe(subscriber);
+        toSource(publisher.flatMapConcatIterable(identity())).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         assertTrue(subscriber.subscriptionReceived());
         subscriber.request(1);
@@ -219,7 +219,7 @@ public class PublisherConcatMapIterableTest {
     }
 
     private void requestWithEmptyIterable(boolean success) {
-        toSource(publisher.concatMapIterable(identity())).subscribe(subscriber);
+        toSource(publisher.flatMapConcatIterable(identity())).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         assertTrue(subscriber.subscriptionReceived());
         subscriber.request(1);
@@ -238,7 +238,7 @@ public class PublisherConcatMapIterableTest {
 
     @Test
     public void exceptionFromOnErrorIsPropagated() {
-        toSource(publisher.concatMapIterable(identity())
+        toSource(publisher.flatMapConcatIterable(identity())
                 .doOnError(t -> {
                     throw DELIBERATE_EXCEPTION;
                 })).subscribe(subscriber);
@@ -249,7 +249,7 @@ public class PublisherConcatMapIterableTest {
 
     @Test
     public void exceptionFromOnCompleteIsPropagated() {
-        toSource(publisher.concatMapIterable(identity())
+        toSource(publisher.flatMapConcatIterable(identity())
                 .doOnComplete(() -> {
                     throw DELIBERATE_EXCEPTION;
                 })).subscribe(subscriber);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
@@ -87,7 +87,7 @@ public class PublisherFlatMapSingleTest {
     public void concurrentSingleAndPublisherTermination() throws Exception {
         final List<String> elements = range(0, 1000).mapToObj(Integer::toString).collect(toList());
         final Publisher<String> publisher = Publisher.from(elements);
-        final Single<List<String>> single = publisher.flatMapSingle(x -> executor.submit(() -> x), 1024)
+        final Single<List<String>> single = publisher.flatMapMergeSingle(x -> executor.submit(() -> x), 1024)
                 .reduce(ArrayList::new, (strings, s) -> {
                     strings.add(s);
                     return strings;
@@ -102,7 +102,7 @@ public class PublisherFlatMapSingleTest {
     public void concurrentSingleErrorAndPublisherTermination() throws Exception {
         final Publisher<Integer> publisher = Publisher.from(() -> range(0, 1000).iterator());
         AtomicReference<Throwable> error = new AtomicReference<>();
-        final Single<List<Integer>> single = publisher.flatMapSingleDelayError(x -> executor.submit(() -> {
+        final Single<List<Integer>> single = publisher.flatMapMergeSingleDelayError(x -> executor.submit(() -> {
             if (x % 2 == 0) {
                 return x;
             }
@@ -128,7 +128,7 @@ public class PublisherFlatMapSingleTest {
 
     @Test
     public void testSingleItemSyncSingle() {
-        toSource(source.flatMapSingle(integer1 -> Single.success(2), 2)).subscribe(subscriber);
+        toSource(source.flatMapMergeSingle(integer1 -> Single.success(2), 2)).subscribe(subscriber);
         subscriber.request(1);
         source.onNext(1);
         source.onComplete();
@@ -138,7 +138,7 @@ public class PublisherFlatMapSingleTest {
 
     @Test
     public void testSingleItemCompletesWithNull() {
-        toSource(source.<Integer>flatMapSingle(integer1 -> Single.success(null), 2)).subscribe(subscriber);
+        toSource(source.<Integer>flatMapMergeSingle(integer1 -> Single.success(null), 2)).subscribe(subscriber);
         subscriber.request(1);
         source.onNext(1);
         source.onComplete();
@@ -149,7 +149,7 @@ public class PublisherFlatMapSingleTest {
     @Test
     public void testSingleItemSourceCompleteFirst() {
         LegacyTestSingle<Integer> single = new LegacyTestSingle<>();
-        toSource(source.flatMapSingle(integer1 -> single, 2)).subscribe(subscriber);
+        toSource(source.flatMapMergeSingle(integer1 -> single, 2)).subscribe(subscriber);
         subscriber.request(1);
         source.onNext(1);
         source.onComplete();
@@ -161,7 +161,7 @@ public class PublisherFlatMapSingleTest {
     @Test
     public void testSingleItemSingleCompleteFirst() {
         LegacyTestSingle<Integer> single = new LegacyTestSingle<>();
-        toSource(source.flatMapSingle(integer1 -> single, 2)).subscribe(subscriber);
+        toSource(source.flatMapMergeSingle(integer1 -> single, 2)).subscribe(subscriber);
         subscriber.request(1);
         source.onNext(1);
         single.onSuccess(2);
@@ -172,7 +172,7 @@ public class PublisherFlatMapSingleTest {
 
     @Test
     public void testSingleItemSingleError() {
-        toSource(source.<Integer>flatMapSingle(integer1 -> Single.error(DELIBERATE_EXCEPTION), 2))
+        toSource(source.<Integer>flatMapMergeSingle(integer1 -> Single.error(DELIBERATE_EXCEPTION), 2))
                 .subscribe(subscriber);
         subscriber.request(1);
         source.onNext(1);
@@ -182,7 +182,7 @@ public class PublisherFlatMapSingleTest {
     @Test
     public void testSingleErrorPostSourceComplete() {
         LegacyTestSingle<Integer> single = new LegacyTestSingle<>();
-        toSource(source.flatMapSingle(integer1 -> single, 2)).subscribe(subscriber);
+        toSource(source.flatMapMergeSingle(integer1 -> single, 2)).subscribe(subscriber);
         subscriber.request(1);
         source.onNext(1);
         source.onComplete();
@@ -192,7 +192,7 @@ public class PublisherFlatMapSingleTest {
 
     @Test
     public void testSourceEmitsErrorNoOnNexts() {
-        toSource(source.flatMapSingle(integer1 -> Single.success(2), 2)).subscribe(subscriber);
+        toSource(source.flatMapMergeSingle(integer1 -> Single.success(2), 2)).subscribe(subscriber);
         subscriber.request(1);
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.takeError(), sameInstance(DELIBERATE_EXCEPTION));
@@ -200,7 +200,7 @@ public class PublisherFlatMapSingleTest {
 
     @Test
     public void testSourceEmitsErrorPostOnNexts() {
-        toSource(source.flatMapSingle(integer1 -> Single.success(2), 2)).subscribe(subscriber);
+        toSource(source.flatMapMergeSingle(integer1 -> Single.success(2), 2)).subscribe(subscriber);
         subscriber.request(1);
         source.onNext(1);
         source.onError(DELIBERATE_EXCEPTION);
@@ -211,7 +211,7 @@ public class PublisherFlatMapSingleTest {
     @Test
     public void testSourceEmitsErrorPostOnNextsSingleNotCompleted() {
         LegacyTestSingle<Integer> single = new LegacyTestSingle<>(true);
-        toSource(source.flatMapSingle(integer1 -> single, 2)).subscribe(subscriber);
+        toSource(source.flatMapMergeSingle(integer1 -> single, 2)).subscribe(subscriber);
         subscriber.request(1);
         source.onNext(1);
         source.onError(DELIBERATE_EXCEPTION);
@@ -226,7 +226,7 @@ public class PublisherFlatMapSingleTest {
     @Test
     public void testSubscriberCancel() {
         LegacyTestSingle<Integer> single = new LegacyTestSingle<>();
-        toSource(source.flatMapSingle(integer1 -> single, 2)).subscribe(subscriber);
+        toSource(source.flatMapMergeSingle(integer1 -> single, 2)).subscribe(subscriber);
         subscriber.request(1);
         source.onNext(1);
         subscriber.cancel();
@@ -241,7 +241,7 @@ public class PublisherFlatMapSingleTest {
         final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber.Builder<Integer>()
                 .disableDemandCheck().build();
         LegacyTestSingle<Integer> single = new LegacyTestSingle<>(true);
-        toSource(source.flatMapSingle(integer1 -> single, 2)).subscribe(subscriber);
+        toSource(source.flatMapMergeSingle(integer1 -> single, 2)).subscribe(subscriber);
         subscriber.request(1);
         source.onNext(1);
         subscriber.cancel();
@@ -258,7 +258,7 @@ public class PublisherFlatMapSingleTest {
     @Test
     public void testSingleErrorPostCancel() {
         LegacyTestSingle<Integer> single = new LegacyTestSingle<>(true);
-        toSource(source.flatMapSingle(integer1 -> single, 2)).subscribe(subscriber);
+        toSource(source.flatMapMergeSingle(integer1 -> single, 2)).subscribe(subscriber);
         subscriber.request(1);
         source.onNext(1);
         subscriber.cancel();
@@ -273,7 +273,7 @@ public class PublisherFlatMapSingleTest {
     @Test
     public void testMaxConcurrency() {
         List<LegacyTestSingle<Integer>> emittedSingles = new ArrayList<>();
-        toSource(source.flatMapSingle(integer -> {
+        toSource(source.flatMapMergeSingle(integer -> {
             LegacyTestSingle<Integer> s = new LegacyTestSingle<>();
             emittedSingles.add(s);
             return s;
@@ -306,7 +306,7 @@ public class PublisherFlatMapSingleTest {
 
     @Test
     public void testMapperThrows() {
-        toSource(source.<Integer>flatMapSingle(integer1 -> {
+        toSource(source.<Integer>flatMapMergeSingle(integer1 -> {
             throw DELIBERATE_EXCEPTION;
         }, 2)).subscribe(subscriber);
         source.onSubscribe(subscription);
@@ -328,7 +328,7 @@ public class PublisherFlatMapSingleTest {
     @Test
     public void testNoFlowControl() {
         List<LegacyTestSingle<Integer>> emittedSingles = new ArrayList<>();
-        toSource(source.flatMapSingle(integer1 -> {
+        toSource(source.flatMapMergeSingle(integer1 -> {
             LegacyTestSingle<Integer> s1 = new LegacyTestSingle<>();
             emittedSingles.add(s1);
             return s1;
@@ -364,7 +364,7 @@ public class PublisherFlatMapSingleTest {
 
     @Test
     public void testRequestPostSingleError() {
-        toSource(source.<Integer>flatMapSingleDelayError(integer1 -> Single.error(DELIBERATE_EXCEPTION), 2))
+        toSource(source.<Integer>flatMapMergeSingleDelayError(integer1 -> Single.error(DELIBERATE_EXCEPTION), 2))
                 .subscribe(subscriber);
         source.onSubscribe(subscription);
         subscriber.request(3);
@@ -382,7 +382,7 @@ public class PublisherFlatMapSingleTest {
 
     @Test
     public void testRequestMultipleTimes() {
-        toSource(source.flatMapSingle(integer1 -> Single.success(2), 10)).subscribe(subscriber);
+        toSource(source.flatMapMergeSingle(integer1 -> Single.success(2), 10)).subscribe(subscriber);
         source.onSubscribe(subscription);
         subscriber.request(2);
         assertThat(subscription.requested(), is(2L));
@@ -395,7 +395,7 @@ public class PublisherFlatMapSingleTest {
 
     @Test
     public void testRequestMultipleTimesBreachMaxConcurrency() {
-        toSource(source.flatMapSingle(integer -> Single.success(2), 2)).subscribe(subscriber);
+        toSource(source.flatMapMergeSingle(integer -> Single.success(2), 2)).subscribe(subscriber);
         source.onSubscribe(subscription);
         subscriber.request(2);
         subscriber.request(2);
@@ -410,7 +410,7 @@ public class PublisherFlatMapSingleTest {
     @Test
     public void testMultipleSingleErrors() {
         List<DeliberateException> errors = new ArrayList<>();
-        toSource(source.flatMapSingleDelayError(integer -> {
+        toSource(source.flatMapMergeSingleDelayError(integer -> {
             DeliberateException de = new DeliberateException();
             errors.add(de);
             return Single.<Integer>error(de);
@@ -428,7 +428,7 @@ public class PublisherFlatMapSingleTest {
     @Test
     public void testRequestLongMaxValue() {
         int maxConcurrency = 2;
-        toSource(source.flatMapSingle(integer1 -> Single.success(2), maxConcurrency)).subscribe(subscriber);
+        toSource(source.flatMapMergeSingle(integer1 -> Single.success(2), maxConcurrency)).subscribe(subscriber);
         source.onSubscribe(subscription);
         subscriber.request(Long.MAX_VALUE);
         assertThat(subscription.requested(), is((long) maxConcurrency));
@@ -441,7 +441,7 @@ public class PublisherFlatMapSingleTest {
     @Test
     public void testAccumulateToLongMaxValue() {
         int maxConcurrency = 2;
-        toSource(source.flatMapSingle(integer1 -> Single.success(2), maxConcurrency)).subscribe(subscriber);
+        toSource(source.flatMapMergeSingle(integer1 -> Single.success(2), maxConcurrency)).subscribe(subscriber);
         source.onSubscribe(subscription);
         subscriber.request(Long.MAX_VALUE - 1);
         assertThat(subscription.requested(), is((long) maxConcurrency));
@@ -454,7 +454,7 @@ public class PublisherFlatMapSingleTest {
     @Test
     public void testAccumulateToIntMaxValue() {
         int maxConcurrency = 2;
-        toSource(source.flatMapSingle(integer1 -> Single.success(2), maxConcurrency)).subscribe(subscriber);
+        toSource(source.flatMapMergeSingle(integer1 -> Single.success(2), maxConcurrency)).subscribe(subscriber);
         source.onSubscribe(subscription);
         subscriber.request(Integer.MAX_VALUE - 1);
         assertThat(subscription.requested(), is((long) maxConcurrency));
@@ -516,7 +516,7 @@ public class PublisherFlatMapSingleTest {
     public void testEmitFromQueue() throws Exception {
         List<LegacyTestSingle<Integer>> emittedSingles = new ArrayList<>();
         LegacyBlockingSubscriber<Integer> subscriber = new LegacyBlockingSubscriber<>();
-        toSource(source.flatMapSingle(integer -> {
+        toSource(source.flatMapMergeSingle(integer -> {
             LegacyTestSingle<Integer> s = new LegacyTestSingle<>();
             emittedSingles.add(s);
             return s;
@@ -545,7 +545,7 @@ public class PublisherFlatMapSingleTest {
     public void testRequestAndEmitConcurrency() throws Exception {
         int totalToRequest = 100000;
         Set<Integer> received = new LinkedHashSet<>(totalToRequest);
-        toSource(source.flatMapSingle(Single::success, 2).doBeforeNext(received::add)).subscribe(subscriber);
+        toSource(source.flatMapMergeSingle(Single::success, 2).doBeforeNext(received::add)).subscribe(subscriber);
         source.onSubscribe(subscription);
         CountDownLatch requestingStarting = new CountDownLatch(1);
         Future<?> submit = executorService.submit(() -> {

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherConcatMapIterableTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherConcatMapIterableTckTest.java
@@ -25,6 +25,6 @@ import java.util.Collections;
 public class PublisherConcatMapIterableTckTest extends AbstractPublisherOperatorTckTest<Integer> {
     @Override
     protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
-        return publisher.concatMapIterable(Collections::singletonList);
+        return publisher.flatMapConcatIterable(Collections::singletonList);
     }
 }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapSingleDelayErrorTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapSingleDelayErrorTckTest.java
@@ -24,6 +24,6 @@ import org.testng.annotations.Test;
 public class PublisherFlatMapSingleDelayErrorTckTest extends AbstractPublisherOperatorTckTest<Integer> {
     @Override
     protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
-        return publisher.flatMapSingleDelayError(Single::success, 10);
+        return publisher.flatMapMergeSingleDelayError(Single::success, 10);
     }
 }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapSingleTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapSingleTckTest.java
@@ -24,6 +24,6 @@ import org.testng.annotations.Test;
 public class PublisherFlatMapSingleTckTest extends AbstractPublisherOperatorTckTest<Integer> {
     @Override
     protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
-        return publisher.flatMapSingle(Single::success, 10);
+        return publisher.flatMapMergeSingle(Single::success, 10);
     }
 }

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscoverer.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscoverer.java
@@ -230,7 +230,7 @@ final class DefaultDnsServiceDiscoverer
 
         DiscoverEntry(final String inetHost) {
             this.inetHost = inetHost;
-            publisher = new EntriesPublisher().flatMapIterable(identity());
+            publisher = new EntriesPublisher().flatMapConcatIterable(identity());
         }
 
         void close0() {

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/GatewayService.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/GatewayService.java
@@ -87,7 +87,7 @@ final class GatewayService extends HttpService {
         // Recommendations are a List and we want to query details for each recommendation in parallel.
         // Turning the List into a Publisher helps us use relevant operators to do so.
         return from(recommendations)
-                .flatMapSingle(reco -> {
+                .flatMapMergeSingle(reco -> {
                     Single<Metadata> metadata =
                             metadataClient.request(metadataClient.get("/metadata?entityId=" + reco.getEntityId()))
                                     // Since HTTP payload is a buffer, we deserialize into Metadata.

--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/StreamingGatewayService.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/StreamingGatewayService.java
@@ -78,7 +78,7 @@ final class StreamingGatewayService extends StreamingHttpService {
     }
 
     private Publisher<FullRecommendation> queryRecommendationDetails(Publisher<Recommendation> recommendations) {
-        return recommendations.flatMapSingle(recommendation -> {
+        return recommendations.flatMapMergeSingle(recommendation -> {
             Single<Metadata> metadata =
                     metadataClient.request(metadataClient.get("/metadata?entityId=" + recommendation.getEntityId()))
                             // Since HTTP payload is a buffer, we deserialize into Metadata.

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConcurrentRequestsHttpConnectionFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConcurrentRequestsHttpConnectionFilterTest.java
@@ -180,7 +180,7 @@ public class ConcurrentRequestsHttpConnectionFilterTest {
 
             try {
                 Publisher.from(resp1, resp2, resp3) // Don't consume payloads to build up concurrency
-                        .flatMapSingle(Function.identity())
+                        .flatMapMergeSingle(Function.identity())
                         .toFuture().get();
 
                 fail("Should not allow three concurrent requests to complete normally");

--- a/servicetalk-serialization-api/src/main/java/io/servicetalk/serialization/api/DefaultSerializer.java
+++ b/servicetalk-serialization-api/src/main/java/io/servicetalk/serialization/api/DefaultSerializer.java
@@ -291,7 +291,7 @@ public final class DefaultSerializer implements Serializer {
         // The StreamingDeserializer will be used to buffer data in between Buffers. It is not thread safe but
         // the concatMap should ensure there is no concurrency, and will ensure visibility when transitioning
         // between Buffers.
-        toSource(source.concatMapIterable(deSerializer::deserialize)
+        toSource(source.flatMapConcatIterable(deSerializer::deserialize)
                 .doBeforeComplete(deSerializer::close))
                 .subscribe(subscriber);
     }


### PR DESCRIPTION
__Motivation__

Flattening a result can be done in order or in parallel. For `Publisher#flatMapSingle` variants we process each new `Single` in parallel so there is no order guarantee between the `Single` created for an emitted item and the result of that single as emitted on the final stream. eg:

`from(1,2,3).flatMapSingle(t -> aSingleForT)`

Assuming each generated `aSingleForT` generates items `T1`, `T2`, `T3` for the original items `1, 2, 3` then the values `T1`, `T2`, `T3` can be emitted in any order from the resulting `Publisher`. This behavior is subtle and is currently misrepresented in the name which could lead to confusion.

__Modification__

- Rename `flatMapSingle*` to `flatMapMergeSingle*`
- Rename `concatMapIterable` to `flatMapConcatIterable`
- Removed `flatMapIterable` as it just uses `concatMapIterable` and there is just one usage of it. We can do without this operator in the public API.

__Result__

More intuitive names.