### PR TITLE
Fix race conditions in `AbstractToFutureTest`

### DIFF
--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractToFutureTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractToFutureTest.java
@@ -32,7 +32,9 @@ import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.concurrent.internal.PlatformDependent.throwException;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -76,43 +78,55 @@ public abstract class AbstractToFutureTest<T> {
         assertThat(future.isDone(), is(true));
         assertThat(future.get(), is(expectedResult()));
         assertThat(future.get(0, MILLISECONDS), is(expectedResult()));
+        assertThat(future.isCancelled(), is(false));
         verify(mockCancellable, never()).cancel();
     }
 
     @Test
     public void testSucceededAfterGet() throws Exception {
         Future<T> future = toFuture();
-        exec.executor().schedule(this::completeSource, 50, MILLISECONDS);
-        assertThat(future.isDone(), is(false));
+        exec.executor().schedule(this::completeSource, 10, MILLISECONDS);
         assertThat(future.get(), is(expectedResult()));
         assertThat(future.isDone(), is(true));
         assertThat(future.isCancelled(), is(false));
+        verify(mockCancellable, never()).cancel();
     }
 
     @Test
     public void testSucceededAfterGetWithTimeout() throws Exception {
         Future<T> future = toFuture();
-        exec.executor().schedule(this::completeSource, 50, MILLISECONDS);
-        assertThat(future.isDone(), is(false));
-        assertThat(future.get(100, MILLISECONDS), is(expectedResult()));
+        exec.executor().schedule(this::completeSource, 10, MILLISECONDS);
+        assertThat(future.get(3, SECONDS), is(expectedResult()));
         assertThat(future.isDone(), is(true));
         assertThat(future.isCancelled(), is(false));
+        verify(mockCancellable, never()).cancel();
     }
 
     @Test
     public void testSucceededAfterGetWithEnoughTimeout() throws Exception {
         Future<T> future = toFuture();
-        exec.executor().schedule(this::completeSource, 100, MILLISECONDS);
-        assertThat(future.isDone(), is(false));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        exec.executor().execute(() -> {
+            try {
+                latch.await();
+                completeSource();
+            } catch (InterruptedException e) {
+                throwException(e);
+            }
+        });
         try {
             future.get(50, MILLISECONDS);
             fail("Expected TimeoutException");
         } catch (Exception e) {
             assertThat(e, is(instanceOf(TimeoutException.class)));
+            assertThat(future.isDone(), is(false));
+            latch.countDown();
         }
-        assertThat(future.isDone(), is(false));
         assertThat(future.get(), is(expectedResult()));
         assertThat(future.isDone(), is(true));
+        assertThat(future.isCancelled(), is(false));
+        verify(mockCancellable, never()).cancel();
     }
 
     @Test
@@ -133,6 +147,7 @@ public abstract class AbstractToFutureTest<T> {
         } catch (ExecutionException e) {
             assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
         }
+        assertThat(future.isCancelled(), is(false));
         verify(mockCancellable, never()).cancel();
     }
 
@@ -146,8 +161,7 @@ public abstract class AbstractToFutureTest<T> {
     @Test
     public void testFailedAfterGet() throws Exception {
         Future<T> future = toFuture();
-        exec.executor().schedule(() -> failSource(DELIBERATE_EXCEPTION), 50, MILLISECONDS);
-        assertThat(future.isDone(), is(false));
+        exec.executor().schedule(() -> failSource(DELIBERATE_EXCEPTION), 10, MILLISECONDS);
         try {
             future.get();
             fail("Expected DeliberateException");
@@ -155,35 +169,30 @@ public abstract class AbstractToFutureTest<T> {
             assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
         }
         assertThat(future.isDone(), is(true));
+        assertThat(future.isCancelled(), is(false));
+        verify(mockCancellable, never()).cancel();
     }
 
     @Test
     public void testFailedAfterGetWithTimeout() throws Exception {
         Future<T> future = toFuture();
-        exec.executor().schedule(() -> failSource(DELIBERATE_EXCEPTION), 50, MILLISECONDS);
-        assertThat(future.isDone(), is(false));
+        exec.executor().schedule(() -> failSource(DELIBERATE_EXCEPTION), 10, MILLISECONDS);
         try {
-            future.get(100, MILLISECONDS);
+            future.get(3, SECONDS);
             fail("Expected DeliberateException");
         } catch (ExecutionException e) {
             assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
         }
         assertThat(future.isDone(), is(true));
+        assertThat(future.isCancelled(), is(false));
+        verify(mockCancellable, never()).cancel();
     }
 
     @Test(expected = TimeoutException.class)
     public void testGetTimeoutException() throws Exception {
         Future<T> future = toFuture();
         assertThat(future.isDone(), is(false));
-        assertThat(future.get(50, MILLISECONDS), is(expectedResult()));
-    }
-
-    @Test(expected = TimeoutException.class)
-    public void testGetWithZeroTimeoutException() throws Exception {
-        Future<T> future = toFuture();
-        assertThat(future.isDone(), is(false));
-        exec.executor().schedule(() -> failSource(DELIBERATE_EXCEPTION), 50, MILLISECONDS);
-        assertThat(future.get(0, MILLISECONDS), is(expectedResult()));
+        assertThat(future.get(10, MILLISECONDS), is(expectedResult()));
     }
 
     @Test
@@ -204,7 +213,6 @@ public abstract class AbstractToFutureTest<T> {
         task.subscribe();
 
         exec.executor().schedule(this::completeSource, 100, MILLISECONDS);
-        assertThat(future.isDone(), is(false));
         latch.await();
         assertThat(future.isDone(), is(true));
     }
@@ -293,6 +301,12 @@ public abstract class AbstractToFutureTest<T> {
         assertThat(future.cancel(true), is(true));
         assertThat(future.isCancelled(), is(true));
         assertThat(future.isDone(), is(true));
+        try {
+            future.get();
+            fail("Expected CancellationException");
+        } catch (Exception e) {
+            assertThat(e, is(instanceOf(CancellationException.class)));
+        }
         assertThat(future.cancel(true), is(false));
         assertThat(future.cancel(false), is(false));
         verify(mockCancellable).cancel();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToFutureTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToFutureTest.java
@@ -27,6 +27,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 public class SingleToFutureTest extends AbstractToFutureTest<Integer> {
 
@@ -63,21 +65,21 @@ public class SingleToFutureTest extends AbstractToFutureTest<Integer> {
     @Test
     public void testSucceededNull() throws Exception {
         Future<Integer> future = toFuture();
-        exec.executor().schedule(() -> source.onSuccess(null), 50, MILLISECONDS);
-        assertThat(future.isDone(), is(false));
+        exec.executor().schedule(() -> source.onSuccess(null), 10, MILLISECONDS);
         assertThat(future.get(), is(nullValue()));
         assertThat(future.isDone(), is(true));
         assertThat(future.isCancelled(), is(false));
+        verify(mockCancellable, never()).cancel();
     }
 
     @Test
     public void testSucceededThrowable() throws Exception {
         TestSingle<Throwable> throwableSingle = new TestSingle<>();
         Future<Throwable> future = throwableSingle.toFuture();
-        exec.executor().schedule(() -> throwableSingle.onSuccess(DELIBERATE_EXCEPTION), 50, MILLISECONDS);
-        assertThat(future.isDone(), is(false));
+        exec.executor().schedule(() -> throwableSingle.onSuccess(DELIBERATE_EXCEPTION), 10, MILLISECONDS);
         assertThat(future.get(), is(DELIBERATE_EXCEPTION));
         assertThat(future.isDone(), is(true));
         assertThat(future.isCancelled(), is(false));
+        verify(mockCancellable, never()).cancel();
     }
 }


### PR DESCRIPTION
Motivation:

`AbstractToFutureTest` has may have race condition in nosy environments
because some of the tests rely on correct scheduling and sequencing of
the code.

Modifications:

- Use `CountDownLatch` instead of relying on delays and timeouts;
- Reduce delays;

Result:

No flacky tests in `AbstractToFutureTest`.

Resolves #568.
Resolves #574.