### PR TITLE
Revisit no offloads strategy merge behavior

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpExecutionStrategy.java
@@ -191,7 +191,7 @@ class DefaultHttpExecutionStrategy implements HttpExecutionStrategy {
         }
 
         if (other instanceof NoOffloadsHttpExecutionStrategy) {
-            return this;
+            return other;
         }
 
         final Executor otherExecutor = other.executor();

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/NoOffloadsHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/NoOffloadsHttpExecutionStrategy.java
@@ -96,7 +96,7 @@ final class NoOffloadsHttpExecutionStrategy implements HttpExecutionStrategy {
 
     @Override
     public HttpExecutionStrategy merge(final HttpExecutionStrategy other) {
-        return other == this ? this : other.merge(this);
+        return this;
     }
 
     @Override

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpExecutionStrategyMergeTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpExecutionStrategyMergeTest.java
@@ -93,7 +93,7 @@ public class DefaultHttpExecutionStrategyMergeTest {
     public void mergeWithNoOffloads() {
         HttpExecutionStrategy strategy = customStrategyBuilder().offloadSend().executor(executor).build();
         HttpExecutionStrategy merged = strategy.merge(noOffloadsStrategy());
-        assertThat("Unexpected merge result.", merged, is(sameInstance(strategy)));
+        assertThat("Unexpected merge result.", merged, is(sameInstance(noOffloadsStrategy())));
     }
 
     @Test

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
@@ -136,8 +136,7 @@ public abstract class AbstractHttpServiceAsyncContextTest {
         Queue<Throwable> errorQueue = new ConcurrentLinkedQueue<>();
 
         try (ServerContext ctx = serverWithService(HttpServers.forAddress(localAddress(0))
-                .appendServiceFilter(filterFactory(useImmediate, asyncFilter, errorQueue))
-                        .executionStrategy(noOffloadsStrategy()),
+                .appendServiceFilter(filterFactory(useImmediate, asyncFilter, errorQueue)),
                 useImmediate, asyncService);
 
              StreamingHttpConnection connection = new DefaultHttpConnectionBuilder<SocketAddress>()

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BlockingStreamingHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BlockingStreamingHttpServiceAsyncContextTest.java
@@ -37,25 +37,21 @@ public class BlockingStreamingHttpServiceAsyncContextTest extends AbstractHttpSe
     }
 
     private static BlockingStreamingHttpService newEmptyAsyncContextService() {
-        return new BlockingStreamingHttpService() {
-            @Override
-            public void handle(final HttpServiceContext ctx, final BlockingStreamingHttpRequest request,
-                               final BlockingStreamingHttpServerResponse response) throws Exception {
-                request.payloadBody().forEach(__ -> { });
+        return (ctx, request, response) -> {
+            request.payloadBody().forEach(__ -> { });
 
-                if (!AsyncContext.isEmpty()) {
-                    response.status(INTERNAL_SERVER_ERROR).sendMetaData().close();
-                    return;
-                }
-                CharSequence requestId = request.headers().getAndRemove(REQUEST_ID_HEADER);
-                if (requestId != null) {
-                    AsyncContext.put(K1, requestId);
-                    response.setHeader(REQUEST_ID_HEADER, requestId);
-                } else {
-                    response.status(BAD_REQUEST);
-                }
-                response.sendMetaData().close();
+            if (!AsyncContext.isEmpty()) {
+                response.status(INTERNAL_SERVER_ERROR).sendMetaData().close();
+                return;
             }
+            CharSequence requestId = request.headers().getAndRemove(REQUEST_ID_HEADER);
+            if (requestId != null) {
+                AsyncContext.put(K1, requestId);
+                response.setHeader(REQUEST_ID_HEADER, requestId);
+            } else {
+                response.status(BAD_REQUEST);
+            }
+            response.sendMetaData().close();
         };
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -113,17 +113,22 @@ public class ClientEffectiveStrategyTest {
                 ClientEffectiveStrategyTest::userStrategyNoExecutorWithLB));
         params.add(wrap("userStrategyNoExecutorWithCF",
                 ClientEffectiveStrategyTest::userStrategyNoExecutorWithCF));
-        // TODO (nkant): We are not yet sure how this should behave, will revisit
-        /*
         params.add(wrap("userStrategyNoOffloadsNoFilter",
                 ClientEffectiveStrategyTest::userStrategyNoOffloadsNoFilter));
         params.add(wrap("userStrategyNoOffloadsWithFilter",
                 ClientEffectiveStrategyTest::userStrategyNoOffloadsWithFilter));
+        params.add(wrap("userStrategyNoOffloadsWithLB",
+                ClientEffectiveStrategyTest::userStrategyNoOffloadsWithLB));
+        params.add(wrap("userStrategyNoOffloadsWithCF",
+                ClientEffectiveStrategyTest::userStrategyNoOffloadsWithCF));
         params.add(wrap("userStrategyNoOffloadsNoExecutorNoFilter",
                 ClientEffectiveStrategyTest::userStrategyNoOffloadsNoExecutorNoFilter));
         params.add(wrap("userStrategyNoOffloadsNoExecutorWithFilter",
                 ClientEffectiveStrategyTest::userStrategyNoOffloadsNoExecutorWithFilter));
-        */
+        params.add(wrap("userStrategyNoOffloadsNoExecutorWithLB",
+                ClientEffectiveStrategyTest::userStrategyNoOffloadsNoExecutorWithLB));
+        params.add(wrap("userStrategyNoOffloadsNoExecutorWithCF",
+                ClientEffectiveStrategyTest::userStrategyNoOffloadsNoExecutorWithCF));
         params.add(wrap("customUserStrategyNoFilter",
                 ClientEffectiveStrategyTest::customUserStrategyNoFilter));
         params.add(wrap("customUserStrategyWithFilter",
@@ -246,7 +251,21 @@ public class ClientEffectiveStrategyTest {
     private static Params userStrategyNoOffloadsWithFilter() {
         Params params = new Params();
         params.initStateHolderUserStrategyNoOffloads(true, false, false);
-        params.allPointsOffloadedForAllClients();
+        params.noPointsOffloadedForAllClients();
+        return params;
+    }
+
+    private static Params userStrategyNoOffloadsWithLB() {
+        Params params = new Params();
+        params.initStateHolderUserStrategyNoOffloads(false, true, false);
+        params.noPointsOffloadedForAllClients();
+        return params;
+    }
+
+    private static Params userStrategyNoOffloadsWithCF() {
+        Params params = new Params();
+        params.initStateHolderUserStrategyNoOffloads(false, false, true);
+        params.noPointsOffloadedForAllClients();
         return params;
     }
 
@@ -260,7 +279,21 @@ public class ClientEffectiveStrategyTest {
     private static Params userStrategyNoOffloadsNoExecutorWithFilter() {
         Params params = new Params();
         params.initStateHolderUserStrategyNoOffloadsNoExecutor(true, false, false);
-        params.allPointsOffloadedForAllClients();
+        params.noPointsOffloadedForAllClients();
+        return params;
+    }
+
+    private static Params userStrategyNoOffloadsNoExecutorWithLB() {
+        Params params = new Params();
+        params.initStateHolderUserStrategyNoOffloadsNoExecutor(false, true, false);
+        params.noPointsOffloadedForAllClients();
+        return params;
+    }
+
+    private static Params userStrategyNoOffloadsNoExecutorWithCF() {
+        Params params = new Params();
+        params.initStateHolderUserStrategyNoOffloadsNoExecutor(false, false, true);
+        params.noPointsOffloadedForAllClients();
         return params;
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
@@ -108,8 +108,6 @@ public class ServerEffectiveStrategyTest {
                 ServerEffectiveStrategyTest::userStrategyNoExecutorNoFilter));
         params.add(wrap("userStrategyNoExecutorWithFilter",
                 ServerEffectiveStrategyTest::userStrategyNoExecutorWithFilter));
-        // TODO (nkant): We are not yet sure how this should behave, will revisit
-        /*
         params.add(wrap("userStrategyNoOffloadsNoExecutorNoFilter",
                 ServerEffectiveStrategyTest::userStrategyNoOffloadsNoExecutorNoFilter));
         params.add(wrap("userStrategyNoOffloadsNoExecutorWithFilter",
@@ -118,7 +116,6 @@ public class ServerEffectiveStrategyTest {
                 ServerEffectiveStrategyTest::userStrategyNoOffloadsWithExecutorNoFilter));
         params.add(wrap("userStrategyNoOffloadsWithExecutorWithFilter",
                 ServerEffectiveStrategyTest::userStrategyNoOffloadsWithExecutorWithFilter));
-        */
         params.add(wrap("customUserStrategyNoFilter",
                 ServerEffectiveStrategyTest::customUserStrategyNoFilter));
         params.add(wrap("customUserStrategyWithFilter",


### PR DESCRIPTION
__Motivation__

If a user specifies a strategy, we always respect it, the behavior should be the same when a user specifies `noOffloadsStrategy`.
However, the merge method implemented today returns the "other strategy".

__Modification__

- Fix the behavior to always "return self" when merging with `noOffloadsStrategy`
- Uncomment the effective strategy tests for no-offloads and fixed the tests.

__Result__

Consistent behavior when user specifies a strategy on the builder.