### PR TITLE
JDK11 PR build should run the test target

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -101,7 +101,7 @@ services:
     - REDIS_HOST=redis-4
     - REDIS_PORT=6379
     - REDIS_AUTH_PORT=6378
-    command: bash -cl "./gradlew clean build"
+    command: bash -cl "./gradlew clean test"
     volumes:
     - ~/.ssh:/root/.ssh
     - ~/.gradle${EXECUTOR_NUMBER}:/root/.gradle


### PR DESCRIPTION
Motivation:
Currently the JDK11 PR build runs the 'build' gradle task which runs checkstyle,
pmd, and other tasks that are not expected to change from the JDK8 build. This
puts extra load on the build servers.

Modifications:
- Run the 'test' gradle task

Result:
Less load on build servers for JDK11 build, and quicker feedback.