### PR TITLE
Bypass OIO adaptation for fully Jersey-buffered response bodies

### DIFF
--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/BufferedResponseOutputStream.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/BufferedResponseOutputStream.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.router.jersey;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.buffer.api.BufferAllocator;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.function.Consumer;
+
+final class BufferedResponseOutputStream extends OutputStream {
+    private final BufferAllocator allocator;
+    private final Consumer<Buffer> responseBodyConsumer;
+
+    BufferedResponseOutputStream(final BufferAllocator allocator, final Consumer<Buffer> responseBodyConsumer) {
+        this.allocator = allocator;
+        this.responseBodyConsumer = responseBodyConsumer;
+    }
+
+    @Override
+    public void write(final int b) {
+        throw new UnsupportedOperationException("Only intended to be used with buffered responses");
+    }
+
+    /*
+     * No need to protect against multiple call because this is used only in the case when a single byte[] has been
+     * used to buffer the response body.
+     */
+    @Override
+    public void write(final byte[] b, final int off, final int len) throws IOException {
+        // Do not wrap b in case Jersey decides to reuse it
+        final Buffer buf = allocator.newBuffer(len);
+        buf.writeBytes(b, off, len);
+        responseBodyConsumer.accept(buf);
+    }
+}


### PR DESCRIPTION
__Motivation__

By default, Jersey buffers an initial chunk of 8KB to try to compute response length for small responses.

Our implementation of `ContainerResponseWriter` could leverage this in `writeResponseStatusAndHeaders` in the sense that if a `contentLength` has been computed, we could bypass the creation of a `ConnectableBufferOutputStream` and a `CopyingOutputStream` and instead provide a simple `OutputStream` that calls `DefaultContainerResponseWriter#sendResponse` on `close`.

In essence this is an aggregated response by-pass optimization based on the fact Jersey has determined it has in hand the single `byte[]` that will form the response payload.

__Modifications__

Add `BufferedResponseOutputStream` and use it only when Jersey has been able to compute a response size.

__Results__

Less object allocations and better performance for responses with small bodies and that rely on OIO adaptation.