### PR TITLE
Implement [Completable, Single].concat(Publisher)

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CancellableThenSubscription.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CancellableThenSubscription.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.PublisherSource.Subscription;
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.internal.FlowControlUtil.addWithOverflowProtectionIfNotNegative;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
+import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
+
+/**
+ * An implementation of {@link Subscription} that starts as a {@link Cancellable} but then is replaced with an actual
+ * {@link Subscription}.
+ * It is assumed that the order of methods called on this class is as follows:
+ * <ul>
+ *     <li>{@link #setCancellable(Cancellable)} is always the first method that is called before any other method.</li>
+ *     <li>Zero or more calls to {@link #request(long)} or {@link #cancel()}</li>
+ *     <li>Exactly one call to {@link #setSubscription(Subscription)}</li>
+ * </ul>
+ */
+abstract class CancellableThenSubscription implements Subscription {
+
+    private static final Long AWAITING_SUBSCRIPTION_SET = 0L;
+    private static final Long INVALID_REQUEST_N = Long.MIN_VALUE;
+    private static final Cancellable CANCELLED = () -> { };
+    /**
+     * Can be the following:
+     * <ul>
+     *     <li>{@code null}: till {@link #setCancellable(Cancellable)} is called.</li>
+     *     <li>{@link Long} till {@link #setSubscription(Subscription)} is called.</li>
+     *     <li>{@link Subscription} after {@link #setSubscription(Subscription)} is called.</li>
+     *     <li>Stays at {@link CancellableThenSubscription#CANCELLED} after {@link #cancel()} is called.</li>
+     * </ul>
+     */
+    private static final AtomicReferenceFieldUpdater<CancellableThenSubscription, Object> stateUpdater =
+            newUpdater(CancellableThenSubscription.class, Object.class, "state");
+
+    @Nullable
+    private volatile Object state;
+    @Nullable
+    private Cancellable firstCancellable;
+
+    @Override
+    public void request(final long n) {
+        final Object currentState = state;
+        if (currentState == CANCELLED ||
+                // Pre-existing invalid request-n, should be sent as-is to the original Subscription
+                currentState instanceof Long && (long) currentState == INVALID_REQUEST_N) {
+            return;
+        }
+
+        final boolean shouldAdjustRequestNBy1 = shouldAdjustRequestNBy1();
+        final long adjustedN = isRequestNValid(n) ? shouldAdjustRequestNBy1 ? n - 1 : n : INVALID_REQUEST_N;
+
+        if (shouldAdjustRequestNBy1) {
+            emitAdjustedItemIfAvailable();
+            if (n == 1) {
+                // Only 1 item was requested and we emitted (or scheduled to emit) that item, nothing else is required
+                // to be done.
+                return;
+            }
+        }
+
+        for (;;) {
+            final Object s = state;
+            if (s instanceof Subscription) {
+                Subscription subscription = (Subscription) s;
+                subscription.request(adjustedN);
+                break;
+            } else if (s == null || s instanceof Long) {
+                if (isRequestNValid(n) && s != null) {
+                    if (stateUpdater.compareAndSet(this, s,
+                            addWithOverflowProtectionIfNotNegative((long) s, adjustedN))) {
+                        break;
+                    }
+                } else if (stateUpdater.compareAndSet(this, s, adjustedN)) {
+                    break;
+                }
+            }
+        }
+    }
+
+    boolean shouldAdjustRequestNBy1() {
+        return false; // Noop by default
+    }
+
+    void emitAdjustedItemIfAvailable() {
+        // Noop by default
+    }
+
+    @Override
+    public void cancel() {
+        Object oldState = stateUpdater.getAndSet(this, CANCELLED);
+        if (oldState instanceof Cancellable) {
+            ((Cancellable) oldState).cancel();
+        }
+        if (oldState == null || oldState instanceof Long) {
+            // according to the contract, setCancellable() should happen-before call to any other method.
+            assert firstCancellable != null;
+            firstCancellable.cancel();
+        }
+    }
+
+    void setCancellable(Cancellable cancellable) {
+        firstCancellable = cancellable;
+        if (state == CANCELLED) {
+            cancellable.cancel();
+        }
+    }
+
+    void setSubscription(Subscription subscription) {
+        for (;;) {
+            final Object s = state;
+            if (s instanceof Long) {
+                long toRequest = (long) s;
+                if (toRequest == AWAITING_SUBSCRIPTION_SET &&
+                        stateUpdater.compareAndSet(this, AWAITING_SUBSCRIPTION_SET, subscription)) {
+                    break;
+                }
+                if (stateUpdater.compareAndSet(this, s, AWAITING_SUBSCRIPTION_SET)) {
+                    subscription.request(toRequest);
+                    if (stateUpdater.compareAndSet(this, AWAITING_SUBSCRIPTION_SET, subscription)) {
+                        break;
+                    }
+                }
+            } else if (s == null && stateUpdater.compareAndSet(this, null, subscription)) {
+                break;
+            } else if (s == CANCELLED) {
+                subscription.cancel();
+                break;
+            }
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -366,7 +366,7 @@ public abstract class Completable {
      * {@link Completable} has terminated successfully.
      */
     public final <T> Publisher<T> concat(Publisher<? extends T> next) {
-        return this.<T>toPublisher().concat(next);
+        return new CompletableConcatWithPublisher<>(this, next, executor);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableConcatWithPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableConcatWithPublisher.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.CompletableSource;
+import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.internal.SignalOffloader;
+
+import javax.annotation.Nullable;
+
+final class CompletableConcatWithPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
+    private final Completable original;
+    private final Publisher<? extends T> next;
+
+    CompletableConcatWithPublisher(final Completable original, Publisher<? extends T> next, Executor executor) {
+        super(executor);
+        this.original = original;
+        this.next = next;
+    }
+
+    @Override
+    void handleSubscribe(final Subscriber<? super T> subscriber, final SignalOffloader signalOffloader,
+                         final AsyncContextMap contextMap, final AsyncContextProvider contextProvider) {
+        original.delegateSubscribe(new ConcatSubscriber<>(subscriber, next), signalOffloader, contextMap,
+                contextProvider);
+    }
+
+    private static final class ConcatSubscriber<T> extends CancellableThenSubscription
+            implements CompletableSource.Subscriber, PublisherSource.Subscriber<T> {
+
+        private final Subscriber<? super T> target;
+        private final Publisher<? extends T> next;
+        private boolean subscribedToPublisher;
+
+        ConcatSubscriber(final Subscriber<? super T> subscriber, final Publisher<? extends T> next) {
+            this.target = subscriber;
+            this.next = next;
+        }
+
+        @Override
+        public void onSubscribe(final Cancellable cancellable) {
+            setCancellable(cancellable);
+            target.onSubscribe(this);
+        }
+
+        @Override
+        public void onComplete() {
+            if (subscribedToPublisher) {
+                target.onComplete();
+            } else {
+                subscribedToPublisher = true;
+                next.subscribeInternal(this);
+            }
+        }
+
+        @Override
+        public void onSubscribe(final Subscription subscription) {
+            setSubscription(subscription);
+        }
+
+        @Override
+        public void onNext(@Nullable final T t) {
+            target.onNext(t);
+        }
+
+        @Override
+        public void onError(final Throwable t) {
+            target.onError(t);
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -444,7 +444,7 @@ public abstract class Single<T> {
      * all elements from {@code next} {@link Publisher}.
      */
     public final Publisher<T> concat(Publisher<? extends T> next) {
-        return toPublisher().concat(next);
+        return new SingleConcatWithPublisher<>(this, next, executor);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleConcatWithPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleConcatWithPublisher.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.concurrent.internal.SignalOffloader;
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import javax.annotation.Nullable;
+
+import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
+
+final class SingleConcatWithPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
+    private final Single<? extends T> original;
+    private final Publisher<? extends T> next;
+
+    SingleConcatWithPublisher(final Single<? extends T> original, Publisher<? extends T> next, Executor executor) {
+        super(executor);
+        this.original = original;
+        this.next = next;
+    }
+
+    @Override
+    void handleSubscribe(final Subscriber<? super T> subscriber, final SignalOffloader signalOffloader,
+                         final AsyncContextMap contextMap, final AsyncContextProvider contextProvider) {
+        original.delegateSubscribe(new ConcatSubscriber<>(subscriber, next), signalOffloader, contextMap,
+                contextProvider);
+    }
+
+    private static final class ConcatSubscriber<T> extends CancellableThenSubscription
+            implements SingleSource.Subscriber<T>, Subscriber<T> {
+        private static final Object INITIAL_VALUE = new Object();
+        private static final Object REQUESTED = new Object();
+        private static final AtomicReferenceFieldUpdater<ConcatSubscriber, Object> mayBeResultUpdater =
+                newUpdater(ConcatSubscriber.class, Object.class, "mayBeResult");
+
+        private final Subscriber<? super T> target;
+        private final Publisher<? extends T> next;
+
+        /**
+         * Following values are possible:
+         * <ul>
+         *     <li>{@link ConcatSubscriber#INITIAL_VALUE} upon creation</li>
+         *     <li>Actual result if {@link #onSuccess(Object)} invoked before {@link #emitAdjustedItemIfAvailable()}
+         *     </li>
+         *     <li>{@link ConcatSubscriber#REQUESTED} if {@link #emitAdjustedItemIfAvailable()} invoked before
+         *     {@link #onSuccess(Object)}</li>
+         * </ul>
+         */
+        @Nullable
+        private volatile Object mayBeResult = INITIAL_VALUE;
+        private boolean adjustedRequestNForSingle;
+
+        ConcatSubscriber(final Subscriber<? super T> subscriber, final Publisher<? extends T> next) {
+            this.target = subscriber;
+            this.next = next;
+        }
+
+        @Override
+        public void onSubscribe(final Cancellable cancellable) {
+            setCancellable(cancellable);
+            target.onSubscribe(this);
+        }
+
+        @Override
+        public void onSuccess(@Nullable final T result) {
+            Object oldValue = mayBeResultUpdater.getAndSet(this, result);
+            if (oldValue == REQUESTED) {
+                emitSingleSuccessToTarget(result);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            target.onComplete();
+        }
+
+        @Override
+        public void onSubscribe(final Subscription subscription) {
+            setSubscription(subscription);
+        }
+
+        @Override
+        public void onNext(@Nullable final T t) {
+            target.onNext(t);
+        }
+
+        @Override
+        public void onError(final Throwable t) {
+            target.onError(t);
+        }
+
+        @Override
+        boolean shouldAdjustRequestNBy1() {
+            if (adjustedRequestNForSingle) {
+                return false;
+            }
+            adjustedRequestNForSingle = true;
+            return true;
+        }
+
+        @Override
+        void emitAdjustedItemIfAvailable() {
+            Object oldVal = mayBeResultUpdater.getAndSet(this, REQUESTED);
+            if (oldVal != INITIAL_VALUE) {
+                @SuppressWarnings("unchecked")
+                T t = (T) oldVal;
+                emitSingleSuccessToTarget(t);
+            }
+        }
+
+        private void emitSingleSuccessToTarget(@Nullable final T result) {
+            target.onNext(result);
+            next.subscribeInternal(this);
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithPublisherTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api.completable;
+
+import io.servicetalk.concurrent.api.TestCancellable;
+import io.servicetalk.concurrent.api.TestCompletable;
+import io.servicetalk.concurrent.api.TestPublisher;
+import io.servicetalk.concurrent.api.TestPublisherSubscriber;
+import io.servicetalk.concurrent.api.TestSubscription;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TerminalNotification;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class CompletableConcatWithPublisherTest {
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+
+    private TestPublisherSubscriber<Integer> subscriber;
+    private TestCompletable source;
+    private TestPublisher<Integer> next;
+    private TestSubscription subscription;
+    private TestCancellable cancellable;
+
+    @Before
+    public void setUp() throws Exception {
+        subscriber = new TestPublisherSubscriber<>();
+        cancellable = new TestCancellable();
+        source = new TestCompletable.Builder().disableAutoOnSubscribe().build();
+        next = new TestPublisher.Builder<Integer>().disableAutoOnSubscribe().build();
+        subscription = new TestSubscription();
+        toSource(source.concat(next)).subscribe(subscriber);
+        source.onSubscribe(cancellable);
+        assertThat("Subscriber did not receive subscription.", subscriber.subscriptionReceived(), is(true));
+    }
+
+    @Test
+    public void bothCompletion() {
+        triggerNextSubscribe();
+        assertThat("Subscriber terminated unexpectedly.", subscriber.isTerminated(), is(false));
+        subscriber.request(1);
+        assertThat("Unexpected items requested.", subscription.requested(), is(1L));
+        next.onNext(1);
+        assertThat(subscriber.takeItems(), contains(1));
+        next.onComplete();
+        TerminalNotification terminal = subscriber.takeTerminal();
+        assertThat("Subscriber not terminated.", terminal, is(notNullValue()));
+        assertThat("Unexpected termination.", terminal.cause(), is(nullValue()));
+    }
+
+    @Test
+    public void sourceCompletionNextError() {
+        triggerNextSubscribe();
+        assertThat("Subscriber terminated unexpectedly.", subscriber.isTerminated(), is(false));
+        next.onError(DELIBERATE_EXCEPTION);
+        assertThat("Unexpected subscriber termination.", subscriber.takeError(), sameInstance(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    public void invalidRequestBeforeNextSubscribe() {
+        subscriber.request(-1);
+        triggerNextSubscribe();
+        assertThat("Invalid request-n not propagated.", subscription.requested(), is(lessThan(0L)));
+    }
+
+    @Test
+    public void invalidRequestAfterNextSubscribe() {
+        triggerNextSubscribe();
+        subscriber.request(-1);
+        assertThat("Invalid request-n not propagated.", subscription.requested(), is(lessThan(0L)));
+    }
+
+    @Test
+    public void multipleInvalidRequest() {
+        subscriber.request(-1);
+        triggerNextSubscribe();
+        subscriber.request(-10);
+        assertThat("Invalid request-n not propagated.", subscription.requested(), is(lessThan(0L)));
+    }
+
+    @Test
+    public void invalidThenValidRequest() {
+        subscriber.request(-1);
+        subscriber.request(10);
+        triggerNextSubscribe();
+        assertThat("Invalid request-n not propagated.", subscription.requested(), is(lessThan(0L)));
+    }
+
+    @Test
+    public void invalidThenValidRequestAcrossNext() {
+        subscriber.request(-1);
+        triggerNextSubscribe();
+        subscriber.request(10);
+        assertThat("Invalid request-n not propagated.", subscription.requested(), is(lessThan(0L)));
+    }
+
+    @Test
+    public void sourceError() {
+        source.onError(DELIBERATE_EXCEPTION);
+        assertThat("Unexpected subscriber termination.", subscriber.takeError(), sameInstance(DELIBERATE_EXCEPTION));
+        assertFalse("Next source subscribed unexpectedly.", next.isSubscribed());
+    }
+
+    @Test
+    public void cancelSource() {
+        assertThat("Subscriber terminated unexpectedly.", subscriber.isTerminated(), is(false));
+        subscriber.cancel();
+        assertTrue("Original completable not cancelled.", cancellable.isCancelled());
+        assertFalse("Next source subscribed unexpectedly.", next.isSubscribed());
+        triggerNextSubscribe();
+        assertTrue("Next source not cancelled.", subscription.isCancelled());
+    }
+
+    @Test
+    public void cancelSourcePostRequest() {
+        assertThat("Subscriber terminated unexpectedly.", subscriber.isTerminated(), is(false));
+        subscriber.request(1);
+        subscriber.cancel();
+        assertTrue("Original completable not cancelled.", cancellable.isCancelled());
+        assertFalse("Next source subscribed unexpectedly.", next.isSubscribed());
+    }
+
+    @Test
+    public void cancelNext() {
+        triggerNextSubscribe();
+        assertThat("Subscriber terminated unexpectedly.", subscriber.isTerminated(), is(false));
+        subscriber.cancel();
+        assertFalse("Original completable cancelled unexpectedly.", cancellable.isCancelled());
+        assertTrue("Next source not cancelled.", subscription.isCancelled());
+    }
+
+    private void triggerNextSubscribe() {
+        source.onComplete();
+        next.onSubscribe(subscription);
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api.single;
+
+import io.servicetalk.concurrent.api.TestCancellable;
+import io.servicetalk.concurrent.api.TestPublisher;
+import io.servicetalk.concurrent.api.TestPublisherSubscriber;
+import io.servicetalk.concurrent.api.TestSingle;
+import io.servicetalk.concurrent.api.TestSubscription;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TerminalNotification;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class SingleConcatWithPublisherTest {
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+
+    private TestPublisherSubscriber<Integer> subscriber;
+    private TestSingle<Integer> source;
+    private TestPublisher<Integer> next;
+    private TestSubscription subscription;
+    private TestCancellable cancellable;
+
+    @Before
+    public void setUp() throws Exception {
+        subscriber = new TestPublisherSubscriber.Builder<Integer>().disableDemandCheck().build();
+        cancellable = new TestCancellable();
+        source = new TestSingle.Builder<Integer>().disableAutoOnSubscribe().build();
+        next = new TestPublisher.Builder<Integer>().disableAutoOnSubscribe().build();
+        subscription = new TestSubscription();
+        toSource(source.concat(next)).subscribe(subscriber);
+        source.onSubscribe(cancellable);
+        assertThat("Subscriber did not receive subscription.", subscriber.subscriptionReceived(), is(true));
+    }
+
+    @Test
+    public void bothCompletion() {
+        triggerNextSubscribe();
+        assertThat("Subscriber terminated unexpectedly.", subscriber.isTerminated(), is(false));
+        subscriber.request(2);
+        assertThat("Unexpected items requested.", subscription.requested(), is(2L));
+        next.onNext(2);
+        assertThat(subscriber.takeItems(), contains(1, 2));
+        next.onComplete();
+        TerminalNotification terminal = subscriber.takeTerminal();
+        assertThat("Subscriber not terminated.", terminal, is(notNullValue()));
+        assertThat("Unexpected termination.", terminal.cause(), is(nullValue()));
+    }
+
+    @Test
+    public void sourceCompletionNextError() {
+        triggerNextSubscribe();
+        assertThat("Subscriber terminated unexpectedly.", subscriber.isTerminated(), is(false));
+        next.onError(DELIBERATE_EXCEPTION);
+        assertThat("Unexpected subscriber termination.", subscriber.takeError(), sameInstance(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    public void invalidRequestBeforeNextSubscribe() {
+        subscriber.request(-1);
+        triggerNextSubscribe();
+        assertThat("Invalid request-n not propagated.", subscription.requested(), is(lessThan(0L)));
+    }
+
+    @Test
+    public void invalidRequestAfterNextSubscribe() {
+        triggerNextSubscribe();
+        subscriber.request(-1);
+        assertThat("Invalid request-n not propagated.", subscription.requested(), is(lessThan(0L)));
+    }
+
+    @Test
+    public void multipleInvalidRequest() {
+        subscriber.request(-1);
+        triggerNextSubscribe();
+        subscriber.request(-10);
+        assertThat("Invalid request-n not propagated.", subscription.requested(), is(lessThan(0L)));
+    }
+
+    @Test
+    public void invalidThenValidRequest() {
+        subscriber.request(-1);
+        subscriber.request(10);
+        triggerNextSubscribe();
+        assertThat("Invalid request-n not propagated.", subscription.requested(), is(lessThan(0L)));
+    }
+
+    @Test
+    public void invalidThenValidRequestAcrossNext() {
+        subscriber.request(-1);
+        triggerNextSubscribe();
+        subscriber.request(10);
+        assertThat("Invalid request-n not propagated.", subscription.requested(), is(lessThan(0L)));
+    }
+
+    @Test
+    public void sourceError() {
+        source.onError(DELIBERATE_EXCEPTION);
+        assertThat("Unexpected subscriber termination.", subscriber.takeError(), sameInstance(DELIBERATE_EXCEPTION));
+        assertFalse("Next source subscribed unexpectedly.", next.isSubscribed());
+    }
+
+    @Test
+    public void cancelSource() {
+        assertThat("Subscriber terminated unexpectedly.", subscriber.isTerminated(), is(false));
+        subscriber.cancel();
+        assertTrue("Original single not cancelled.", cancellable.isCancelled());
+        assertFalse("Next source subscribed unexpectedly.", next.isSubscribed());
+    }
+
+    @Test
+    public void cancelSourcePostRequest() {
+        assertThat("Subscriber terminated unexpectedly.", subscriber.isTerminated(), is(false));
+        subscriber.request(1);
+        subscriber.cancel();
+        assertTrue("Original single not cancelled.", cancellable.isCancelled());
+        assertFalse("Next source subscribed unexpectedly.", next.isSubscribed());
+    }
+
+    @Test
+    public void cancelNext() {
+        triggerNextSubscribe();
+        assertThat("Subscriber terminated unexpectedly.", subscriber.isTerminated(), is(false));
+        subscriber.cancel();
+        assertFalse("Original single cancelled unexpectedly.", cancellable.isCancelled());
+        assertTrue("Next source not cancelled.", subscription.isCancelled());
+    }
+
+    private void triggerNextSubscribe() {
+        subscriber.request(1);
+        source.onSuccess(1);
+        next.onSubscribe(subscription);
+    }
+}


### PR DESCRIPTION
__Motivation__

Currently these operators are implemented by converting the original source to `Publisher` which is costlier in terms of object allocation.

__Modification__

Implemented these operators from scratch.

__Result__

Less memory overhead when using these operators.