### PR TITLE
Remove volatile for operators that share subscribers across subscribes

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractCompletableAndSingleConcatenated.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractCompletableAndSingleConcatenated.java
@@ -60,7 +60,7 @@ abstract class AbstractCompletableAndSingleConcatenated<T> extends AbstractNoHan
 
         private final Subscriber<? super T> target;
         @Nullable
-        private volatile SequentialCancellable sequentialCancellable;
+        private SequentialCancellable sequentialCancellable;
 
         AbstractConcatWithSubscriber(final Subscriber<? super T> target) {
             this.target = target;
@@ -68,9 +68,8 @@ abstract class AbstractCompletableAndSingleConcatenated<T> extends AbstractNoHan
 
         @Override
         public final void onSubscribe(final Cancellable cancellable) {
-            SequentialCancellable sequentialCancellable = this.sequentialCancellable;
             if (sequentialCancellable == null) {
-                this.sequentialCancellable = sequentialCancellable = new SequentialCancellable(cancellable);
+                sequentialCancellable = new SequentialCancellable(cancellable);
                 target.onSubscribe(sequentialCancellable);
             } else {
                 sequentialCancellable.nextCancellable(cancellable);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableConcatWithCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableConcatWithCompletable.java
@@ -68,7 +68,7 @@ final class CompletableConcatWithCompletable extends AbstractNoHandleSubscribeCo
         private final Subscriber target;
         private final Completable next;
         @Nullable
-        private volatile SequentialCancellable sequentialCancellable;
+        private SequentialCancellable sequentialCancellable;
         @SuppressWarnings("unused")
         private volatile int subscribedToNext;
 
@@ -79,9 +79,8 @@ final class CompletableConcatWithCompletable extends AbstractNoHandleSubscribeCo
 
         @Override
         public void onSubscribe(Cancellable cancellable) {
-            SequentialCancellable sequentialCancellable = this.sequentialCancellable;
             if (sequentialCancellable == null) {
-                this.sequentialCancellable = sequentialCancellable = new SequentialCancellable(cancellable);
+                sequentialCancellable = new SequentialCancellable(cancellable);
                 target.onSubscribe(sequentialCancellable);
             } else {
                 sequentialCancellable.nextCancellable(cancellable);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ConcatPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ConcatPublisher.java
@@ -39,8 +39,7 @@ final class ConcatPublisher<T> extends AbstractAsynchronousPublisherOperator<T, 
         private final Subscriber<? super T> target;
         private final Publisher<? extends T> next;
         private final SequentialSubscription subscription = new SequentialSubscription();
-        // Volatile for visibility across subscribes, there is no concurrent access of this field.
-        private volatile boolean nextSubscribed;
+        private boolean nextSubscribed;
 
         ConcatSubscriber(Subscriber<? super T> target, Publisher<? extends T> next) {
             this.target = target;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ResumeCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ResumeCompletable.java
@@ -47,13 +47,13 @@ final class ResumeCompletable extends AbstractNoHandleSubscribeCompletable {
 
     private static final class ResumeSubscriber implements Subscriber {
         private final Subscriber subscriber;
-        @Nullable
-        private volatile Function<Throwable, ? extends Completable> nextFactory;
         private final SignalOffloader signalOffloader;
         private final AsyncContextMap contextMap;
         private final AsyncContextProvider contextProvider;
         @Nullable
-        private volatile SequentialCancellable sequentialCancellable;
+        private SequentialCancellable sequentialCancellable;
+        @Nullable
+        private Function<Throwable, ? extends Completable> nextFactory;
 
         ResumeSubscriber(Subscriber subscriber, Function<Throwable, ? extends Completable> nextFactory,
                          SignalOffloader signalOffloader, AsyncContextMap contextMap,
@@ -67,9 +67,8 @@ final class ResumeCompletable extends AbstractNoHandleSubscribeCompletable {
 
         @Override
         public void onSubscribe(Cancellable cancellable) {
-            SequentialCancellable sequentialCancellable = this.sequentialCancellable;
             if (sequentialCancellable == null) {
-                this.sequentialCancellable = sequentialCancellable = new SequentialCancellable(cancellable);
+                sequentialCancellable = new SequentialCancellable(cancellable);
                 subscriber.onSubscribe(sequentialCancellable);
             } else {
                 // Only a single re-subscribe is allowed.
@@ -85,7 +84,6 @@ final class ResumeCompletable extends AbstractNoHandleSubscribeCompletable {
 
         @Override
         public void onError(Throwable throwable) {
-            final Function<Throwable, ? extends Completable> nextFactory = this.nextFactory;
             if (nextFactory == null) {
                 subscriber.onError(throwable);
                 return;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ResumeSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ResumeSingle.java
@@ -54,13 +54,13 @@ final class ResumeSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
 
     private static final class ResumeSubscriber<T> implements Subscriber<T> {
         private final Subscriber<? super T> subscriber;
-        @Nullable
-        private volatile Function<Throwable, ? extends Single<? extends T>> nextFactory;
         private final SignalOffloader signalOffloader;
         private final AsyncContextMap contextMap;
         private final AsyncContextProvider contextProvider;
         @Nullable
-        private volatile SequentialCancellable sequentialCancellable;
+        private SequentialCancellable sequentialCancellable;
+        @Nullable
+        private Function<Throwable, ? extends Single<? extends T>> nextFactory;
 
         ResumeSubscriber(Subscriber<? super T> subscriber,
                          Function<Throwable, ? extends Single<? extends T>> nextFactory,
@@ -75,9 +75,8 @@ final class ResumeSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
 
         @Override
         public void onSubscribe(Cancellable cancellable) {
-            SequentialCancellable sequentialCancellable = this.sequentialCancellable;
             if (sequentialCancellable == null) {
-                this.sequentialCancellable = sequentialCancellable = new SequentialCancellable(cancellable);
+                sequentialCancellable = new SequentialCancellable(cancellable);
                 subscriber.onSubscribe(sequentialCancellable);
             } else {
                 // Only a single re-subscribe is allowed.
@@ -93,7 +92,6 @@ final class ResumeSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
 
         @Override
         public void onError(Throwable throwable) {
-            final Function<Throwable, ? extends Single<? extends T>> nextFactory = this.nextFactory;
             if (nextFactory == null) {
                 subscriber.onError(throwable);
                 return;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleConcatWithCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleConcatWithCompletable.java
@@ -46,7 +46,7 @@ final class SingleConcatWithCompletable<T> extends AbstractCompletableAndSingleC
     private static final class ConcatWithSubscriber<T> extends AbstractConcatWithSubscriber<T> {
         private final Completable next;
         @Nullable
-        private volatile T result;
+        private T result;
 
         ConcatWithSubscriber(final Subscriber<? super T> target, final Completable next) {
             super(target);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleFlatMapCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleFlatMapCompletable.java
@@ -53,7 +53,7 @@ final class SingleFlatMapCompletable<T> extends AbstractNoHandleSubscribeComplet
         private final AsyncContextMap contextMap;
         private final AsyncContextProvider contextProvider;
         @Nullable
-        private volatile SequentialCancellable sequentialCancellable;
+        private SequentialCancellable sequentialCancellable;
 
         SubscriberImpl(Subscriber subscriber, Function<T, ? extends Completable> nextFactory,
                        final SignalOffloader signalOffloader, final AsyncContextMap contextMap,
@@ -67,9 +67,8 @@ final class SingleFlatMapCompletable<T> extends AbstractNoHandleSubscribeComplet
 
         @Override
         public void onSubscribe(Cancellable cancellable) {
-            SequentialCancellable sequentialCancellable = this.sequentialCancellable;
             if (sequentialCancellable == null) {
-                this.sequentialCancellable = sequentialCancellable = new SequentialCancellable(cancellable);
+                sequentialCancellable = new SequentialCancellable(cancellable);
                 subscriber.onSubscribe(sequentialCancellable);
             } else {
                 sequentialCancellable.nextCancellable(cancellable);


### PR DESCRIPTION
Motivation:
We currently have volatile variables in operator Subscriber implementations if
they are used across subscribe calls. This was done because it wasn't clear if
there was any visibility guarantees between calling subscribe(Subscriber) and
the state within the Subscriber. However having the member variables being
volatile doesn't necessarily guarantee they will be visible when the Subscriber
methods are invoked (it may increase the likelihood but doesn't provide any
strong guarantees).

Modifications:
- Remove volatile in cases where it was used in operator implementations that
shared the same Subscriber across multiple (typically sequential) subscribe
calls.

Result:
Less volatiles where not necessary.