### PR TITLE
Ignore flaky test `NettyHttpServerConnectionAcceptorTest#testAcceptCo…

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionAcceptorTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionAcceptorTest.java
@@ -26,6 +26,7 @@ import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.transport.api.ConnectionAcceptor;
 import io.servicetalk.transport.api.ConnectionContext;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -130,6 +131,7 @@ public class NettyHttpServerConnectionAcceptorTest extends AbstractNettyHttpServ
         return parameters;
     }
 
+    @Ignore("Flaky on CI: https://github.com/servicetalk/servicetalk/issues/452")
     @Test
     public void testAcceptConnection() throws Exception {
         try {


### PR DESCRIPTION
…nnection`

__Motivation__

`NettyHttpServerConnectionAcceptorTest#testAcceptConnection` is flaky and is an annoyance for regular development.
Tracking issue: https://github.com/servicetalk/servicetalk/issues/452

__Modification__

Ignored this test

__Result__

Less annoyance for regular development.