### PR TITLE
Optimize request-response completion logic in NettyHttpServerConnection

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -27,6 +27,7 @@ import io.servicetalk.concurrent.api.Processors;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.SubscribableCompletable;
+import io.servicetalk.concurrent.internal.DuplicateSubscribeException;
 import io.servicetalk.concurrent.internal.RejectedSubscribeError;
 import io.servicetalk.concurrent.internal.TerminalNotification;
 import io.servicetalk.http.api.DefaultHttpExecutionContext;
@@ -592,6 +593,9 @@ final class NettyHttpServer {
                 if (cState instanceof TerminalNotification) {
                     TerminalNotification terminalNotification = (TerminalNotification) cState;
                     terminalNotification.terminate(subscriber);
+                    break;
+                } else if (cState instanceof Subscriber) {
+                    subscriber.onError(new DuplicateSubscribeException(cState, subscriber));
                     break;
                 } else if (cState == CANCELLED ||
                         cState == null && stateUpdater.compareAndSet(this, null, subscriber)) {


### PR DESCRIPTION
Motivation:

`NettyHttpServerConnection` uses `Processor` to prevent accepting a new
request on the same connection before current request-response
processing will finish. It uses `Processors.newCompletableProcessor`
that handles multiple subscribes. However, in this code-path only ST
internal code may subscribe to this `Processor`. Therefore we don't need
to take care about multiple subscribes and can use simplified version of
the `Processor`.

Modifications:

- Implement `SingleSubscribeProcessor` that doesn't handle multiple
subscribes;
- Use the `SingleSubscribeProcessor` instead of
`Processors.newCompletableProcessor` in
`NettyHttpServerConnection.handleRequestAndWriteResponse`;

Result:

~3% less CPU time spent on `Processor.onComplete` according to the
flame graphs and ~3% RPS increase.