### PR TITLE
Use UnpooledUnsafeHeapByteBuf to allocate byte-arrays without zeroing

### DIFF
--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/ServiceTalkBufferAllocator.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/ServiceTalkBufferAllocator.java
@@ -49,7 +49,9 @@ final class ServiceTalkBufferAllocator extends AbstractByteBufAllocator implemen
 
     @Override
     protected ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
-        return new UnreleasableHeapByteBuf(this, initialCapacity, maxCapacity);
+        return io.netty.util.internal.PlatformDependent.hasUnsafe() ?
+                new UnreleasableUnsafeHeapByteBuf(this, initialCapacity, maxCapacity) :
+                new UnreleasableHeapByteBuf(this, initialCapacity, maxCapacity);
     }
 
     @Override
@@ -57,10 +59,9 @@ final class ServiceTalkBufferAllocator extends AbstractByteBufAllocator implemen
         if (noZeroing) {
             return new UnreleasableUnsafeNoZeroingDirectByteBuf(this, initialCapacity, maxCapacity);
         }
-        if (io.netty.util.internal.PlatformDependent.hasUnsafe()) {
-            return new UnreleasableUnsafeDirectByteBuf(this, initialCapacity, maxCapacity);
-        }
-        return new UnreleasableDirectByteBuf(this, initialCapacity, maxCapacity);
+        return io.netty.util.internal.PlatformDependent.hasUnsafe() ?
+                new UnreleasableUnsafeDirectByteBuf(this, initialCapacity, maxCapacity) :
+                new UnreleasableDirectByteBuf(this, initialCapacity, maxCapacity);
     }
 
     @Override

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableUnsafeHeapByteBuf.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableUnsafeHeapByteBuf.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.buffer.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledUnsafeHeapByteBuf;
+
+class UnreleasableUnsafeHeapByteBuf extends UnpooledUnsafeHeapByteBuf {
+
+    UnreleasableUnsafeHeapByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
+        super(alloc, initialCapacity, maxCapacity);
+    }
+
+    @Override
+    public ByteBuf asReadOnly() {
+        return Unpooled.unreleasableBuffer(super.asReadOnly());
+    }
+
+    @Override
+    public ByteBuf readSlice(int length) {
+        return Unpooled.unreleasableBuffer(super.readSlice(length));
+    }
+
+    @Override
+    public ByteBuf readRetainedSlice(int length) {
+        return readSlice(length);
+    }
+
+    @Override
+    public ByteBuf slice() {
+        return Unpooled.unreleasableBuffer(super.slice());
+    }
+
+    @Override
+    public ByteBuf slice(int index, int length) {
+        return Unpooled.unreleasableBuffer(super.slice(index, length));
+    }
+
+    @Override
+    public ByteBuf retainedSlice() {
+        return slice();
+    }
+
+    @Override
+    public ByteBuf retainedSlice(int index, int length) {
+        return slice(index, length);
+    }
+
+    @Override
+    public ByteBuf duplicate() {
+        return Unpooled.unreleasableBuffer(super.duplicate());
+    }
+
+    @Override
+    public ByteBuf retainedDuplicate() {
+        return duplicate();
+    }
+
+    @Override
+    public ByteBuf retain(int increment) {
+        return this;
+    }
+
+    @Override
+    public ByteBuf retain() {
+        return this;
+    }
+
+    @Override
+    public ByteBuf touch() {
+        return this;
+    }
+
+    @Override
+    public ByteBuf touch(Object hint) {
+        return this;
+    }
+
+    @Override
+    public boolean release() {
+        return false;
+    }
+
+    @Override
+    public boolean release(int decrement) {
+        return false;
+    }
+}


### PR DESCRIPTION
Motivation:

The latest netty release 4.1.37.Final makes `UnpooledUnsafeHeapByteBuf`
public. We may use it in `ServiceTalkBufferAllocator` to avoid zeroing
when ST allocates byte-arrays.

Modifications:

- Add `UnreleasableUnsafeHeapByteBuf` that extends
`UnpooledUnsafeHeapByteBuf`;
- Use `UnreleasableUnsafeHeapByteBuf` in
`ServiceTalkBufferAllocator.newHeapBuffer`;

Result:

Faster allocation of byte-arrays with the length >
`uninitializedArrayAllocationThreshold` (1024 by default in netty).
For 16KB payload body server's performance increased by 6% in RPS.

Note:

This feature works only on JDK9+, when `Unsafe` is available and the
following JDK options are set:
`--add-exports java.base/jdk.internal.misc=ALL-UNNAMED`;
`-Dio.netty.tryReflectionSetAccessible=true`;
`io.netty.noUnsafe=false` (default, no need to set explicitly).

`-Dio.netty.uninitializedArrayAllocationThreshold=int` could be used to
control the threshold.