### PR TITLE
Remove Publisher<Object> from StreamingHttpClientFilterFactory

### DIFF
--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/LoadBalancerReadyEvent.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/LoadBalancerReadyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.client.api;
+package io.servicetalk.client.api.internal;
+
+import io.servicetalk.client.api.LoadBalancer;
 
 import java.util.function.Function;
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientFilterFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientFilterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.client.api.GroupKey;
-import io.servicetalk.client.api.LoadBalancer;
-import io.servicetalk.concurrent.api.Publisher;
 
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -40,10 +38,9 @@ public interface MultiAddressHttpClientFilterFactory<U> {
      *
      * @param address the {@code UnresolvedAddress} for the {@link FilterableStreamingHttpClient}
      * @param client the {@link FilterableStreamingHttpClient} to filter
-     * @param lbEvents the {@link LoadBalancer} events stream
      * @return the filtered {@link FilterableStreamingHttpClient}
      */
-    StreamingHttpClientFilter create(U address, FilterableStreamingHttpClient client, Publisher<Object> lbEvents);
+    StreamingHttpClientFilter create(U address, FilterableStreamingHttpClient client);
 
     /**
      * Returns a composed function that first applies the {@code before} function to its input, and then applies
@@ -63,7 +60,7 @@ public interface MultiAddressHttpClientFilterFactory<U> {
      */
     default MultiAddressHttpClientFilterFactory<U> append(MultiAddressHttpClientFilterFactory<U> before) {
         requireNonNull(before);
-        return (group, client, lbEvents) -> create(group, before.create(group, client, lbEvents), lbEvents);
+        return (group, client) -> create(group, before.create(group, client));
     }
 
     /**
@@ -88,8 +85,7 @@ public interface MultiAddressHttpClientFilterFactory<U> {
      */
     static <U> MultiAddressHttpClientFilterFactory<U> from(
             BiFunction<U, FilterableStreamingHttpClient, StreamingHttpClientFilter> function) {
-        requireNonNull(function);
-        return (address, client, __) -> function.apply(address, client);
+        return function::apply;
     }
 
     /**
@@ -103,6 +99,6 @@ public interface MultiAddressHttpClientFilterFactory<U> {
     static <U> MultiAddressHttpClientFilterFactory<U> from(
             Function<FilterableStreamingHttpClient, StreamingHttpClientFilter> function) {
         requireNonNull(function);
-        return (__, client, ___) -> function.apply(client);
+        return (__, client) -> function.apply(client);
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StrategyInfluencerAwareConversions.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StrategyInfluencerAwareConversions.java
@@ -15,8 +15,6 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.concurrent.api.Publisher;
-
 import java.util.function.Predicate;
 
 import static java.util.Objects.requireNonNull;
@@ -39,13 +37,12 @@ final class StrategyInfluencerAwareConversions {
                 }
 
                 @Override
-                public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client,
-                                                        final Publisher<Object> lbEvents) {
-                    return original.create(address, client, lbEvents);
+                public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
+                    return original.create(address, client);
                 }
             };
         }
-        return (client, lbEvents) -> new StreamingHttpClientFilter(original.create(address, client, lbEvents));
+        return client -> new StreamingHttpClientFilter(original.create(address, client));
     }
 
     static <U> MultiAddressHttpClientFilterFactory<U> toMultiAddressClientFactory(
@@ -59,13 +56,12 @@ final class StrategyInfluencerAwareConversions {
                 }
 
                 @Override
-                public StreamingHttpClientFilter create(final U address, final FilterableStreamingHttpClient client,
-                                                        final Publisher<Object> lbEvents) {
-                    return new StreamingHttpClientFilter(original.create(client, lbEvents));
+                public StreamingHttpClientFilter create(final U address, final FilterableStreamingHttpClient client) {
+                    return new StreamingHttpClientFilter(original.create(client));
                 }
             };
         }
-        return (address, client, lbEvents) -> new StreamingHttpClientFilter(original.create(client, lbEvents));
+        return (address, client) -> new StreamingHttpClientFilter(original.create(client));
     }
 
     static StreamingHttpServiceFilterFactory toConditionalServiceFilterFactory(
@@ -126,14 +122,12 @@ final class StrategyInfluencerAwareConversions {
                 }
 
                 @Override
-                public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client,
-                                                        final Publisher<Object> lbEvents) {
-                    return new ConditionalHttpClientFilter(predicate, original.create(client, lbEvents), client);
+                public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
+                    return new ConditionalHttpClientFilter(predicate, original.create(client), client);
                 }
             };
         }
-        return (client, lbEvents) ->
-                new ConditionalHttpClientFilter(predicate, original.create(client, lbEvents), client);
+        return client -> new ConditionalHttpClientFilter(predicate, original.create(client), client);
     }
 
     static <U> MultiAddressHttpClientFilterFactory<U> toMultiAddressConditionalFilterFactory(
@@ -152,15 +146,13 @@ final class StrategyInfluencerAwareConversions {
 
                 @Override
                 public StreamingHttpClientFilter create(final U address,
-                                                        final FilterableStreamingHttpClient client,
-                                                        final Publisher<Object> lbEvents) {
-                    return new ConditionalHttpClientFilter(predicate,
-                            original.create(address, client, lbEvents), client);
+                                                        final FilterableStreamingHttpClient client) {
+                    return new ConditionalHttpClientFilter(predicate, original.create(address, client), client);
                 }
            };
         }
-        return (address, client, lbEvents) ->
-                new ConditionalHttpClientFilter(predicate, original.create(address, client, lbEvents), client);
+        return (address, client) ->
+                new ConditionalHttpClientFilter(predicate, original.create(address, client), client);
     }
 
     interface StrategyInfluencingStreamingServiceFilterFactory

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilterFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,6 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.client.api.LoadBalancer;
-import io.servicetalk.concurrent.api.Publisher;
-
 import static io.servicetalk.http.api.StrategyInfluencerAwareConversions.toMultiAddressClientFactory;
 import static java.util.Objects.requireNonNull;
 
@@ -31,10 +28,9 @@ public interface StreamingHttpClientFilterFactory {
      * Creates a {@link StreamingHttpClientFilter} using the provided {@link StreamingHttpClientFilter}.
      *
      * @param client {@link FilterableStreamingHttpClient} to filter
-     * @param lbEvents the {@link LoadBalancer} events stream
      * @return {@link StreamingHttpClientFilter} using the provided {@link StreamingHttpClientFilter}.
      */
-    StreamingHttpClientFilter create(FilterableStreamingHttpClient client, Publisher<Object> lbEvents);
+    StreamingHttpClientFilter create(FilterableStreamingHttpClient client);
 
     /**
      * Returns a composed function that first applies the {@code before} function to its input, and then applies
@@ -54,7 +50,7 @@ public interface StreamingHttpClientFilterFactory {
      */
     default StreamingHttpClientFilterFactory append(StreamingHttpClientFilterFactory before) {
         requireNonNull(before);
-        return (client, lbEvents) -> create(before.create(client, lbEvents), lbEvents);
+        return client -> create(before.create(client));
     }
 
     /**

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/ConditionalHttpClientFilterTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/ConditionalHttpClientFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +17,13 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
-import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class ConditionalHttpClientFilterTest extends AbstractConditionalHttpFilterTest {
 
-    private static final StreamingHttpClientFilterFactory REQ_FILTER = (client, __) ->
-            new StreamingHttpClientFilter(client) {
+    private static final StreamingHttpClientFilterFactory REQ_FILTER = client -> new StreamingHttpClientFilter(client) {
         @Override
         protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                         final HttpExecutionStrategy strategy,
@@ -42,9 +40,7 @@ public class ConditionalHttpClientFilterTest extends AbstractConditionalHttpFilt
         }
 
         @Override
-        public StreamingHttpClientFilter create(
-                final FilterableStreamingHttpClient client,
-                final Publisher<Object> lbEvents) {
+        public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
             return new ConditionalHttpClientFilter(TEST_REQ_PREDICATE, new StreamingHttpClientFilter(client) {
                 @Override
                 protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/SimpleHttpRequesterFilterTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/SimpleHttpRequesterFilterTest.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ConnectionContext;
 
@@ -65,8 +64,7 @@ public class SimpleHttpRequesterFilterTest extends AbstractHttpRequesterFilterTe
     private static final class HeaderEnrichingRequestFilter implements StreamingHttpClientFilterFactory,
                                                                        StreamingHttpConnectionFilterFactory {
         @Override
-        public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client,
-                                                final Publisher<Object> lbEvents) {
+        public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
             return new StreamingHttpClientFilter(client) {
                 @Override
                 protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
@@ -143,8 +141,7 @@ public class SimpleHttpRequesterFilterTest extends AbstractHttpRequesterFilterTe
         AtomicInteger requestCalls = new AtomicInteger();
 
         @Override
-        public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client,
-                                                final Publisher<Object> lbEvents) {
+        public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
             return new StreamingHttpClientFilter(client) {
 
                 @Override
@@ -211,8 +208,7 @@ public class SimpleHttpRequesterFilterTest extends AbstractHttpRequesterFilterTe
     private static final class SecurityEnforcingFilter implements StreamingHttpClientFilterFactory,
                                                                   StreamingHttpConnectionFilterFactory {
         @Override
-        public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client,
-                                                final Publisher<Object> lbEvents) {
+        public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
             return new StreamingHttpClientFilter(client) {
                 @Override
                 public Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpRequesterFilterTest.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpRequesterFilterTest.java
@@ -360,7 +360,7 @@ public abstract class AbstractHttpRequesterFilterTest {
 
     private <FF extends StreamingHttpClientFilterFactory & StreamingHttpConnectionFilterFactory> StreamingHttpClient
         newClient(final RequestHandler rh, final RequestWithContextHandler rwch, final FF filterFactory) {
-        StreamingHttpClientFilterFactory handlerFilter = (client, __) -> new StreamingHttpClientFilter(client) {
+        StreamingHttpClientFilterFactory handlerFilter = client -> new StreamingHttpClientFilter(client) {
 
                     @Override
                     protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpClient.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ public final class TestStreamingHttpClient {
                     public StreamingHttpRequest newRequest(final HttpRequestMethod method, final String requestTarget) {
                         return reqRespFactory.newRequest(method, requestTarget);
                     }
-                }, Publisher.empty());
+                });
         return from(filterChain);
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -66,7 +66,6 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.concurrent.api.AsyncCloseables.toListenableAsyncCloseable;
-import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.SslConfigProviders.plainByDefault;
@@ -122,7 +121,7 @@ final class DefaultMultiAddressUrlHttpClientBuilder extends MultiAddressHttpClie
 
             // Need to wrap the top level client (group) in order for non-relative redirects to work
             urlClient = maxRedirects <= 0 ? urlClient :
-                    new RedirectingHttpRequesterFilter(false, maxRedirects).create(urlClient, empty());
+                    new RedirectingHttpRequesterFilter(false, maxRedirects).create(urlClient);
 
             return new FilterableClientToClient(urlClient, buildContext.executionContext.executionStrategy(),
                     buildContext.builder.buildStrategyInfluencerForClient(

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
@@ -74,8 +73,7 @@ final class HostHeaderHttpRequesterFilter implements StreamingHttpClientFilterFa
     }
 
     @Override
-    public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client,
-                                            final Publisher<Object> lbEvents) {
+    public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
         return new StreamingHttpClientFilter(client) {
 
             @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancerReadySubscriber.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancerReadySubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.client.api.internal;
+package io.servicetalk.http.netty;
 
-import io.servicetalk.client.api.LoadBalancerReadyEvent;
+import io.servicetalk.client.api.internal.LoadBalancerReadyEvent;
 import io.servicetalk.concurrent.CompletableSource.Processor;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
@@ -31,7 +31,7 @@ import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
  * Designed to listen for {@link LoadBalancerReadyEvent}s and provide notification when a {@link LoadBalancerReadyEvent}
  * returns {@code true} from {@link LoadBalancerReadyEvent#isReady()}.
  */
-public final class LoadBalancerReadySubscriber implements Subscriber<Object> {
+final class LoadBalancerReadySubscriber implements Subscriber<Object> {
     @Nullable
     private volatile Processor onHostsAvailable = newCompletableProcessor();
 
@@ -42,7 +42,7 @@ public final class LoadBalancerReadySubscriber implements Subscriber<Object> {
      * from {@link LoadBalancerReadyEvent#isReady()}, or {@code null} if this event has already been seen and a
      * a {@link LoadBalancerReadyEvent} that returns {@code true} has not been seend.
      */
-    public Completable onHostsAvailable() {
+    Completable onHostsAvailable() {
         Processor onHostsAvailable = this.onHostsAvailable;
         return onHostsAvailable == null ? completed() : fromSource(onHostsAvailable);
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -563,7 +563,7 @@ public class ClientEffectiveStrategyTest {
                         }
                         if (addFilter) {
                             // Here since we do not override mergeForEffectiveStrategy, it will default to offload-all.
-                            clientBuilder.appendClientFilter((client, __) -> new StreamingHttpClientFilter(client) { });
+                            clientBuilder.appendClientFilter(client -> new StreamingHttpClientFilter(client) { });
                         }
                     });
         }
@@ -585,8 +585,7 @@ public class ClientEffectiveStrategyTest {
         }
 
         @Override
-        public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client,
-                                                final Publisher<Object> lbEvents) {
+        public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
             return new StreamingHttpClientFilter(client) {
 
                 @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ClientPriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ClientPriorKnowledgeFeatureParityTest.java
@@ -437,7 +437,7 @@ public class H2ClientPriorKnowledgeFeatureParityTest {
         final Queue<Throwable> errorQueue = new ConcurrentLinkedQueue<>();
         try (BlockingHttpClient client = forSingleAddress(HostAndPort.of(serverAddress))
                 .h2PriorKnowledge(h2PriorKnowledge).executionStrategy(clientExecutionStrategy)
-                .appendClientFilter((client2, lbEvents) -> new StreamingHttpClientFilter(client2) {
+                .appendClientFilter(client2 -> new StreamingHttpClientFilter(client2) {
                     @Override
                     protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                                     final HttpExecutionStrategy strategy,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientAsyncContextTest.java
@@ -86,8 +86,8 @@ public class HttpClientAsyncContextTest {
             final boolean useImmediate, final Queue<Throwable> errorQueue, final ServerContext serverContext) {
         SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> clientBuilder = HttpClients.forSingleAddress(
                 serverHostAndPort(serverContext))
-                .appendClientFilter((c, lbEvents) -> new TestStreamingHttpClientFilter(c, errorQueue))
-                .appendClientFilter((c, lbEvents) -> new TestStreamingHttpClientFilter(c, errorQueue));
+                .appendClientFilter(c -> new TestStreamingHttpClientFilter(c, errorQueue))
+                .appendClientFilter(c -> new TestStreamingHttpClientFilter(c, errorQueue));
         if (useImmediate) {
             clientBuilder.executionStrategy(HttpExecutionStrategies.noOffloadsStrategy());
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RedirectingClientAndConnectionFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RedirectingClientAndConnectionFilterTest.java
@@ -95,7 +95,7 @@ public final class RedirectingClientAndConnectionFilterTest {
                 CompositeCloseable closeables = AsyncCloseables.newCompositeCloseable();
                 try {
                     StreamingHttpClient client = closeables.prepend(HttpClients.forSingleAddress(serverHostAndPort)
-                            .appendClientFilter((clientFilter, __) -> new StreamingHttpClientFilter(clientFilter) {
+                            .appendClientFilter(clientFilter -> new StreamingHttpClientFilter(clientFilter) {
                                 @Override
                                 public Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(
                                         final HttpExecutionStrategy strategy, final HttpRequestMetaData metaData) {

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilter.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.http.utils;
 
-import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableReservedStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
@@ -128,8 +127,7 @@ public final class RedirectingHttpRequesterFilter implements StreamingHttpClient
     }
 
     @Override
-    public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client,
-                                            final Publisher<Object> lbEvents) {
+    public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
         return new StreamingHttpClientFilter(client) {
 
             @Override

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RetryingHttpRequesterFilter.java
@@ -68,8 +68,7 @@ public final class RetryingHttpRequesterFilter implements StreamingHttpClientFil
     }
 
     @Override
-    public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client,
-                                            final Publisher<Object> lbEvents) {
+    public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
         return new StreamingHttpClientFilter(client) {
 
             private final BiIntFunction<Throwable, Completable> retryStrategy =

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilter.java
@@ -16,7 +16,6 @@
 package io.servicetalk.http.utils;
 
 import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
@@ -74,9 +73,7 @@ public final class TimeoutHttpRequesterFilter implements StreamingHttpClientFilt
     }
 
     @Override
-    public StreamingHttpClientFilter create(
-            final FilterableStreamingHttpClient client,
-            final Publisher<Object> lbEvents) {
+    public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
         return new StreamingHttpClientFilter(client) {
             @Override
             protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,8 +110,7 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     private StreamingHttpClient newClient(StreamingHttpClientFilterFactory customFilter) {
-        StreamingHttpClientFilterFactory mockResponse = (client, __) ->
-                new StreamingHttpClientFilter(client) {
+        StreamingHttpClientFilterFactory mockResponse = client -> new StreamingHttpClientFilter(client) {
                     @Override
                     protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                                     final HttpExecutionStrategy strategy,

--- a/servicetalk-loadbalancer/build.gradle
+++ b/servicetalk-loadbalancer/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ dependencies {
   implementation "io.servicetalk:servicetalk-annotations:$project.version"
   implementation "io.servicetalk:servicetalk-concurrent-api-internal:$project.version"
   implementation "io.servicetalk:servicetalk-concurrent-internal:$project.version"
+  implementation "io.servicetalk:servicetalk-client-api-internal:$project.version"
   implementation "org.slf4j:slf4j-api"
 
   testImplementation "io.servicetalk:servicetalk-concurrent-api-testFixtures:$project.version"

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -47,8 +47,8 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.client.api.LoadBalancerReadyEvent.LOAD_BALANCER_NOT_READY_EVENT;
-import static io.servicetalk.client.api.LoadBalancerReadyEvent.LOAD_BALANCER_READY_EVENT;
+import static io.servicetalk.client.api.internal.LoadBalancerReadyEvent.LOAD_BALANCER_NOT_READY_EVENT;
+import static io.servicetalk.client.api.internal.LoadBalancerReadyEvent.LOAD_BALANCER_READY_EVENT;
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.concurrent.api.AsyncCloseables.toAsyncCloseable;
 import static io.servicetalk.concurrent.api.Completable.mergeAllDelayError;

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -17,9 +17,9 @@ package io.servicetalk.loadbalancer;
 
 import io.servicetalk.client.api.ConnectionFactory;
 import io.servicetalk.client.api.DefaultServiceDiscovererEvent;
-import io.servicetalk.client.api.LoadBalancerReadyEvent;
 import io.servicetalk.client.api.NoAvailableHostException;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.client.api.internal.LoadBalancerReadyEvent;
 import io.servicetalk.concurrent.CompletableSource.Processor;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilter.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.opentracing.http;
 
-import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
@@ -72,8 +71,7 @@ public class TracingHttpRequesterFilter extends AbstractTracingHttpFilter
     }
 
     @Override
-    public final StreamingHttpClientFilter create(final FilterableStreamingHttpClient client,
-                                                  final Publisher<Object> lbEvents) {
+    public final StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
         return new StreamingHttpClientFilter(client) {
             @Override
             protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,


### PR DESCRIPTION
Motivation:
StreamingHttpClientFilterFactory has an argument to of Publisher<Object> which
provides the “load balancer ready stream”. This argument is only used in a
single filter and assumes all load balancers will support this feature at
construction time. We can simplify the StreamingHttpClientFilterFactory by
removing the Publisher<Object> argument.

Modifications:
- Remove Publisher<Object> from StreamingHttpClientFilterFactory
- Remove Publisher<Object> from MultiAddressHttpClientFilterFactory
- Move LoadBalancerReadyStreamingHttpClientFilter from http.api to http.netty
and keep it package private.
- Move LoadBalancerReadyEvent from client.api to client.api.internal
- Move LoadBalancerReadySubscriber from client.api.internal to http.netty as
package private.

Result:
StreamingHttpClientFilterFactory APIs are simplified and less opinionated toward
our current implementation.