### PR TITLE
Update Jackson to 2.9.9.1

### DIFF
--- a/servicetalk-bom-internal/gradle.properties
+++ b/servicetalk-bom-internal/gradle.properties
@@ -42,7 +42,7 @@ mockitoCoreVersion=2.19.0
 reactiveStreamsVersion=1.0.2
 rxJavaVersion=2.1.13
 jcToolsVersion=2.1.2
-jacksonVersion=2.9.9
+jacksonVersion=2.9.9.1
 
 openTracingVersion=0.31.0
 


### PR DESCRIPTION
__Motivation__

Micro-patch version 2.9.9.1 of jackson-databind fixes two gadget-based CVEs.

See: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9#micro-patches