### PR TITLE
Reduce number of operators for content-length computation

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -39,7 +39,6 @@ import io.servicetalk.transport.netty.internal.NettyConnectionContext;
 
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.Publisher.defer;
 import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
@@ -51,7 +50,6 @@ import static io.servicetalk.http.netty.HeaderUtils.canAddRequestContentLength;
 import static io.servicetalk.http.netty.HeaderUtils.setRequestContentLength;
 import static io.servicetalk.transport.netty.internal.FlushStrategies.flushOnEnd;
 import static java.util.Objects.requireNonNull;
-import static java.util.function.Function.identity;
 
 abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext>
         implements FilterableStreamingHttpConnection, ClientInvoker<FlushStrategy> {
@@ -98,8 +96,7 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
         Publisher<Object> flatRequest;
         // See https://tools.ietf.org/html/rfc7230#section-3.3.3
         if (canAddRequestContentLength(request)) {
-            flatRequest = defer(() -> setRequestContentLength(request)
-                    .flatMapPublisher(identity()).subscribeShareContext());
+            flatRequest = setRequestContentLength(request);
         } else {
             flatRequest = Publisher.<Object>from(request).concat(request.payloadBodyAndTrailers());
             if (!mayHaveTrailers(request)) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -87,7 +87,6 @@ import static io.servicetalk.http.netty.HeaderUtils.canAddResponseContentLength;
 import static io.servicetalk.http.netty.HeaderUtils.setResponseContentLength;
 import static io.servicetalk.transport.netty.internal.CloseHandler.forPipelinedRequestResponse;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
-import static java.util.function.Function.identity;
 
 final class NettyHttpServer {
 
@@ -356,7 +355,7 @@ final class NettyHttpServer {
             // Add the content-length if necessary, falling back to transfer-encoding
             // otherwise.
             if (canAddResponseContentLength(response, requestMethod)) {
-                return setResponseContentLength(response).flatMapPublisher(identity());
+                return setResponseContentLength(response);
             } else {
                 Publisher<Object> flatResponse = Publisher.<Object>from(response)
                         .concat(response.payloadBodyAndTrailers());

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentLengthTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentLengthTest.java
@@ -122,8 +122,7 @@ public class ContentLengthTest extends AbstractNettyHttpServerTest {
 
     private static void setRequestContentLengthAndVerify(final StreamingHttpRequest request,
                                                          final Matcher<CharSequence> matcher) throws Exception {
-        Collection<Object> flattened = setRequestContentLength(request)
-                .toFuture().get().toFuture().get();
+        Collection<Object> flattened = setRequestContentLength(request).toFuture().get();
         assertThat("Unexpected items in the flattened request.", flattened, hasSize(greaterThanOrEqualTo(2)));
         Object firstItem = flattened.iterator().next();
         assertThat("Unexpected items in the flattened request.", firstItem, is(instanceOf(HttpMetaData.class)));
@@ -132,8 +131,7 @@ public class ContentLengthTest extends AbstractNettyHttpServerTest {
 
     private static void setResponseContentLengthAndVerify(final StreamingHttpResponse response,
                                                           final Matcher<CharSequence> matcher) throws Exception {
-        Collection<Object> flattened = setResponseContentLength(response)
-                .toFuture().get().toFuture().get();
+        Collection<Object> flattened = setResponseContentLength(response).toFuture().get();
         assertThat("Unexpected items in the flattened response.", flattened, hasSize(greaterThanOrEqualTo(2)));
         Object firstItem = flattened.iterator().next();
         assertThat("Unexpected items in the flattened response.", firstItem, is(instanceOf(HttpMetaData.class)));


### PR DESCRIPTION
Motivation:

We can avoid using `Single.defer` and `Single.map` operators for
content-length computation.

Modifications:

- Change `HeaderUtils.setRequestContentLength` return type from
`Single<Publisher<Object>>` to `Publisher<Object>`;

Result:

Less number of operators in use for content-length computation.