### PR TITLE
Rename `timeout` to `idleTimeout`

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncCloseables.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncCloseables.java
@@ -45,7 +45,7 @@ public final class AsyncCloseables {
      * @return A {@link Completable} that is notified once the close is complete.
      */
     public static Completable closeAsyncGracefully(AsyncCloseable closable, long timeout, TimeUnit timeoutUnit) {
-        return closable.closeAsyncGracefully().timeout(timeout, timeoutUnit).onErrorResume(
+        return closable.closeAsyncGracefully().idleTimeout(timeout, timeoutUnit).onErrorResume(
                 t -> t instanceof TimeoutException ? closable.closeAsync() : Completable.error(t)
         );
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -243,8 +243,8 @@ public abstract class Completable {
      * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    public final Completable timeout(long duration, TimeUnit unit) {
-        return timeout(duration, unit, executor);
+    public final Completable idleTimeout(long duration, TimeUnit unit) {
+        return idleTimeout(duration, unit, executor);
     }
 
     /**
@@ -262,7 +262,7 @@ public abstract class Completable {
      * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    public final Completable timeout(long duration, TimeUnit unit, Executor timeoutExecutor) {
+    public final Completable idleTimeout(long duration, TimeUnit unit, Executor timeoutExecutor) {
         return new TimeoutCompletable(this, duration, unit, timeoutExecutor);
     }
 
@@ -279,8 +279,8 @@ public abstract class Completable {
      * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    public final Completable timeout(Duration duration) {
-        return timeout(duration, executor);
+    public final Completable idleTimeout(Duration duration) {
+        return idleTimeout(duration, executor);
     }
 
     /**
@@ -297,7 +297,7 @@ public abstract class Completable {
      * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    public final Completable timeout(Duration duration, Executor timeoutExecutor) {
+    public final Completable idleTimeout(Duration duration, Executor timeoutExecutor) {
         return new TimeoutCompletable(this, duration, timeoutExecutor);
     }
 
@@ -1224,10 +1224,10 @@ public abstract class Completable {
      * offloading if necessary, and also offloading if {@link Cancellable#cancel()} will be called if this operation may
      * block.
      * <p>
-     * To apply a timeout see {@link #timeout(long, TimeUnit)} and related methods.
+     * To apply a timeout see {@link #idleTimeout(long, TimeUnit)} and related methods.
      * @param future The {@link Future} to convert.
      * @return A {@link Completable} that derives results from {@link Future}.
-     * @see #timeout(long, TimeUnit)
+     * @see #idleTimeout(long, TimeUnit)
      */
     public static Completable fromFuture(Future<?> future) {
         return Single.fromFuture(future).toCompletable();

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -719,9 +719,9 @@ public abstract class Publisher<T> {
      * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
      * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
-     * @see #timeout(long, TimeUnit, Executor)
+     * @see #idleTimeout(long, TimeUnit, Executor)
      */
-    public final Publisher<T> timeout(long duration, TimeUnit unit) {
+    public final Publisher<T> idleTimeout(long duration, TimeUnit unit) {
         return new TimeoutPublisher<>(this, executor, duration, unit);
     }
 
@@ -737,9 +737,9 @@ public abstract class Publisher<T> {
      * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
      * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
-     * @see #timeout(long, TimeUnit, Executor)
+     * @see #idleTimeout(long, TimeUnit, Executor)
      */
-    public final Publisher<T> timeout(Duration duration) {
+    public final Publisher<T> idleTimeout(Duration duration) {
         return new TimeoutPublisher<>(this, executor, duration);
     }
 
@@ -758,7 +758,7 @@ public abstract class Publisher<T> {
      * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    public final Publisher<T> timeout(long duration, TimeUnit unit, Executor timeoutExecutor) {
+    public final Publisher<T> idleTimeout(long duration, TimeUnit unit, Executor timeoutExecutor) {
         return new TimeoutPublisher<>(this, executor, duration, unit, timeoutExecutor);
     }
 
@@ -776,7 +776,7 @@ public abstract class Publisher<T> {
      * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    public final Publisher<T> timeout(Duration duration, Executor timeoutExecutor) {
+    public final Publisher<T> idleTimeout(Duration duration, Executor timeoutExecutor) {
         return new TimeoutPublisher<>(this, executor, duration, timeoutExecutor);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -323,8 +323,8 @@ public abstract class Single<T> {
      * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    public final Single<T> timeout(long duration, TimeUnit unit) {
-        return timeout(duration, unit, executor);
+    public final Single<T> idleTimeout(long duration, TimeUnit unit) {
+        return idleTimeout(duration, unit, executor);
     }
 
     /**
@@ -342,7 +342,7 @@ public abstract class Single<T> {
      * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    public final Single<T> timeout(long duration, TimeUnit unit, Executor timeoutExecutor) {
+    public final Single<T> idleTimeout(long duration, TimeUnit unit, Executor timeoutExecutor) {
         return new TimeoutSingle<>(this, duration, unit, timeoutExecutor);
     }
 
@@ -360,8 +360,8 @@ public abstract class Single<T> {
      * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    public final Single<T> timeout(Duration duration) {
-        return timeout(duration, executor);
+    public final Single<T> idleTimeout(Duration duration) {
+        return idleTimeout(duration, executor);
     }
 
     /**
@@ -378,7 +378,7 @@ public abstract class Single<T> {
      * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    public final Single<T> timeout(Duration duration, Executor timeoutExecutor) {
+    public final Single<T> idleTimeout(Duration duration, Executor timeoutExecutor) {
         return new TimeoutSingle<>(this, duration, timeoutExecutor);
     }
 
@@ -1129,11 +1129,11 @@ public abstract class Single<T> {
      * results will block. The caller of subscribe is responsible for offloading if necessary, and also offloading if
      * {@link Cancellable#cancel()} will be called and this operation may block.
      * <p>
-     * To apply a timeout see {@link #timeout(long, TimeUnit)} and related methods.
+     * To apply a timeout see {@link #idleTimeout(long, TimeUnit)} and related methods.
      * @param future The {@link Future} to convert.
      * @param <T> The data type the {@link Future} provides when complete.
      * @return A {@link Single} that derives results from {@link Future}.
-     * @see #timeout(long, TimeUnit)
+     * @see #idleTimeout(long, TimeUnit)
      */
     public static <T> Single<T> fromFuture(Future<? extends T> future) {
         return new FutureToSingle<>(future);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableExecutorPreservationTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableExecutorPreservationTest.java
@@ -38,8 +38,8 @@ public class CompletableExecutorPreservationTest {
 
     @Test
     public void testTimeoutCompletable() {
-        assertSame(EXEC.executor(), completable.timeout(1, MILLISECONDS).executor());
-        assertSame(EXEC.executor(), completable.timeout(Duration.ofMillis(1)).executor());
+        assertSame(EXEC.executor(), completable.idleTimeout(1, MILLISECONDS).executor());
+        assertSame(EXEC.executor(), completable.idleTimeout(Duration.ofMillis(1)).executor());
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleExecutorPreservationTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleExecutorPreservationTest.java
@@ -37,8 +37,8 @@ public class SingleExecutorPreservationTest {
 
     @Test
     public void testTimeoutSingle() {
-        assertSame(EXEC.executor(), single.timeout(1, MILLISECONDS).executor());
-        assertSame(EXEC.executor(), single.timeout(Duration.ofMillis(1)).executor());
+        assertSame(EXEC.executor(), single.idleTimeout(1, MILLISECONDS).executor());
+        assertSame(EXEC.executor(), single.idleTimeout(Duration.ofMillis(1)).executor());
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/TimeoutCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/TimeoutCompletableTest.java
@@ -57,7 +57,7 @@ public class TimeoutCompletableTest {
 
     @Test
     public void executorScheduleThrows() {
-        listener.listen(source.ignoreResult().timeout(1, NANOSECONDS, new DelegatingExecutor(testExecutor) {
+        listener.listen(source.ignoreResult().idleTimeout(1, NANOSECONDS, new DelegatingExecutor(testExecutor) {
             @Override
             public Cancellable schedule(final Runnable task, final long delay, final TimeUnit unit) {
                 throw DELIBERATE_EXCEPTION;
@@ -136,7 +136,7 @@ public class TimeoutCompletableTest {
     }
 
     private void init(Completable source, boolean expectOnSubscribe) {
-        listener.listen(source.timeout(1, NANOSECONDS, testExecutor), expectOnSubscribe);
+        listener.listen(source.idleTimeout(1, NANOSECONDS, testExecutor), expectOnSubscribe);
         assertThat(testExecutor.scheduledTasksPending(), is(1));
         if (expectOnSubscribe) {
             listener.verifyNoEmissions();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/TimeoutPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/TimeoutPublisherTest.java
@@ -73,7 +73,7 @@ public class TimeoutPublisherTest {
 
     @Test
     public void executorScheduleThrows() {
-        toSource(publisher.timeout(1, NANOSECONDS, new DelegatingExecutor(testExecutor) {
+        toSource(publisher.idleTimeout(1, NANOSECONDS, new DelegatingExecutor(testExecutor) {
             @Override
             public Cancellable schedule(final Runnable task, final long delay, final TimeUnit unit) {
                 throw DELIBERATE_EXCEPTION;
@@ -218,7 +218,7 @@ public class TimeoutPublisherTest {
         // the run() method.
         // Just in case the timer fires earlier than expected (after the first timer) we countdown the latch so the
         // test won't fail.
-        toSource(publisher.timeout(10, MILLISECONDS, new Executor() {
+        toSource(publisher.idleTimeout(10, MILLISECONDS, new Executor() {
             private final AtomicInteger timerCount = new AtomicInteger();
 
             @Override
@@ -287,7 +287,7 @@ public class TimeoutPublisherTest {
     }
 
     private void init(Publisher<Integer> publisher, boolean expectOnSubscribe) {
-        toSource(publisher.timeout(1, NANOSECONDS, testExecutor)).subscribe(subscriber);
+        toSource(publisher.idleTimeout(1, NANOSECONDS, testExecutor)).subscribe(subscriber);
         assertThat(testExecutor.scheduledTasksPending(), is(1));
         if (expectOnSubscribe) {
             assertTrue(subscriber.subscriptionReceived());

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractFutureToSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractFutureToSingleTest.java
@@ -78,7 +78,7 @@ public abstract class AbstractFutureToSingleTest {
     @Test
     public void timeout() throws Exception {
         CompletableFuture<String> future = new CompletableFuture<>();
-        Single<String> single = from(future).timeout(1, MILLISECONDS);
+        Single<String> single = from(future).idleTimeout(1, MILLISECONDS);
         thrown.expect(ExecutionException.class);
         thrown.expectCause(is(instanceOf(TimeoutException.class)));
         single.toFuture().get();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/TimeoutSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/TimeoutSingleTest.java
@@ -60,7 +60,7 @@ public class TimeoutSingleTest {
 
     @Test
     public void executorScheduleThrows() {
-        toSource(source.timeout(1, NANOSECONDS, new DelegatingExecutor(testExecutor) {
+        toSource(source.idleTimeout(1, NANOSECONDS, new DelegatingExecutor(testExecutor) {
             @Override
             public Cancellable schedule(final Runnable task, final long delay, final TimeUnit unit) {
                 throw DELIBERATE_EXCEPTION;
@@ -144,7 +144,7 @@ public class TimeoutSingleTest {
     }
 
     private void init(final Single<Integer> source, final boolean expectOnSubscribe) {
-        toSource(source.timeout(1, NANOSECONDS, testExecutor)).subscribe(subscriber);
+        toSource(source.idleTimeout(1, NANOSECONDS, testExecutor)).subscribe(subscriber);
         assertThat(testExecutor.scheduledTasksPending(), is(1));
         if (expectOnSubscribe) {
             assertTrue(subscriber.cancellableReceived());

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherTimeoutTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherTimeoutTckTest.java
@@ -22,6 +22,6 @@ import static java.util.concurrent.TimeUnit.HOURS;
 public class PublisherTimeoutTckTest extends AbstractPublisherOperatorTckTest<Integer> {
     @Override
     protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
-        return publisher.timeout(1, HOURS);
+        return publisher.idleTimeout(1, HOURS);
     }
 }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilter.java
@@ -64,8 +64,8 @@ public final class TimeoutHttpRequesterFilter implements HttpClientFilterFactory
     private Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                   final HttpExecutionStrategy strategy,
                                                   final StreamingHttpRequest request) {
-        return timeoutExecutor != null ? delegate.request(strategy, request).timeout(duration, timeoutExecutor) :
-                delegate.request(strategy, request).timeout(duration);
+        return timeoutExecutor != null ? delegate.request(strategy, request).idleTimeout(duration, timeoutExecutor) :
+                delegate.request(strategy, request).idleTimeout(duration);
     }
 
     @Override


### PR DESCRIPTION
__Motivation__

`timeout()` operators does not indicate what are they timing out on. `idleTimeout` is a better name.

__Modification__

Renamed:

`*#timeout()` => `*#idleTimeout()`

__Result__

More intuitive names.