### PR TITLE
Shorten `lift` operator names

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -895,23 +895,23 @@ public abstract class Completable {
      * <pre>{@code
      *     Completable<X> pub = ...;
      *     pub.map(..) // A
-     *        .liftSynchronous(original -> modified)
+     *        .liftSync(original -> modified)
      *        .doAfterFinally(..) // B
      * }</pre>
      * The {@code original -> modified} "operator" <strong>MUST</strong> be "synchronous" in that it does not interact
      * with the original {@link Subscriber} from outside the modified {@link Subscriber} or {@link Cancellable}
      * threads. That is to say this operator will not impact the {@link Executor} constraints already in place between
      * <i>A</i> and <i>B</i> above. If you need asynchronous behavior, or are unsure, see
-     * {@link #liftAsynchronous(CompletableOperator)}.
+     * {@link #liftAsync(CompletableOperator)}.
      *
      * @param operator The custom operator logic. The input is the "original" {@link Subscriber} to this
      * {@link Completable} and the return is the "modified" {@link Subscriber} that provides custom operator business
      * logic.
      * @return a {@link Completable} that when subscribed, the {@code operator} argument will be used to wrap the
      * {@link Subscriber} before subscribing to this {@link Completable}.
-     * @see #liftAsynchronous(CompletableOperator)
+     * @see #liftAsync(CompletableOperator)
      */
-    public final Completable liftSynchronous(CompletableOperator operator) {
+    public final Completable liftSync(CompletableOperator operator) {
         return new LiftSynchronousCompletableOperator(this, operator, executor);
     }
 
@@ -924,7 +924,7 @@ public abstract class Completable {
      * <pre>{@code
      *     Publisher<X> pub = ...;
      *     pub.map(..) // A
-     *        .liftAsynchronous(original -> modified)
+     *        .liftAsync(original -> modified)
      *        .doAfterFinally(..) // B
      * }</pre>
      *
@@ -944,9 +944,9 @@ public abstract class Completable {
      * logic.
      * @return a {@link Completable} that when subscribed, the {@code operator} argument will be used to wrap the
      * {@link Subscriber} before subscribing to this {@link Completable}.
-     * @see #liftSynchronous(CompletableOperator)
+     * @see #liftSync(CompletableOperator)
      */
-    public final Completable liftAsynchronous(CompletableOperator operator) {
+    public final Completable liftAsync(CompletableOperator operator) {
         return new LiftAsynchronousCompletableOperator(this, operator, executor);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -1845,7 +1845,7 @@ public abstract class Publisher<T> {
      * <pre>{@code
      *     Publisher<X> pub = ...;
      *     pub.map(..) // A
-     *        .liftSynchronous(original -> modified)
+     *        .liftSync(original -> modified)
      *        .filter(..) // B
      * }</pre>
      *
@@ -1853,16 +1853,16 @@ public abstract class Publisher<T> {
      * with the original {@link Subscriber} from outside the modified {@link Subscriber} or {@link Subscription}
      * threads. That is to say this operator will not impact the {@link Executor} constraints already in place between
      * <i>A</i> and <i>B</i> above. If you need asynchronous behavior, or are unsure, see
-     * {@link #liftAsynchronous(PublisherOperator)}.
+     * {@link #liftAsync(PublisherOperator)}.
      * @param operator The custom operator logic. The input is the "original" {@link Subscriber} to this
      * {@link Publisher} and the return is the "modified" {@link Subscriber} that provides custom operator business
      * logic.
      * @param <R> Type of the items emitted by the returned {@link Publisher}.
      * @return a {@link Publisher} which when subscribed, the {@code operator} argument will be used to wrap the
      * {@link Subscriber} before subscribing to this {@link Publisher}.
-     * @see #liftAsynchronous(PublisherOperator)
+     * @see #liftAsync(PublisherOperator)
      */
-    public final <R> Publisher<R> liftSynchronous(PublisherOperator<? super T, ? extends R> operator) {
+    public final <R> Publisher<R> liftSync(PublisherOperator<? super T, ? extends R> operator) {
         return new LiftSynchronousPublisherOperator<>(this, operator, executor);
     }
 
@@ -1875,7 +1875,7 @@ public abstract class Publisher<T> {
      * <pre>{@code
      *     Publisher<X> pub = ...;
      *     pub.map(..) // A
-     *        .liftAsynchronous(original -> modified)
+     *        .liftAsync(original -> modified)
      *        .filter(..) // B
      * }</pre>
      * The {@code original -> modified} "operator" MAY be "asynchronous" in that it may interact with the original
@@ -1896,9 +1896,9 @@ public abstract class Publisher<T> {
      * @param <R> Type of the items emitted by the returned {@link Publisher}.
      * @return a {@link Publisher} which when subscribed, the {@code operator} argument will be used to wrap the
      * {@link Subscriber} before subscribing to this {@link Publisher}.
-     * @see #liftSynchronous(PublisherOperator)
+     * @see #liftSync(PublisherOperator)
      */
-    public final <R> Publisher<R> liftAsynchronous(PublisherOperator<? super T, ? extends R> operator) {
+    public final <R> Publisher<R> liftAsync(PublisherOperator<? super T, ? extends R> operator) {
         return new LiftAsynchronousPublisherOperator<>(this, operator, executor);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -924,23 +924,23 @@ public abstract class Single<T> {
      * <pre>{@code
      *     Single<X> pub = ...;
      *     pub.map(..) // A
-     *        .liftSynchronous(original -> modified)
+     *        .liftSync(original -> modified)
      *        .doAfterFinally(..) // B
      * }</pre>
      * The {@code original -> modified} "operator" <strong>MUST</strong> be "synchronous" in that it does not interact
      * with the original {@link Subscriber} from outside the modified {@link Subscriber} or {@link Cancellable}
      * threads. That is to say this operator will not impact the {@link Executor} constraints already in place between
      * <i>A</i> and <i>B</i> above. If you need asynchronous behavior, or are unsure, see
-     * {@link #liftAsynchronous(SingleOperator)}.
+     * {@link #liftAsync(SingleOperator)}.
      * @param operator The custom operator logic. The input is the "original" {@link Subscriber} to this
      * {@link Single} and the return is the "modified" {@link Subscriber} that provides custom operator business
      * logic.
      * @param <R> Type of the items emitted by the returned {@link Single}.
      * @return a {@link Single} which when subscribed, the {@code operator} argument will be used to wrap the
      * {@link Subscriber} before subscribing to this {@link Single}.
-     * @see #liftAsynchronous(SingleOperator)
+     * @see #liftAsync(SingleOperator)
      */
-    public final <R> Single<R> liftSynchronous(SingleOperator<? super T, ? extends R> operator) {
+    public final <R> Single<R> liftSync(SingleOperator<? super T, ? extends R> operator) {
         return new LiftSynchronousSingleOperator<>(this, operator, executor);
     }
 
@@ -953,7 +953,7 @@ public abstract class Single<T> {
      * <pre>{@code
      *     Publisher<X> pub = ...;
      *     pub.map(..) // Aw
-     *        .liftAsynchronous(original -> modified)
+     *        .liftAsync(original -> modified)
      *        .doAfterFinally(..) // B
      * }</pre>
      * The {@code original -> modified} "operator" MAY be "asynchronous" in that it may interact with the original
@@ -973,9 +973,9 @@ public abstract class Single<T> {
      * @param <R> Type of the items emitted by the returned {@link Single}.
      * @return a {@link Single} which when subscribed, the {@code operator} argument will be used to wrap the
      * {@link Subscriber} before subscribing to this {@link Single}.
-     * @see #liftSynchronous(SingleOperator)
+     * @see #liftSync(SingleOperator)
      */
-    public final <R> Single<R> liftAsynchronous(SingleOperator<? super T, ? extends R> operator) {
+    public final <R> Single<R> liftAsync(SingleOperator<? super T, ? extends R> operator) {
         return new LiftAsynchronousSingleOperator<>(this, operator, executor);
     }
 

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/CompletableLiftAsynchronousTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/CompletableLiftAsynchronousTckTest.java
@@ -24,6 +24,6 @@ public class CompletableLiftAsynchronousTckTest extends AbstractCompletableOpera
 
     @Override
     protected Completable composeCompletable(final Completable completable) {
-        return completable.liftAsynchronous(subscriber -> subscriber);
+        return completable.liftAsync(subscriber -> subscriber);
     }
 }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/CompletableLiftSynchronousTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/CompletableLiftSynchronousTckTest.java
@@ -24,6 +24,6 @@ public class CompletableLiftSynchronousTckTest extends AbstractCompletableOperat
 
     @Override
     protected Completable composeCompletable(final Completable completable) {
-        return completable.liftSynchronous(subscriber -> subscriber);
+        return completable.liftSync(subscriber -> subscriber);
     }
 }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherLiftAsynchronousTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherLiftAsynchronousTckTest.java
@@ -23,6 +23,6 @@ import org.testng.annotations.Test;
 public class PublisherLiftAsynchronousTckTest extends AbstractPublisherOperatorTckTest<Integer> {
     @Override
     protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
-        return publisher.liftAsynchronous(subscriber -> subscriber);
+        return publisher.liftAsync(subscriber -> subscriber);
     }
 }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherLiftSynchronousTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherLiftSynchronousTckTest.java
@@ -23,6 +23,6 @@ import org.testng.annotations.Test;
 public class PublisherLiftSynchronousTckTest extends AbstractPublisherOperatorTckTest<Integer> {
     @Override
     protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
-        return publisher.liftSynchronous(subscriber -> subscriber);
+        return publisher.liftSync(subscriber -> subscriber);
     }
 }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleLiftAsynchronousTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleLiftAsynchronousTckTest.java
@@ -24,6 +24,6 @@ public class SingleLiftAsynchronousTckTest extends AbstractSingleOperatorTckTest
 
     @Override
     protected Single<Integer> composeSingle(final Single<Integer> single) {
-        return single.liftAsynchronous(subscriber -> subscriber);
+        return single.liftAsync(subscriber -> subscriber);
     }
 }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleLiftSynchronousTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleLiftSynchronousTckTest.java
@@ -24,6 +24,6 @@ public class SingleLiftSynchronousTckTest extends AbstractSingleOperatorTckTest<
 
     @Override
     protected Single<Integer> composeSingle(final Single<Integer> single) {
-        return single.liftSynchronous(subscriber -> subscriber);
+        return single.liftSync(subscriber -> subscriber);
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpRequest.java
@@ -160,7 +160,7 @@ class DefaultStreamingHttpRequest<P> extends DefaultHttpRequestMetaData implemen
 
     @Override
     public Publisher<Buffer> payloadBody() {
-        return payloadBody.liftSynchronous(HttpBufferFilterOperator.INSTANCE);
+        return payloadBody.liftSync(HttpBufferFilterOperator.INSTANCE);
     }
 
     @Override
@@ -173,14 +173,14 @@ class DefaultStreamingHttpRequest<P> extends DefaultHttpRequestMetaData implemen
     @Override
     public final StreamingHttpRequest payloadBody(Publisher<Buffer> payloadBody) {
         return new BufferStreamingHttpRequest(this, allocator,
-                payloadBody.liftSynchronous(new BridgeFlowControlAndDiscardOperator(payloadBody())), trailersSingle);
+                payloadBody.liftSync(new BridgeFlowControlAndDiscardOperator(payloadBody())), trailersSingle);
     }
 
     @Override
     public final <T> StreamingHttpRequest payloadBody(final Publisher<T> payloadBody,
                                                       final HttpSerializer<T> serializer) {
         return new BufferStreamingHttpRequest(this, allocator, serializer.serialize(headers(),
-                    payloadBody.liftSynchronous(new SerializeBridgeFlowControlAndDiscardOperator<>(payloadBody())),
+                    payloadBody.liftSync(new SerializeBridgeFlowControlAndDiscardOperator<>(payloadBody())),
                     allocator),
                 trailersSingle);
     }
@@ -209,7 +209,7 @@ class DefaultStreamingHttpRequest<P> extends DefaultHttpRequestMetaData implemen
                                                     BiFunction<T, HttpHeaders, HttpHeaders> trailersTransformer) {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
         return new BufferStreamingHttpRequest(this, allocator, payloadBody()
-                .liftSynchronous(new HttpPayloadAndTrailersFromSingleOperator<>(stateSupplier, transformer,
+                .liftSync(new HttpPayloadAndTrailersFromSingleOperator<>(stateSupplier, transformer,
                         trailersTransformer, trailersSingle, outTrailersSingle)),
                 fromSource(outTrailersSingle));
     }
@@ -220,7 +220,7 @@ class DefaultStreamingHttpRequest<P> extends DefaultHttpRequestMetaData implemen
                                                        BiFunction<T, HttpHeaders, HttpHeaders> trailersTransformer) {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
         return new DefaultStreamingHttpRequest<>(this, allocator, payloadBody
-                .liftSynchronous(new HttpPayloadAndTrailersFromSingleOperator<>(stateSupplier, transformer,
+                .liftSync(new HttpPayloadAndTrailersFromSingleOperator<>(stateSupplier, transformer,
                         trailersTransformer, trailersSingle, outTrailersSingle)),
                 fromSource(outTrailersSingle));
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpResponse.java
@@ -91,7 +91,7 @@ class DefaultStreamingHttpResponse<P> extends DefaultHttpResponseMetaData implem
 
     @Override
     public Publisher<Buffer> payloadBody() {
-        return payloadBody.liftSynchronous(HttpBufferFilterOperator.INSTANCE);
+        return payloadBody.liftSync(HttpBufferFilterOperator.INSTANCE);
     }
 
     @Override
@@ -104,14 +104,14 @@ class DefaultStreamingHttpResponse<P> extends DefaultHttpResponseMetaData implem
     @Override
     public final StreamingHttpResponse payloadBody(final Publisher<Buffer> payloadBody) {
         return new BufferStreamingHttpResponse(this, allocator,
-                payloadBody.liftSynchronous(new BridgeFlowControlAndDiscardOperator(payloadBody())), trailersSingle);
+                payloadBody.liftSync(new BridgeFlowControlAndDiscardOperator(payloadBody())), trailersSingle);
     }
 
     @Override
     public final <T> StreamingHttpResponse payloadBody(final Publisher<T> payloadBody,
                                                        final HttpSerializer<T> serializer) {
         return new BufferStreamingHttpResponse(this, allocator, serializer.serialize(headers(),
-                    payloadBody.liftSynchronous(new SerializeBridgeFlowControlAndDiscardOperator<>(payloadBody())),
+                    payloadBody.liftSync(new SerializeBridgeFlowControlAndDiscardOperator<>(payloadBody())),
                     allocator),
                 trailersSingle);
     }
@@ -140,7 +140,7 @@ class DefaultStreamingHttpResponse<P> extends DefaultHttpResponseMetaData implem
                                                      final BiFunction<T, HttpHeaders, HttpHeaders> trailersTrans) {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
         return new BufferStreamingHttpResponse(this, allocator, payloadBody()
-                .liftSynchronous(new HttpPayloadAndTrailersFromSingleOperator<>(stateSupplier, transformer,
+                .liftSync(new HttpPayloadAndTrailersFromSingleOperator<>(stateSupplier, transformer,
                         trailersTrans, trailersSingle, outTrailersSingle)),
                 fromSource(outTrailersSingle));
     }
@@ -151,7 +151,7 @@ class DefaultStreamingHttpResponse<P> extends DefaultHttpResponseMetaData implem
                                                         final BiFunction<T, HttpHeaders, HttpHeaders> trailersTrans) {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
         return new DefaultStreamingHttpResponse<>(this, allocator, payloadBody
-                .liftSynchronous(new HttpPayloadAndTrailersFromSingleOperator<>(stateSupplier, transformer,
+                .liftSync(new HttpPayloadAndTrailersFromSingleOperator<>(stateSupplier, transformer,
                         trailersTrans, trailersSingle, outTrailersSingle)),
                 fromSource(outTrailersSingle));
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/TransportStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/TransportStreamingHttpRequest.java
@@ -128,7 +128,7 @@ final class TransportStreamingHttpRequest extends DefaultHttpRequestMetaData imp
 
     @Override
     public Publisher<Buffer> payloadBody() {
-        return payloadAndTrailers.liftSynchronous(HttpTransportBufferFilterOperator.INSTANCE);
+        return payloadAndTrailers.liftSync(HttpTransportBufferFilterOperator.INSTANCE);
     }
 
     @Override
@@ -140,7 +140,7 @@ final class TransportStreamingHttpRequest extends DefaultHttpRequestMetaData imp
     public StreamingHttpRequest payloadBody(Publisher<Buffer> payloadBody) {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
         return new BufferStreamingHttpRequest(this, allocator,
-                payloadBody.liftSynchronous(new BridgeFlowControlAndDiscardOperator(payloadAndTrailers.liftSynchronous(
+                payloadBody.liftSync(new BridgeFlowControlAndDiscardOperator(payloadAndTrailers.liftSync(
                         new HttpBufferTrailersSpliceOperator(outTrailersSingle)))),
                 fromSource(outTrailersSingle));
     }
@@ -149,8 +149,8 @@ final class TransportStreamingHttpRequest extends DefaultHttpRequestMetaData imp
     public <T> StreamingHttpRequest payloadBody(final Publisher<T> payloadBody, final HttpSerializer<T> serializer) {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
         return new BufferStreamingHttpRequest(this, allocator, serializer.serialize(headers(),
-                payloadBody.liftSynchronous(new SerializeBridgeFlowControlAndDiscardOperator<>(
-                        payloadAndTrailers.liftSynchronous(new HttpBufferTrailersSpliceOperator(outTrailersSingle)))),
+                payloadBody.liftSync(new SerializeBridgeFlowControlAndDiscardOperator<>(
+                        payloadAndTrailers.liftSync(new HttpBufferTrailersSpliceOperator(outTrailersSingle)))),
                 allocator),
             fromSource(outTrailersSingle));
     }
@@ -160,7 +160,7 @@ final class TransportStreamingHttpRequest extends DefaultHttpRequestMetaData imp
                                                          final HttpSerializer<T> serializer) {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
         return new BufferStreamingHttpRequest(this, allocator, serializer.serialize(headers(),
-                transformer.apply(payloadAndTrailers.liftSynchronous(new HttpBufferTrailersSpliceOperator(
+                transformer.apply(payloadAndTrailers.liftSync(new HttpBufferTrailersSpliceOperator(
                         outTrailersSingle))), allocator),
                 fromSource(outTrailersSingle));
     }
@@ -168,14 +168,14 @@ final class TransportStreamingHttpRequest extends DefaultHttpRequestMetaData imp
     @Override
     public StreamingHttpRequest transformPayloadBody(final UnaryOperator<Publisher<Buffer>> transformer) {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
-        return new BufferStreamingHttpRequest(this, allocator, transformer.apply(payloadAndTrailers.liftSynchronous(
+        return new BufferStreamingHttpRequest(this, allocator, transformer.apply(payloadAndTrailers.liftSync(
                 new HttpBufferTrailersSpliceOperator(outTrailersSingle))), fromSource(outTrailersSingle));
     }
 
     @Override
     public StreamingHttpRequest transformRawPayloadBody(final UnaryOperator<Publisher<?>> transformer) {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
-        return new DefaultStreamingHttpRequest<>(this, allocator, transformer.apply(payloadAndTrailers.liftSynchronous(
+        return new DefaultStreamingHttpRequest<>(this, allocator, transformer.apply(payloadAndTrailers.liftSync(
                 new HttpObjectTrailersSpliceOperator(outTrailersSingle))), fromSource(outTrailersSingle));
     }
 
@@ -184,7 +184,7 @@ final class TransportStreamingHttpRequest extends DefaultHttpRequestMetaData imp
                                               final BiFunction<Buffer, T, Buffer> transformer,
                                               final BiFunction<T, HttpHeaders, HttpHeaders> trailersTransformer) {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
-        return new BufferStreamingHttpRequest(this, allocator, payloadAndTrailers.liftSynchronous(
+        return new BufferStreamingHttpRequest(this, allocator, payloadAndTrailers.liftSync(
                 new HttpDataSourceTranformations.HttpRawBuffersAndTrailersOperator<>(stateSupplier, transformer,
                         trailersTransformer, outTrailersSingle)),
                 fromSource(outTrailersSingle));
@@ -195,7 +195,7 @@ final class TransportStreamingHttpRequest extends DefaultHttpRequestMetaData imp
                                                  final BiFunction<Object, T, ?> transformer,
                                                  final BiFunction<T, HttpHeaders, HttpHeaders> trailersTransformer) {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
-        return new DefaultStreamingHttpRequest<>(this, allocator, payloadAndTrailers.liftSynchronous(
+        return new DefaultStreamingHttpRequest<>(this, allocator, payloadAndTrailers.liftSync(
                 new HttpDataSourceTranformations.HttpRawObjectsAndTrailersOperator<>(stateSupplier, transformer,
                         trailersTransformer, outTrailersSingle)),
                 fromSource(outTrailersSingle));
@@ -213,7 +213,7 @@ final class TransportStreamingHttpRequest extends DefaultHttpRequestMetaData imp
     @Override
     public BlockingStreamingHttpRequest toBlockingStreamingRequest() {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
-        return new DefaultBlockingStreamingHttpRequest<>(this, allocator, payloadAndTrailers.liftSynchronous(
+        return new DefaultBlockingStreamingHttpRequest<>(this, allocator, payloadAndTrailers.liftSync(
                 new HttpObjectTrailersSpliceOperator(outTrailersSingle)).toIterable(), fromSource(outTrailersSingle));
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/TransportStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/TransportStreamingHttpResponse.java
@@ -64,7 +64,7 @@ final class TransportStreamingHttpResponse extends DefaultHttpResponseMetaData i
 
     @Override
     public Publisher<Buffer> payloadBody() {
-        return payloadAndTrailers.liftSynchronous(HttpTransportBufferFilterOperator.INSTANCE);
+        return payloadAndTrailers.liftSync(HttpTransportBufferFilterOperator.INSTANCE);
     }
 
     @Override
@@ -76,7 +76,7 @@ final class TransportStreamingHttpResponse extends DefaultHttpResponseMetaData i
     public StreamingHttpResponse payloadBody(final Publisher<Buffer> payloadBody) {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
         return new BufferStreamingHttpResponse(this, allocator,
-                payloadBody.liftSynchronous(new BridgeFlowControlAndDiscardOperator(payloadAndTrailers.liftSynchronous(
+                payloadBody.liftSync(new BridgeFlowControlAndDiscardOperator(payloadAndTrailers.liftSync(
                         new HttpBufferTrailersSpliceOperator(outTrailersSingle)))),
                 fromSource(outTrailersSingle));
     }
@@ -86,8 +86,8 @@ final class TransportStreamingHttpResponse extends DefaultHttpResponseMetaData i
                                                  final HttpSerializer<T> serializer) {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
         return new BufferStreamingHttpResponse(this, allocator, serializer.serialize(headers(),
-                payloadBody.liftSynchronous(new SerializeBridgeFlowControlAndDiscardOperator<>(
-                        payloadAndTrailers.liftSynchronous(new HttpBufferTrailersSpliceOperator(outTrailersSingle)))),
+                payloadBody.liftSync(new SerializeBridgeFlowControlAndDiscardOperator<>(
+                        payloadAndTrailers.liftSync(new HttpBufferTrailersSpliceOperator(outTrailersSingle)))),
                 allocator),
                 fromSource(outTrailersSingle));
     }
@@ -97,7 +97,7 @@ final class TransportStreamingHttpResponse extends DefaultHttpResponseMetaData i
                                                           final HttpSerializer<T> serializer) {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
         return new BufferStreamingHttpResponse(this, allocator, serializer.serialize(headers(),
-                transformer.apply(payloadAndTrailers.liftSynchronous(new HttpBufferTrailersSpliceOperator(
+                transformer.apply(payloadAndTrailers.liftSync(new HttpBufferTrailersSpliceOperator(
                         outTrailersSingle))), allocator),
                 fromSource(outTrailersSingle));
     }
@@ -105,14 +105,14 @@ final class TransportStreamingHttpResponse extends DefaultHttpResponseMetaData i
     @Override
     public StreamingHttpResponse transformPayloadBody(final UnaryOperator<Publisher<Buffer>> transformer) {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
-        return new BufferStreamingHttpResponse(this, allocator, transformer.apply(payloadAndTrailers.liftSynchronous(
+        return new BufferStreamingHttpResponse(this, allocator, transformer.apply(payloadAndTrailers.liftSync(
                 new HttpBufferTrailersSpliceOperator(outTrailersSingle))), fromSource(outTrailersSingle));
     }
 
     @Override
     public StreamingHttpResponse transformRawPayloadBody(final UnaryOperator<Publisher<?>> transformer) {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
-        return new DefaultStreamingHttpResponse<>(this, allocator, transformer.apply(payloadAndTrailers.liftSynchronous(
+        return new DefaultStreamingHttpResponse<>(this, allocator, transformer.apply(payloadAndTrailers.liftSync(
                 new HttpObjectTrailersSpliceOperator(outTrailersSingle))), fromSource(outTrailersSingle));
     }
 
@@ -121,7 +121,7 @@ final class TransportStreamingHttpResponse extends DefaultHttpResponseMetaData i
                                                final BiFunction<Buffer, T, Buffer> transformer,
                                                final BiFunction<T, HttpHeaders, HttpHeaders> trailersTransformer) {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
-        return new BufferStreamingHttpResponse(this, allocator, payloadAndTrailers.liftSynchronous(
+        return new BufferStreamingHttpResponse(this, allocator, payloadAndTrailers.liftSync(
                 new HttpRawBuffersAndTrailersOperator<>(stateSupplier, transformer,
                         trailersTransformer, outTrailersSingle)),
                 fromSource(outTrailersSingle));
@@ -132,7 +132,7 @@ final class TransportStreamingHttpResponse extends DefaultHttpResponseMetaData i
                                                   final BiFunction<Object, T, ?> transformer,
                                                   final BiFunction<T, HttpHeaders, HttpHeaders> trailersTransformer) {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
-        return new DefaultStreamingHttpResponse<>(this, allocator, payloadAndTrailers.liftSynchronous(
+        return new DefaultStreamingHttpResponse<>(this, allocator, payloadAndTrailers.liftSync(
                 new HttpRawObjectsAndTrailersOperator<>(stateSupplier, transformer,
                         trailersTransformer, outTrailersSingle)),
                 fromSource(outTrailersSingle));
@@ -150,7 +150,7 @@ final class TransportStreamingHttpResponse extends DefaultHttpResponseMetaData i
     @Override
     public BlockingStreamingHttpResponse toBlockingStreamingResponse() {
         final Processor<HttpHeaders, HttpHeaders> outTrailersSingle = newSingleProcessor();
-        return new DefaultBlockingStreamingHttpResponse<>(this, allocator, payloadAndTrailers.liftSynchronous(
+        return new DefaultBlockingStreamingHttpResponse<>(this, allocator, payloadAndTrailers.liftSync(
                 new HttpObjectTrailersSpliceOperator(outTrailersSingle)).toIterable(), fromSource(outTrailersSingle));
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ConcurrentRequestsHttpConnectionFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ConcurrentRequestsHttpConnectionFilter.java
@@ -82,7 +82,7 @@ final class ConcurrentRequestsHttpConnectionFilter implements HttpConnectionFilt
                     switch (result) {
                         case Accepted:
                             toSource(delegate.request(strategy, request)
-                                    .liftSynchronous(new DoBeforeFinallyOnHttpResponseOperator(
+                                    .liftSync(new DoBeforeFinallyOnHttpResponseOperator(
                                             limiter::requestFinished)))
                                     .subscribe(subscriber);
                             return;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultStreamingHttpClientFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultStreamingHttpClientFilter.java
@@ -65,7 +65,7 @@ final class DefaultStreamingHttpClientFilter extends StreamingHttpClientFilter {
         // correct.
         return loadBalancer.selectConnection(SELECTOR_FOR_REQUEST)
                 .flatMap(c -> c.request(strategy, request)
-                        .liftSynchronous(new DoBeforeFinallyOnHttpResponseOperator(c::requestFinished)));
+                        .liftSync(new DoBeforeFinallyOnHttpResponseOperator(c::requestFinished)));
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -274,7 +274,7 @@ final class NettyHttpServer {
                     // but FlushStrategy are implemented considering individual responses.
                     // Since this operator is present on the flattened single write stream, with or without pipelined
                     // requests processed in parallel, we can send WriteEventsListener callbacks per response.
-                    .liftSynchronous(subscriber -> new Subscriber<Object>() {
+                    .liftSync(subscriber -> new Subscriber<Object>() {
                         @Override
                         public void onSubscribe(final Subscription s) {
                             subscriber.onSubscribe(s);

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/DoBeforeFinallyOnHttpResponseOperator.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/DoBeforeFinallyOnHttpResponseOperator.java
@@ -53,12 +53,12 @@ import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
  *     // coarse grained, any terminal signal calls the provided `Runnable`
  *     return requester.request(strategy, request)
  *                     .doBeforeSubscribe(__ -> tracker.requestStarted())
- *                     .liftSynchronous(new DoBeforeFinallyOnHttpResponseOperator(tracker::requestFinished));
+ *                     .liftSync(new DoBeforeFinallyOnHttpResponseOperator(tracker::requestFinished));
  *
  *     // fine grained, `tracker` implements `TerminalSignalConsumer`, terminal signal indicated by the callback method
  *     return requester.request(strategy, request)
  *                     .doBeforeSubscribe(__ -> tracker.requestStarted())
- *                     .liftSynchronous(new DoBeforeFinallyOnHttpResponseOperator(tracker));
+ *                     .liftSync(new DoBeforeFinallyOnHttpResponseOperator(tracker));
  * }</pre>
  */
 public final class DoBeforeFinallyOnHttpResponseOperator
@@ -133,7 +133,7 @@ public final class DoBeforeFinallyOnHttpResponseOperator
                 sendNullResponse();
             } else if (stateUpdater.compareAndSet(this, IDLE, PROCESSING_PAYLOAD)) {
                 subscriber.onSuccess(response.transformRawPayloadBody(payload ->
-                        payload.liftSynchronous(subscriber ->
+                        payload.liftSync(subscriber ->
                                 new Subscriber<Object>() {
                                     @Override
                                     public void onSubscribe(final Subscription subscription) {

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/DoBeforeFinallyOnHttpResponseOperatorTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/DoBeforeFinallyOnHttpResponseOperatorTest.java
@@ -83,7 +83,7 @@ public class DoBeforeFinallyOnHttpResponseOperatorTest {
     public void nullAsSuccess() {
         final ResponseSubscriber subscriber = new ResponseSubscriber();
 
-        toSource(Single.<StreamingHttpResponse>success(null).liftSynchronous(operator)).subscribe(subscriber);
+        toSource(Single.<StreamingHttpResponse>success(null).liftSync(operator)).subscribe(subscriber);
         assertThat("onSubscribe not called.", subscriber.cancellable, is(notNullValue()));
         verify(doBeforeFinally).onComplete();
 
@@ -104,7 +104,7 @@ public class DoBeforeFinallyOnHttpResponseOperatorTest {
         };
 
         final ResponseSubscriber subscriber = new ResponseSubscriber();
-        toSource(original.liftSynchronous(operator)).subscribe(subscriber);
+        toSource(original.liftSync(operator)).subscribe(subscriber);
         assertThat("Original Single not subscribed.", subRef.get(), is(notNullValue()));
         assertThat("onSubscribe not called.", subscriber.cancellable, is(notNullValue()));
 
@@ -131,7 +131,7 @@ public class DoBeforeFinallyOnHttpResponseOperatorTest {
     public void cancelBeforeOnSuccess() throws Exception {
         LegacyTestSingle<StreamingHttpResponse> responseSingle = new LegacyTestSingle<>(true);
         final ResponseSubscriber subscriber = new ResponseSubscriber();
-        toSource(responseSingle.liftSynchronous(operator)).subscribe(subscriber);
+        toSource(responseSingle.liftSync(operator)).subscribe(subscriber);
         assertThat("onSubscribe not called.", subscriber.cancellable, is(notNullValue()));
 
         subscriber.cancellable.cancel();
@@ -152,7 +152,7 @@ public class DoBeforeFinallyOnHttpResponseOperatorTest {
     public void cancelBeforeOnError() {
         LegacyTestSingle<StreamingHttpResponse> responseSingle = new LegacyTestSingle<>(true);
         final ResponseSubscriber subscriber = new ResponseSubscriber();
-        toSource(responseSingle.liftSynchronous(operator)).subscribe(subscriber);
+        toSource(responseSingle.liftSync(operator)).subscribe(subscriber);
         assertThat("onSubscribe not called.", subscriber.cancellable, is(notNullValue()));
 
         subscriber.cancellable.cancel();
@@ -168,7 +168,7 @@ public class DoBeforeFinallyOnHttpResponseOperatorTest {
     public void cancelAfterOnSuccess() {
         LegacyTestSingle<StreamingHttpResponse> responseSingle = new LegacyTestSingle<>(true);
         final ResponseSubscriber subscriber = new ResponseSubscriber();
-        toSource(responseSingle.liftSynchronous(operator)).subscribe(subscriber);
+        toSource(responseSingle.liftSync(operator)).subscribe(subscriber);
         assertThat("onSubscribe not called.", subscriber.cancellable, is(notNullValue()));
 
         final StreamingHttpResponse response = reqRespFactory.ok().payloadBody(never());
@@ -188,7 +188,7 @@ public class DoBeforeFinallyOnHttpResponseOperatorTest {
     public void cancelAfterOnError() {
         LegacyTestSingle<StreamingHttpResponse> responseSingle = new LegacyTestSingle<>(true);
         final ResponseSubscriber subscriber = new ResponseSubscriber();
-        toSource(responseSingle.liftSynchronous(operator)).subscribe(subscriber);
+        toSource(responseSingle.liftSync(operator)).subscribe(subscriber);
         assertThat("onSubscribe not called.", subscriber.cancellable, is(notNullValue()));
 
         responseSingle.onError(DELIBERATE_EXCEPTION);
@@ -207,7 +207,7 @@ public class DoBeforeFinallyOnHttpResponseOperatorTest {
         TestPublisher<Buffer> payload = new TestPublisher<>();
         LegacyTestSingle<StreamingHttpResponse> responseSingle = new LegacyTestSingle<>(true);
         final ResponseSubscriber subscriber = new ResponseSubscriber();
-        toSource(responseSingle.liftSynchronous(operator)).subscribe(subscriber);
+        toSource(responseSingle.liftSync(operator)).subscribe(subscriber);
         assertThat("onSubscribe not called.", subscriber.cancellable, is(notNullValue()));
 
         final StreamingHttpResponse response = reqRespFactory.ok().payloadBody(payload);

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/AbstractTracingHttpFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/AbstractTracingHttpFilter.java
@@ -106,7 +106,7 @@ abstract class AbstractTracingHttpFilter {
         }
 
         Single<StreamingHttpResponse> track(Single<StreamingHttpResponse> responseSingle) {
-            return responseSingle.liftSynchronous(new DoBeforeFinallyOnHttpResponseOperator(this))
+            return responseSingle.liftSync(new DoBeforeFinallyOnHttpResponseOperator(this))
                     // DoBeforeFinallyOnHttpResponseOperator conditionally outputs a Single<Meta> with a failed
                     // Publisher<Data> instead of the real Publisher<Data> in case a cancel signal is observed before
                     // completion of Meta. So in order for downstream operators to get a consistent view of the data

--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/CommanderUtils.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/CommanderUtils.java
@@ -71,7 +71,7 @@ final class CommanderUtils {
                 return fromSource(single);
             }
             return Single.error(new RedisClientException("Read '" + status + "' but expected 'QUEUED'"));
-        }).<T>liftSynchronous(sub -> new Subscriber<T>() {
+        }).<T>liftSync(sub -> new Subscriber<T>() {
             @Override
             public void onSubscribe(final Cancellable cancellable) {
                 // Allowing cancellation of commands within a transaction would require needing to know whether the

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/Flush.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/Flush.java
@@ -49,7 +49,7 @@ final class Flush {
     static <T> Publisher<T> composeFlushes(Channel channel, Publisher<T> source, FlushStrategy flushStrategy) {
         requireNonNull(channel);
         requireNonNull(flushStrategy);
-        return source.liftSynchronous(subscriber -> new FlushSubscriber<>(flushStrategy, subscriber, channel));
+        return source.liftSync(subscriber -> new FlushSubscriber<>(flushStrategy, subscriber, channel));
     }
 
     private static final class FlushSubscriber<T> implements Subscriber<T> {


### PR DESCRIPTION
__Motivation__

`lift*` operators are a bit of a niche and we can assume understanding of "sync"/"async" terminology as compared to the complete names of "synchronous"/"asynchronous"

__Modification__

Renamed:

`liftSynchronous` => `liftSync`
`liftAsynchronous` => `liftAsync`

__Result__

Shorter names.