### PR TITLE
Reset thread interrupt status when catching `InterruptedException`

### DIFF
--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FutureUtils.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FutureUtils.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import static io.servicetalk.concurrent.internal.PlatformDependent.throwException;
+import static java.lang.Thread.currentThread;
 
 /**
  * A set of utilities for interacting with {@link Future}.
@@ -50,6 +51,7 @@ public final class FutureUtils {
         try {
             return future.get();
         } catch (InterruptedException e) {
+            currentThread().interrupt(); // Reset the interrupted flag.
             throwException(e);
         } catch (ExecutionException e) {
             throwException(e.getCause());

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpDataSourceTranformations.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpDataSourceTranformations.java
@@ -48,6 +48,7 @@ import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateSubscription;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.System.nanoTime;
+import static java.lang.Thread.currentThread;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
@@ -455,7 +456,10 @@ final class HttpDataSourceTranformations {
                         final HttpHeaders trailersOut;
                         try {
                             trailersOut = trailersTrans.apply(userState, inTrailersFuture.get());
-                        } catch (InterruptedException | ExecutionException e) {
+                        } catch (InterruptedException e) {
+                            currentThread().interrupt(); // Reset the interrupted flag.
+                            throw new CompletionException(e);
+                        } catch (ExecutionException e) {
                             throw new CompletionException(e);
                         }
                         outTrailersSingle.onSuccess(trailersOut);
@@ -583,7 +587,10 @@ final class HttpDataSourceTranformations {
                         final HttpHeaders trailersOut;
                         try {
                             trailersOut = trailersTrans.apply(userState, inTrailersFuture.get());
-                        } catch (InterruptedException | ExecutionException e) {
+                        } catch (InterruptedException e) {
+                            currentThread().interrupt(); // Reset the interrupted flag.
+                            throw new CompletionException(e);
+                        } catch (ExecutionException e) {
                             throw new CompletionException(e);
                         }
                         outTrailersSingle.onSuccess(trailersOut);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/RequestResponseFactories.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/RequestResponseFactories.java
@@ -17,6 +17,8 @@ package io.servicetalk.http.api;
 
 import java.util.concurrent.ExecutionException;
 
+import static java.lang.Thread.currentThread;
+
 final class RequestResponseFactories {
 
     private RequestResponseFactories() {
@@ -123,7 +125,10 @@ final class RequestResponseFactories {
                                           HttpRequestMethod method, String requestTarget) {
         try {
             return requestFactory.newRequest(method, requestTarget).toRequest().toFuture().get();
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (InterruptedException e) {
+            currentThread().interrupt(); // Reset the interrupted flag.
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
             throw new RuntimeException(e);
         }
     }

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/ZipkinPublisher.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/ZipkinPublisher.java
@@ -47,6 +47,7 @@ import javax.annotation.Nullable;
 import static io.netty.channel.ChannelOption.RCVBUF_ALLOCATOR;
 import static io.servicetalk.transport.netty.internal.BuilderUtils.datagramChannel;
 import static io.servicetalk.transport.netty.internal.NettyIoExecutors.createEventLoopGroup;
+import static java.lang.Thread.currentThread;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -215,6 +216,7 @@ public final class ZipkinPublisher implements InMemorySpanEventListener, Closeab
             final Bootstrap bootstrap = transport.buildBootstrap(group, encoder, collectorAddress);
             channel = bootstrap.bind(0).sync().channel();
         } catch (InterruptedException e) {
+            currentThread().interrupt(); // Reset the interrupted flag.
             throw new IllegalStateException("Failed to create " + transport + " client");
         } catch (Exception e) {
             logger.warn("Failed to create {} client", transport, e);


### PR DESCRIPTION
__Motivation__

When an `InterruptedException` is thrown, the thread's interrupted status is reset.
If we are re-throwing and not handling interrupts, then we should set the status so that any subsequent blocking code can see the interrupt status.

__Modification__

Reset the interrupt status by calling `Thread.currentThread().interrupt();` where we are catching `InterruptedException`

__Result__

Better handling of interrupts.