### PR TITLE
Revert "Remove `-SNAPSHOT` suffix from all project versions"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-annotations/gradle.properties
+++ b/servicetalk-annotations/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-benchmarks/gradle.properties
+++ b/servicetalk-benchmarks/gradle.properties
@@ -15,6 +15,6 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT
 
 jmhVersion=1.21

--- a/servicetalk-bom-internal/gradle.properties
+++ b/servicetalk-bom-internal/gradle.properties
@@ -15,7 +15,7 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT
 
 nettyVersion=4.1.36.Final
 jsr305Version=3.0.2

--- a/servicetalk-bom/gradle.properties
+++ b/servicetalk-bom/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-buffer-api/gradle.properties
+++ b/servicetalk-buffer-api/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-buffer-netty/gradle.properties
+++ b/servicetalk-buffer-netty/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-client-api-internal/gradle.properties
+++ b/servicetalk-client-api-internal/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-client-api/gradle.properties
+++ b/servicetalk-client-api/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-concurrent-api-internal/gradle.properties
+++ b/servicetalk-concurrent-api-internal/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-concurrent-api/gradle.properties
+++ b/servicetalk-concurrent-api/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-concurrent-internal/gradle.properties
+++ b/servicetalk-concurrent-internal/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-concurrent-reactivestreams/gradle.properties
+++ b/servicetalk-concurrent-reactivestreams/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-concurrent/gradle.properties
+++ b/servicetalk-concurrent/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-data-jackson-jersey/gradle.properties
+++ b/servicetalk-data-jackson-jersey/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-data-jackson/gradle.properties
+++ b/servicetalk-data-jackson/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-dns-discovery-netty/gradle.properties
+++ b/servicetalk-dns-discovery-netty/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-examples/gradle.properties
+++ b/servicetalk-examples/gradle.properties
@@ -15,7 +15,7 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT
 
 jsr305Version=3.0.2
 log4jVersion=2.11.0

--- a/servicetalk-gradle-plugin-internal/gradle.properties
+++ b/servicetalk-gradle-plugin-internal/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-http-api/gradle.properties
+++ b/servicetalk-http-api/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-http-netty/gradle.properties
+++ b/servicetalk-http-netty/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-http-router-jersey-internal/gradle.properties
+++ b/servicetalk-http-router-jersey-internal/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-http-router-jersey/gradle.properties
+++ b/servicetalk-http-router-jersey/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-http-router-predicate/gradle.properties
+++ b/servicetalk-http-router-predicate/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-http-security-jersey/gradle.properties
+++ b/servicetalk-http-security-jersey/gradle.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-http-utils/gradle.properties
+++ b/servicetalk-http-utils/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-loadbalancer/gradle.properties
+++ b/servicetalk-loadbalancer/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-log4j2-mdc-utils/gradle.properties
+++ b/servicetalk-log4j2-mdc-utils/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-log4j2-mdc/gradle.properties
+++ b/servicetalk-log4j2-mdc/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-oio-api/gradle.properties
+++ b/servicetalk-oio-api/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-opentracing-asynccontext/gradle.properties
+++ b/servicetalk-opentracing-asynccontext/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-opentracing-http/gradle.properties
+++ b/servicetalk-opentracing-http/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-opentracing-inmemory-api/gradle.properties
+++ b/servicetalk-opentracing-inmemory-api/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-opentracing-inmemory/gradle.properties
+++ b/servicetalk-opentracing-inmemory/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-opentracing-internal/gradle.properties
+++ b/servicetalk-opentracing-internal/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-opentracing-log4j2/gradle.properties
+++ b/servicetalk-opentracing-log4j2/gradle.properties
@@ -15,6 +15,6 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT
 
 log4jVersion=2.11.0

--- a/servicetalk-opentracing-zipkin-publisher/gradle.properties
+++ b/servicetalk-opentracing-zipkin-publisher/gradle.properties
@@ -15,6 +15,6 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT
 
 zipkinVersion=2.11.1

--- a/servicetalk-serialization-api/gradle.properties
+++ b/servicetalk-serialization-api/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-tcp-netty-internal/gradle.properties
+++ b/servicetalk-tcp-netty-internal/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-test-resources/gradle.properties
+++ b/servicetalk-test-resources/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-transport-api/gradle.properties
+++ b/servicetalk-transport-api/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-transport-netty-internal/gradle.properties
+++ b/servicetalk-transport-netty-internal/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT

--- a/servicetalk-transport-netty/gradle.properties
+++ b/servicetalk-transport-netty/gradle.properties
@@ -15,4 +15,4 @@
 #
 
 group=io.servicetalk
-version=0.14.0
+version=0.14.0-SNAPSHOT


### PR DESCRIPTION
Motivation:

Without `-SNAPSHOT` suffix gradle can not build any module independently
and we can not use this repo as `--include-build` from another project.
We decided to revert it back and automate the release process in CI.

Modifications:

- This reverts commit 9825586c to add `-SNAPSHOT` suffix back;

Result:

All versions have `-SNAPSHOT` suffix.