### PR TITLE
Improving http predicate router tests.

### DIFF
--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/DefaultFallbackServiceTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/DefaultFallbackServiceTest.java
@@ -15,26 +15,12 @@
  */
 package io.servicetalk.http.router.predicate;
 
-import io.servicetalk.buffer.api.BufferAllocator;
-import io.servicetalk.buffer.api.ReadOnlyBufferAllocators;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.http.api.DefaultHttpHeadersFactory;
-import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
-import io.servicetalk.http.api.HttpServiceContext;
-import io.servicetalk.http.api.StreamingHttpRequest;
-import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpService;
-import io.servicetalk.transport.api.ExecutionContext;
 
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 
-import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
 import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
@@ -42,29 +28,8 @@ import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseStatus.NOT_FOUND;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
 
-public class DefaultFallbackServiceTest {
-    static final BufferAllocator allocator = ReadOnlyBufferAllocators.DEFAULT_RO_ALLOCATOR;
-    static final StreamingHttpRequestResponseFactory reqRespFactory =
-            new DefaultStreamingHttpRequestResponseFactory(allocator, DefaultHttpHeadersFactory.INSTANCE);
-
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule();
-
-    @Mock
-    private HttpServiceContext ctx;
-    @Mock
-    private ExecutionContext executionCtx;
-    @Mock
-    private StreamingHttpRequest request;
-
-    @Before
-    public void setUp() {
-        when(request.version()).thenReturn(HTTP_1_1);
-        when(ctx.executionContext()).thenReturn(executionCtx);
-        when(executionCtx.executor()).thenReturn(immediate());
-    }
+public class DefaultFallbackServiceTest extends BaseHttpPredicateRouterBuilderTest {
 
     @Test
     public void testDefaultFallbackService() throws Exception {

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpServerOverrideOffloadingTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpServerOverrideOffloadingTest.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.CompletableSource.Processor;
 import io.servicetalk.concurrent.api.DefaultThreadFactory;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpServiceContext;
@@ -32,7 +33,9 @@ import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
 
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -58,6 +61,9 @@ import static org.hamcrest.Matchers.is;
 
 public class HttpServerOverrideOffloadingTest {
     private static final String IO_EXECUTOR_THREAD_NAME_PREFIX = "http-server-io-executor-";
+
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
 
     private final IoExecutor ioExecutor;
     private final Executor executor;


### PR DESCRIPTION
Motivation:

Two tests that should have them were lacking timeouts, and one test was
duplicating things from a base class.

Modifications:

- Add timeout to HttpServerOverrideOffloadingTest.
- Make DefaultFallbackServiceTest extend BaseHttpPredicateRouterBuilderTest
  and remove unnecessary fields and methods.

Results:

Tests will no longer run forever if they're broken.