### PR TITLE
Reduce contention when Round Robin

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -99,8 +99,9 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends ListenableA
             newUpdater(RoundRobinLoadBalancer.class, "index");
 
     /**
-     * With a relatively small number of connections we can minimize connection creation under low to moderate
-     * concurrency, without sacrificing too much latency due to the cost of a CAS operation per selection attempt.
+     * With a relatively small number of connections we can minimize connection creation under moderate concurrency by
+     * exhausting the full search space without sacrificing too much latency caused by the cost of a CAS operation per
+     * selection attempt.
      */
     private static final int MIN_SEARCH_SPACE = 64;
 


### PR DESCRIPTION
__Motivation__

When the number of addresses is small and connections per address is large, the current RRLB implementation keeps attempting to select from the front of the queue. This results in many needlessly failing CAS operations before finding the available connection. This problem is amplified as the number of connections increases and starts to consume considerable CPU time above 100 connections.

__Modifications__

Change RRLB to leverage a Copy On Write, datastructure to allow for a stable randomly accessible set when selecting connections. The algorithm uses random selection in a snapshot of the set to find an available connection up to a configurable number of attempts, defined by the search factor.
Overloaded constructor to allow users to define the search factor, which allows trading off latency for connection count.

__Result__

Lower CPU overhead while selection connections, much higher throughput overall at similar tail latencies.