### PR TITLE
`StreamingHttpClientFilter#reserveConnection` should return a `FilterableReservedStreamingHttpConnection`

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FilterableStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FilterableStreamingHttpClient.java
@@ -30,6 +30,6 @@ public interface FilterableStreamingHttpClient extends StreamingHttpRequester {
      * For example this may provide some insight into shard or other info.
      * @return a {@link Single} that provides the {@link ReservedStreamingHttpConnection} upon completion.
      */
-    Single<ReservedStreamingHttpConnection> reserveConnection(HttpExecutionStrategy strategy,
-                                                              HttpRequestMetaData metaData);
+    Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(HttpExecutionStrategy strategy,
+                                                                                  HttpRequestMetaData metaData);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/LoadBalancerReadyStreamingHttpClientFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/LoadBalancerReadyStreamingHttpClientFilter.java
@@ -57,9 +57,10 @@ public final class LoadBalancerReadyStreamingHttpClientFilter extends StreamingH
     }
 
     @Override
-    public Single<ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
-                                                                     final HttpRequestMetaData metaData) {
-        return delegate().reserveConnection(strategy, metaData).retryWhen(retryWhenFunction());
+    public Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(
+            final HttpExecutionStrategy strategy, final HttpRequestMetaData metaData) {
+        return delegate().reserveConnection(strategy, metaData)
+                .retryWhen(retryWhenFunction());
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ReservedStreamingHttpConnectionFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ReservedStreamingHttpConnectionFilter.java
@@ -18,37 +18,25 @@ package io.servicetalk.http.api;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.http.api.StreamingHttpClientToBlockingHttpClient.ReservedStreamingHttpConnectionToReservedBlockingHttpConnection;
-import io.servicetalk.http.api.StreamingHttpClientToBlockingStreamingHttpClient.ReservedStreamingHttpConnectionToBlockingStreaming;
-import io.servicetalk.http.api.StreamingHttpClientToHttpClient.ReservedStreamingHttpConnectionToReservedHttpConnection;
 import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ExecutionContext;
 
-import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static java.util.Objects.requireNonNull;
 
 /**
  * A {@link ReservedStreamingHttpConnectionFilter} that delegates all methods to a different
  * {@link ReservedStreamingHttpConnectionFilter}.
  */
-public class ReservedStreamingHttpConnectionFilter implements ReservedStreamingHttpConnection {
-    private final ReservedStreamingHttpConnection delegate;
-    private final HttpExecutionStrategy strategy;
-    private final HttpExecutionStrategyInfluencer influencer;
+public class ReservedStreamingHttpConnectionFilter implements FilterableReservedStreamingHttpConnection {
+    private final FilterableReservedStreamingHttpConnection delegate;
 
     /**
      * Create a new instance.
      *
-     * @param delegate The {@link ReservedStreamingHttpConnection} to delegate all calls to
+     * @param delegate The {@link FilterableReservedStreamingHttpConnection} to delegate all calls to
      */
-    protected ReservedStreamingHttpConnectionFilter(final ReservedStreamingHttpConnection delegate) {
+    protected ReservedStreamingHttpConnectionFilter(final FilterableReservedStreamingHttpConnection delegate) {
         this.delegate = requireNonNull(delegate);
-        if (delegate instanceof HttpExecutionStrategyInfluencer) {
-            influencer = (HttpExecutionStrategyInfluencer) delegate;
-        } else {
-            influencer = strategy -> defaultStrategy().merge(strategy);
-        }
-        this.strategy = influencer.influenceStrategy(defaultStrategy());
     }
 
     @Override
@@ -64,26 +52,6 @@ public class ReservedStreamingHttpConnectionFilter implements ReservedStreamingH
     @Override
     public <T> Publisher<T> settingStream(final SettingKey<T> settingKey) {
         return delegate.settingStream(settingKey);
-    }
-
-    @Override
-    public final Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-        return request(delegate, strategy, request);
-    }
-
-    @Override
-    public ReservedHttpConnection asConnection() {
-        return new ReservedStreamingHttpConnectionToReservedHttpConnection(this, influencer);
-    }
-
-    @Override
-    public ReservedBlockingStreamingHttpConnection asBlockingStreamingConnection() {
-        return new ReservedStreamingHttpConnectionToBlockingStreaming(this, influencer);
-    }
-
-    @Override
-    public ReservedBlockingHttpConnection asBlockingConnection() {
-        return new ReservedStreamingHttpConnectionToReservedBlockingHttpConnection(this, influencer);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClient.java
@@ -40,6 +40,10 @@ public interface StreamingHttpClient extends FilterableStreamingHttpClient {
      */
     Single<ReservedStreamingHttpConnection> reserveConnection(HttpRequestMetaData metaData);
 
+    @Override
+    Single<ReservedStreamingHttpConnection> reserveConnection(HttpExecutionStrategy strategy,
+                                                              HttpRequestMetaData metaData);
+
     /**
      * Convert this {@link StreamingHttpClient} to the {@link HttpClient} API.
      * <p>

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilter.java
@@ -43,8 +43,8 @@ public class StreamingHttpClientFilter implements FilterableStreamingHttpClient 
     }
 
     @Override
-    public Single<ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
-                                                                     final HttpRequestMetaData metaData) {
+    public Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(
+            final HttpExecutionStrategy strategy, final HttpRequestMetaData metaData) {
         return delegate.reserveConnection(strategy, metaData).map(ClientFilterToReservedConnectionFilter::new);
     }
 
@@ -113,7 +113,7 @@ public class StreamingHttpClientFilter implements FilterableStreamingHttpClient 
     }
 
     private final class ClientFilterToReservedConnectionFilter extends ReservedStreamingHttpConnectionFilter {
-        ClientFilterToReservedConnectionFilter(final ReservedStreamingHttpConnection delegate) {
+        ClientFilterToReservedConnectionFilter(final FilterableReservedStreamingHttpConnection delegate) {
             super(delegate);
         }
 

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/SimpleHttpRequesterFilterTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/SimpleHttpRequesterFilterTest.java
@@ -76,9 +76,8 @@ public class SimpleHttpRequesterFilterTest extends AbstractHttpRequesterFilterTe
                 }
 
                 @Override
-                public Single<ReservedStreamingHttpConnection> reserveConnection(
-                        final HttpExecutionStrategy strategy,
-                        final HttpRequestMetaData metaData) {
+                public Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(
+                        final HttpExecutionStrategy strategy, final HttpRequestMetaData metaData) {
                     return delegate().reserveConnection(strategy, metaData).map(r ->
                             new ReservedStreamingHttpConnectionFilter(r) {
                                 @Override
@@ -156,9 +155,8 @@ public class SimpleHttpRequesterFilterTest extends AbstractHttpRequesterFilterTe
                 }
 
                 @Override
-                public Single<ReservedStreamingHttpConnection> reserveConnection(
-                        final HttpExecutionStrategy strategy,
-                        final HttpRequestMetaData metaData) {
+                public Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(
+                        final HttpExecutionStrategy strategy, final HttpRequestMetaData metaData) {
                     return delegate().reserveConnection(strategy, metaData)
                             .map(r -> new ReservedStreamingHttpConnectionFilter(r) {
                                 @Override
@@ -217,9 +215,8 @@ public class SimpleHttpRequesterFilterTest extends AbstractHttpRequesterFilterTe
                                                 final Publisher<Object> lbEvents) {
             return new StreamingHttpClientFilter(client) {
                 @Override
-                public Single<ReservedStreamingHttpConnection> reserveConnection(
-                        final HttpExecutionStrategy strategy,
-                        final HttpRequestMetaData metaData) {
+                public Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(
+                        final HttpExecutionStrategy strategy, final HttpRequestMetaData metaData) {
                     return delegate().reserveConnection(strategy, metaData)
                             .map(r -> new ReservedStreamingHttpConnectionFilter(r) {
                                 @Override

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpRequesterFilterTest.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpRequesterFilterTest.java
@@ -369,9 +369,8 @@ public abstract class AbstractHttpRequesterFilterTest {
                     }
 
                     @Override
-                    public Single<ReservedStreamingHttpConnection> reserveConnection(
-                            final HttpExecutionStrategy strategy,
-                            final HttpRequestMetaData metaData) {
+                    public Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(
+                            final HttpExecutionStrategy strategy, final HttpRequestMetaData metaData) {
                         return succeeded(newReservedConnection()).map(rc ->
                                 new ReservedStreamingHttpConnectionFilter(rc) {
                                     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -27,6 +27,7 @@ import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.SubscribableCompletable;
+import io.servicetalk.http.api.FilterableReservedStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpHeadersFactory;
@@ -34,7 +35,6 @@ import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.MultiAddressHttpClientBuilder;
 import io.servicetalk.http.api.MultiAddressHttpClientFilterFactory;
-import io.servicetalk.http.api.ReservedStreamingHttpConnection;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.SslConfigProvider;
 import io.servicetalk.http.api.StreamingHttpClient;
@@ -294,8 +294,8 @@ final class DefaultMultiAddressUrlHttpClientBuilder extends MultiAddressHttpClie
         }
 
         @Override
-        public Single<ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
-                                                                         final HttpRequestMetaData metaData) {
+        public Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(
+                final HttpExecutionStrategy strategy, final HttpRequestMetaData metaData) {
             return defer(() -> selectClient(metaData).reserveConnection(strategy, metaData).subscribeShareContext());
         }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -34,6 +34,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.DefaultHttpHeadersFactory;
 import io.servicetalk.http.api.EmptyHttpHeaders;
+import io.servicetalk.http.api.FilterableReservedStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpHeadersFactory;
@@ -142,8 +143,8 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
         }
 
         @Override
-        public Single<ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
-                                                                         final HttpRequestMetaData metaData) {
+        public Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(
+                final HttpExecutionStrategy strategy, final HttpRequestMetaData metaData) {
             return defer(() -> selectClient(metaData).reserveConnection(strategy, metaData).subscribeShareContext());
         }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RedirectingClientAndConnectionFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RedirectingClientAndConnectionFilterTest.java
@@ -21,13 +21,13 @@ import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.http.api.BlockingHttpRequester;
+import io.servicetalk.http.api.FilterableReservedStreamingHttpConnection;
 import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.api.HttpConnection;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpRequest;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpResponse;
-import io.servicetalk.http.api.ReservedStreamingHttpConnection;
 import io.servicetalk.http.api.ReservedStreamingHttpConnectionFilter;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
@@ -97,9 +97,8 @@ public final class RedirectingClientAndConnectionFilterTest {
                     StreamingHttpClient client = closeables.prepend(HttpClients.forSingleAddress(serverHostAndPort)
                             .appendClientFilter((clientFilter, __) -> new StreamingHttpClientFilter(clientFilter) {
                                 @Override
-                                public Single<ReservedStreamingHttpConnection> reserveConnection(
-                                        final HttpExecutionStrategy strategy,
-                                        final HttpRequestMetaData metaData) {
+                                public Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(
+                                        final HttpExecutionStrategy strategy, final HttpRequestMetaData metaData) {
                                     return delegate().reserveConnection(strategy, metaData).map(r ->
                                             new ReservedStreamingHttpConnectionFilter(closeables.prepend(r)) {
                                                 @Override

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilter.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.utils;
 
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.FilterableReservedStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpClient;
@@ -25,7 +26,6 @@ import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpExecutionStrategyInfluencer;
 import io.servicetalk.http.api.HttpHeaderNames;
 import io.servicetalk.http.api.HttpRequestMetaData;
-import io.servicetalk.http.api.ReservedStreamingHttpConnection;
 import io.servicetalk.http.api.ReservedStreamingHttpConnectionFilter;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
@@ -141,7 +141,7 @@ public final class RedirectingHttpRequesterFilter implements StreamingHttpClient
             }
 
             @Override
-            public Single<ReservedStreamingHttpConnection> reserveConnection(
+            public Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(
                     final HttpExecutionStrategy strategy,
                     final HttpRequestMetaData metaData) {
                 return delegate().reserveConnection(strategy, metaData)


### PR DESCRIPTION
__Motivation__

In the filters layers, we do not expose higher level APIs as there is a risk to use the wrong method during delegation.
Reserved connection is an exception to that rule.

__Modification__

Modify APIs to now return `FilterableReservedStreamingHttpConnection` instead.

__Result__

Consistent usage of filterable and non-filterable APIs.