### PR TITLE
Fix build failure due to ResponseCheckingClientFilter and StreamingHt…

### DIFF
--- a/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/ResponseCheckingClientFilter.java
+++ b/servicetalk-examples/src/main/java/io/servicetalk/examples/http/service/composition/ResponseCheckingClientFilter.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.examples.http.service.composition;
 
-import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.HttpExecutionStrategy;
@@ -41,8 +40,7 @@ final class ResponseCheckingClientFilter implements StreamingHttpClientFilterFac
     }
 
     @Override
-    public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client,
-                                            final Publisher<Object> lbEvents) {
+    public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
         return new StreamingHttpClientFilter(client) {
             @Override
             protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,


### PR DESCRIPTION
…tpClientFilterFactory API change

Motivation:
The StreamingHttpClientFilterFactory API changed and removed the
Publisher<Object> argument. The ResponseCheckingClientFilter was added around
the same time this change was merged and was not updated, and therefore the
build is broken.

Modifications:
- Remove the Publisher<Object> argument from ResponseCheckingClientFilter

Result:
Build is functional.