### PR TITLE
ServiceTalk-specific MessageBodyWriters should not handle SSE responses

### DIFF
--- a/servicetalk-data-jackson-jersey/build.gradle
+++ b/servicetalk-data-jackson-jersey/build.gradle
@@ -43,7 +43,7 @@ dependencies {
   implementation "io.servicetalk:servicetalk-http-router-jersey-internal:$project.version"
   implementation "io.servicetalk:servicetalk-http-utils:$project.version"
   implementation "io.servicetalk:servicetalk-transport-netty:$project.version"
-  implementation "org.glassfish.jersey.core:jersey-common"
+  implementation "org.glassfish.jersey.core:jersey-server"
   implementation "org.slf4j:slf4j-api"
 
   testImplementation "io.servicetalk:servicetalk-concurrent-api-testFixtures:$project.version"

--- a/servicetalk-data-jackson-jersey/docs/modules/ROOT/pages/index.adoc
+++ b/servicetalk-data-jackson-jersey/docs/modules/ROOT/pages/index.adoc
@@ -6,6 +6,8 @@ It is a replacement for `jersey-media-json-jackson` and allows avoiding the inpu
 with out-of-the-box body readers and also allows accepting/returning `Single<Pojo>` and `Publisher<Pojo>`
 from resource methods.
 
+CAUTION: This serializer can not currently be used with Server-Sent Events (SSE).
+
 == Using a custom ObjectMapper
 
 If you have configured a Jackson `ObjectMapper` and want to use it with this module, you need to provide it to the

--- a/servicetalk-http-router-jersey/docs/modules/ROOT/pages/index.adoc
+++ b/servicetalk-http-router-jersey/docs/modules/ROOT/pages/index.adoc
@@ -105,6 +105,7 @@ of `Buffer`s.
 
 CAUTION: Using `Buffer` and async payloads will prevent off-the-shelf
 payload-aware <<filter-inter>> from working properly.
+Moreover, such payloads can not currently be used with Server-Sent Events (SSE).
 
 Let's look at some examples.
 The first one is a rewrite of the previous `hello` example but,

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/AbstractMessageBodyReaderWriter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/AbstractMessageBodyReaderWriter.java
@@ -21,6 +21,8 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.transport.api.ConnectionContext;
 
 import org.glassfish.jersey.internal.util.collection.Ref;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.server.model.ResourceMethod;
 
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
@@ -95,7 +97,7 @@ abstract class AbstractMessageBodyReaderWriter<Source, T, SourceOfT, WrappedSour
                                      final Type genericType,
                                      final Annotation[] annotations,
                                      final MediaType mediaType) {
-        return isSupported(genericType);
+        return !isSse(requestCtxProvider.get()) && isSupported(genericType);
     }
 
     final void writeTo(final Publisher<Buffer> publisher) throws WebApplicationException {
@@ -131,6 +133,11 @@ abstract class AbstractMessageBodyReaderWriter<Source, T, SourceOfT, WrappedSour
     static Buffer newBufferForRequestContent(final int contentLength,
                                              final BufferAllocator allocator) {
         return contentLength == -1 ? allocator.newBuffer() : allocator.newBuffer(contentLength);
+    }
+
+    static boolean isSse(ContainerRequestContext requestCtx) {
+        final ResourceMethod method = ((ExtendedUriInfo) requestCtx.getUriInfo()).getMatchedResourceMethod();
+        return method != null && method.isSse();
     }
 
     @Nullable

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/BufferMessageBodyReaderWriter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/BufferMessageBodyReaderWriter.java
@@ -40,6 +40,7 @@ import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
 
 import static io.servicetalk.http.router.jersey.AbstractMessageBodyReaderWriter.getRequestContentLength;
+import static io.servicetalk.http.router.jersey.AbstractMessageBodyReaderWriter.isSse;
 import static io.servicetalk.http.router.jersey.AbstractMessageBodyReaderWriter.newBufferForRequestContent;
 import static io.servicetalk.http.router.jersey.internal.BufferPublisherInputStream.handleEntityStream;
 import static io.servicetalk.http.router.jersey.internal.RequestProperties.setResponseBufferPublisher;
@@ -107,7 +108,7 @@ final class BufferMessageBodyReaderWriter implements MessageBodyReader<Buffer>, 
                                final Type genericType,
                                final Annotation[] annotations,
                                final MediaType mediaType) {
-        return Buffer.class.isAssignableFrom(type);
+        return !isSse(requestCtxProvider.get()) && Buffer.class.isAssignableFrom(type);
     }
 
     @Override

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AsynchronousResourceTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AsynchronousResourceTest.java
@@ -203,4 +203,14 @@ public class AsynchronousResourceTest extends AbstractAsynchronousResourceTest {
                     __ -> null);
         });
     }
+
+    @Test
+    public void sseUnsupported() {
+        runTwiceToEnsureEndpointCache(() -> {
+            // Jersey's OutboundEventWriter ignores the lack of a MessageBodyWriter for the event (an error is logged
+            // but no feedback is provided to the client side)
+            sendAndAssertResponse(get("/sse/unsupported"), OK, newAsciiString(SERVER_SENT_EVENTS),
+                    isEmptyString(), __ -> null);
+        });
+    }
 }


### PR DESCRIPTION
__Motivation__

Our `MessageBodyWriter` use a fast lane response strategy to bypass OIO when resource methods produce ServiceTalk types.

This fails with SSE because our `MessageBodyWriter` assume a call to `write` while SSE performs one write per message sent by the server in order to serialize them.

__Modifications__

- Make our `MessageBodyWriter` gracefully opt-out of the SSE response path by returning `false` from `isWriteable` when the response is SSE.
- Document SSE limitations.

__Results__

ServiceTalk-specific `MessageBodyWriters` do not attempt to serialize SSE events.