### PR TITLE
Fix inferring Content-Length for HEAD responses

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
@@ -142,7 +142,7 @@ public class ContentHeadersTest extends AbstractNettyHttpServerTest {
 
                 // ----- Response -----
                 new ResponseTest(aggregatedResponse(OK), GET, defaults(), HAVE_CONTENT_LENGTH),
-                new ResponseTest(aggregatedResponse(OK), HEAD, defaults(), HAVE_CONTENT_LENGTH),
+                new ResponseTest(aggregatedResponse(OK), HEAD, defaults(), HAVE_NEITHER),
                 new ResponseTest(aggregatedResponse(OK), POST, defaults(), HAVE_CONTENT_LENGTH),
                 new ResponseTest(aggregatedResponse(OK), PUT, defaults(), HAVE_CONTENT_LENGTH),
                 new ResponseTest(aggregatedResponse(OK), DELETE, defaults(), HAVE_CONTENT_LENGTH),
@@ -152,7 +152,7 @@ public class ContentHeadersTest extends AbstractNettyHttpServerTest {
                 new ResponseTest(aggregatedResponse(OK), PATCH, defaults(), HAVE_CONTENT_LENGTH),
 
                 new ResponseTest(aggregatedResponse(OK), GET, withoutPayload(), HAVE_CONTENT_LENGTH_ZERO),
-                new ResponseTest(aggregatedResponse(OK), HEAD, withoutPayload(), HAVE_CONTENT_LENGTH_ZERO),
+                new ResponseTest(aggregatedResponse(OK), HEAD, withoutPayload(), HAVE_NEITHER),
                 new ResponseTest(aggregatedResponse(OK), POST, withoutPayload(), HAVE_CONTENT_LENGTH_ZERO),
                 new ResponseTest(aggregatedResponse(OK), PUT, withoutPayload(), HAVE_CONTENT_LENGTH_ZERO),
                 new ResponseTest(aggregatedResponse(OK), DELETE, withoutPayload(), HAVE_CONTENT_LENGTH_ZERO),
@@ -323,11 +323,6 @@ public class ContentHeadersTest extends AbstractNettyHttpServerTest {
     @Override
     Single<ServerContext> listen(final HttpServerBuilder builder) {
         return testDefinition.listen(builder);
-    }
-
-    @Nullable
-    private static String checkHeaders(final Expectation expectation, final HttpHeaders headers) {
-        return expectation.assertHeaders(headers);
     }
 
     private static HttpRequest newAggregatedRequest(final HttpRequestMethod requestMethod) {


### PR DESCRIPTION
__Motivation__

HEAD requests should either have the content-length already set (= what GET will return) or
have the header omitted when unknown, but never have any payload anyway so we shouldn't try to infer it.
This lead to a bug when folks use the aggregated API the current code would infer to length 0 always,
which is incorrect when no payload was set.

__Modifications__

Ensure that we don't try to compute Content-Length for HEAD responses
Update tests to reflect the expected behavior.

__Result__

Aggregation now either retains the pre-existing content-length or omits computing the header.