### PR TITLE
Use Streaming consistently in the Filter class names

### DIFF
--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/GatewayServer.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/GatewayServer.java
@@ -24,8 +24,8 @@ import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.netty.HttpClients;
 import io.servicetalk.http.netty.HttpServers;
 import io.servicetalk.http.router.predicate.HttpPredicateRouterBuilder;
-import io.servicetalk.http.utils.RetryingStreamingHttpRequesterFilter;
-import io.servicetalk.http.utils.TimeoutStreamingHttpRequesterFilter;
+import io.servicetalk.http.utils.RetryingHttpRequesterFilter;
+import io.servicetalk.http.utils.TimeoutHttpRequesterFilter;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
@@ -115,11 +115,11 @@ public final class GatewayServer {
         return resources.prepend(
                 HttpClients.forSingleAddress(serviceAddress)
                         // Set retry and timeout filters for all clients.
-                        .appendClientFilter(new RetryingStreamingHttpRequesterFilter.Builder()
+                        .appendClientFilter(new RetryingHttpRequesterFilter.Builder()
                                 .maxRetries(3)
                                 .buildWithExponentialBackoffAndJitter(ofMillis(100)))
                         // Apply a timeout filter for the client to guard against latent clients.
-                        .appendClientFilter(new TimeoutStreamingHttpRequesterFilter(ofMillis(500)))
+                        .appendClientFilter(new TimeoutHttpRequesterFilter(ofMillis(500)))
                         .ioExecutor(ioExecutor)
                         .buildStreaming());
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -43,7 +43,7 @@ public abstract class HttpServerBuilder {
     @Nullable
     private ConnectionAcceptorFactory connectionAcceptorFactory;
     @Nullable
-    private HttpServiceFilterFactory serviceFilter;
+    private StreamingHttpServiceFilterFactory serviceFilter;
     private boolean drainRequestPayloadBody = true;
 
     /**
@@ -241,10 +241,10 @@ public abstract class HttpServerBuilder {
      * <pre>
      *     filter1 =&gt; filter2 =&gt; filter3 =&gt; service
      * </pre>
-     * @param factory {@link HttpServiceFilterFactory} to append.
+     * @param factory {@link StreamingHttpServiceFilterFactory} to append.
      * @return {@code this}
      */
-    public final HttpServerBuilder appendServiceFilter(final HttpServiceFilterFactory factory) {
+    public final HttpServerBuilder appendServiceFilter(final StreamingHttpServiceFilterFactory factory) {
         if (serviceFilter == null) {
             serviceFilter = factory;
         } else {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceFilterFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceFilterFactory.java
@@ -21,7 +21,7 @@ import static java.util.Objects.requireNonNull;
  * A factory for {@link StreamingHttpServiceFilter}.
  */
 @FunctionalInterface
-public interface HttpServiceFilterFactory {
+public interface StreamingHttpServiceFilterFactory {
 
     /**
      * Create a {@link StreamingHttpServiceFilter} using the provided {@link StreamingHttpService}.
@@ -47,7 +47,7 @@ public interface HttpServiceFilterFactory {
      * @return a composed function that first applies the {@code before}
      * function and then applies this function
      */
-    default HttpServiceFilterFactory append(HttpServiceFilterFactory before) {
+    default StreamingHttpServiceFilterFactory append(StreamingHttpServiceFilterFactory before) {
         requireNonNull(before);
         return service -> create(before.create(service));
     }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/ConditionalHttpServiceFilterTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/ConditionalHttpServiceFilterTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.mock;
 
 public class ConditionalHttpServiceFilterTest extends AbstractConditionalHttpFilterTest {
 
-    private static final class TestCondFilterFactory implements HttpServiceFilterFactory {
+    private static final class TestCondFilterFactory implements StreamingHttpServiceFilterFactory {
         private final AtomicBoolean closed;
 
         private TestCondFilterFactory(AtomicBoolean closed) {
@@ -78,7 +78,7 @@ public class ConditionalHttpServiceFilterTest extends AbstractConditionalHttpFil
         private final StreamingHttpServiceFilter filterChain;
         private final ListenableAsyncCloseable closeable = emptyAsyncCloseable();
 
-        private TestStreamingHttpService(HttpServiceFilterFactory factory) {
+        private TestStreamingHttpService(StreamingHttpServiceFilterFactory factory) {
             filterChain = factory.create(new StreamingHttpService() {
                 @Override
                 public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpServiceFilterTest.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpServiceFilterTest.java
@@ -112,7 +112,7 @@ public abstract class AbstractHttpServiceFilterTest {
     }
 
     protected final StreamingHttpRequester createFilter(final RequestHandler handler,
-                                                        final HttpServiceFilterFactory factory) {
+                                                        final StreamingHttpServiceFilterFactory factory) {
 
         StreamingHttpServiceFilter service = factory.create(new StreamingHttpService() {
             @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpConnectionBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpConnectionBuilder.java
@@ -251,7 +251,7 @@ public final class DefaultHttpConnectionBuilder<ResolvedAddress> extends HttpCon
 
     @Override
     public DefaultHttpConnectionBuilder<ResolvedAddress> enableHostHeaderFallback(final CharSequence hostHeader) {
-        hostHeaderFilterFactory = __ -> new HostHeaderStreamingHttpRequesterFilter(hostHeader);
+        hostHeaderFilterFactory = __ -> new HostHeaderHttpRequesterFilter(hostHeader);
         return this;
     }
 
@@ -273,10 +273,10 @@ public final class DefaultHttpConnectionBuilder<ResolvedAddress> extends HttpCon
         return this;
     }
 
-    private static <R> HostHeaderStreamingHttpRequesterFilter defaultHostHeaderFilterFactory(final R address) {
+    private static <R> HostHeaderHttpRequesterFilter defaultHostHeaderFilterFactory(final R address) {
         // Make a best effort to infer HOST header for HttpConnection
         if (address instanceof InetSocketAddress) {
-            return new HostHeaderStreamingHttpRequesterFilter(HostAndPort.of((InetSocketAddress) address));
+            return new HostHeaderHttpRequesterFilter(HostAndPort.of((InetSocketAddress) address));
         }
         throw new IllegalArgumentException("Unsupported host header address type, provide an override");
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -46,7 +46,7 @@ import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.HttpClientBuildContext;
-import io.servicetalk.http.utils.RedirectingStreamingHttpRequesterFilter;
+import io.servicetalk.http.utils.RedirectingHttpRequesterFilter;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
@@ -123,7 +123,7 @@ final class DefaultMultiAddressUrlHttpClientBuilder extends MultiAddressHttpClie
 
             // Need to wrap the top level client (group) in order for non-relative redirects to work
             urlClient = maxRedirects <= 0 ? urlClient :
-                    new RedirectingStreamingHttpRequesterFilter(false, maxRedirects).create(urlClient, empty());
+                    new RedirectingHttpRequesterFilter(false, maxRedirects).create(urlClient, empty());
 
             return new DefaultStreamingHttpClient(urlClient);
         } catch (final Throwable t) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -253,12 +253,12 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
         return new HttpClientBuildContext<>(clonedBuilder, exec, reqRespFactory);
     }
 
-    private static <U> HostHeaderStreamingHttpRequesterFilter defaultHostHeaderFilterFactory(final U address) {
+    private static <U> HostHeaderHttpRequesterFilter defaultHostHeaderFilterFactory(final U address) {
         if (address instanceof CharSequence) {
-            return new HostHeaderStreamingHttpRequesterFilter((CharSequence) address);
+            return new HostHeaderHttpRequesterFilter((CharSequence) address);
         }
         if (address instanceof HostAndPort) {
-            return new HostHeaderStreamingHttpRequesterFilter((HostAndPort) address);
+            return new HostHeaderHttpRequesterFilter((HostAndPort) address);
         }
         throw new IllegalArgumentException("Unsupported host header address type, provide an override");
     }
@@ -369,7 +369,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
 
     @Override
     public DefaultSingleAddressHttpClientBuilder<U, R> enableHostHeaderFallback(final CharSequence hostHeader) {
-        hostHeaderFilterFactory = address -> new HostHeaderStreamingHttpRequesterFilter(hostHeader);
+        hostHeaderFilterFactory = address -> new HostHeaderHttpRequesterFilter(hostHeader);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilter.java
@@ -40,15 +40,15 @@ import static java.util.Objects.requireNonNull;
 /**
  * A filter which will apply a fallback value for the {@link HttpHeaderNames#HOST} header if one is not present.
  */
-final class HostHeaderStreamingHttpRequesterFilter implements StreamingHttpClientFilterFactory,
-                                                              StreamingHttpConnectionFilterFactory {
+final class HostHeaderHttpRequesterFilter implements StreamingHttpClientFilterFactory,
+                                                     StreamingHttpConnectionFilterFactory {
     private final CharSequence fallbackHost;
 
     /**
      * Create a new instance.
      * @param fallbackHost The address to use as a fallback if a {@link HttpHeaderNames#HOST} header is not present.
      */
-    HostHeaderStreamingHttpRequesterFilter(HostAndPort fallbackHost) {
+    HostHeaderHttpRequesterFilter(HostAndPort fallbackHost) {
         this(fallbackHost.hostName(), fallbackHost.port());
     }
 
@@ -58,7 +58,7 @@ final class HostHeaderStreamingHttpRequesterFilter implements StreamingHttpClien
      * present.
      * @param fallbackPort The port to use as a fallback if a {@link HttpHeaderNames#HOST} header is not present.
      */
-    HostHeaderStreamingHttpRequesterFilter(String fallbackHostName, int fallbackPort) {
+    HostHeaderHttpRequesterFilter(String fallbackHostName, int fallbackPort) {
         this.fallbackHost = requireNonNull(newAsciiString(toSocketAddressString(fallbackHostName, fallbackPort)));
     }
 
@@ -66,7 +66,7 @@ final class HostHeaderStreamingHttpRequesterFilter implements StreamingHttpClien
      * Create a new instance.
      * @param fallbackHost The address to use as a fallback if a {@link HttpHeaderNames#HOST} header is not present.
      */
-    HostHeaderStreamingHttpRequesterFilter(CharSequence fallbackHost) {
+    HostHeaderHttpRequesterFilter(CharSequence fallbackHost) {
         this.fallbackHost = newAsciiString(isValidIpV6Address(fallbackHost) && fallbackHost.charAt(0) != '[' ?
                 "[" + fallbackHost + "]" : fallbackHost.toString());
     }
@@ -80,7 +80,7 @@ final class HostHeaderStreamingHttpRequesterFilter implements StreamingHttpClien
             protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                             final HttpExecutionStrategy strategy,
                                                             final StreamingHttpRequest request) {
-                return HostHeaderStreamingHttpRequesterFilter.this.request(delegate, strategy, request);
+                return HostHeaderHttpRequesterFilter.this.request(delegate, strategy, request);
             }
 
             @Override
@@ -97,7 +97,7 @@ final class HostHeaderStreamingHttpRequesterFilter implements StreamingHttpClien
             @Override
             public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
                                                             final StreamingHttpRequest request) {
-                return HostHeaderStreamingHttpRequesterFilter.this.request(delegate(), strategy, request);
+                return HostHeaderHttpRequesterFilter.this.request(delegate(), strategy, request);
             }
 
             @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
@@ -24,12 +24,12 @@ import io.servicetalk.http.api.HttpConnectionBuilder;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.HttpServiceContext;
-import io.servicetalk.http.api.HttpServiceFilterFactory;
 import io.servicetalk.http.api.StreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
 import io.servicetalk.transport.api.DelegatingConnectionAcceptor;
 import io.servicetalk.transport.api.ServerContext;
 
@@ -148,9 +148,9 @@ public abstract class AbstractHttpServiceAsyncContextTest {
         }
     }
 
-    private static HttpServiceFilterFactory filterFactory(final boolean useImmediate,
-                                                          final boolean asyncFilter,
-                                                          final Queue<Throwable> errorQueue) {
+    private static StreamingHttpServiceFilterFactory filterFactory(final boolean useImmediate,
+                                                                   final boolean asyncFilter,
+                                                                   final Queue<Throwable> errorQueue) {
         return service -> new StreamingHttpServiceFilter(service) {
             @Override
             public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilterTest.java
@@ -67,7 +67,7 @@ public class HostHeaderHttpRequesterFilterTest {
         try (ServerContext context = buildServer();
              BlockingHttpClient client = forSingleAddress(serverHostAndPort(context))
                     .disableHostHeaderFallback() // turn off the default
-                    .appendClientFilter(new HostHeaderStreamingHttpRequesterFilter(HostAndPort.of("foo.bar", -1)))
+                    .appendClientFilter(new HostHeaderHttpRequesterFilter(HostAndPort.of("foo.bar", -1)))
                     .buildBlocking()) {
                 assertEquals("foo.bar:-1",
                         client.request(client.get("/")).payloadBody(textDeserializer()));
@@ -79,7 +79,7 @@ public class HostHeaderHttpRequesterFilterTest {
         try (ServerContext context = buildServer();
              BlockingHttpClient client = forSingleAddress(serverHostAndPort(context))
                     .disableHostHeaderFallback() // turn off the default
-                    .appendConnectionFilter(new HostHeaderStreamingHttpRequesterFilter(HostAndPort.of("foo.bar", -1)))
+                    .appendConnectionFilter(new HostHeaderHttpRequesterFilter(HostAndPort.of("foo.bar", -1)))
                     .buildBlocking()) {
                 assertEquals("foo.bar:-1",
                         client.request(client.get("/")).payloadBody(textDeserializer()));
@@ -90,7 +90,7 @@ public class HostHeaderHttpRequesterFilterTest {
     public void connectionBuilderAppendConnectionFilter() throws Exception {
         try (ServerContext context = buildServer();
              BlockingHttpConnection conn = new DefaultHttpConnectionBuilder<>()
-                    .appendConnectionFilter(new HostHeaderStreamingHttpRequesterFilter(HostAndPort.of("foo.bar", -1)))
+                    .appendConnectionFilter(new HostHeaderHttpRequesterFilter(HostAndPort.of("foo.bar", -1)))
                     .buildBlocking(context.listenAddress())) {
                 assertEquals("foo.bar:-1",
                         conn.request(conn.get("/")).payloadBody(textDeserializer()));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServerFilterOrderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServerFilterOrderTest.java
@@ -18,9 +18,9 @@ package io.servicetalk.http.netty;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpResponse;
-import io.servicetalk.http.api.HttpServiceFilterFactory;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
 import io.servicetalk.transport.api.ServerContext;
 
 import org.junit.Test;
@@ -69,7 +69,7 @@ public class HttpServerFilterOrderTest {
         return service;
     }
 
-    private static HttpServiceFilterFactory addFilter(StreamingHttpService filter) {
+    private static StreamingHttpServiceFilterFactory addFilter(StreamingHttpService filter) {
         return orig -> {
             when(filter.handle(any(), any(), any()))
                     .thenAnswer(i -> orig.handle(i.getArgument(0), i.getArgument(1), i.getArgument(2)));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RedirectingClientAndConnectionFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RedirectingClientAndConnectionFilterTest.java
@@ -31,7 +31,7 @@ import io.servicetalk.http.api.ReservedStreamingHttpConnection;
 import io.servicetalk.http.api.ReservedStreamingHttpConnectionFilter;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
-import io.servicetalk.http.utils.RedirectingStreamingHttpRequesterFilter;
+import io.servicetalk.http.utils.RedirectingHttpRequesterFilter;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
 
@@ -60,7 +60,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 /**
- * This test-case is for integration testing the {@link RedirectingStreamingHttpRequesterFilter} with the various types
+ * This test-case is for integration testing the {@link RedirectingHttpRequesterFilter} with the various types
  * of {@link HttpClient} and {@link HttpConnection} builders.
  */
 @RunWith(Parameterized.class)
@@ -89,7 +89,7 @@ public final class RedirectingClientAndConnectionFilterTest {
             case Client:
                 return HttpClients.forSingleAddress(serverHostAndPort)
                         .appendClientFilter(r -> r.headers().contains("X-REDIRECT"),
-                                new RedirectingStreamingHttpRequesterFilter())
+                                new RedirectingHttpRequesterFilter())
                         .buildBlocking();
             case Reserved:
                 CompositeCloseable closeables = AsyncCloseables.newCompositeCloseable();
@@ -116,7 +116,7 @@ public final class RedirectingClientAndConnectionFilterTest {
                                 }
                             })
                             .appendClientFilter(r -> r.headers().contains("X-REDIRECT"),
-                                    new RedirectingStreamingHttpRequesterFilter())
+                                    new RedirectingHttpRequesterFilter())
                             .buildStreaming());
                     return client.asBlockingClient().reserveConnection(client.get(""));
                 } catch (Throwable t) {
@@ -126,7 +126,7 @@ public final class RedirectingClientAndConnectionFilterTest {
             case Connection:
                 return new DefaultHttpConnectionBuilder<>()
                         .appendConnectionFilter(r -> r.headers().contains("X-REDIRECT"),
-                                new RedirectingStreamingHttpRequesterFilter())
+                                new RedirectingHttpRequesterFilter())
                         .buildBlocking(serverSocketAddress);
 
             default:

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilter.java
@@ -51,8 +51,8 @@ import io.servicetalk.http.api.StreamingHttpResponse;
  *     limited to automatically following relative redirects only.</li>
  * </ul>
  */
-public final class RedirectingStreamingHttpRequesterFilter implements StreamingHttpClientFilterFactory,
-                                                                      StreamingHttpConnectionFilterFactory {
+public final class RedirectingHttpRequesterFilter implements StreamingHttpClientFilterFactory,
+                                                             StreamingHttpConnectionFilterFactory {
 
     // https://tools.ietf.org/html/rfc2068#section-10.3 says:
     // A user agent SHOULD NOT automatically redirect a request more than 5 times,
@@ -66,7 +66,7 @@ public final class RedirectingStreamingHttpRequesterFilter implements StreamingH
     /**
      * Create a new instance, only performing relative redirects.
      */
-    public RedirectingStreamingHttpRequesterFilter() {
+    public RedirectingHttpRequesterFilter() {
         this(true, true);
     }
 
@@ -75,7 +75,7 @@ public final class RedirectingStreamingHttpRequesterFilter implements StreamingH
      *
      * @param maxRedirects The maximum number of follow up redirects.
      */
-    public RedirectingStreamingHttpRequesterFilter(final int maxRedirects) {
+    public RedirectingHttpRequesterFilter(final int maxRedirects) {
         this(true, true, maxRedirects);
     }
 
@@ -84,7 +84,7 @@ public final class RedirectingStreamingHttpRequesterFilter implements StreamingH
      *
      * @param onlyRelativeClient Limits the redirects to relative paths for {@link HttpClient} filters.
      */
-    public RedirectingStreamingHttpRequesterFilter(final boolean onlyRelativeClient) {
+    public RedirectingHttpRequesterFilter(final boolean onlyRelativeClient) {
         this(onlyRelativeClient, true, DEFAULT_MAX_REDIRECTS);
     }
 
@@ -94,8 +94,8 @@ public final class RedirectingStreamingHttpRequesterFilter implements StreamingH
      * @param onlyRelativeClient Limits the redirects to relative paths for {@link HttpClient} filters.
      * @param maxRedirects The maximum number of follow up redirects.
      */
-    public RedirectingStreamingHttpRequesterFilter(final boolean onlyRelativeClient,
-                                                   final int maxRedirects) {
+    public RedirectingHttpRequesterFilter(final boolean onlyRelativeClient,
+                                          final int maxRedirects) {
         this(onlyRelativeClient, true, maxRedirects);
     }
 
@@ -105,8 +105,8 @@ public final class RedirectingStreamingHttpRequesterFilter implements StreamingH
      * @param onlyRelativeClient Limits the redirects to relative paths for {@link HttpClient} filters.
      * @param onlyRelativeConnection Limits the redirects to relative paths for {@link HttpConnection} filters.
      */
-    public RedirectingStreamingHttpRequesterFilter(final boolean onlyRelativeClient,
-                                                   final boolean onlyRelativeConnection) {
+    public RedirectingHttpRequesterFilter(final boolean onlyRelativeClient,
+                                          final boolean onlyRelativeConnection) {
         this(onlyRelativeClient, onlyRelativeConnection, DEFAULT_MAX_REDIRECTS);
     }
 
@@ -117,9 +117,9 @@ public final class RedirectingStreamingHttpRequesterFilter implements StreamingH
      * @param onlyRelativeConnection Limits the redirects to relative paths for {@link HttpConnection} filters.
      * @param maxRedirects The maximum number of follow up redirects.
      */
-    public RedirectingStreamingHttpRequesterFilter(final boolean onlyRelativeClient,
-                                                   final boolean onlyRelativeConnection,
-                                                   final int maxRedirects) {
+    public RedirectingHttpRequesterFilter(final boolean onlyRelativeClient,
+                                          final boolean onlyRelativeConnection,
+                                          final int maxRedirects) {
         this.onlyRelativeClient = onlyRelativeClient;
         this.onlyRelativeConnection = onlyRelativeConnection;
         this.maxRedirects = maxRedirects;
@@ -134,7 +134,7 @@ public final class RedirectingStreamingHttpRequesterFilter implements StreamingH
             protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                             final HttpExecutionStrategy strategy,
                                                             final StreamingHttpRequest request) {
-                return RedirectingStreamingHttpRequesterFilter.this.request(delegate, strategy, request,
+                return RedirectingHttpRequesterFilter.this.request(delegate, strategy, request,
                         onlyRelativeClient);
             }
 
@@ -149,7 +149,7 @@ public final class RedirectingStreamingHttpRequesterFilter implements StreamingH
                                     final StreamingHttpRequester delegate,
                                     final HttpExecutionStrategy strategy,
                                     final StreamingHttpRequest request) {
-                                return RedirectingStreamingHttpRequesterFilter.this.request(delegate, strategy, request,
+                                return RedirectingHttpRequesterFilter.this.request(delegate, strategy, request,
                                         onlyRelativeConnection);
                             }
                         });
@@ -169,7 +169,7 @@ public final class RedirectingStreamingHttpRequesterFilter implements StreamingH
             @Override
             public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
                                                          final StreamingHttpRequest request) {
-                return RedirectingStreamingHttpRequesterFilter.this.request(delegate(), strategy, request,
+                return RedirectingHttpRequesterFilter.this.request(delegate(), strategy, request,
                         onlyRelativeConnection);
             }
 

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RetryingHttpRequesterFilter.java
@@ -44,12 +44,12 @@ import static io.servicetalk.concurrent.api.Completable.failed;
  *
  * @see RetryStrategies
  */
-public final class RetryingStreamingHttpRequesterFilter implements StreamingHttpClientFilterFactory,
-                                                                   StreamingHttpConnectionFilterFactory {
+public final class RetryingHttpRequesterFilter implements StreamingHttpClientFilterFactory,
+                                                          StreamingHttpConnectionFilterFactory {
 
     private final ReadOnlyRetryableSettings<HttpRequestMetaData> settings;
 
-    private RetryingStreamingHttpRequesterFilter(final ReadOnlyRetryableSettings<HttpRequestMetaData> settings) {
+    private RetryingHttpRequesterFilter(final ReadOnlyRetryableSettings<HttpRequestMetaData> settings) {
         this.settings = settings;
     }
 
@@ -77,7 +77,7 @@ public final class RetryingStreamingHttpRequesterFilter implements StreamingHttp
             protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                             final HttpExecutionStrategy strategy,
                                                             final StreamingHttpRequest request) {
-                return RetryingStreamingHttpRequesterFilter.this.request(delegate, strategy, request, retryStrategy);
+                return RetryingHttpRequesterFilter.this.request(delegate, strategy, request, retryStrategy);
             }
 
             @Override
@@ -98,7 +98,7 @@ public final class RetryingStreamingHttpRequesterFilter implements StreamingHttp
             @Override
             public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
                                                          final StreamingHttpRequest request) {
-                return RetryingStreamingHttpRequesterFilter.this.request(delegate(), strategy, request, retryStrategy);
+                return RetryingHttpRequesterFilter.this.request(delegate(), strategy, request, retryStrategy);
             }
 
             @Override
@@ -110,16 +110,16 @@ public final class RetryingStreamingHttpRequesterFilter implements StreamingHttp
     }
 
     /**
-     * A builder for {@link RetryingStreamingHttpRequesterFilter}, which puts an upper bound on retry attempts.
+     * A builder for {@link RetryingHttpRequesterFilter}, which puts an upper bound on retry attempts.
      * To configure the maximum number of retry attempts see {@link #maxRetries(int)}.
      */
     public static final class Builder
-            extends AbstractRetryingFilterBuilder<Builder, RetryingStreamingHttpRequesterFilter, HttpRequestMetaData> {
+            extends AbstractRetryingFilterBuilder<Builder, RetryingHttpRequesterFilter, HttpRequestMetaData> {
 
         @Override
-        protected RetryingStreamingHttpRequesterFilter build(
+        protected RetryingHttpRequesterFilter build(
                 final ReadOnlyRetryableSettings<HttpRequestMetaData> readOnlySettings) {
-            return new RetryingStreamingHttpRequesterFilter(readOnlySettings);
+            return new RetryingHttpRequesterFilter(readOnlySettings);
         }
 
         /**

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilter.java
@@ -37,8 +37,8 @@ import static java.util.Objects.requireNonNull;
 /**
  * A filter to enable timeouts for HTTP requests.
  */
-public final class TimeoutStreamingHttpRequesterFilter implements StreamingHttpClientFilterFactory,
-                                                                  StreamingHttpConnectionFilterFactory {
+public final class TimeoutHttpRequesterFilter implements StreamingHttpClientFilterFactory,
+                                                         StreamingHttpConnectionFilterFactory {
     private final Duration duration;
     @Nullable
     private final Executor timeoutExecutor;
@@ -48,7 +48,7 @@ public final class TimeoutStreamingHttpRequesterFilter implements StreamingHttpC
      *
      * @param duration the timeout {@link Duration}
      */
-    public TimeoutStreamingHttpRequesterFilter(final Duration duration) {
+    public TimeoutHttpRequesterFilter(final Duration duration) {
         this.duration = duration;
         this.timeoutExecutor = null;
     }
@@ -59,7 +59,7 @@ public final class TimeoutStreamingHttpRequesterFilter implements StreamingHttpC
      * @param duration the timeout {@link Duration}
      * @param timeoutExecutor the {@link Executor} to use for managing the timer notifications
      */
-    public TimeoutStreamingHttpRequesterFilter(final Duration duration, final Executor timeoutExecutor) {
+    public TimeoutHttpRequesterFilter(final Duration duration, final Executor timeoutExecutor) {
         this.duration = duration;
         this.timeoutExecutor = requireNonNull(timeoutExecutor);
     }
@@ -80,7 +80,7 @@ public final class TimeoutStreamingHttpRequesterFilter implements StreamingHttpC
             protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                             final HttpExecutionStrategy strategy,
                                                             final StreamingHttpRequest request) {
-                return TimeoutStreamingHttpRequesterFilter.this.request(delegate, strategy, request);
+                return TimeoutHttpRequesterFilter.this.request(delegate, strategy, request);
             }
 
             @Override
@@ -97,7 +97,7 @@ public final class TimeoutStreamingHttpRequesterFilter implements StreamingHttpC
             @Override
             public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
                                                             final StreamingHttpRequest request) {
-                return TimeoutStreamingHttpRequesterFilter.this.request(delegate(), strategy, request);
+                return TimeoutHttpRequesterFilter.this.request(delegate(), strategy, request);
             }
 
             @Override

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/auth/BasicAuthHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/auth/BasicAuthHttpServiceFilter.java
@@ -27,12 +27,12 @@ import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpMetaData;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpServiceContext;
-import io.servicetalk.http.api.HttpServiceFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,7 +64,7 @@ import static java.util.Objects.requireNonNull;
  * @param <UserInfo> a type for authenticated user info object
  * @see Builder
  */
-public final class BasicAuthHttpServiceFilter<UserInfo> implements HttpServiceFilterFactory {
+public final class BasicAuthHttpServiceFilter<UserInfo> implements StreamingHttpServiceFilterFactory {
 
     /**
      * Verifies {@code user-id} and {@code password}, parsed from the 'Basic' HTTP Authentication Scheme credentials.
@@ -181,7 +181,7 @@ public final class BasicAuthHttpServiceFilter<UserInfo> implements HttpServiceFi
          *
          * @return a new {@link Builder}
          */
-        public HttpServiceFilterFactory buildServer() {
+        public StreamingHttpServiceFilterFactory buildServer() {
             return new BasicAuthHttpServiceFilter<>(credentialsVerifier, realm, false, userInfoKey, utf8);
         }
 
@@ -206,9 +206,9 @@ public final class BasicAuthHttpServiceFilter<UserInfo> implements HttpServiceFi
          * </tr>
          * </table></blockquote>
          *
-         * @return a new {@link HttpServiceFilterFactory}
+         * @return a new {@link StreamingHttpServiceFilterFactory}
          */
-        public HttpServiceFilterFactory buildProxy() {
+        public StreamingHttpServiceFilterFactory buildProxy() {
             return new BasicAuthHttpServiceFilter<>(credentialsVerifier, realm, true, userInfoKey, utf8);
         }
     }

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilterTest.java
@@ -201,7 +201,7 @@ public class RedirectingHttpRequesterFilterTest {
                                        @Nullable final CharSequence requestedLocation) throws Exception {
 
         StreamingHttpClient redirectingRequester =
-                newClient(new RedirectingStreamingHttpRequesterFilter(false, maxRedirects));
+                newClient(new RedirectingHttpRequesterFilter(false, maxRedirects));
 
         StreamingHttpRequest request = redirectingRequester.newRequest(method, "/path");
         request.headers().set(HOST, "servicetalk.io");
@@ -225,7 +225,7 @@ public class RedirectingHttpRequesterFilterTest {
 
         final int maxRedirects = MAX_REDIRECTS;
         StreamingHttpClient redirectingRequester = newClient(
-                new RedirectingStreamingHttpRequesterFilter(false, maxRedirects));
+                new RedirectingHttpRequesterFilter(false, maxRedirects));
 
         StreamingHttpRequest request = redirectingRequester.get("/path");
         request.headers().set(HOST, "servicetalk.io");
@@ -241,7 +241,7 @@ public class RedirectingHttpRequesterFilterTest {
     public void requestWithNullResponse() throws Exception {
         when(httpClient.request(any(), any())).thenReturn(succeeded(null));
 
-        StreamingHttpClient redirectingRequester = newClient(new RedirectingStreamingHttpRequesterFilter(false));
+        StreamingHttpClient redirectingRequester = newClient(new RedirectingHttpRequesterFilter(false));
 
         StreamingHttpRequest request = redirectingRequester.get("/path");
         request.headers().set(HOST, "servicetalk.io");
@@ -291,7 +291,7 @@ public class RedirectingHttpRequesterFilterTest {
     private void testRequestForRedirect(final HttpRequestMethod method,
                                         final HttpResponseStatus requestedStatus) throws Exception {
 
-        StreamingHttpClient redirectingRequester = newClient(new RedirectingStreamingHttpRequesterFilter(false));
+        StreamingHttpClient redirectingRequester = newClient(new RedirectingHttpRequesterFilter(false));
 
         StreamingHttpRequest request = redirectingRequester.newRequest(method, "/path");
         request.headers().set(HOST, "servicetalk.io");
@@ -314,7 +314,7 @@ public class RedirectingHttpRequesterFilterTest {
                 createRedirectResponse(3),
                 succeeded(reqRespFactory.ok()));
 
-        StreamingHttpClient redirectingRequester = newClient(new RedirectingStreamingHttpRequesterFilter(false));
+        StreamingHttpClient redirectingRequester = newClient(new RedirectingHttpRequesterFilter(false));
 
         StreamingHttpRequest request = redirectingRequester.get("/path");
         request.headers().set(HOST, "servicetalk.io");
@@ -334,7 +334,7 @@ public class RedirectingHttpRequesterFilterTest {
 
     @Test
     public void getRequestForRedirectWithAbsoluteFormRequestTarget() throws Exception {
-        StreamingHttpClient redirectingRequester = newClient(new RedirectingStreamingHttpRequesterFilter(false));
+        StreamingHttpClient redirectingRequester = newClient(new RedirectingHttpRequesterFilter(false));
 
         StreamingHttpRequest request = redirectingRequester.get("http://servicetalk.io/path");
         request.headers().set(REQUESTED_STATUS, String.valueOf(SEE_OTHER.code()));
@@ -349,7 +349,7 @@ public class RedirectingHttpRequesterFilterTest {
 
     @Test
     public void redirectForOnlyRelativeWithAbsoluteRelativeLocation() throws Exception {
-        StreamingHttpClient redirectingRequester = newClient(new RedirectingStreamingHttpRequesterFilter(true));
+        StreamingHttpClient redirectingRequester = newClient(new RedirectingHttpRequesterFilter(true));
 
         StreamingHttpRequest request = redirectingRequester.get("/path");
         request.headers().set(HOST, "servicetalk.io");
@@ -365,7 +365,7 @@ public class RedirectingHttpRequesterFilterTest {
 
     @Test
     public void redirectForOnlyRelativeWithAbsoluteRelativeLocationWithPortDoesntRedirect() throws Exception {
-        StreamingHttpClient redirectingRequester = newClient(new RedirectingStreamingHttpRequesterFilter(true));
+        StreamingHttpClient redirectingRequester = newClient(new RedirectingHttpRequesterFilter(true));
 
         StreamingHttpRequest request = redirectingRequester.get("/path");
         request.headers().set(HOST, "servicetalk.io");
@@ -381,7 +381,7 @@ public class RedirectingHttpRequesterFilterTest {
 
     @Test
     public void redirectForOnlyRelativeWithRelativeLocation() throws Exception {
-        StreamingHttpClient redirectingRequester = newClient(new RedirectingStreamingHttpRequesterFilter(true));
+        StreamingHttpClient redirectingRequester = newClient(new RedirectingHttpRequesterFilter(true));
 
         StreamingHttpRequest request = redirectingRequester.get("/path");
         request.headers().set(HOST, "servicetalk.io");
@@ -397,7 +397,7 @@ public class RedirectingHttpRequesterFilterTest {
 
     @Test
     public void redirectForOnlyRelativeWithAbsoluteNonRelativeLocationDoesntRedirect() throws Exception {
-        StreamingHttpClient redirectingRequester = newClient(new RedirectingStreamingHttpRequesterFilter(true));
+        StreamingHttpClient redirectingRequester = newClient(new RedirectingHttpRequesterFilter(true));
 
         StreamingHttpRequest request = redirectingRequester.get("/path");
         request.headers().set(HOST, "servicetalk.io");
@@ -413,7 +413,7 @@ public class RedirectingHttpRequesterFilterTest {
 
     @Test
     public void absoluteTargetRedirectForOnlyRelativeWithAbsoluteRelativeLocation() throws Exception {
-        StreamingHttpClient redirectingRequester = newClient(new RedirectingStreamingHttpRequesterFilter(true));
+        StreamingHttpClient redirectingRequester = newClient(new RedirectingHttpRequesterFilter(true));
 
         StreamingHttpRequest request = redirectingRequester.get("http://servicetalk.io/path");
         request.headers().set(REQUESTED_STATUS, String.valueOf(SEE_OTHER.code()));
@@ -428,7 +428,7 @@ public class RedirectingHttpRequesterFilterTest {
 
     @Test
     public void absoluteTargetRedirectForOnlyRelativeWithNonRelativeLocationDoesntRedirect() throws Exception {
-        StreamingHttpClient redirectingRequester = newClient(new RedirectingStreamingHttpRequesterFilter(true));
+        StreamingHttpClient redirectingRequester = newClient(new RedirectingHttpRequesterFilter(true));
 
         StreamingHttpRequest request = redirectingRequester.get("http://servicetalk.io/path");
         request.headers().set(REQUESTED_STATUS, String.valueOf(SEE_OTHER.code()));

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilter.java
@@ -42,7 +42,7 @@ import static io.opentracing.tag.Tags.SPAN_KIND_CLIENT;
 /**
  * An HTTP filter that supports open tracing.
  */
-public class TracingStreamingHttpRequesterFilter extends AbstractTracingHttpFilter implements
+public class TracingHttpRequesterFilter extends AbstractTracingHttpFilter implements
                                                StreamingHttpClientFilterFactory, StreamingHttpConnectionFilterFactory {
 
     /**
@@ -51,8 +51,8 @@ public class TracingStreamingHttpRequesterFilter extends AbstractTracingHttpFilt
      * @param tracer The {@link Tracer}.
      * @param componentName The component name used during building new spans.
      */
-    public TracingStreamingHttpRequesterFilter(final Tracer tracer,
-                                               final String componentName) {
+    public TracingHttpRequesterFilter(final Tracer tracer,
+                                      final String componentName) {
         this(tracer, componentName, true);
     }
 
@@ -63,9 +63,9 @@ public class TracingStreamingHttpRequesterFilter extends AbstractTracingHttpFilt
      * @param componentName The component name used during building new spans.
      * @param validateTraceKeyFormat {@code true} to validate the contents of the trace ids.
      */
-    public TracingStreamingHttpRequesterFilter(final Tracer tracer,
-                                               final String componentName,
-                                               boolean validateTraceKeyFormat) {
+    public TracingHttpRequesterFilter(final Tracer tracer,
+                                      final String componentName,
+                                      boolean validateTraceKeyFormat) {
         super(tracer, componentName, validateTraceKeyFormat);
     }
 

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpServiceFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpServiceFilter.java
@@ -20,12 +20,12 @@ import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.HttpServiceContext;
-import io.servicetalk.http.api.HttpServiceFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
 
 import io.opentracing.Scope;
 import io.opentracing.SpanContext;
@@ -42,7 +42,7 @@ import static io.opentracing.tag.Tags.SPAN_KIND_SERVER;
 /**
  * A {@link StreamingHttpService} that supports open tracing.
  */
-public class TracingHttpServiceFilter extends AbstractTracingHttpFilter implements HttpServiceFilterFactory {
+public class TracingHttpServiceFilter extends AbstractTracingHttpFilter implements StreamingHttpServiceFilterFactory {
 
     /**
      * Create a new instance.

--- a/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilterTest.java
+++ b/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilterTest.java
@@ -97,7 +97,7 @@ public class TracingHttpRequesterFilterTest {
                 .addListener(spanListener).build();
         try (ServerContext context = buildServer()) {
             try (HttpClient client = forSingleAddress(serverHostAndPort(context))
-                    .appendConnectionFilter(new TracingStreamingHttpRequesterFilter(tracer, "testClient")).build()) {
+                    .appendConnectionFilter(new TracingHttpRequesterFilter(tracer, "testClient")).build()) {
                 HttpResponse response = client.request(client.get(requestUrl)).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(httpSerializer.deserializerFor(
                         TestSpanState.class));
@@ -129,7 +129,7 @@ public class TracingHttpRequesterFilterTest {
                 .addListener(spanListener).build();
         try (ServerContext context = buildServer()) {
             try (HttpClient client = forSingleAddress(serverHostAndPort(context))
-                    .appendConnectionFilter(new TracingStreamingHttpRequesterFilter(tracer, "testClient")).build()) {
+                    .appendConnectionFilter(new TracingHttpRequesterFilter(tracer, "testClient")).build()) {
                 try (InMemoryScope clientScope = tracer.buildSpan("test").startActive(true)) {
                     HttpResponse response = client.request(client.get(requestUrl)).toFuture().get();
                     TestSpanState serverSpanState = response.payloadBody(httpSerializer.deserializerFor(
@@ -164,7 +164,7 @@ public class TracingHttpRequesterFilterTest {
         try (ServerContext context = buildServer()) {
             try (HttpClient client = forSingleAddress(serverHostAndPort(context))
                     .appendConnectionFilter(
-                            new TracingStreamingHttpRequesterFilter(mockTracer, "testClient")).build()) {
+                            new TracingHttpRequesterFilter(mockTracer, "testClient")).build()) {
                 HttpRequest request = client.get("/");
                 expected.expect(ExecutionException.class);
                 expected.expectCause(is(DELIBERATE_EXCEPTION));


### PR DESCRIPTION
Motivation:
The Filter interfaces on the client side now include Streaming in the name, but
this server does not. Also the concrete filter names don't need Streaming in the
name because we will not provide multiple implementations of these filters.

Modifications:
- HttpServiceFilter -> StreamingHttpServiceFilter
- All concrete client filter classes shouldn't have Streaming in the name

Result:
More consistent naming for filters.