### PR TITLE
Provide a way for server builder to specify an execution strategy

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpService.java
@@ -17,7 +17,7 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.api.Single;
 
-import static io.servicetalk.http.api.HttpExecutionStrategies.OFFLOAD_RECEIVE_META_STRATEGY;
+import static io.servicetalk.http.api.HttpApiConversions.DEFAULT_BLOCKING_SERVICE_STRATEGY;
 
 /**
  * The equivalent of {@link HttpService} but with synchronous/blocking APIs instead of asynchronous APIs.
@@ -50,6 +50,6 @@ public interface BlockingHttpService extends AutoCloseable {
      * @return The {@link HttpExecutionStrategy} for this {@link BlockingStreamingHttpService}.
      */
     default HttpExecutionStrategy computeExecutionStrategy(HttpExecutionStrategy other) {
-        return other.merge(OFFLOAD_RECEIVE_META_STRATEGY);
+        return other.merge(DEFAULT_BLOCKING_SERVICE_STRATEGY);
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpService.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.http.api;
 
-import static io.servicetalk.http.api.HttpExecutionStrategies.OFFLOAD_RECEIVE_META_AND_SEND_STRATEGY;
+import static io.servicetalk.http.api.HttpApiConversions.DEFAULT_BLOCKING_STREAMING_SERVICE_STRATEGY;
 
 /**
  * The equivalent of {@link StreamingHttpService} but with synchronous/blocking APIs instead of asynchronous APIs.
@@ -47,6 +47,6 @@ public interface BlockingStreamingHttpService extends AutoCloseable {
      * @return The {@link HttpExecutionStrategy} for this {@link BlockingStreamingHttpService}.
      */
     default HttpExecutionStrategy computeExecutionStrategy(HttpExecutionStrategy other) {
-        return other.merge(OFFLOAD_RECEIVE_META_AND_SEND_STRATEGY);
+        return other.merge(DEFAULT_BLOCKING_STREAMING_SERVICE_STRATEGY);
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
@@ -38,20 +38,20 @@ import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnError;
 import static io.servicetalk.http.api.BlockingUtils.blockingToCompletable;
-import static io.servicetalk.http.api.HttpExecutionStrategies.OFFLOAD_RECEIVE_META_AND_SEND_STRATEGY;
+import static io.servicetalk.http.api.HttpApiConversions.DEFAULT_BLOCKING_STREAMING_SERVICE_STRATEGY;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.StreamingHttpResponses.newResponseWithTrailers;
 import static java.lang.Thread.currentThread;
 import static java.util.Objects.requireNonNull;
 
-final class BlockingStreamingHttpServiceToStreamingHttpService implements StreamingHttpService {
+final class BlockingStreamingToStreamingService implements StreamingHttpService {
 
     private static final Logger LOGGER =
-            LoggerFactory.getLogger(BlockingStreamingHttpServiceToStreamingHttpService.class);
+            LoggerFactory.getLogger(BlockingStreamingToStreamingService.class);
 
     private final BlockingStreamingHttpService service;
 
-    BlockingStreamingHttpServiceToStreamingHttpService(final BlockingStreamingHttpService service) {
+    BlockingStreamingToStreamingService(final BlockingStreamingHttpService service) {
         this.service = requireNonNull(service);
     }
 
@@ -134,7 +134,7 @@ final class BlockingStreamingHttpServiceToStreamingHttpService implements Stream
         // Since we are converting to a different programming model, try altering the strategy for the returned service
         // to contain an appropriate default. We achieve this by merging the expected strategy with the provided
         // service strategy.
-        return service.computeExecutionStrategy(other.merge(OFFLOAD_RECEIVE_META_AND_SEND_STRATEGY));
+        return service.computeExecutionStrategy(other.merge(DEFAULT_BLOCKING_STREAMING_SERVICE_STRATEGY));
     }
 
     private static final class BufferHttpPayloadWriter implements HttpPayloadWriter<Buffer> {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingToStreamingService.java
@@ -20,13 +20,13 @@ import io.servicetalk.concurrent.api.Single;
 
 import static io.servicetalk.http.api.BlockingUtils.blockingToCompletable;
 import static io.servicetalk.http.api.BlockingUtils.blockingToSingle;
-import static io.servicetalk.http.api.HttpExecutionStrategies.OFFLOAD_RECEIVE_META_STRATEGY;
+import static io.servicetalk.http.api.HttpApiConversions.DEFAULT_BLOCKING_SERVICE_STRATEGY;
 import static java.util.Objects.requireNonNull;
 
-final class BlockingHttpServiceToStreamingHttpService implements StreamingHttpService {
+final class BlockingToStreamingService implements StreamingHttpService {
     private final BlockingHttpService service;
 
-    BlockingHttpServiceToStreamingHttpService(final BlockingHttpService service) {
+    BlockingToStreamingService(final BlockingHttpService service) {
         this.service = requireNonNull(service);
     }
 
@@ -48,6 +48,6 @@ final class BlockingHttpServiceToStreamingHttpService implements StreamingHttpSe
         // Since we are converting to a different programming model, try altering the strategy for the returned service
         // to contain an appropriate default. We achieve this by merging the expected strategy with the provided
         // service strategy.
-        return service.computeExecutionStrategy(other.merge(OFFLOAD_RECEIVE_META_STRATEGY));
+        return service.computeExecutionStrategy(other.merge(DEFAULT_BLOCKING_SERVICE_STRATEGY));
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpApiConversions.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpApiConversions.java
@@ -15,10 +15,24 @@
  */
 package io.servicetalk.http.api;
 
+import static io.servicetalk.http.api.HttpExecutionStrategies.OFFLOAD_ALL_STRATEGY;
+import static io.servicetalk.http.api.HttpExecutionStrategies.OFFLOAD_RECEIVE_DATA_AND_SEND_STRATEGY;
+import static io.servicetalk.http.api.HttpExecutionStrategies.OFFLOAD_RECEIVE_DATA_STRATEGY;
+import static io.servicetalk.http.api.HttpExecutionStrategies.OFFLOAD_RECEIVE_META_STRATEGY;
+
 /**
  * Conversion routines to {@link StreamingHttpService}.
  */
 public final class HttpApiConversions {
+
+    /**
+     * For aggregation, we invoke the service after the payload is completed, hence we need to offload data.
+     */
+    static final HttpExecutionStrategy DEFAULT_SERVICE_STRATEGY = OFFLOAD_RECEIVE_DATA_AND_SEND_STRATEGY;
+    static final HttpExecutionStrategy DEFAULT_STREAMING_SERVICE_STRATEGY = OFFLOAD_ALL_STRATEGY;
+    static final HttpExecutionStrategy DEFAULT_BLOCKING_SERVICE_STRATEGY = OFFLOAD_RECEIVE_DATA_STRATEGY;
+    static final HttpExecutionStrategy DEFAULT_BLOCKING_STREAMING_SERVICE_STRATEGY = OFFLOAD_RECEIVE_META_STRATEGY;
+
     private HttpApiConversions() {
         // no instances
     }
@@ -30,7 +44,7 @@ public final class HttpApiConversions {
      * @return The conversion result.
      */
     public static StreamingHttpService toStreamingHttpService(HttpService service) {
-        return new HttpServiceToStreamingHttpService(service);
+        return new ServiceToStreamingService(service);
     }
 
     /**
@@ -40,7 +54,7 @@ public final class HttpApiConversions {
      * @return The conversion result.
      */
     public static StreamingHttpService toStreamingHttpService(BlockingStreamingHttpService handler) {
-        return new BlockingStreamingHttpServiceToStreamingHttpService(handler);
+        return new BlockingStreamingToStreamingService(handler);
     }
 
     /**
@@ -50,6 +64,6 @@ public final class HttpApiConversions {
      * @return The conversion result.
      */
     public static StreamingHttpService toStreamingHttpService(BlockingHttpService handler) {
-        return new BlockingHttpServiceToStreamingHttpService(handler);
+        return new BlockingToStreamingService(handler);
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
@@ -37,10 +37,12 @@ public final class HttpExecutionStrategies {
     static final HttpExecutionStrategy OFFLOAD_NONE_STRATEGY = customStrategyBuilder().mergeStrategy(Merge).build();
     static final HttpExecutionStrategy OFFLOAD_RECEIVE_META_STRATEGY =
             customStrategyBuilder().offloadReceiveMetadata().mergeStrategy(Merge).build();
+    static final HttpExecutionStrategy OFFLOAD_RECEIVE_DATA_STRATEGY =
+            customStrategyBuilder().offloadReceiveData().mergeStrategy(Merge).build();
+    static final HttpExecutionStrategy OFFLOAD_RECEIVE_DATA_AND_SEND_STRATEGY =
+            customStrategyBuilder().offloadReceiveData().offloadSend().mergeStrategy(Merge).build();
     static final HttpExecutionStrategy OFFLOAD_ALL_STRATEGY = customStrategyBuilder().offloadAll()
             .mergeStrategy(Merge).build();
-    static final HttpExecutionStrategy OFFLOAD_RECEIVE_META_AND_SEND_STRATEGY =
-            customStrategyBuilder().offloadReceiveMetadata().offloadSend().mergeStrategy(Merge).build();
     static final HttpExecutionStrategy OFFLOAD_SEND_STRATEGY = customStrategyBuilder().offloadSend()
             .mergeStrategy(Merge).build();
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpService.java
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 
-import static io.servicetalk.http.api.HttpExecutionStrategies.OFFLOAD_RECEIVE_META_AND_SEND_STRATEGY;
+import static io.servicetalk.http.api.HttpApiConversions.DEFAULT_SERVICE_STRATEGY;
 
 /**
  * Same as {@link StreamingHttpService} but that accepts {@link HttpRequest} and returns {@link HttpResponse}.
@@ -55,6 +55,6 @@ public interface HttpService extends AsyncCloseable {
      * @return The {@link HttpExecutionStrategy} for this {@link BlockingStreamingHttpService}.
      */
     default HttpExecutionStrategy computeExecutionStrategy(HttpExecutionStrategy other) {
-        return other.merge(OFFLOAD_RECEIVE_META_AND_SEND_STRATEGY);
+        return other.merge(DEFAULT_SERVICE_STRATEGY);
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ServiceToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ServiceToStreamingService.java
@@ -18,13 +18,13 @@ package io.servicetalk.http.api;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 
-import static io.servicetalk.http.api.HttpExecutionStrategies.OFFLOAD_RECEIVE_META_AND_SEND_STRATEGY;
+import static io.servicetalk.http.api.HttpApiConversions.DEFAULT_SERVICE_STRATEGY;
 import static java.util.Objects.requireNonNull;
 
-final class HttpServiceToStreamingHttpService implements StreamingHttpService {
+final class ServiceToStreamingService implements StreamingHttpService {
     private final HttpService aggregatedService;
 
-    HttpServiceToStreamingHttpService(final HttpService aggregatedService) {
+    ServiceToStreamingService(final HttpService aggregatedService) {
         this.aggregatedService = requireNonNull(aggregatedService);
     }
 
@@ -51,6 +51,6 @@ final class HttpServiceToStreamingHttpService implements StreamingHttpService {
         // Since we are converting to a different programming model, try altering the strategy for the returned service
         // to contain an appropriate default. We achieve this by merging the expected strategy with the provided
         // service strategy.
-        return aggregatedService.computeExecutionStrategy(other.merge(OFFLOAD_RECEIVE_META_AND_SEND_STRATEGY));
+        return aggregatedService.computeExecutionStrategy(other.merge(DEFAULT_SERVICE_STRATEGY));
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpService.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
-import static io.servicetalk.http.api.HttpExecutionStrategies.OFFLOAD_ALL_STRATEGY;
+import static io.servicetalk.http.api.HttpApiConversions.DEFAULT_STREAMING_SERVICE_STRATEGY;
 
 /**
  * A service contract for the HTTP protocol.
@@ -57,6 +57,6 @@ public interface StreamingHttpService extends AsyncCloseable {
      * @return The {@link HttpExecutionStrategy} for this {@link StreamingHttpService}.
      */
     default HttpExecutionStrategy computeExecutionStrategy(HttpExecutionStrategy other) {
-        return other.merge(OFFLOAD_ALL_STRATEGY);
+        return other.merge(DEFAULT_STREAMING_SERVICE_STRATEGY);
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceFilter.java
@@ -17,9 +17,8 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.transport.api.ExecutionStrategy;
 
-import static io.servicetalk.http.api.HttpExecutionStrategies.OFFLOAD_ALL_STRATEGY;
+import static io.servicetalk.http.api.HttpApiConversions.DEFAULT_STREAMING_SERVICE_STRATEGY;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -47,7 +46,7 @@ public class StreamingHttpServiceFilter implements StreamingHttpService {
 
     @Override
     public HttpExecutionStrategy computeExecutionStrategy(HttpExecutionStrategy other) {
-        return delegate.computeExecutionStrategy(executionStrategy().merge(other));
+        return delegate.computeExecutionStrategy(DEFAULT_STREAMING_SERVICE_STRATEGY.merge(other));
     }
 
     @Override
@@ -67,17 +66,5 @@ public class StreamingHttpServiceFilter implements StreamingHttpService {
      */
     protected final StreamingHttpService delegate() {
         return delegate;
-    }
-
-    /**
-     * The {@link ExecutionStrategy} considering the programming constraints of this {@link StreamingHttpServiceFilter}
-     * in isolation. This strategy should be the "least common denominator" for example if any blocking is done this
-     * method should reflect that.
-     *
-     * @return The {@link ExecutionStrategy} considering the programming constraints of this
-     * {@link StreamingHttpServiceFilter} in isolation.
-     */
-    protected HttpExecutionStrategy executionStrategy() {
-        return OFFLOAD_ALL_STRATEGY;
     }
 }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingToStreamingServiceTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingToStreamingServiceTest.java
@@ -71,7 +71,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class BlockingStreamingHttpServiceToStreamingHttpServiceTest {
+public class BlockingStreamingToStreamingServiceTest {
 
     private static final String X_TOTAL_LENGTH = "x-total-length";
     private static final String HELLO_WORLD = "Hello\nWorld\n";

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
@@ -161,8 +161,8 @@ public abstract class AbstractHttpServiceAsyncContextTest {
             }
 
             @Override
-            public HttpExecutionStrategy executionStrategy() {
-                return noOffloadsStrategy();
+            public HttpExecutionStrategy computeExecutionStrategy(final HttpExecutionStrategy other) {
+                return delegate().computeExecutionStrategy(noOffloadsStrategy().merge(other));
             }
 
             private Single<StreamingHttpResponse> doHandle(final HttpServiceContext ctx,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/InvokingThreadsRecorder.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/InvokingThreadsRecorder.java
@@ -53,7 +53,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 final class InvokingThreadsRecorder<T> {
-    private static final String IO_EXECUTOR_NAME_PREFIX = "io-executor";
+    static final String IO_EXECUTOR_NAME_PREFIX = "io-executor";
 
     @Nullable
     private final HttpExecutionStrategy strategy;
@@ -128,6 +128,11 @@ final class InvokingThreadsRecorder<T> {
         assert invokingThreads != null;
         assertThat("Unexpected thread for point: " + offloadPoint, invokingThreads.get(offloadPoint).getName(),
                 both(not(startsWith(IO_EXECUTOR_NAME_PREFIX))).and(startsWith(executorNamePrefix)));
+    }
+
+    Thread invokingThread(final T offloadPoint) {
+        assert invokingThreads != null;
+        return invokingThreads.get(offloadPoint);
     }
 
     void verifyOffloadCount() {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
@@ -16,22 +16,14 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.buffer.api.Buffer;
-import io.servicetalk.concurrent.api.AsyncCloseables;
 import io.servicetalk.concurrent.api.DefaultThreadFactory;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.http.api.BlockingHttpClient;
-import io.servicetalk.http.api.BlockingHttpService;
-import io.servicetalk.http.api.BlockingStreamingHttpRequest;
-import io.servicetalk.http.api.BlockingStreamingHttpServerResponse;
-import io.servicetalk.http.api.BlockingStreamingHttpService;
 import io.servicetalk.http.api.HttpExecutionStrategy;
-import io.servicetalk.http.api.HttpRequest;
 import io.servicetalk.http.api.HttpResponse;
-import io.servicetalk.http.api.HttpResponseFactory;
 import io.servicetalk.http.api.HttpServerBuilder;
-import io.servicetalk.http.api.HttpService;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
@@ -55,11 +47,11 @@ import java.util.Collection;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
 import static io.servicetalk.concurrent.api.Single.succeeded;
@@ -67,12 +59,17 @@ import static io.servicetalk.concurrent.internal.PlatformDependent.throwExceptio
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.netty.InvokingThreadsRecorder.IO_EXECUTOR_NAME_PREFIX;
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.noStrategy;
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.userStrategy;
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.userStrategyNoVerify;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.either;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assume.assumeThat;
 
 @RunWith(Parameterized.class)
@@ -345,16 +342,16 @@ public class ServerEffectiveStrategyTest {
         }
 
         void defaultOffloadPoints() {
-            addOffloadedPointFor(ServiceType.Blocking, ServerOffloadPoint.ServiceHandle);
-            addNonOffloadedPointFor(ServiceType.Blocking, ServerOffloadPoint.RequestPayload,
+            addOffloadedPointFor(ServiceType.Blocking, ServerOffloadPoint.ServiceHandle,
+                    ServerOffloadPoint.RequestPayload);
+            addNonOffloadedPointFor(ServiceType.Blocking, ServerOffloadPoint.Response);
+
+            addOffloadedPointFor(ServiceType.BlockingStreaming, ServerOffloadPoint.ServiceHandle);
+            addNonOffloadedPointFor(ServiceType.BlockingStreaming, ServerOffloadPoint.RequestPayload,
                     ServerOffloadPoint.Response);
 
-            addOffloadedPointFor(ServiceType.BlockingStreaming, ServerOffloadPoint.ServiceHandle,
-             ServerOffloadPoint.Response);
-            addNonOffloadedPointFor(ServiceType.BlockingStreaming, ServerOffloadPoint.RequestPayload);
-
-            addOffloadedPointFor(ServiceType.Async, ServerOffloadPoint.ServiceHandle, ServerOffloadPoint.Response);
-            addNonOffloadedPointFor(ServiceType.Async, ServerOffloadPoint.RequestPayload);
+            addOffloadedPointFor(ServiceType.Async, ServerOffloadPoint.ServiceHandle, ServerOffloadPoint.Response,
+                    ServerOffloadPoint.RequestPayload);
 
             addOffloadedPointFor(ServiceType.AsyncStreaming, ServerOffloadPoint.ServiceHandle,
                     ServerOffloadPoint.Response, ServerOffloadPoint.RequestPayload);
@@ -411,132 +408,73 @@ public class ServerEffectiveStrategyTest {
         BlockingHttpClient startBlocking() {
             assert invokingThreadsRecorder != null;
             final HttpExecutionStrategy strategy = invokingThreadsRecorder.executionStrategy();
-            if (strategy == null) {
-                initState(builder -> builder.listenBlocking(this::blockingHandler));
-            } else {
-                initState(builder -> builder.listenBlocking(new BlockingHttpService() {
-                    @Override
-                    public HttpResponse handle(final HttpServiceContext ctx, final HttpRequest request,
-                                               final HttpResponseFactory factory) throws Exception {
-                        return blockingHandler(ctx, request, factory);
-                    }
-
-                    @Override
-                    public HttpExecutionStrategy computeExecutionStrategy(HttpExecutionStrategy other) {
-                        return strategy.merge(other);
-                    }
-                }));
-            }
+            initState(builder -> {
+                if (strategy != null) {
+                    builder.executionStrategy(strategy);
+                }
+                return builder.listenBlocking((ctx, request, factory) -> {
+                    invokingThreadsRecorder.recordThread(ServerOffloadPoint.ServiceHandle);
+                    return factory.ok().payloadBody(request.payloadBody());
+                });
+            });
             return invokingThreadsRecorder.client().asBlockingClient();
-        }
-
-        private HttpResponse blockingHandler(@SuppressWarnings("unused") final HttpServiceContext ctx,
-                                             final HttpRequest request,
-                                             final HttpResponseFactory factory)
-                throws InterruptedException, ExecutionException {
-            HttpResponse response = factory.ok().payloadBody(request.payloadBody());
-            return noOffloadsStrategy ? response : serviceExecutor.submit(() -> response).toFuture().get();
         }
 
         BlockingHttpClient startBlockingStreaming() {
             assert invokingThreadsRecorder != null;
             final HttpExecutionStrategy strategy = invokingThreadsRecorder.executionStrategy();
-            if (strategy == null) {
-                initState(builder -> builder.listenBlockingStreaming(this::blockingStreamingHandler));
-            } else {
-                initState(builder -> builder.listenBlockingStreaming(new BlockingStreamingHttpService() {
-                    @Override
-                    public void handle(final HttpServiceContext ctx, final BlockingStreamingHttpRequest request,
-                                       final BlockingStreamingHttpServerResponse response) throws Exception {
-                        blockingStreamingHandler(ctx, request, response);
-                    }
-
-                    @Override
-                    public HttpExecutionStrategy computeExecutionStrategy(HttpExecutionStrategy other) {
-                        return strategy.merge(other);
-                    }
-                }));
-            }
-            return invokingThreadsRecorder.client().asBlockingClient();
-        }
-
-        private void blockingStreamingHandler(@SuppressWarnings("unused") final HttpServiceContext ctx,
-                                              final BlockingStreamingHttpRequest request,
-                final BlockingStreamingHttpServerResponse response)
-                throws InterruptedException, ExecutionException {
-            // noOffloads is not valid for blocking streaming, so no conditional here
-            serviceExecutor.submit(() -> {
-                try (PayloadWriter<Buffer> payloadWriter = response.sendMetaData()) {
-                    request.payloadBody().forEach(buffer -> {
-                        try {
-                            payloadWriter.write(buffer);
-                        } catch (IOException e) {
-                            throwException(e);
-                        }
-                    });
-                } catch (IOException e) {
-                    throwException(e);
+            initState(builder -> {
+                if (strategy != null) {
+                    builder.executionStrategy(strategy);
                 }
-            }).toFuture().get();
+                return builder.listenBlockingStreaming((ctx, request, response) -> {
+                    invokingThreadsRecorder.recordThread(ServerOffloadPoint.ServiceHandle);
+                    try (PayloadWriter<Buffer> payloadWriter = response.sendMetaData()) {
+                        request.payloadBody().forEach(buffer -> {
+                            try {
+                                payloadWriter.write(buffer);
+                            } catch (IOException e) {
+                                throwException(e);
+                            }
+                        });
+                    } catch (IOException e) {
+                        throwException(e);
+                    }
+                });
+            });
+            return invokingThreadsRecorder.client().asBlockingClient();
         }
 
         BlockingHttpClient startAsync() {
             assert invokingThreadsRecorder != null;
             final HttpExecutionStrategy strategy = invokingThreadsRecorder.executionStrategy();
-            if (strategy == null) {
-                initState(builder -> builder.listen(this::asyncHandler));
-            } else {
-                initState(builder -> builder.listen(new HttpService() {
-                    @Override
-                    public Single<HttpResponse> handle(final HttpServiceContext ctx, final HttpRequest request,
-                                                       final HttpResponseFactory factory) {
-                        return asyncHandler(ctx, request, factory);
-                    }
-
-                    @Override
-                    public HttpExecutionStrategy computeExecutionStrategy(HttpExecutionStrategy other) {
-                        return strategy.merge(other);
-                    }
-                }));
-            }
+            initState(builder -> {
+                if (strategy != null) {
+                    builder.executionStrategy(strategy);
+                }
+                return builder.listen((ctx, request, factory) -> {
+                    invokingThreadsRecorder.recordThread(ServerOffloadPoint.ServiceHandle);
+                    HttpResponse response = factory.ok().payloadBody(request.payloadBody());
+                    return succeeded(response);
+                });
+            });
             return invokingThreadsRecorder.client().asBlockingClient();
-        }
-
-        private Single<HttpResponse> asyncHandler(@SuppressWarnings("unused") final HttpServiceContext ctx,
-                                                  final HttpRequest request,
-                                                  final HttpResponseFactory factory) {
-            HttpResponse response = factory.ok().payloadBody(request.payloadBody());
-            return noOffloadsStrategy ? succeeded(response) : serviceExecutor.submit(() -> response);
         }
 
         BlockingHttpClient startAsyncStreaming() {
             assert invokingThreadsRecorder != null;
             final HttpExecutionStrategy strategy = invokingThreadsRecorder.executionStrategy();
-            if (strategy == null) {
-                initState(builder -> builder.listenStreaming(this::asyncStreamingHandler));
-            } else {
-                initState(builder -> builder.listenStreaming(new StreamingHttpService() {
-                    @Override
-                    public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
-                                                                final StreamingHttpRequest request,
-                                                                final StreamingHttpResponseFactory factory) {
-                        return asyncStreamingHandler(ctx, request, factory);
-                    }
-
-                    @Override
-                    public HttpExecutionStrategy computeExecutionStrategy(HttpExecutionStrategy other) {
-                        return strategy.merge(other);
-                    }
-                }));
-            }
+            initState(builder -> {
+                if (strategy != null) {
+                    builder.executionStrategy(strategy);
+                }
+                return builder.listenStreaming((ctx, request, factory) -> {
+                    invokingThreadsRecorder.recordThread(ServerOffloadPoint.ServiceHandle);
+                    StreamingHttpResponse response = factory.ok().payloadBody(request.payloadBody());
+                    return succeeded(response);
+                });
+            });
             return invokingThreadsRecorder.client().asBlockingClient();
-        }
-
-        private Single<StreamingHttpResponse> asyncStreamingHandler(
-                @SuppressWarnings("unused") final HttpServiceContext ctx, final StreamingHttpRequest request,
-                final StreamingHttpResponseFactory factory) {
-            StreamingHttpResponse response = factory.ok().payloadBody(request.payloadBody());
-            return noOffloadsStrategy ? succeeded(response) : serviceExecutor.submit(() -> response);
         }
 
         Executor executor() {
@@ -550,14 +488,27 @@ public class ServerEffectiveStrategyTest {
             }
             invokingThreadsRecorder.verifyOffloadCount();
             for (ServerOffloadPoint offloadPoint : offloadPoints.get(serviceType)) {
-                if (executorUsedForStrategy && offloadPoint != ServerOffloadPoint.Response) {
+                if (executorUsedForStrategy) {
                     invokingThreadsRecorder.assertOffload(offloadPoint, USER_STRATEGY_EXECUTOR_NAME_PREFIX);
                 } else {
                     invokingThreadsRecorder.assertOffload(offloadPoint);
                 }
             }
             for (ServerOffloadPoint offloadPoint : nonOffloadPoints.get(serviceType)) {
-                invokingThreadsRecorder.assertNoOffload(offloadPoint);
+                if (offloadPoint == ServerOffloadPoint.Response) {
+                    if (offloadPoints.get(serviceType).contains(ServerOffloadPoint.ServiceHandle)) {
+                        Thread serviceInvoker =
+                                invokingThreadsRecorder.invokingThread(ServerOffloadPoint.ServiceHandle);
+                        Thread responseInvoker = invokingThreadsRecorder.invokingThread(ServerOffloadPoint.Response);
+                        // If service#handle is offloaded, and response is not then response may be requested
+                        // synchronously from service#handle
+                        assertThat("Unexpected thread for response (not-offloaded)",
+                                responseInvoker.getName(), either(equalTo(serviceInvoker.getName()))
+                                        .or(startsWith(IO_EXECUTOR_NAME_PREFIX)));
+                    }
+                } else {
+                    invokingThreadsRecorder.assertNoOffload(offloadPoint);
+                }
             }
         }
 
@@ -566,7 +517,7 @@ public class ServerEffectiveStrategyTest {
             try {
                 invokingThreadsRecorder.dispose();
             } finally {
-                AsyncCloseables.newCompositeCloseable().appendAll(executor, serviceExecutor).close();
+                newCompositeCloseable().appendAll(executor, serviceExecutor).close();
             }
         }
 
@@ -599,7 +550,6 @@ public class ServerEffectiveStrategyTest {
         public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
                                                     final StreamingHttpRequest request,
                                                     final StreamingHttpResponseFactory responseFactory) {
-            recorder.recordThread(ServerOffloadPoint.ServiceHandle);
             return delegate().handle(ctx, request.transformPayloadBody(publisher ->
                     publisher.doBeforeOnNext(__ -> recorder.recordThread(ServerOffloadPoint.RequestPayload))),
                     responseFactory)
@@ -608,8 +558,8 @@ public class ServerEffectiveStrategyTest {
         }
 
         @Override
-        protected HttpExecutionStrategy executionStrategy() {
-            return defaultStrategy();
+        public HttpExecutionStrategy computeExecutionStrategy(final HttpExecutionStrategy other) {
+            return delegate().computeExecutionStrategy(defaultStrategy().merge(other));
         }
     }
 


### PR DESCRIPTION
__Motivation__

We thought `*HttpService` providing a method to provide it’s strategy is more useful as the service knows the offloading requirement, however, this means that we need to update the strategy provided by the service if we find a conflicting filter in the filter chain. This requirement makes it such that the strategy handling is different for client and server; as at the client we never merge strategies for provided at the builder. Understanding execution strategy behavior is complex in itself and having different behaviors for client and server makes it harder to understand.

We should make the behavior/expectations from user consistent and hence we will have the user specify strategy at the server builder understanding the filter chain and if a custom strategy is provided, ST will never override it.

__Modification__

- Added `executionStrategy()` method for the server builder.
- Removed `executionStrategy()` method for the service filters.
- Fixed wrongly specified default strategies for aggregated programming models.

__Result__

Consistent behavior across client and server with user specified custom strategy.