### PR TITLE
Reduce test times on CI server

### DIFF
--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcurrentUtilsTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcurrentUtilsTest.java
@@ -95,7 +95,7 @@ public final class ConcurrentUtilsTest {
 
     @Test
     public void testExecuteExclusive() throws Exception {
-        final Task[] tasks = new Task[1000];
+        final Task[] tasks = new Task[20];
         final AtomicInteger runCount = new AtomicInteger();
         final CountDownLatch allOthersDone = new CountDownLatch(1);
         final AtomicReference<Throwable> causeRef = new AtomicReference<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MulticastPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MulticastPublisherTest.java
@@ -147,7 +147,7 @@ public class MulticastPublisherTest {
 
     @Test
     public void concurrentRequestN() throws InterruptedException {
-        final int expectedSubscribers = 2000;
+        final int expectedSubscribers = 50;
         Publisher<Integer> multicast = source.multicastToExactly(expectedSubscribers, expectedSubscribers);
         @SuppressWarnings("unchecked")
         TestPublisherSubscriber<Integer>[] subscribers = (TestPublisherSubscriber<Integer>[])

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
@@ -544,7 +544,7 @@ public class PublisherFlatMapSingleTest {
 
     @Test
     public void testRequestAndEmitConcurrency() throws Exception {
-        int totalToRequest = 100000;
+        int totalToRequest = 1000;
         Set<Integer> received = new LinkedHashSet<>(totalToRequest);
         toSource(source.flatMapMergeSingle(Single::succeeded, 2).doBeforeOnNext(received::add)).subscribe(subscriber);
         source.onSubscribe(subscription);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherGroupByConcurrencyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherGroupByConcurrencyTest.java
@@ -76,7 +76,7 @@ public final class PublisherGroupByConcurrencyTest {
 
     @Test
     public void testConcurrentEmissionAndGroupCancel() throws Exception {
-        int itemCount = 100_000;
+        int itemCount = 1000;
         Queue<GroupSubscriber> subs = subscribeToAll(itemCount, true);
         Task cancels = drainGroupSubscribers(subs, GroupSubscriber::cancel).awaitStart();
         sendRangeToSource(0, itemCount).onComplete();
@@ -86,7 +86,7 @@ public final class PublisherGroupByConcurrencyTest {
 
     @Test
     public void testConcurrentEmissionAndGroupRequestN() throws Exception {
-        int itemCount = 100_000;
+        int itemCount = 1000;
         Queue<GroupSubscriber> subs = subscribeToAll(itemCount, false);
         Task requestNs = requestAndDrainGroupSubscribers(subs).awaitStart();
         sendRangeToSource(0, itemCount).onComplete();
@@ -96,7 +96,7 @@ public final class PublisherGroupByConcurrencyTest {
 
     @Test
     public void testConcurrentGroupsCancel() throws Exception {
-        int itemCount = 100_000;
+        int itemCount = 1000;
         Queue<GroupSubscriber> subs = subscribeToAll(itemCount, false);
         final TestSubscription subscription = new TestSubscription();
         source.onSubscribe(subscription);

--- a/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/SubscriberUtilsTest.java
+++ b/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/SubscriberUtilsTest.java
@@ -120,27 +120,27 @@ public class SubscriberUtilsTest {
 
     @Test
     public void calculateSourceRequestedConcurrentA() throws Exception {
-        calculateSourceRequestedConcurrentLoop(333, 1, 3, 10, 10);
+        calculateSourceRequestedConcurrentLoop(5, 1, 3, 10, 10);
     }
 
     @Test
     public void calculateSourceRequestedConcurrentB() throws Exception {
-        calculateSourceRequestedConcurrentLoop(50, 5, 6, 100, 123456);
+        calculateSourceRequestedConcurrentLoop(5, 5, 6, 100, 123456);
     }
 
     @Test
     public void calculateSourceRequestedConcurrentC() throws Exception {
-        calculateSourceRequestedConcurrentLoop(10, 1, 3, 2, 900103);
+        calculateSourceRequestedConcurrentLoop(5, 1, 3, 2, 900103);
     }
 
     @Test
     public void calculateSourceRequestedConcurrentD() throws Exception {
-        calculateSourceRequestedConcurrentLoop(123, 1, 5635, 483, 800026);
+        calculateSourceRequestedConcurrentLoop(5, 1, 5635, 483, 800026);
     }
 
     @Test
     public void calculateSourceRequestedConcurrentE() throws Exception {
-        calculateSourceRequestedConcurrentLoop(222, 6, 512, Integer.MAX_VALUE, 1000001);
+        calculateSourceRequestedConcurrentLoop(5, 6, 512, Integer.MAX_VALUE, 1000001);
     }
 
     private void calculateSourceRequestedConcurrentLoop(


### PR DESCRIPTION
Motivation:
There are a handful of resource intensive tests that run many iterations or
multiple repetitions. This consumes resources on CI servers that may be resource
constrained.

Modifications:
- Reduce iterations and resourced required by some of the longest running tests
  on CI

Result:
Faster CI builds.