### PR TITLE
Opt out of offload all for basic auth filter

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BasicAuthStrategyInfluencerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BasicAuthStrategyInfluencerTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.SingleSource.Subscriber;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.CompositeCloseable;
+import io.servicetalk.concurrent.api.DefaultThreadFactory;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpExecutionStrategyInfluencer;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpService;
+import io.servicetalk.http.utils.auth.BasicAuthHttpServiceFilter;
+import io.servicetalk.http.utils.auth.BasicAuthHttpServiceFilter.CredentialsVerifier;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.IoExecutor;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.netty.NettyIoExecutors;
+
+import org.hamcrest.Matcher;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
+import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
+import static io.servicetalk.concurrent.api.Completable.completed;
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpHeaderNames.AUTHORIZATION;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.util.Base64.getEncoder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BasicAuthStrategyInfluencerTest {
+    public static final String IO_EXECUTOR_NAME_PREFIX = "io-executor-";
+
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+
+    @Nullable
+    private OffloadCheckingService service;
+    @Nullable
+    private IoExecutor ioExecutor;
+    @Nullable
+    private ServerContext serverContext;
+    @Nullable
+    private BlockingHttpClient client;
+    @Mock
+    private CredentialsVerifier<String> credentialsVerifier;
+
+    @After
+    public void tearDown() throws Exception {
+        CompositeCloseable closeable = newCompositeCloseable();
+        if (client != null) {
+            client.close();
+        }
+        if (serverContext != null) {
+            closeable.append(serverContext);
+        }
+        if (ioExecutor != null) {
+            closeable.append(ioExecutor);
+        }
+        closeable.close();
+    }
+
+    @Test
+    public void defaultOffloads() throws Exception {
+        BlockingHttpClient client = setup(false);
+        assert service != null;
+        HttpResponse response = makeRequest(client);
+        assertThat("Unexpected response.", response.status().code(), is(200));
+        service.assertHandleOffload(not(startsWith(IO_EXECUTOR_NAME_PREFIX)));
+        service.assertRequestOffload(not(startsWith(IO_EXECUTOR_NAME_PREFIX)));
+        service.assertResponseOffload(not(startsWith(IO_EXECUTOR_NAME_PREFIX)));
+    }
+
+    @Test
+    public void noOffloadsInfluence() throws Exception {
+        BlockingHttpClient client = setup(true);
+        assert service != null;
+        HttpResponse response = makeRequest(client);
+        assertThat("Unexpected response.", response.status().code(), is(200));
+        service.assertHandleOffload(startsWith(IO_EXECUTOR_NAME_PREFIX));
+        service.assertRequestOffload(startsWith(IO_EXECUTOR_NAME_PREFIX));
+        service.assertResponseOffload(startsWith(IO_EXECUTOR_NAME_PREFIX));
+    }
+
+    private HttpResponse makeRequest(final BlockingHttpClient client) throws Exception {
+        return client.request(client.get("/").addHeader(AUTHORIZATION, "Basic " +
+                getEncoder().encodeToString("foo:bar".getBytes(ISO_8859_1))));
+    }
+
+    private BlockingHttpClient setup(boolean noOffloadsInfluence) throws Exception {
+        ioExecutor = NettyIoExecutors.createIoExecutor(new DefaultThreadFactory(IO_EXECUTOR_NAME_PREFIX));
+        HttpServerBuilder serverBuilder = HttpServers.forPort(0);
+        when(credentialsVerifier.apply(anyString(), anyString())).thenReturn(succeeded("success"));
+        when(credentialsVerifier.closeAsync()).thenReturn(completed());
+        when(credentialsVerifier.closeAsyncGracefully()).thenReturn(completed());
+        CredentialsVerifier<String> verifier = credentialsVerifier;
+        if (noOffloadsInfluence) {
+            verifier = new InfluencingVerifier(verifier, strategy -> strategy);
+            serverBuilder.executionStrategy(noOffloadsStrategy());
+        }
+        serverBuilder.appendServiceFilter(new BasicAuthHttpServiceFilter.Builder<>(verifier, "dummy")
+                .buildServer());
+        serverBuilder.ioExecutor(ioExecutor);
+        service = new OffloadCheckingService();
+        serverContext = serverBuilder.listenStreamingAndAwait(service);
+
+        SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
+                HttpClients.forSingleAddress(serverHostAndPort(serverContext));
+        this.client = clientBuilder.buildBlocking();
+        return this.client;
+    }
+
+    private static final class OffloadCheckingService implements StreamingHttpService, HttpExecutionStrategyInfluencer {
+
+        private enum OffloadPoint {
+            ServiceHandle,
+            RequestPayload,
+            Response
+        }
+
+        private final ConcurrentMap<OffloadPoint, Thread> invoker = new ConcurrentHashMap<>();
+
+        @Override
+        public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx, final StreamingHttpRequest request,
+                                                    final StreamingHttpResponseFactory responseFactory) {
+            invoker.put(OffloadPoint.ServiceHandle, Thread.currentThread());
+            return new Single<StreamingHttpResponse>() {
+                @Override
+                protected void handleSubscribe(final Subscriber<? super StreamingHttpResponse> subscriber) {
+                    invoker.put(OffloadPoint.Response, Thread.currentThread());
+                    subscriber.onSubscribe(IGNORE_CANCEL);
+                    subscriber.onSuccess(responseFactory.ok()
+                            .payloadBody(request.payloadBody()
+                                    .whenOnSubscribe(__ ->
+                                            invoker.put(OffloadPoint.RequestPayload, Thread.currentThread()))));
+                }
+            };
+        }
+
+        public void assertHandleOffload(Matcher<String> threadNameMatcher) {
+            assertThat("Unexpected thread invoked Service#handle",
+                    invoker.get(OffloadPoint.ServiceHandle).getName(), threadNameMatcher);
+        }
+
+        public void assertRequestOffload(Matcher<String> threadNameMatcher) {
+            assertThat("Unexpected thread invoked request payload",
+                    invoker.get(OffloadPoint.RequestPayload).getName(), threadNameMatcher);
+        }
+
+        public void assertResponseOffload(Matcher<String> threadNameMatcher) {
+            assertThat("Unexpected thread invoked response",
+                    invoker.get(OffloadPoint.Response).getName(), threadNameMatcher);
+        }
+
+        @Override
+        public HttpExecutionStrategy influenceStrategy(final HttpExecutionStrategy strategy) {
+            // Do not influence strategy to avoid influencing the results!
+            return strategy;
+        }
+    }
+
+    private static final class InfluencingVerifier
+            implements CredentialsVerifier<String>, HttpExecutionStrategyInfluencer {
+
+        private final CredentialsVerifier<String> delegate;
+        private final HttpExecutionStrategyInfluencer influencer;
+
+        InfluencingVerifier(final CredentialsVerifier<String> delegate,
+                            final HttpExecutionStrategyInfluencer influencer) {
+            this.delegate = delegate;
+            this.influencer = influencer;
+        }
+
+        @Override
+        public Single<String> apply(final String userId, final String password) {
+            return delegate.apply(userId, password);
+        }
+
+        @Override
+        public HttpExecutionStrategy influenceStrategy(final HttpExecutionStrategy strategy) {
+            return influencer.influenceStrategy(strategy);
+        }
+
+        @Override
+        public Completable closeAsync() {
+            return delegate.closeAsync();
+        }
+    }
+}


### PR DESCRIPTION
__Motivation__

`BasicAuthHttpServiceFilter` does not opt-out of offload-all default mode for filters.
We should provide a way to opt-out of this behavior.

__Modification__

Implement `HttpExecutionStrategyInfluencer` for the factory and delegate to `CredentialVerifier` if `CredentialVerifier` implements that interface.
Otherwise, offload all as we do not know if `CredentialVerifier` blocks or not.

__Result__

A way to opt out of offload-all for basic auth users.