### PR TITLE
Fix Checkstyle DTDs

### DIFF
--- a/servicetalk-benchmarks/gradle/checkstyle/suppressions.xml
+++ b/servicetalk-benchmarks/gradle/checkstyle/suppressions.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   -->
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
-    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
   <suppress checks="JavadocMethod" files=".*[\\/]src[\\/]jmh[\\/].*"/>

--- a/servicetalk-data-jackson-jersey/gradle/checkstyle/suppressions.xml
+++ b/servicetalk-data-jackson-jersey/gradle/checkstyle/suppressions.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   -->
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
-    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
   <!-- CheckStyle wrongly thinks a Junit TestSuite is a utility class -->

--- a/servicetalk-gradle-plugin-internal/src/main/resources/io/servicetalk/gradle/plugin/internal/checkstyle/checkstyle.xml
+++ b/servicetalk-gradle-plugin-internal/src/main/resources/io/servicetalk/gradle/plugin/internal/checkstyle/checkstyle.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   -->
 <!DOCTYPE module PUBLIC
-    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-    "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
   <property name="charset" value="UTF-8"/>

--- a/servicetalk-gradle-plugin-internal/src/main/resources/io/servicetalk/gradle/plugin/internal/checkstyle/global-suppressions.xml
+++ b/servicetalk-gradle-plugin-internal/src/main/resources/io/servicetalk/gradle/plugin/internal/checkstyle/global-suppressions.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   -->
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
-    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
   <!-- Ignore for all files except that one, which name ends with "package-info.java" -->

--- a/servicetalk-http-api/gradle/checkstyle/suppressions.xml
+++ b/servicetalk-http-api/gradle/checkstyle/suppressions.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   -->
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
-    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
   <suppress checks="ModifiedControlVariable" files="io/servicetalk/http/api/HttpUri.java"/>

--- a/servicetalk-http-netty/gradle/checkstyle/suppressions.xml
+++ b/servicetalk-http-netty/gradle/checkstyle/suppressions.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   -->
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
-    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
   <suppress checks="FallThrough" files="io/servicetalk/http/netty/HttpObjectDecoder.java"/>

--- a/servicetalk-http-router-jersey/gradle/checkstyle/suppressions.xml
+++ b/servicetalk-http-router-jersey/gradle/checkstyle/suppressions.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   -->
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
-    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
   <suppress checks="MissingSwitchDefault" files="io/servicetalk/http/router/jersey/ExecutionStrategyTest.java"/>

--- a/servicetalk-http-utils/gradle/checkstyle/suppressions.xml
+++ b/servicetalk-http-utils/gradle/checkstyle/suppressions.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   -->
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
-    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
   <!-- We use new String(byte[], Charset) to create a String from byte-array with specified charset -->

--- a/servicetalk-redis-api/gradle/checkstyle/suppressions.xml
+++ b/servicetalk-redis-api/gradle/checkstyle/suppressions.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   -->
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
-    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
   <suppress id="CopyrightHeader" files="io/servicetalk/redis/api/StringByteSizeUtil.java"/>

--- a/servicetalk-transport-netty-internal/gradle/checkstyle/suppressions.xml
+++ b/servicetalk-transport-netty-internal/gradle/checkstyle/suppressions.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   -->
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
-    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
   <!-- The list of test cases must be kept single-line each. -->


### PR DESCRIPTION
__Motivation__

Builds are breaking because we use the wrong Checkstyle DTDs.

Example:
```
Caused by: com.puppycrawl.tools.checkstyle.api.CheckstyleException: Unable to find: /workspace/gradle/checkstyle/suppressions.xml
       	at com.puppycrawl.tools.checkstyle.filters.SuppressionsLoader.getSuppressionLoader(SuppressionsLoader.java:264)
       	at com.puppycrawl.tools.checkstyle.filters.SuppressionsLoader.loadSuppressions(SuppressionsLoader.java:218)
       	at com.puppycrawl.tools.checkstyle.filters.SuppressionsLoader.loadSuppressions(SuppressionsLoader.java:205)
       	at com.puppycrawl.tools.checkstyle.filters.SuppressionFilter.finishLocalSetup(SuppressionFilter.java:102)
       	at com.puppycrawl.tools.checkstyle.api.AutomaticBean.configure(AutomaticBean.java:195)
       	at com.puppycrawl.tools.checkstyle.Checker.setupChild(Checker.java:459)
       	... 64 more
       Caused by: java.io.FileNotFoundException: http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd
```

__Modifications__

Use the correct DTDs:

- [configuration_1_3](https://github.com/checkstyle/checkstyle/blob/checkstyle-8.16/src/main/resources/com/puppycrawl/tools/checkstyle/configuration_1_3.dtd#L3-L6)
- [suppressions_1_2 ](https://github.com/checkstyle/checkstyle/blob/checkstyle-8.16/src/main/resources/com/puppycrawl/tools/checkstyle/suppressions_1_2.dtd)

__Results__

Working builds.
