### PR TITLE
Wire ancillary test fixtures tasks their main counterparts

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
@@ -55,7 +55,7 @@ class ProjectUtils {
     }
   }
 
-  static Jar createJavadocJarTask(Project project, SourceSet sourceSet) {
+  static Javadoc getOrCreateJavadocTask(Project project, SourceSet sourceSet) {
     def javadocTaskName = sourceSet.getTaskName(null, "javadoc")
     def javadocTask = project.tasks.findByName(javadocTaskName)
     if (!javadocTask) {
@@ -68,8 +68,15 @@ class ProjectUtils {
         conventionMapping.title = { "$project.name $project.version $sourceSet.name API" as String }
       }
     }
+    javadocTask
+  }
 
-    return createTask(project, sourceSet.getTaskName(null, "javadocJar"), Jar) {
+  static Jar createJavadocJarTask(Project project, SourceSet sourceSet) {
+    createJavadocJarTask(project, sourceSet, getOrCreateJavadocTask(project, sourceSet))
+  }
+
+  static Jar createJavadocJarTask(Project project, SourceSet sourceSet, Javadoc javadocTask) {
+    createTask(project, sourceSet.getTaskName(null, "javadocJar"), Jar) {
       description = "Assembles a Jar archive containing the $sourceSet.name Javadoc."
       group = JavaBasePlugin.DOCUMENTATION_GROUP
       appendix = sourceSet.name == "main" ? null : sourceSet.name

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -39,6 +39,7 @@ import static ProjectUtils.createJavadocJarTask
 import static ProjectUtils.createSourcesJarTask
 import static ProjectUtils.fixBomDependencies
 import static ProjectUtils.writeToFile
+import static io.servicetalk.gradle.plugin.internal.ProjectUtils.getOrCreateJavadocTask
 
 class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
   void apply(Project project) {
@@ -365,8 +366,12 @@ class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
         testRuntimeOnly project.configurations["testFixturesRuntime"]
       }
 
-      def sourcesJar = createSourcesJarTask(project, testFixturesSourceSet)
-      def javadocJar = createJavadocJarTask(project, testFixturesSourceSet)
+      def sourcesJarTask = createSourcesJarTask(project, testFixturesSourceSet)
+      project.tasks.findByName("jar").dependsOn(sourcesJarTask)
+      def javadocTask = getOrCreateJavadocTask(project, testFixturesSourceSet)
+      project.tasks.findByName("javadoc").dependsOn(javadocTask)
+      def javadocJarTask = createJavadocJarTask(project, testFixturesSourceSet)
+      project.tasks.findByName("jar").dependsOn(javadocJarTask)
 
       publishing {
         publications {
@@ -374,8 +379,8 @@ class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
             artifactId = "$testFixturesJar.baseName-$testFixturesJar.appendix"
             from new TestFixturesComponent(project)
             artifact(testFixturesJar)
-            artifact(sourcesJar)
-            artifact(javadocJar)
+            artifact(sourcesJarTask)
+            artifact(javadocJarTask)
             fixBomDependencies(pom)
           }
         }


### PR DESCRIPTION
__Motivation__

A recent issue [1] has shown that PRBs don't run the same commands as the snapshot/release builds, which can lead to passing PRB but a broken main builds.

It seems that the issue happens for tasks related to our custom handling of test fixtures. For example, in this particular issue, it is the `testFixturesJavadoc` Gradle task that is only run when the `bintrayUpload` task is called.

__Modifications__

Make:
- `javadoc` depend on `testFixturesJavadoc` 
- `jar` depend on `testFixturesJavadocJar` and `testFixturesSourcesJar`

__Results__

All tasks are run when `build` task is run.

[1] https://github.com/servicetalk/servicetalk/pull/594