### PR TITLE
Better test timeout values

### DIFF
--- a/servicetalk-concurrent-internal/src/testFixtures/java/io/servicetalk/concurrent/internal/ServiceTalkTestTimeout.java
+++ b/servicetalk-concurrent-internal/src/testFixtures/java/io/servicetalk/concurrent/internal/ServiceTalkTestTimeout.java
@@ -45,6 +45,7 @@ import javax.annotation.Nullable;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Standard timeout shared by test classes. The {@link #lookForStuckThread} setting is ignored.
@@ -55,11 +56,11 @@ public final class ServiceTalkTestTimeout extends Timeout {
     private final Runnable onTimeout;
 
     public ServiceTalkTestTimeout() {
-        this(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        this(DEFAULT_TIMEOUT_SECONDS, SECONDS);
     }
 
     public ServiceTalkTestTimeout(long timeout, TimeUnit unit) {
-        this(max(timeout, DEFAULT_TIMEOUT_SECONDS), unit, () -> { });
+        this(max(timeout, unit.convert(DEFAULT_TIMEOUT_SECONDS, SECONDS)), unit, () -> { });
     }
 
     public ServiceTalkTestTimeout(long timeout, TimeUnit unit, Runnable onTimeout) {


### PR DESCRIPTION
__Motivation__

Some tests use a specific timeout for tests using `ServiceTalkTestTimeout` `Rule` however the values are based on local builds (default: 10 sec).
This may get into situations where the test has lower timeout for CI which is generally slower.

__Modification__

By default increase the specified timeout to the default CI timeout, this will help test that inadvetently lower the timeout.

__Result__

Better test timeouts.