### PR TITLE
Validate user supplied values in request/response

### DIFF
--- a/servicetalk-http-api/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-http-api/gradle/spotbugs/test-exclusions.xml
@@ -39,4 +39,9 @@
     <Method name="next"/>
     <Bug pattern="IT_NO_SUCH_ELEMENT"/>
   </Match>
+  <!-- Deliberately passing null to verify validations -->
+  <Match>
+    <Class name="io.servicetalk.http.api.InvalidMetadataValuesTest"/>
+    <Bug pattern="NP_NONNULL_PARAM_VIOLATION"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpCookiePair.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpCookiePair.java
@@ -18,7 +18,7 @@ package io.servicetalk.http.api;
 import static io.servicetalk.http.api.CharSequences.caseInsensitiveHashCode;
 import static io.servicetalk.http.api.CharSequences.contentEqualsIgnoreCase;
 import static io.servicetalk.http.api.CharSequences.indexOf;
-import static java.util.Objects.requireNonNull;
+import static io.servicetalk.http.api.HeaderUtils.validateCookieNameAndValue;
 
 /**
  * Default implementation of {@link HttpCookiePair}.
@@ -47,8 +47,9 @@ public final class DefaultHttpCookiePair implements HttpCookiePair {
      * <a href="https://tools.ietf.org/html/rfc6265#section-4.1.1">cookie-value</a>
      */
     public DefaultHttpCookiePair(final CharSequence cookieName, final CharSequence cookieValue, boolean isWrapped) {
-        this.name = requireNonNull(cookieName);
-        this.value = requireNonNull(cookieValue);
+        validateCookieNameAndValue(cookieName, cookieValue);
+        this.name = cookieName;
+        this.value = cookieValue;
         this.isWrapped = isWrapped;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
@@ -21,9 +21,9 @@ import javax.annotation.Nullable;
 import static io.servicetalk.http.api.CharSequences.caseInsensitiveHashCode;
 import static io.servicetalk.http.api.CharSequences.contentEqualsIgnoreCase;
 import static io.servicetalk.http.api.CharSequences.newAsciiString;
+import static io.servicetalk.http.api.HeaderUtils.validateCookieNameAndValue;
 import static io.servicetalk.http.api.HeaderUtils.validateCookieTokenAndHeaderName;
 import static java.lang.Long.parseLong;
-import static java.util.Objects.requireNonNull;
 
 /**
  * Default implementation of {@link HttpSetCookie}.
@@ -116,8 +116,9 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                                 @Nullable final CharSequence domain, @Nullable final CharSequence expires,
                                 @Nullable final Long maxAge, final boolean wrapped, final boolean secure,
                                 final boolean httpOnly) {
-        this.name = requireNonNull(name);
-        this.value = requireNonNull(value);
+        validateCookieNameAndValue(name, value);
+        this.name = name;
+        this.value = value;
         this.path = path;
         this.domain = domain;
         this.expires = expires;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -158,6 +158,15 @@ public final class HeaderUtils {
         }
     }
 
+    static void validateCookieNameAndValue(final CharSequence cookieName, final CharSequence cookieValue) {
+        if (cookieName == null || cookieName.length() == 0) {
+            throw new IllegalArgumentException("Null or empty cookie names are not allowed.");
+        }
+        if (cookieValue == null) {
+            throw new IllegalArgumentException("Null cookie values are not allowed.");
+        }
+    }
+
     /**
      * Validate {@code key} is valid <a href="https://tools.ietf.org/html/rfc6265#section-4.1.1">cookie-name</a>
      * (aka <a href="https://tools.ietf.org/html/rfc2616#section-2.2">token</a>) and a

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpQuery.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpQuery.java
@@ -70,6 +70,7 @@ final class HttpQuery implements Iterable<Map.Entry<String, String>> {
     }
 
     public HttpQuery add(final String key, final String value) {
+        validateQueryParam(key, value);
         if (getValues(key).add(value)) {
             updateQueryParams();
         }
@@ -97,6 +98,7 @@ final class HttpQuery implements Iterable<Map.Entry<String, String>> {
     }
 
     public HttpQuery set(final String key, final String value) {
+        validateQueryParam(key, value);
         final ArrayList<String> list = new ArrayList<>(DEFAULT_LIST_SIZE);
         final boolean changed = list.add(value);
         params.put(key, list);
@@ -179,6 +181,15 @@ final class HttpQuery implements Iterable<Map.Entry<String, String>> {
 
     private List<String> getValues(final String key) {
         return params.computeIfAbsent(key, k -> new ArrayList<>(DEFAULT_LIST_SIZE));
+    }
+
+    private void validateQueryParam(final String key, final String value) {
+        if (key == null || key.isEmpty()) {
+            throw new IllegalArgumentException("Null or empty query parameter names are not allowed.");
+        }
+        if (value == null) {
+            throw new IllegalArgumentException("Null query parameter values are not allowed.");
+        }
     }
 
     private static final class ValuesIterator implements Iterator<String> {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiMap.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiMap.java
@@ -694,6 +694,9 @@ abstract class MultiMap<K, V> {
         MultiMapEntry<K, V> bucketLastOrPrevious;
 
         MultiMapEntry(final V value, final int keyHash) {
+            if (value == null) {
+                throw new IllegalArgumentException("Null values are not allowed");
+            }
             this.value = value;
             this.keyHash = keyHash;
         }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/InvalidMetadataValuesTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/InvalidMetadataValuesTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.buffer.netty.BufferAllocators;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.HttpRequestMethod.GET;
+import static io.servicetalk.http.api.StreamingHttpRequests.newRequest;
+import static io.servicetalk.http.api.StreamingHttpResponses.newResponse;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assume.assumeThat;
+
+@SuppressWarnings("ConstantConditions")
+@RunWith(Parameterized.class)
+public class InvalidMetadataValuesTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private final HttpMetaData metaData;
+
+    public InvalidMetadataValuesTest(final HttpMetaData metaData, @SuppressWarnings("unused") String testName) {
+        this.metaData = metaData;
+    }
+
+    @Parameterized.Parameters(name = "{index}: source = {1}")
+    public static List<Object[]> data() throws ExecutionException, InterruptedException {
+        List<Object[]> params = new ArrayList<>();
+        params.add(new Object[]{newRequest(GET, "/", HTTP_1_1,
+                DefaultHttpHeadersFactory.INSTANCE.newHeaders(), BufferAllocators.DEFAULT_ALLOCATOR,
+                DefaultHttpHeadersFactory.INSTANCE), "streaming request"});
+        params.add(new Object[]{newResponse(HttpResponseStatus.OK, HTTP_1_1,
+                DefaultHttpHeadersFactory.INSTANCE.newHeaders(), BufferAllocators.DEFAULT_ALLOCATOR,
+                DefaultHttpHeadersFactory.INSTANCE), "streaming response"});
+        params.add(new Object[]{newRequest(GET, "/", HTTP_1_1,
+                DefaultHttpHeadersFactory.INSTANCE.newHeaders(), BufferAllocators.DEFAULT_ALLOCATOR,
+                DefaultHttpHeadersFactory.INSTANCE).toRequest().toFuture().get(), "request"});
+        params.add(new Object[]{newResponse(HttpResponseStatus.OK, HTTP_1_1,
+                DefaultHttpHeadersFactory.INSTANCE.newHeaders(), BufferAllocators.DEFAULT_ALLOCATOR,
+                DefaultHttpHeadersFactory.INSTANCE).toResponse().toFuture().get(), "response"});
+        params.add(new Object[]{newRequest(GET, "/", HTTP_1_1,
+                DefaultHttpHeadersFactory.INSTANCE.newHeaders(), BufferAllocators.DEFAULT_ALLOCATOR,
+                DefaultHttpHeadersFactory.INSTANCE).toBlockingStreamingRequest(), "blocking streaming request"});
+        params.add(new Object[]{newResponse(HttpResponseStatus.OK, HTTP_1_1,
+                DefaultHttpHeadersFactory.INSTANCE.newHeaders(), BufferAllocators.DEFAULT_ALLOCATOR,
+                DefaultHttpHeadersFactory.INSTANCE).toBlockingStreamingResponse(), "blocking streaming response"});
+        return params;
+    }
+
+    @Test
+    public void nullHeaderNameToAdd() {
+        expectedException.expect(IllegalArgumentException.class);
+        metaData.addHeader(null, "foo");
+    }
+
+    @Test
+    public void emptyHeaderNameToAdd() {
+        expectedException.expect(IllegalArgumentException.class);
+        metaData.addHeader("", "foo");
+    }
+
+    @Test
+    public void nullHeaderValueToAdd() {
+        expectedException.expect(IllegalArgumentException.class);
+        metaData.addHeader("foo", null);
+    }
+
+    @Test
+    public void nullHeaderNameToSet() {
+        expectedException.expect(IllegalArgumentException.class);
+        metaData.setHeader(null, "foo");
+    }
+
+    @Test
+    public void emptyHeaderNameToSet() {
+        expectedException.expect(IllegalArgumentException.class);
+        metaData.setHeader("", "foo");
+    }
+
+    @Test
+    public void nullHeaderValueToSet() {
+        expectedException.expect(IllegalArgumentException.class);
+        metaData.setHeader("foo", null);
+    }
+
+    @Test
+    public void nullQPNameToAdd() {
+        HttpRequestMetaData requestMeta = assumeRequestMeta();
+        expectedException.expect(IllegalArgumentException.class);
+        requestMeta.addQueryParameter(null, "foo");
+    }
+
+    @Test
+    public void emptyQPNameToAdd() {
+        HttpRequestMetaData requestMeta = assumeRequestMeta();
+        expectedException.expect(IllegalArgumentException.class);
+        requestMeta.addQueryParameter("", "foo");
+    }
+
+    @Test
+    public void nullQPValueToAdd() {
+        HttpRequestMetaData requestMeta = assumeRequestMeta();
+        expectedException.expect(IllegalArgumentException.class);
+        requestMeta.addQueryParameter("foo", null);
+    }
+
+    @Test
+    public void nullQPNameToSet() {
+        HttpRequestMetaData requestMeta = assumeRequestMeta();
+        expectedException.expect(IllegalArgumentException.class);
+        requestMeta.setQueryParameter(null, "");
+    }
+
+    @Test
+    public void emptyQPNameToSet() {
+        HttpRequestMetaData requestMeta = assumeRequestMeta();
+        expectedException.expect(IllegalArgumentException.class);
+        requestMeta.setQueryParameter("", "foo");
+    }
+
+    @Test
+    public void nullQPValueToSet() {
+        HttpRequestMetaData requestMeta = assumeRequestMeta();
+        expectedException.expect(IllegalArgumentException.class);
+        requestMeta.setQueryParameter("foo", null);
+    }
+
+    @Test
+    public void nullCookieName() {
+        expectedException.expect(IllegalArgumentException.class);
+        metaData.addCookie(null, "foo");
+    }
+
+    @Test
+    public void emptyCookieName() {
+        expectedException.expect(IllegalArgumentException.class);
+        metaData.addCookie("", "");
+    }
+
+    @Test
+    public void nullCookieValue() {
+        expectedException.expect(IllegalArgumentException.class);
+        metaData.addCookie("foo", null);
+    }
+
+    @Test
+    public void nullSetCookieName() {
+        expectedException.expect(IllegalArgumentException.class);
+        metaData.addSetCookie(null, "foo");
+    }
+
+    @Test
+    public void emptySetCookieName() {
+        expectedException.expect(IllegalArgumentException.class);
+        metaData.addSetCookie("", "");
+    }
+
+    @Test
+    public void nullSetCookieValue() {
+        expectedException.expect(IllegalArgumentException.class);
+        metaData.addSetCookie("foo", null);
+    }
+
+    private HttpRequestMetaData assumeRequestMeta() {
+        assumeThat("Test not applicable for response.", metaData, is(instanceOf(HttpRequestMetaData.class)));
+        return (HttpRequestMetaData) metaData;
+    }
+}

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilterTest.java
@@ -101,7 +101,9 @@ public class RedirectingHttpRequesterFilterTest {
                         : HttpResponseStatus.of(parseUnsignedInt(statusHeader.toString()), "");
                 StreamingHttpResponse response = reqRespFactory.newResponse(status);
                 CharSequence redirectLocation = request.headers().get(REQUESTED_LOCATION);
-                response.headers().set(LOCATION, redirectLocation);
+                if (redirectLocation != null) {
+                    response.headers().set(LOCATION, redirectLocation);
+                }
                 return succeeded(response);
             } catch (Throwable t) {
                 return failed(t);


### PR DESCRIPTION
__Motivation__

Invalid values like `null` passed as headers, cookies, query parameters must be validated. Failure to do so leads to hard to debug issues, eg: today if header value is `null` the client appears to hang as we throw an error from the HTTP encoder which gets unnoticed and nothing gets written to the channel (if there was no payload, trailers). This leads to hard to debug issues specifically if such invalid values are passed conditionally.

__Modification__

- Make sure we are validating such user input for metadata.
- Made the validations consistent (always throw `IllegalArgumentException`

__Result__

Better validations and early failures in presence of invalid values.