### PR TITLE
Do not convert the original `Buffer` to read-only in `AsciiBuffer` ctor

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AsciiBuffer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AsciiBuffer.java
@@ -39,6 +39,7 @@ import static io.servicetalk.buffer.api.EmptyBuffer.EMPTY_BUFFER;
 import static io.servicetalk.http.api.CharSequences.contentEqualsIgnoreCaseUnknownTypes;
 import static io.servicetalk.http.api.CharSequences.contentEqualsUnknownTypes;
 import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.util.Objects.requireNonNull;
 
 final class AsciiBuffer implements CharSequence {
     static final CharSequence EMPTY_ASCII_BUFFER = new AsciiBuffer(EMPTY_BUFFER);
@@ -52,7 +53,7 @@ final class AsciiBuffer implements CharSequence {
     private int hash;
 
     AsciiBuffer(Buffer buffer) {
-        this.buffer = buffer.asReadOnly();
+        this.buffer = requireNonNull(buffer);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

`AsciiBuffer` does not expose an internal `Buffer` as part of public API
and therefore there is no need to prevent its modifications with
read-only wrapper. Removing `asReadOnly()` conversion helps to reduce
number of wrapping layers.

Modifications:

- Remove `asReadOnly()` conversion from `AsciiBuffer` ctor;

Result:

Reduce number of wrapping layers inside `AsciiBuffer` implementation.