### PR TITLE
Use correct timeunit for TCK tests

### DIFF
--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/AbstractTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/AbstractTckTest.java
@@ -19,6 +19,8 @@ import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
 
 import static io.servicetalk.concurrent.internal.ServiceTalkTestTimeout.DEFAULT_TIMEOUT_SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 abstract class AbstractTckTest<T> extends PublisherVerification<T> {
 
@@ -27,6 +29,6 @@ abstract class AbstractTckTest<T> extends PublisherVerification<T> {
     }
 
     private static TestEnvironment newTestEnvironment() {
-        return new TestEnvironment(DEFAULT_TIMEOUT_SECONDS);
+        return new TestEnvironment(MILLISECONDS.convert(DEFAULT_TIMEOUT_SECONDS, SECONDS));
     }
 }


### PR DESCRIPTION
__Motivation__

Recent changes to timeouts in https://github.com/servicetalk/servicetalk/pull/601 used the wrong timeunits 🤕

__Modification__

Converting timeout to millis before passing to the environment.

__Result__

Use correct timeout.