### PR TITLE
Remove unnecessary delegation in (Single|Completable)ToFutureTest

### DIFF
--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToFutureTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToFutureTest.java
@@ -15,8 +15,6 @@
  */
 package io.servicetalk.concurrent.api.completable;
 
-import io.servicetalk.concurrent.Cancellable;
-import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.api.AbstractToFutureTest;
 import io.servicetalk.concurrent.api.TestCompletable;
 
@@ -26,22 +24,7 @@ public class CompletableToFutureTest extends AbstractToFutureTest<Void> {
 
     private final TestCompletable source = new TestCompletable.Builder().build(subscriber -> {
         subscriber.onSubscribe(mockCancellable);
-        return new CompletableSource.Subscriber() {
-            @Override
-            public void onSubscribe(final Cancellable cancellable) {
-                subscriber.onSubscribe(cancellable);
-            }
-
-            @Override
-            public void onComplete() {
-                subscriber.onComplete();
-            }
-
-            @Override
-            public void onError(final Throwable t) {
-                subscriber.onError(t);
-            }
-        };
+        return subscriber;
     });
 
     @Override

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToFutureTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToFutureTest.java
@@ -15,15 +15,12 @@
  */
 package io.servicetalk.concurrent.api.single;
 
-import io.servicetalk.concurrent.Cancellable;
-import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.AbstractToFutureTest;
 import io.servicetalk.concurrent.api.TestSingle;
 
 import org.junit.Test;
 
 import java.util.concurrent.Future;
-import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -35,22 +32,7 @@ public class SingleToFutureTest extends AbstractToFutureTest<Integer> {
 
     private final TestSingle<Integer> source = new TestSingle.Builder<Integer>().build(subscriber -> {
         subscriber.onSubscribe(mockCancellable);
-        return new SingleSource.Subscriber<Integer>() {
-            @Override
-            public void onSubscribe(final Cancellable cancellable) {
-                subscriber.onSubscribe(cancellable);
-            }
-
-            @Override
-            public void onSuccess(@Nullable final Integer result) {
-                subscriber.onSuccess(result);
-            }
-
-            @Override
-            public void onError(final Throwable t) {
-                subscriber.onError(t);
-            }
-        };
+        return subscriber;
     });
 
     @Override


### PR DESCRIPTION
Motivation:

`SingleToFutureTest` and `CompletableToFutureTest` unnecessary create a
delegating wrapper for `Subscriber`.

Modifications:

- Return original `Subscriber` instead of wrapping it with delegating
one in `SingleToFutureTest` and `CompletableToFutureTest`;

Result:

Less code in tests.