### PR TITLE
Remove patch version from docsite

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: servicetalk
 title: ServiceTalk
-version: 0.15.0-SNAPSHOT
+version: 0.15-SNAPSHOT
 nav:
   - modules/ROOT/nav.adoc

--- a/servicetalk-concurrent-api/docs/antora.yml
+++ b/servicetalk-concurrent-api/docs/antora.yml
@@ -1,5 +1,5 @@
 name: servicetalk-concurrent-api
 title: ServiceTalk Concurrent API
-version: 0.15.0-SNAPSHOT
+version: 0.15-SNAPSHOT
 nav:
   - modules/ROOT/nav.adoc

--- a/servicetalk-data-jackson-jersey/docs/antora.yml
+++ b/servicetalk-data-jackson-jersey/docs/antora.yml
@@ -1,5 +1,5 @@
 name: servicetalk-data-jackson-jersey
 title: ServiceTalk Data Jackson Jersey
-version: 0.15.0-SNAPSHOT
+version: 0.15-SNAPSHOT
 nav:
   - modules/ROOT/nav.adoc

--- a/servicetalk-examples/docs/antora.yml
+++ b/servicetalk-examples/docs/antora.yml
@@ -1,5 +1,5 @@
 name: servicetalk-examples
 title: Examples
-version: 0.15.0-SNAPSHOT
+version: 0.15-SNAPSHOT
 nav:
 - modules/ROOT/nav.adoc

--- a/servicetalk-http-api/docs/antora.yml
+++ b/servicetalk-http-api/docs/antora.yml
@@ -1,5 +1,5 @@
 name: servicetalk-http-api
 title: ServiceTalk HTTP API
-version: 0.15.0-SNAPSHOT
+version: 0.15-SNAPSHOT
 nav:
   - modules/ROOT/nav.adoc

--- a/servicetalk-http-router-jersey/docs/antora.yml
+++ b/servicetalk-http-router-jersey/docs/antora.yml
@@ -1,5 +1,5 @@
 name: servicetalk-http-router-jersey
 title: ServiceTalk HTTP Router - Jersey
-version: 0.15.0-SNAPSHOT
+version: 0.15-SNAPSHOT
 nav:
   - modules/ROOT/nav.adoc

--- a/servicetalk-http-security-jersey/docs/antora.yml
+++ b/servicetalk-http-security-jersey/docs/antora.yml
@@ -1,5 +1,5 @@
 name: servicetalk-http-security-jersey
 title: ServiceTalk HTTP Security - Jersey
-version: 0.15.0-SNAPSHOT
+version: 0.15-SNAPSHOT
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
Motivation:

Patch versions shouldn't need their own docs, so we should only publish
separate docs for major.minor versions.

Modifications:

Remove patch version from docsite module versions.

Results:

We publish docs for 0.15-SNAPSHOT now, not 0.15.0-SNAPSHOT.