### PR TITLE
Use an empty array for `toArray` conversion

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WrappingSslContext.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WrappingSslContext.java
@@ -28,7 +28,7 @@ final class WrappingSslContext extends DelegatingSslContext {
 
     WrappingSslContext(SslContext context, @Nullable List<String> protocols) {
         super(context);
-        this.protocols = protocols == null ? null : protocols.toArray(new String[protocols.size()]);
+        this.protocols = protocols == null ? null : protocols.toArray(new String[0]);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Using an empty array instead of pre-sized array for `toArray` conversion
allows us to utilize internal JVM optimizations (intrinsics and skip of
zeroing memory).

Modifications:

- Use `new String[0]` instead of `new String[size]` in
`WrappingSslContext`;

Result:

Less allocations, better performance of `WrappingSslContext` ctor,
consistency with other `toArray` invocations.