### PR TITLE
`PooledRecvByteBufAllocatorInitializer` should compose `RecvByteBufAllocator`

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ChannelInitializer.java
@@ -17,6 +17,7 @@ package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.transport.api.ConnectionContext;
 
+import io.netty.channel.AdaptiveRecvByteBufAllocator;
 import io.netty.channel.Channel;
 
 /**
@@ -51,6 +52,12 @@ public interface ChannelInitializer {
      * @return Default initializer for ServiceTalk.
      */
     static ChannelInitializer defaultInitializer() {
-        return (channel, context) -> context;
+        return (channel, context) -> {
+            channel.config().setRecvByteBufAllocator(
+                    new AdaptiveRecvByteBufAllocator(512, 32768, 65536)
+                            .respectMaybeMoreData(false)
+                            .maxMessagesPerRead(4));
+            return context;
+        };
     }
 }


### PR DESCRIPTION
__Motivation__

`PooledRecvByteBufAllocatorInitializer` overrides configured `RecvByteBufAllocator` for the channel but does not consider if there is already an allocator that is set.
Ideally we should be able to decouple these two concerns (use a certain `RecvByteBufAllocator` and copy the I/O buffers).
This will help us configure receive buffer separately.

__Modification__

- Always set a `RecvByteBufAllocator` on the channel.
- `PooledRecvByteBufAllocatorInitializer` now wraps the existing `RecvByteBufAllocator` set on the channel.
- `PooledRecvByteBufAllocatorInitializer` adds `CopyByteBufHandler` using `addLast` as it is done in other `ChannelInitializer`s.

__Result__

Configuring `RecvByteBufAllocator` is decoupled from copying I/O buffers.