### PR TITLE
Log plaintext of SSL connection on server side.

### DIFF
--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
@@ -36,19 +36,18 @@ public class TcpServerChannelInitializer implements ChannelInitializer {
      */
     public TcpServerChannelInitializer(ReadOnlyTcpServerConfig config) {
         ChannelInitializer delegate = ChannelInitializer.defaultInitializer();
-        if (config.wireLoggingInitializer() != null) {
-            delegate = delegate.andThen(config.wireLoggingInitializer());
-        }
         if (config.idleTimeoutMs() > 0) {
             delegate = delegate.andThen(new IdleTimeoutInitializer(config.idleTimeoutMs()));
         }
         if (config.sslContext() != null) {
-            this.delegate = delegate.andThen(new SslServerChannelInitializer(config.sslContext()));
+            delegate = delegate.andThen(new SslServerChannelInitializer(config.sslContext()));
         } else if (config.domainNameMapping() != null) {
-            this.delegate = delegate.andThen(new SslServerChannelInitializer(config.domainNameMapping()));
-        } else {
-            this.delegate = delegate;
+            delegate = delegate.andThen(new SslServerChannelInitializer(config.domainNameMapping()));
         }
+        if (config.wireLoggingInitializer() != null) {
+            delegate = delegate.andThen(config.wireLoggingInitializer());
+        }
+        this.delegate = delegate;
     }
 
     @Override


### PR DESCRIPTION
Motivation:

When enabling wire logging, users generally want to see protocol level
plaintext output, not the encrypted form. The client side already logs
this way, but the server side was logging the encrypted form.

Modification:

Add the wire logger at the end of the channel initialization, on the
server.

Results:

Wire logs show plaintext for both client and server.