### PR TITLE
Do not create unresolved `InetSocketAddress` for resolved address clients

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -34,7 +34,6 @@ import java.net.InetSocketAddress;
 import java.util.function.Function;
 
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.forUnknownHostAndPort;
-import static java.net.InetSocketAddress.createUnresolved;
 
 /**
  * Factory methods for building {@link HttpClient} (and other API variations) instances.
@@ -138,7 +137,7 @@ public final class HttpClients {
     public static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forResolvedAddress(
             final HostAndPort address) {
         return DefaultSingleAddressHttpClientBuilder.forResolvedAddress(address,
-                createUnresolved(address.hostName(), address.port()));
+                new InetSocketAddress(address.hostName(), address.port()));
     }
 
     /**


### PR DESCRIPTION
__Motivation__

`HttpClients.forResolvedAddress()` methods create an `unresolvedAddress` if we are provided with an IP address.
With the recent changes of not doing any resolution while connection, makes it such that we can not use this method.

__Modification__

Use the regular `InetSocketAddress` constructor. If the address is actually resolved, it will not do the resolution, which is what we want.

__Result__

`HttpClients.forResolvedAddress()` is usable.