### PR TITLE
Remove redundant address/port override methods on `HttpServerBuilder`

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -25,8 +25,6 @@ import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.SslConfig;
 
 import java.io.InputStream;
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.net.SocketOption;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -285,26 +283,6 @@ public abstract class HttpServerBuilder {
                                                        final StreamingHttpServiceFilterFactory factory) {
         appendServiceFilter(toConditionalServiceFilterFactory(predicate, factory));
         return this;
-    }
-
-    /**
-     * Sets the address to listen on.
-     *
-     * @param address The listen address for the server.
-     * @return {@code this}.
-     * @see #port(int)
-     */
-    public abstract HttpServerBuilder address(SocketAddress address);
-
-    /**
-     * Sets the port to listen on, the IP address is the wildcard address.
-     *
-     * @param port The listen port for the server
-     * @return {@code this}.
-     * @see #address(SocketAddress)
-     */
-    public HttpServerBuilder port(int port) {
-        return address(new InetSocketAddress(port));
     }
 
     /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -31,8 +31,6 @@ import java.net.SocketOption;
 import java.util.Map;
 import javax.annotation.Nullable;
 
-import static java.util.Objects.requireNonNull;
-
 final class DefaultHttpServerBuilder extends HttpServerBuilder {
 
     private final HttpServerConfig config = new HttpServerConfig();
@@ -112,12 +110,6 @@ final class DefaultHttpServerBuilder extends HttpServerBuilder {
     @Override
     public HttpServerBuilder disableWireLogging() {
         config.tcpConfig().disableWireLogging();
-        return this;
-    }
-
-    @Override
-    public HttpServerBuilder address(final SocketAddress address) {
-        this.address = requireNonNull(address);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpServers.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpServers.java
@@ -35,7 +35,6 @@ public final class HttpServers {
      *
      * @param port The listen port for the server.
      * @return a new builder.
-     * @see HttpServerBuilder#port(int)
      */
     public static HttpServerBuilder forPort(int port) {
         return new DefaultHttpServerBuilder(new InetSocketAddress(port));
@@ -46,7 +45,6 @@ public final class HttpServers {
      *
      * @param socketAddress The listen address for the server.
      * @return a new builder.
-     * @see HttpServerBuilder#address(SocketAddress)
      */
     public static HttpServerBuilder forAddress(SocketAddress socketAddress) {
         return new DefaultHttpServerBuilder(socketAddress);


### PR DESCRIPTION
__Motivation__

`HttpServerBuilder` instances are created providing an address/port. Providing ways to override it in the builder seems redundant and confusing.

__Modification__

Removed these methods.

__Result__

Less confusion 🎉