### PR TITLE
Ignore `.shelf/` folder generated by IntelliJ IDEA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-annotations/.gitignore
+++ b/servicetalk-annotations/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-benchmarks/.gitignore
+++ b/servicetalk-benchmarks/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-bom-internal/.gitignore
+++ b/servicetalk-bom-internal/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 /fileTemplates/
 
 # gradle

--- a/servicetalk-bom/.gitignore
+++ b/servicetalk-bom/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 /fileTemplates/
 
 # gradle

--- a/servicetalk-buffer-api/.gitignore
+++ b/servicetalk-buffer-api/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-buffer-netty/.gitignore
+++ b/servicetalk-buffer-netty/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-client-api-internal/.gitignore
+++ b/servicetalk-client-api-internal/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-client-api/.gitignore
+++ b/servicetalk-client-api/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-concurrent-api-internal/.gitignore
+++ b/servicetalk-concurrent-api-internal/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-concurrent-api/.gitignore
+++ b/servicetalk-concurrent-api/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-concurrent-internal/.gitignore
+++ b/servicetalk-concurrent-internal/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-concurrent-reactivestreams/.gitignore
+++ b/servicetalk-concurrent-reactivestreams/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-concurrent/.gitignore
+++ b/servicetalk-concurrent/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-data-jackson-jersey/.gitignore
+++ b/servicetalk-data-jackson-jersey/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-data-jackson/.gitignore
+++ b/servicetalk-data-jackson/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-dns-discovery-netty/.gitignore
+++ b/servicetalk-dns-discovery-netty/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-examples/.gitignore
+++ b/servicetalk-examples/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-gradle-plugin-internal/.gitignore
+++ b/servicetalk-gradle-plugin-internal/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-http-api/.gitignore
+++ b/servicetalk-http-api/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-http-netty/.gitignore
+++ b/servicetalk-http-netty/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-http-router-jersey-internal/.gitignore
+++ b/servicetalk-http-router-jersey-internal/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-http-router-jersey/.gitignore
+++ b/servicetalk-http-router-jersey/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-http-router-predicate/.gitignore
+++ b/servicetalk-http-router-predicate/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-http-utils/.gitignore
+++ b/servicetalk-http-utils/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-loadbalancer/.gitignore
+++ b/servicetalk-loadbalancer/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-log4j2-mdc-utils/.gitignore
+++ b/servicetalk-log4j2-mdc-utils/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-log4j2-mdc/.gitignore
+++ b/servicetalk-log4j2-mdc/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-oio-api/.gitignore
+++ b/servicetalk-oio-api/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-opentracing-asynccontext/.gitignore
+++ b/servicetalk-opentracing-asynccontext/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-opentracing-http/.gitignore
+++ b/servicetalk-opentracing-http/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-opentracing-inmemory-api/.gitignore
+++ b/servicetalk-opentracing-inmemory-api/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-opentracing-inmemory/.gitignore
+++ b/servicetalk-opentracing-inmemory/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-opentracing-internal/.gitignore
+++ b/servicetalk-opentracing-internal/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-opentracing-log4j2/.gitignore
+++ b/servicetalk-opentracing-log4j2/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-opentracing-zipkin-publisher/.gitignore
+++ b/servicetalk-opentracing-zipkin-publisher/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-redis-api/.gitignore
+++ b/servicetalk-redis-api/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-redis-internal/.gitignore
+++ b/servicetalk-redis-internal/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-redis-netty/.gitignore
+++ b/servicetalk-redis-netty/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-redis-utils/.gitignore
+++ b/servicetalk-redis-utils/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-serialization-api/.gitignore
+++ b/servicetalk-serialization-api/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-tcp-netty-internal/.gitignore
+++ b/servicetalk-tcp-netty-internal/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-test-resources/.gitignore
+++ b/servicetalk-test-resources/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-transport-api/.gitignore
+++ b/servicetalk-transport-api/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-transport-netty-internal/.gitignore
+++ b/servicetalk-transport-netty-internal/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/

--- a/servicetalk-transport-netty/.gitignore
+++ b/servicetalk-transport-netty/.gitignore
@@ -7,6 +7,7 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /out/
+/.shelf/
 
 # gradle
 /.gradle/


### PR DESCRIPTION
Motivation:

IntelliJ IDEA may generate a local folder `.shelf/` for version control.
For more information, see
https://www.jetbrains.com/help/idea/shelving-and-unshelving-changes.html

Modifications:

Add `.shelf/` folder to all `.gitignore` files;

Result:

`.shelf/` folder is ignored by git.