### PR TITLE
Revert "Increase ReactiveStreams TCK Timeout on CI (#495)"

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkCorePlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkCorePlugin.groovy
@@ -114,7 +114,7 @@ class ServiceTalkCorePlugin implements Plugin<Project> {
 
         jvmArgs '-server', '-Xms2g', '-Xmx4g', '-dsa', '-da', '-ea:io.servicetalk...',
             '-XX:+AggressiveOpts', '-XX:+TieredCompilation', '-XX:+UseBiasedLocking',
-                '-XX:+OptimizeStringConcat', '-XX:+HeapDumpOnOutOfMemoryError', '-DDEFAULT_TIMEOUT_MILLIS=5000'
+                '-XX:+OptimizeStringConcat', '-XX:+HeapDumpOnOutOfMemoryError'
       }
     }
   }


### PR DESCRIPTION
ReactiveStreams TCK requires an environment variable instead of a system
property. The ReactiveStreams TCK TestEnvironment has a defaultTimeoutMillis but
this doesn't provide the "maximum wait time until some event occurs" and may
result in unconditional waits for this duration. We should consider enhancing
the RS TCK to provide the desired semantics to avoid long wait times (longer
test execution time) or short wait times (test timeouts on CI).