### PR TITLE
JDK11 snapshot build is using JKD8

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -110,8 +110,8 @@ services:
     networks: [test-net]
 
   test-snapshot:
-    depends_on: [java8, redis-4]
-    image: java8:latest
+    depends_on: [java11, redis-4]
+    image: java11:latest
     environment:
       - CI
       - REDIS_HOST=redis-4
@@ -119,7 +119,7 @@ services:
       - REDIS_AUTH_PORT=6378
       - BINTRAY_USER
       - BINTRAY_KEY
-    command: bash -cl "./gradlew clean check"
+    command: bash -cl "./gradlew clean test"
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gradle${EXECUTOR_NUMBER}:/root/.gradle


### PR DESCRIPTION
Motivation:
The JDK11 snapshot build is using JDK8. It should be using JDK11.

Modifications:
- Use JDK11
- Run test intead of check for lighter weight build on CI. The JDK8 build will
run the check.

Result:
JDK11 snapshot build is using JDK11.