### PR TITLE
Remove self-closing p entity from Jersey router test fixtures Javadoc

### DIFF
--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractJerseyStreamingHttpServiceTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractJerseyStreamingHttpServiceTest.java
@@ -317,7 +317,7 @@ public abstract class AbstractJerseyStreamingHttpServiceTest {
 
     /**
      * Runs the provided {@code test} lambda multiple times.
-     * <p/>
+     * <p>
      * some tests depend on Endpoint enhancement which is now backed by a cache, so we test the test code multiple times
      * to ensure that the caching of endpoints doesn't cause any weird side-effects.
      * @param test {@link Runnable} test callback will be executed multiple times, typically this is run from a @{@link


### PR DESCRIPTION
__Motivation__

The build is broken on JDK8 because self closing HTML entities like `<p/>` are not allowed in Javadoc.

Note that the build only breaks for the `bintrayUpload` task, which triggers the generation of test fixtures Javadoc.