### PR TITLE
PublisherConcatWithSingle decouple requestN from state

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherConcatWithCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherConcatWithCompletable.java
@@ -60,7 +60,7 @@ final class PublisherConcatWithCompletable<T> extends AbstractAsynchronousPublis
 
         @Override
         public void onSubscribe(Subscription s) {
-            cancellableUpdater.getAndSet(this, s);
+            cancellable = s;
             target.onSubscribe(this);
         }
 
@@ -80,9 +80,8 @@ final class PublisherConcatWithCompletable<T> extends AbstractAsynchronousPublis
                 final Cancellable c = this.cancellable;
                 if (c == CANCELLED) {
                     cancellable.cancel();
-                    return;
-                }
-                if (cancellableUpdater.compareAndSet(this, c, cancellable)) {
+                    break;
+                } else if (cancellableUpdater.compareAndSet(this, c, cancellable)) {
                     break;
                 }
             }
@@ -100,9 +99,9 @@ final class PublisherConcatWithCompletable<T> extends AbstractAsynchronousPublis
 
         @Override
         public void request(final long n) {
-            Cancellable cancellable = cancellableUpdater.get(this);
-            if (cancellable instanceof Subscription) {
-                ((Subscription) cancellable).request(n);
+            Cancellable currCancellable = cancellable;
+            if (currCancellable instanceof Subscription) {
+                ((Subscription) currCancellable).request(n);
             }
         }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherConcatWithSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherConcatWithSingle.java
@@ -17,12 +17,15 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.SingleSource;
-import io.servicetalk.concurrent.internal.SubscriberUtils;
+import io.servicetalk.concurrent.internal.FlowControlUtil;
 
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.internal.FlowControlUtil.addWithOverflowProtection;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
+import static java.lang.Long.MIN_VALUE;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
@@ -50,27 +53,15 @@ final class PublisherConcatWithSingle<T> extends AbstractAsynchronousPublisherOp
         private static final Object TERMINATED = new Object();
         private static final AtomicReferenceFieldUpdater<ConcatSubscriber, Object> stateUpdater =
                 newUpdater(ConcatSubscriber.class, Object.class, "state");
+        private static final AtomicLongFieldUpdater<ConcatSubscriber> requestNUpdater =
+                AtomicLongFieldUpdater.newUpdater(ConcatSubscriber.class, "requestN");
         private final Subscriber<? super T> target;
         private final Single<? extends T> next;
         private boolean nextSubscribed;
 
         @Nullable
-        private Subscription subscription;
-
-        /**
-         * Can have the following values:
-         * <ul>
-         *     <li>{@code null} at creation.</li>
-         *     <li>{@link Long} representing pending requested items.</li>
-         *     <li>{@link ConcatSubscriber#CANCELLED} once {@link #cancel()} is called, after this state will never
-         *     change.</li>
-         *     <li>{@link Cancellable} once {@link #onSubscribe(Cancellable)} and {@link #cancel()} has not been
-         *     called.</li>
-         *     <li>{@code Result} of the next {@link Single} when available.</li>
-         * </ul>
-         */
-        @Nullable
         private volatile Object state;
+        private volatile long requestN;
 
         ConcatSubscriber(Subscriber<? super T> target, Single<? extends T> next) {
             this.target = target;
@@ -79,22 +70,13 @@ final class PublisherConcatWithSingle<T> extends AbstractAsynchronousPublisherOp
 
         @Override
         public void onSubscribe(Subscription s) {
-            subscription = s;
+            state = s;
             target.onSubscribe(this);
         }
 
         @Override
         public void onNext(T t) {
-            for (;;) {
-                final Object s = state;
-                if (s == CANCELLED) {
-                    return;
-                }
-                assert s instanceof Long;
-                if (stateUpdater.compareAndSet(this, s, ((long) s - 1))) {
-                    break;
-                }
-            }
+            requestNUpdater.decrementAndGet(this);
             target.onNext(t);
         }
 
@@ -109,11 +91,8 @@ final class PublisherConcatWithSingle<T> extends AbstractAsynchronousPublisherOp
                 final Object s = state;
                 if (s == CANCELLED) {
                     cancellable.cancel();
-                    return;
-                }
-                if (s instanceof Long && stateUpdater.compareAndSet(this, s,
-                        (long) s > 0 ? new CancellableWithOutstandingDemand(cancellable) : cancellable)
-                        || s == null && stateUpdater.compareAndSet(this, null, cancellable)) {
+                    break;
+                } else if (stateUpdater.compareAndSet(this, s, cancellable)) {
                     break;
                 }
             }
@@ -121,18 +100,32 @@ final class PublisherConcatWithSingle<T> extends AbstractAsynchronousPublisherOp
 
         @Override
         public void onSuccess(@Nullable final T result) {
+            // requestN may go negative as a result of this decrement. This is done to simplify underflow management
+            // and is compensated for below and in request(n).
+            long requestNBeforeDecrement = requestNUpdater.getAndDecrement(this);
             for (;;) {
                 final Object s = state;
                 if (s == CANCELLED || s == TERMINATED) {
-                    return;
-                }
-                if (s instanceof CancellableWithOutstandingDemand) {
+                    break;
+                } else if (requestNBeforeDecrement > 0) {
                     if (stateUpdater.compareAndSet(this, s, TERMINATED)) {
                         terminateTarget(result);
                         break;
                     }
-                } else if (stateUpdater.compareAndSet(this, s, new SingleResult<>(result))) {
-                    break;
+                } else if (requestNBeforeDecrement == 0) {
+                    if (stateUpdater.compareAndSet(this, s, new SingleResult<>(result))) {
+                        if (s instanceof CancellableWithOutstandingDemand) {
+                            // We have to re-check requestN here because it has changed.
+                            requestNBeforeDecrement = requestN;
+                            // CancellableWithOutstandingDemand means that requestN count has changed, it should not
+                            // be 0 any more. We rely upon this because otherwise we may infinite loop here.
+                            assert requestNBeforeDecrement != 0;
+                        } else {
+                            break;
+                        }
+                    }
+                } else if (stateUpdater.compareAndSet(this, s, TERMINATED)) {
+                    target.onError(newExceptionForInvalidRequestN(requestNBeforeDecrement));
                 }
             }
         }
@@ -149,53 +142,50 @@ final class PublisherConcatWithSingle<T> extends AbstractAsynchronousPublisherOp
 
         @Override
         public void request(final long n) {
-            assert subscription != null;
-            if (!SubscriberUtils.isRequestNValid(n)) {
-                subscription.request(n);
-                return;
+            final long requestNPostUpdate;
+            if (isRequestNValid(n)) {
+                requestNPostUpdate = requestNUpdater.accumulateAndGet(this, n,
+                        FlowControlUtil::addWithOverflowProtectionIfGtEqNegativeOne);
+            } else {
+                requestNPostUpdate = sanitizeInvalidRequestN(n);
+                requestN = requestNPostUpdate;
             }
 
             for (;;) {
                 final Object s = state;
-                if (s == CANCELLED || s == TERMINATED) {
-                    return;
-                }
-                if (s instanceof Long || s == null) {
-                    long nextState = s != null ? addWithOverflowProtection((long) s, n) : n;
-                    if (stateUpdater.compareAndSet(this, s, nextState)) {
-                        subscription.request(n);
-                        return;
+                if (s instanceof Subscription) {
+                    ((Subscription) s).request(n);
+                    break;
+                } else if (s instanceof SingleResult) {
+                    if (stateUpdater.compareAndSet(this, s, TERMINATED)) {
+                        // requestNPostUpdate may be legitimately be 0 after incrementing because the single completion
+                        // unconditionally decrements.
+                        if (requestNPostUpdate >= 0) {
+                            terminateTarget(SingleResult.fromRaw(s));
+                        } else {
+                            target.onError(newExceptionForInvalidRequestN(requestNPostUpdate));
+                        }
+                        break;
                     }
-                } else if (s instanceof CancellableWithOutstandingDemand) {
-                    // already requested
-                    return;
-                } else if (s instanceof Cancellable) {
+                } else if (s instanceof Cancellable && !(s instanceof CancellableWithOutstandingDemand)) {
                     if (stateUpdater.compareAndSet(this, s, new CancellableWithOutstandingDemand((Cancellable) s))) {
-                        return;
+                        break;
                     }
                 } else {
-                    assert s instanceof SingleResult;
-                    if (stateUpdater.compareAndSet(this, s, TERMINATED)) {
-                        terminateTarget(SingleResult.fromRaw(s));
-                        return;
-                    }
+                    break;
                 }
             }
         }
 
         @Override
         public void cancel() {
-            assert subscription != null;
             for (;;) {
                 final Object s = state;
                 if (s == CANCELLED || s == TERMINATED) {
-                    return;
-                }
-                if (stateUpdater.compareAndSet(this, s, CANCELLED)) {
+                    break;
+                } else if (stateUpdater.compareAndSet(this, s, CANCELLED)) {
                     if (s instanceof Cancellable) {
                         ((Cancellable) s).cancel();
-                    } else {
-                        subscription.cancel();
                     }
                     break;
                 }
@@ -205,6 +195,12 @@ final class PublisherConcatWithSingle<T> extends AbstractAsynchronousPublisherOp
         private void terminateTarget(@Nullable final T t) {
             target.onNext(t);
             target.onComplete();
+        }
+
+        private static long sanitizeInvalidRequestN(long n) {
+            // 0 and -1 are used during arithmetic, but they are invalid. so just use -2. this also simplifies underflow
+            // protection when decrementing.
+            return n >= -1 ? -2 : n == MIN_VALUE ? MIN_VALUE + 1 : n;
         }
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherConcatWithSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherConcatWithSingleTest.java
@@ -31,6 +31,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -116,6 +117,94 @@ public class PublisherConcatWithSingleTest {
     @Test
     public void onSuccessWithNullBeforeRequest() {
         testOnSuccessBeforeRequest(null);
+    }
+
+    @Test
+    public void invalidRequestNNegative1BeforeProcessingSingle() {
+        invalidRequestNWhenProcessingSingle(-1, true);
+    }
+
+    @Test
+    public void invalidRequestNNegative1AfterProcessingSingle() {
+        invalidRequestNWhenProcessingSingle(-1, false);
+    }
+
+    @Test
+    public void invalidRequestNZeroBeforeProcessingSingle() {
+        invalidRequestNWhenProcessingSingle(0, true);
+    }
+
+    @Test
+    public void invalidRequestNZeroAfterProcessingSingle() {
+        invalidRequestNWhenProcessingSingle(0, false);
+    }
+
+    @Test
+    public void invalidRequestNLongMinBeforeProcessingSingle() {
+        invalidRequestNWhenProcessingSingle(Long.MIN_VALUE, true);
+    }
+
+    @Test
+    public void invalidRequestNLongMinAfterProcessingSingle() {
+        invalidRequestNWhenProcessingSingle(Long.MIN_VALUE, false);
+    }
+
+    @Test
+    public void validRequestNAfterInvalidRequestNNegative1AfterProcessingSingle() {
+        validRequestNAfterInvalidRequestNWhenProcessingSingle(-1, false);
+    }
+
+    @Test
+    public void validRequestNAfterInvalidRequestNNegative1BeforeProcessingSingle() {
+        validRequestNAfterInvalidRequestNWhenProcessingSingle(-1, true);
+    }
+
+    @Test
+    public void validRequestNAfterInvalidRequestNZeroBeforeProcessingSingle() {
+        validRequestNAfterInvalidRequestNWhenProcessingSingle(0, true);
+    }
+
+    @Test
+    public void validRequestNAfterInvalidRequestNZeroAfterProcessingSingle() {
+        validRequestNAfterInvalidRequestNWhenProcessingSingle(0, false);
+    }
+
+    @Test
+    public void validRequestNAfterInvalidRequestNLongMinBeforeProcessingSingle() {
+        validRequestNAfterInvalidRequestNWhenProcessingSingle(Long.MIN_VALUE, true);
+    }
+
+    @Test
+    public void validRequestNAfterInvalidRequestNLongMinAfterProcessingSingle() {
+        validRequestNAfterInvalidRequestNWhenProcessingSingle(Long.MIN_VALUE, false);
+    }
+
+    private void validRequestNAfterInvalidRequestNWhenProcessingSingle(long n, boolean requestNBeforeSuccess) {
+        completeSource();
+        if (requestNBeforeSuccess) {
+            subscriber.request(n);
+            subscriber.request(Long.MAX_VALUE);
+        }
+        single.onSuccess(10L);
+        if (!requestNBeforeSuccess) {
+            subscriber.request(n);
+            subscriber.request(Long.MAX_VALUE);
+        }
+        assertThat("Unexpected termination (expected error).", subscriber.takeError(),
+                is(instanceOf(IllegalArgumentException.class)));
+    }
+
+    private void invalidRequestNWhenProcessingSingle(long n, boolean requestNBeforeSuccess) {
+        completeSource();
+        if (requestNBeforeSuccess) {
+            subscriber.request(n);
+        }
+        single.onSuccess(10L);
+        if (!requestNBeforeSuccess) {
+            subscriber.request(n);
+        }
+        assertThat("Unexpected termination (expected error).", subscriber.takeError(),
+                is(instanceOf(IllegalArgumentException.class)));
     }
 
     private void testOnSuccessBeforeRequest(@Nullable Long nextResult) {

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FlowControlUtil.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FlowControlUtil.java
@@ -28,6 +28,17 @@ public final class FlowControlUtil {
     }
 
     /**
+     * If {@code x} is {@code >=-1} this method behaves the same as {@link #addWithOverflowProtection(long, long)}.
+     * If {@code x} is {@code <-1} then {@code x} is returned.
+     * @param x first value (may be negative).
+     * @param y second value (should be positive).
+     * @return The result of {@code x+y} or {@link Long#MAX_VALUE} if overflow occurs, or {@code x} if {@code x<-1}.
+     */
+    public static long addWithOverflowProtectionIfGtEqNegativeOne(long x, long y) {
+        return x < -1 ? x : addWithOverflowProtection(x, y);
+    }
+
+    /**
      * If {@code x} is non-negative this method behaves the same as {@link #addWithOverflowProtection(long, long)}.
      * If {@code x} is negative then {@code x} is returned.
      * @param x first value (may be negative).


### PR DESCRIPTION
Motivation:
PublisherConcatWithSingle couples requestN tracking with its  state variable and
keeps the Subscription independent. However Subscription is only necessary
before the completion of the Publisher and can be tracked in the state variable
and the requestN can be tracked independently to avoid boxing/unboxing of Long.

Modifications:
- PublisherConcatWithSingle now has the requestN accounting decoupled from state
management. This avoids boxing/unboxing on each onNext and requestN which is
assumed to be relatively frequent as stream cardinality grows.

Result:
PublisherConcatWithSingle no longer couples requestN and state management.