### PR TITLE
HttpClientBuilder should build pipelined connections by default

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -49,6 +49,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+import static io.servicetalk.http.netty.DefaultHttpConnectionBuilder.reservedConnectionsPipelineEnabled;
 import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.globalDnsServiceDiscoverer;
 import static io.servicetalk.loadbalancer.RoundRobinLoadBalancer.newRoundRobinFactory;
 import static java.util.Objects.requireNonNull;
@@ -179,7 +180,8 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
 
             // closed by the LoadBalancer
             final ConnectionFactory<R, ? extends StreamingHttpConnection> connectionFactory =
-                    connectionFactoryFilter.create(closeOnException.prepend(roConfig.maxPipelinedRequests() == 1 ?
+                    connectionFactoryFilter.create(closeOnException.prepend(
+                            reservedConnectionsPipelineEnabled(roConfig) ?
                             new NonPipelinedLBHttpConnectionFactory<>(roConfig, ctx.executionContext,
                                     connectionFilterFunction, reqRespFactory, strategy) :
                             new PipelinedLBHttpConnectionFactory<>(roConfig, ctx.executionContext,


### PR DESCRIPTION
Motivation:
bdac78b4b3429d0b2ffededf025eee62517c1980 reverted part of the change introduced
by 12393d50150c9b98a431ce91550da65d09d70fd3. The HttpClientBuilder no longer
builds pipelined enabled connections by default.

Modifications:
- DefaultSingleAddressHttpClientBuilder should respect
reservedConnectionsPipelineEnabled when building connections.

Result:
Merge error corrected.