### PR TITLE
Remove enableHostHeaderFallback from HttpClientBuilder variants 

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseHttpBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseHttpBuilder.java
@@ -174,8 +174,7 @@ abstract class BaseHttpBuilder<ResolvedAddress> {
      * This setting disables the default filter such that no {@code Host} header will be manipulated.
      *
      * @return {@code this}
-     * @see SingleAddressHttpClientBuilder#enableHostHeaderFallback(CharSequence)
-     * @see MultiAddressHttpClientBuilder#enableHostHeaderFallback(Function)
+     * @see MultiAddressHttpClientBuilder#unresolvedAddressToHost(Function)
      */
     public abstract BaseHttpBuilder<ResolvedAddress> disableHostHeaderFallback();
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseSingleAddressHttpClientBuilder.java
@@ -20,12 +20,12 @@ import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.LoadBalancerFactory;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
-import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.SslConfig;
 
 import java.io.InputStream;
 import java.net.SocketOption;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
@@ -105,17 +105,9 @@ abstract class BaseSingleAddressHttpClientBuilder<U, R, SDE extends ServiceDisco
     public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> loadBalancerFactory(
             LoadBalancerFactory<R, StreamingHttpConnection> loadBalancerFactory);
 
-    /**
-     * Automatically set the provided {@link HttpHeaderNames#HOST} on {@link StreamingHttpRequest}s when it's missing.
-     * <p>
-     * For known address types such as {@link HostAndPort} the {@link HttpHeaderNames#HOST} is inferred and
-     * automatically set by default, if you have a custom address type or want to override the inferred value use this
-     * method. Use {@link #disableHostHeaderFallback()} if you don't want any {@link HttpHeaderNames#HOST} manipulation
-     * at all.
-     * @param hostHeader the value for the {@link HttpHeaderNames#HOST}
-     * @return {@code this}
-     */
-    public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> enableHostHeaderFallback(CharSequence hostHeader);
+    @Override
+    public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> unresolvedAddressToHost(
+            Function<U, CharSequence> unresolvedAddressToHostFunction);
 
     /**
      * Enable SSL/TLS using the provided {@link SslConfig}. To disable it pass in {@code null}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
@@ -26,6 +26,7 @@ import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.IoExecutor;
 
 import java.net.SocketOption;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
@@ -167,6 +168,19 @@ abstract class HttpClientBuilder<U, R, SDE extends ServiceDiscovererEvent<R>> ex
 
     @Override
     public abstract HttpClientBuilder<U, R, SDE> disableHostHeaderFallback();
+
+    /**
+     * Provides a means to convert {@link U} unresolved address type into a {@link CharSequence}.
+     * An example of where this maybe used is to convert the {@link U} to a default host header. It may also
+     * be used in the event of proxying.
+     *
+     * @param unresolvedAddressToHostFunction invoked to convert the {@link U} unresolved address type into a
+     * {@link CharSequence} suitable for use in
+     * <a href="https://tools.ietf.org/html/rfc7230#section-5.4">Host Header</a> format.
+     * @return {@code this}
+     */
+    public abstract HttpClientBuilder<U, R, SDE> unresolvedAddressToHost(
+            Function<U, CharSequence> unresolvedAddressToHostFunction);
 
     /**
      * Disable automatically delaying {@link StreamingHttpRequest}s until the {@link LoadBalancer} is ready.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -118,18 +118,9 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
     public abstract MultiAddressHttpClientBuilder<U, R> loadBalancerFactory(
             LoadBalancerFactory<R, StreamingHttpConnection> loadBalancerFactory);
 
-    /**
-     * Automatically set the provided {@link HttpHeaderNames#HOST} on {@link StreamingHttpRequest}s when it's missing.
-     * <p>
-     * For known address types such as {@link HostAndPort} the {@link HttpHeaderNames#HOST} is inferred and
-     * automatically set by default, if you have a custom address type or want to override the inferred value use this
-     * method. Use {@link #disableHostHeaderFallback()} if you don't want any {@link HttpHeaderNames#HOST} manipulation
-     * at all.
-     * @param hostHeaderTransformer transforms the {@code UnresolvedAddress} for the {@link HttpHeaderNames#HOST}
-     * @return {@code this}
-     */
-    public abstract MultiAddressHttpClientBuilder<U, R> enableHostHeaderFallback(
-            Function<U, CharSequence> hostHeaderTransformer);
+    @Override
+    public abstract MultiAddressHttpClientBuilder<U, R> unresolvedAddressToHost(
+            Function<U, CharSequence> unresolvedAddressToHostFunction);
 
     /**
      * Append the filter to the chain of filters used to decorate the {@link StreamingHttpClient} created by this

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
@@ -29,6 +29,7 @@ import io.servicetalk.transport.api.SslConfig;
 
 import java.net.SocketOption;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
@@ -120,7 +121,8 @@ public abstract class PartitionedHttpClientBuilder<U, R>
             LoadBalancerFactory<R, StreamingHttpConnection> loadBalancerFactory);
 
     @Override
-    public abstract PartitionedHttpClientBuilder<U, R> enableHostHeaderFallback(CharSequence hostHeader);
+    public abstract PartitionedHttpClientBuilder<U, R> unresolvedAddressToHost(
+            Function<U, CharSequence> unresolvedAddressToHostFunction);
 
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> appendClientFilter(StreamingHttpClientFilterFactory function);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -24,6 +24,7 @@ import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.SslConfig;
 
 import java.net.SocketOption;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
@@ -114,7 +115,8 @@ public abstract class SingleAddressHttpClientBuilder<U, R>
             LoadBalancerFactory<R, StreamingHttpConnection> loadBalancerFactory);
 
     @Override
-    public abstract SingleAddressHttpClientBuilder<U, R> enableHostHeaderFallback(CharSequence hostHeader);
+    public abstract SingleAddressHttpClientBuilder<U, R> unresolvedAddressToHost(
+            Function<U, CharSequence> unresolvedAddressToHostFunction);
 
     @Override
     public abstract SingleAddressHttpClientBuilder<U, R> appendClientFilter(StreamingHttpClientFilterFactory factory);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -362,8 +362,9 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
     }
 
     @Override
-    public PartitionedHttpClientBuilder<U, R> enableHostHeaderFallback(final CharSequence hostHeader) {
-        builderTemplate.enableHostHeaderFallback(hostHeader);
+    public PartitionedHttpClientBuilder<U, R> unresolvedAddressToHost(
+            final Function<U, CharSequence> unresolvedAddressToHostFunction) {
+        builderTemplate.unresolvedAddressToHost(unresolvedAddressToHostFunction);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientConfig.java
@@ -134,16 +134,12 @@ final class HttpClientConfig {
     }
 
     @Nullable
-    public CharSequence connectAddress() {
+    CharSequence connectAddress() {
         return connectAddress;
     }
 
-    public void connectAddress(@Nullable final CharSequence connectAddress) {
+    void connectAddress(@Nullable final CharSequence connectAddress) {
         this.connectAddress = connectAddress;
-    }
-
-    public boolean hasProxy() {
-        return connectAddress != null;
     }
 
     ReadOnlyHttpClientConfig asReadOnly() {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -84,7 +84,7 @@ public final class HttpClients {
      *
      * @param host host to connect to, resolved by default using a DNS {@link ServiceDiscoverer}. This will also be
      * used for the {@link HttpHeaderNames#HOST} together with the {@code port}. Use
-     * {@link SingleAddressHttpClientBuilder#enableHostHeaderFallback(CharSequence)} if you want to override that value
+     * {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)} if you want to override that value
      * or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you want to disable this behavior.
      * @param port port to connect to
      * @return new builder for the address
@@ -100,7 +100,7 @@ public final class HttpClients {
      *
      * @param host host to connect to via the proxy. This will also be used for the {@link HttpHeaderNames#HOST}
      * together with the {@code port}. Use
-     * {@link SingleAddressHttpClientBuilder#enableHostHeaderFallback(CharSequence)} if you want to override that value
+     * {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)} if you want to override that value
      * or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you want to disable this behavior.
      * @param port port to connect to
      * @param proxyHost the proxy host to connect to, resolved by default using a DNS {@link ServiceDiscoverer}.
@@ -118,7 +118,7 @@ public final class HttpClients {
      *
      * @param address the {@code UnresolvedAddress} to connect to, resolved by default using a DNS {@link
      * ServiceDiscoverer}. This address will also be used for the {@link HttpHeaderNames#HOST}.
-     * Use {@link SingleAddressHttpClientBuilder#enableHostHeaderFallback(CharSequence)} if you want to override that
+     * Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)} if you want to override that
      * value or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you want to disable this behavior.
      * @return new builder for the address
      */
@@ -132,7 +132,7 @@ public final class HttpClients {
      * and DNS {@link ServiceDiscoverer}.
      *
      * @param address the {@code UnresolvedAddress} to connect to via the proxy. This address will also be used for the
-     * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#enableHostHeaderFallback(CharSequence)}
+     * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
      * if you want to override that value or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you
      * want to disable this behavior.
      * @param proxyAddress the proxy {@code UnresolvedAddress} to connect to, resolved by default using a DNS {@link
@@ -148,7 +148,7 @@ public final class HttpClients {
      * Creates a {@link SingleAddressHttpClientBuilder} for a resolved address with default {@link LoadBalancer}.
      *
      * @param host resolved host address to connect. This will also be used for the {@link HttpHeaderNames#HOST}
-     * together with the {@code port}. Use {@link SingleAddressHttpClientBuilder#enableHostHeaderFallback(CharSequence)}
+     * together with the {@code port}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
      * if you want to override that value or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()}
      * if you want to disable this behavior.
      * @param port port to connect to
@@ -165,7 +165,7 @@ public final class HttpClients {
      *
      * @param host resolved host address to connect via the proxy. This will also be used for the
      * {@link HttpHeaderNames#HOST} together with the {@code port}. Use
-     * {@link SingleAddressHttpClientBuilder#enableHostHeaderFallback(CharSequence)} if you want to override that value
+     * {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)} if you want to override that value
      * or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you want to disable this behavior.
      * @param port port to connect to via the proxy
      * @param proxyHost The proxy resolved host address to connect.
@@ -182,7 +182,7 @@ public final class HttpClients {
      * ServiceDiscoverer}.
      *
      * @param address the {@code ResolvedAddress} to connect. This address will also be used for the
-     * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#enableHostHeaderFallback(CharSequence)}
+     * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
      * if you want to override that value or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you
      * want to disable this behavior.
      * @return new builder for the address
@@ -198,7 +198,7 @@ public final class HttpClients {
      * and DNS {@link ServiceDiscoverer}.
      *
      * @param address the {@code ResolvedAddress} to connect to via the proxy. This address will also be used for the
-     * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#enableHostHeaderFallback(CharSequence)}
+     * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
      * if you want to override that value or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you
      * want to disable this behavior.
      * @param proxyAddress The proxy {@code ResolvedAddress} to connect.
@@ -215,7 +215,7 @@ public final class HttpClients {
      * ServiceDiscoverer}.
      *
      * @param address the {@code ResolvedAddress} to connect. This address will also be used for the
-     * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#enableHostHeaderFallback(CharSequence)}
+     * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
      * if you want to override that value or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you
      * want to disable this behavior.
      * @return new builder for the address
@@ -230,7 +230,7 @@ public final class HttpClients {
      * and DNS {@link ServiceDiscoverer}.
      *
      * @param address the {@code ResolvedAddress} to connect to via the proxy. This address will also be used for the
-     * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#enableHostHeaderFallback(CharSequence)}
+     * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
      * if you want to override that value or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you
      * want to disable this behavior.
      * @param proxyAddress The proxy {@code ResolvedAddress} to connect.
@@ -249,7 +249,7 @@ public final class HttpClients {
      * The lifecycle of the provided {@link ServiceDiscoverer} should be managed by the caller.
      * @param address the {@code UnresolvedAddress} to connect to resolved using the provided {@code serviceDiscoverer}.
      * This address will also be used for the {@link HttpHeaderNames#HOST} using a best effort conversion. Use {@link
-     * SingleAddressHttpClientBuilder#enableHostHeaderFallback(CharSequence)} if you want to override that value or
+     * SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)} if you want to override that value or
      * {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you want to disable this behavior.
      * @param <U> the type of address before resolution (unresolved address)
      * @param <R> the type of address after resolution (resolved address)
@@ -269,7 +269,7 @@ public final class HttpClients {
      * The lifecycle of the provided {@link ServiceDiscoverer} should be managed by the caller.
      * @param address the {@code UnresolvedAddress} to resolve using the provided {@code serviceDiscoverer}.
      * This address will also be used for the {@link HttpHeaderNames#HOST} using a best effort conversion. Use {@link
-     * PartitionedHttpClientBuilder#enableHostHeaderFallback(CharSequence)} if you want to override that value or
+     * PartitionedHttpClientBuilder#unresolvedAddressToHost(Function)} if you want to override that value or
      * {@link PartitionedHttpClientBuilder#disableHostHeaderFallback()} if you want to disable this behavior.
      * @param partitionAttributesBuilderFactory The factory {@link Function} used to build {@link PartitionAttributes}
      * from {@link HttpRequestMetaData}.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReadOnlyHttpClientConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReadOnlyHttpClientConfig.java
@@ -84,11 +84,11 @@ final class ReadOnlyHttpClientConfig {
     }
 
     @Nullable
-    public CharSequence connectAddress() {
+    CharSequence connectAddress() {
         return connectAddress;
     }
 
-    public boolean hasProxy() {
+    boolean hasProxy() {
         return connectAddress != null;
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOverrideTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOverrideTest.java
@@ -85,6 +85,7 @@ public class FlushStrategyOverrideTest {
                 .disableHostHeaderFallback()
                 .ioExecutor(ctx.ioExecutor())
                 .executionStrategy(noOffloadsStrategy())
+                .unresolvedAddressToHost(InetSocketAddress::getHostString)
                 .buildStreaming();
         conn = client.reserveConnection(client.get("/")).toFuture().get();
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilterTest.java
@@ -47,7 +47,7 @@ public class HostHeaderHttpRequesterFilterTest {
     private static void doHostHeaderTest(String hostHeader, String expectedValue) throws Exception {
         try (ServerContext context = buildServer();
              BlockingHttpClient client = forSingleAddress(serverHostAndPort(context))
-                .enableHostHeaderFallback(hostHeader)
+                .unresolvedAddressToHost(addr -> hostHeader)
                 .buildBlocking()) {
             assertEquals(expectedValue,
                     client.request(client.get("/")).payloadBody(textDeserializer()));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PartitionedHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PartitionedHttpClientTest.java
@@ -137,7 +137,7 @@ public class PartitionedHttpClientTest {
                 // TODO(jayv) This *hack* only works because SRV_NAME is part of the selection criteria,
                 // we need to consider adding metadata to PartitionAttributes.
                 .appendClientBuilderFilter((pa, builder) ->
-                        builder.enableHostHeaderFallback(pa.get(SRV_NAME)))
+                        builder.unresolvedAddressToHost(addr -> pa.get(SRV_NAME)))
                 .buildBlocking()) {
 
             sdPublisher.onSubscribe(new TestSubscription());
@@ -164,7 +164,7 @@ public class PartitionedHttpClientTest {
                 // TODO(jayv) This *hack* only works because SRV_NAME is part of the selection criteria,
                 // we need to consider adding metadata to PartitionAttributes.
                 .appendClientBuilderFilter((pa, builder) ->
-                        builder.enableHostHeaderFallback(pa.get(SRV_NAME)))
+                        builder.unresolvedAddressToHost(addr -> pa.get(SRV_NAME)))
                 .buildBlocking()) {
 
             sdPublisher.onSubscribe(new TestSubscription());

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyPipelinedConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyPipelinedConnection.java
@@ -60,15 +60,6 @@ public final class DefaultNettyPipelinedConnection<Req, Resp> implements NettyPi
      * New instance.
      *
      * @param connection {@link NettyConnection} requests to which are to be pipelined.
-     */
-    public DefaultNettyPipelinedConnection(NettyConnection<Resp, Req> connection) {
-        this(connection, 2);
-    }
-
-    /**
-     * New instance.
-     *
-     * @param connection {@link NettyConnection} requests to which are to be pipelined.
      * @param initialQueueSize Initial size for the write and read queues.
      */
     public DefaultNettyPipelinedConnection(NettyConnection<Resp, Req> connection, int initialQueueSize) {


### PR DESCRIPTION
Motivation:
There are some areas related to proxy methods and generic address
to host-like CharSequence that can be cleaned up to improve code and make less
assumptions about generic types and the type hierarchy that users can have.

Modifications:
- remove methods and/or reduce visibility when possible
- add a method to override the unresolved address -> host-like CharSequence so
we don't have to make assumptions about the user being able to implement
HostAndPort

Result:
Minor cleanup of code, and less assumptions of generics.