### PR TITLE
Correctly choose `ByteBufAllocator` for Netty transport

### DIFF
--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/BufferUtil.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/BufferUtil.java
@@ -27,14 +27,15 @@ import io.netty.buffer.Unpooled;
 import javax.annotation.Nullable;
 
 import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
+import static io.netty.util.internal.PlatformDependent.directBufferPreferred;
 
 /**
  * Internal utilities for {@link Buffer}s.
  */
 public final class BufferUtil {
 
-    public static final BufferAllocator PREFER_HEAP_ALLOCATOR = new ServiceTalkBufferAllocator(false);
-    public static final BufferAllocator PREFER_DIRECT_ALLOCATOR = new ServiceTalkBufferAllocator(true);
+    static final BufferAllocator PREFER_HEAP_ALLOCATOR = new ServiceTalkBufferAllocator(false);
+    static final BufferAllocator PREFER_DIRECT_ALLOCATOR = new ServiceTalkBufferAllocator(true);
 
     private BufferUtil() {
         // no instances
@@ -104,8 +105,8 @@ public final class BufferUtil {
      * @return the {@link ByteBufAllocator} to use.
      */
     public static ByteBufAllocator getByteBufAllocator(BufferAllocator allocator) {
-        return allocator instanceof ServiceTalkBufferAllocator ?
-                (ServiceTalkBufferAllocator) allocator : ByteBufAllocator.DEFAULT;
+        return (ByteBufAllocator) (allocator instanceof ByteBufAllocator ? allocator :
+                directBufferPreferred() ? PREFER_DIRECT_ALLOCATOR : PREFER_HEAP_ALLOCATOR);
     }
 
     /**


### PR DESCRIPTION
Motivation:

Netty-based transport layer will choose `ByteBufAllocator` taking into
account `BufferAllocator`. Determination of `ByteBufAllocator` has two
issues:
1. It checks if `BufferAllocator` is an instance of a pkg-private
`ServiceTalkBufferAllocator`. It does not allow users to implement their
own `BufferAllocator` based on Netty's `ByteBufAllocator`.
2. It fallbacks to Netty's `ByteBufAllocator.DEFAULT` which in most
cases is `PooledByteBufAllocator` and will lead to memory leaks because
we do not expose reference counting API for `Buffer`s.

Modifications:

- Check if provided `BufferAllocator` is an instance of
`ByteBufAllocator`;
- Fallback to the appropriate version of `ServiceTalkBufferAllocator`
which doesn't depend on reference counting;
- Do not expose static allocators in `BufferUtil`, users should use
constant values from `BufferAllocators`;

Result:

1. Users can provide their own implementation of `BufferAllocator`.
2. Users won't have memory leaks if ST can not extract
`ByteBufAllocator` from provided `BufferAllocator`.