### PR TITLE
RedisRequesterUtils may allocate more memory than necessary

### DIFF
--- a/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisRequesterUtils.java
+++ b/servicetalk-redis-api/src/main/java/io/servicetalk/redis/api/RedisRequesterUtils.java
@@ -91,10 +91,8 @@ final class RedisRequesterUtils {
                         if (aggregator == null) {
                             aggregator = redisData.bufferValue();
                             if (!(redisData instanceof LastBulkStringChunk)) {
-                                assert redisData instanceof FirstBulkStringChunk;
-                                // FirstBulkStringChunk includes the number of bytes we expect to read, so proactively
-                                // ensure the buffer is large enough to accumulate all the data.
-                                final int expectedBytes = ((FirstBulkStringChunk) redisData).bulkStringLength();
+                                // Proactively ensure the buffer is large enough to accumulate all the data
+                                final int expectedBytes = calculateExpectedBytes(redisData);
                                 if (!aggregator.tryEnsureWritable(expectedBytes, true)) {
                                     aggregator = requester.executionContext().bufferAllocator().newBuffer(
                                             expectedBytes + aggregator.readableBytes()).writeBytes(aggregator);
@@ -159,10 +157,8 @@ final class RedisRequesterUtils {
                         if (aggregator == null) {
                             aggregator = redisData.bufferValue();
                             if (!(redisData instanceof LastBulkStringChunk)) {
-                                assert redisData instanceof FirstBulkStringChunk;
-                                // FirstBulkStringChunk includes the number of bytes we expect to read, so proactively
-                                // ensure the buffer is large enough to accumulate all the data.
-                                final int expectedBytes = ((FirstBulkStringChunk) redisData).bulkStringLength();
+                                // Proactively ensure the buffer is large enough to accumulate all the data
+                                final int expectedBytes = calculateExpectedBytes(redisData);
                                 if (!aggregator.tryEnsureWritable(expectedBytes, true)) {
                                     aggregator = requester.executionContext().bufferAllocator().newBuffer(
                                             expectedBytes + aggregator.readableBytes()).writeBytes(aggregator);
@@ -291,10 +287,8 @@ final class RedisRequesterUtils {
                                         redisData.bufferValue());
                             } else {
                                 aggregator = redisData.bufferValue();
-                                assert redisData instanceof FirstBulkStringChunk;
-                                // FirstBulkStringChunk includes the number of bytes we expect to read, so proactively
-                                // ensure the buffer is large enough to accumulate all the data.
-                                final int expectedBytes = ((FirstBulkStringChunk) redisData).bulkStringLength();
+                                // Proactively ensure the buffer is large enough to accumulate all the data
+                                final int expectedBytes = calculateExpectedBytes(redisData);
                                 if (!aggregator.tryEnsureWritable(expectedBytes, true)) {
                                     aggregator = requester.executionContext().bufferAllocator().newBuffer(
                                             expectedBytes + aggregator.readableBytes()).writeBytes(aggregator);
@@ -411,5 +405,11 @@ final class RedisRequesterUtils {
             this.length = length;
             this.children = new ArrayList<>(length);
         }
+    }
+
+    private static int calculateExpectedBytes(RedisData redisData) {
+        // FirstBulkStringChunk includes the number of bytes we expect to read
+        assert redisData instanceof FirstBulkStringChunk;
+        return ((FirstBulkStringChunk) redisData).bulkStringLength() - redisData.bufferValue().readableBytes();
     }
 }


### PR DESCRIPTION
Motivation:

When we aggregate `BulkStringChunk`s in `RedisRequesterUtils` we are
making sure that `aggregator` will be able to aggregate all chunks.
However, when we calculate expected bytes for the next chunks we do not
subtract the number of bytes of the `FirstBulkStringChunk` we already
have written to this `aggregator`.

Modifications:

- Subtract the size of existing `Buffer` when calculating expected bytes
in `RedisRequesterUtils`;
- Move calculation logic to a separate method;

Result:

`RedisRequesterUtils` allocates only required number of bytes for the
aggregator.