### PR TITLE
Ignore `out/` folder in all sub folders of `servicetalk-examples`

### DIFF
--- a/servicetalk-examples/.gitignore
+++ b/servicetalk-examples/.gitignore
@@ -6,7 +6,7 @@ hs_err_pid*
 *.iml
 /*.ipr
 /*.iws
-/out/
+**/out/
 /.shelf/
 
 # gradle


### PR DESCRIPTION
Motivation:

After restructuring `servicetalk-examples` project IntelliJ IDEA
generates a separate `out/` folder for each sub-project.

Modifications:

- Ignore `out/` folder in all sub folders of `servicetalk-examples`;

Result:

Ignore IntelliJ IDEA generated `out/` folder in all sub folders of
`servicetalk-examples`.