### PR TITLE
Unify the way CI and release builds are detected

### DIFF
--- a/docs/generation/build.gradle
+++ b/docs/generation/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-  ext.isCiBuild = System.getenv("CI") != null
-  ext.isReleaseBuild = System.getProperty("releaseBuild") != null
+  ext.isCiBuild = "true" != System.getenv("CI")
+  ext.isReleaseBuild = project.hasProperty("releaseBuild")
 
   dependencies {
     classpath "org.jsoup:jsoup:$jsoupVersion"

--- a/docs/generation/gradle/buildSite.gradle
+++ b/docs/generation/gradle/buildSite.gradle
@@ -51,7 +51,7 @@ task buildRemoteSite(type: NodeTask) { task ->
   inputs.file("site-remote.yml")
   outputs.dir(outputDir)
 
-  if (System.getenv("CI") != null) {
+  if (project.ext.isCiBuild) {
     execOverrides {
       it.environment "GIT_CREDENTIALS": "https://${file(System.getProperty("antoraKeyPath")).text}:@github.com"
     }

--- a/servicetalk-concurrent-reactivestreams/build.gradle
+++ b/servicetalk-concurrent-reactivestreams/build.gradle
@@ -53,6 +53,6 @@ task tck(type: Test) {
 }
 
 //TODO: Depend unconditionally when this issue is resolved: https://github.com/servicetalk/servicetalk/issues/145
-if("true" != System.getenv("CI")) {
+if(!ext.isCiBuild) {
   test.dependsOn tck
 }

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
@@ -27,6 +27,13 @@ import org.gradle.api.tasks.javadoc.Javadoc
 
 class ProjectUtils {
 
+  static void addBuildContextExtensions(Project project) {
+    project.ext {
+      isCiBuild = "true" != System.getenv("CI")
+      isReleaseBuild = project.hasProperty("releaseBuild")
+    }
+  }
+
   static void addManifestAttributes(Project project, Manifest manifest) {
     manifest.attributes("Built-JDK": System.getProperty("java.version"),
         "Specification-Title": project.name,

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkCorePlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkCorePlugin.groovy
@@ -20,6 +20,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.MavenPublication
 
+import static io.servicetalk.gradle.plugin.internal.ProjectUtils.addBuildContextExtensions
+
 class ServiceTalkCorePlugin implements Plugin<Project> {
   void apply(Project project) {
     if (project.subprojects) {
@@ -32,6 +34,7 @@ class ServiceTalkCorePlugin implements Plugin<Project> {
   }
 
   private static void configureProject(Project project) {
+    addBuildContextExtensions project
     applyJavaPlugins project
     configureTests project
   }
@@ -64,9 +67,8 @@ class ServiceTalkCorePlugin implements Plugin<Project> {
         }
       }
 
-      def releaseBuild = project.hasProperty("releaseBuild")
       def endsWithSnapshot = project.version.toString().toUpperCase().endsWith("-SNAPSHOT")
-      if (releaseBuild) {
+      if (project.ext.isReleaseBuild) {
         if (endsWithSnapshot) {
           throw new GradleException("Project version for a release build must not contain a '-SNAPSHOT' suffix")
         }

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -288,8 +288,8 @@ class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
       // This task defaults to XML reporting for CI, but humans like HTML
       tasks.withType(SpotBugsTask) {
         reports {
-          xml.enabled = "true" == System.getenv("CI")
-          html.enabled = "true" != System.getenv("CI")
+          xml.enabled = project.ext.isCiBuild
+          html.enabled = !project.ext.isCiBuild
         }
       }
 


### PR DESCRIPTION
__Motivation__

Use a single approach to detect CI and release builds

__Modifications__

- Share the detected CI/release builds booleans in `ext` for the benefit of all projects built with the ST plugin
- Duplicate this logic in the doc build (it's not part of the composite so it doesn't sound wise to make it depend on the ST plugin).

__Results__

One single way of detecting CI and release builds.