### PR TITLE
Linking to correct source code version from the docs.

### DIFF
--- a/docs/generation/gradle/validateSite.gradle
+++ b/docs/generation/gradle/validateSite.gradle
@@ -6,6 +6,8 @@ def httpLinks = [
 // links to exclude from validation (for example because they require authentication)
 def excludedLinks = [
     //"http://somedomain.tld/someoptionalpath"
+    // Exclude the repo until it's public, otherwise thr 404's fail the validation.
+    "https://github.com/apple/servicetalk"
 ]
 
 configurations {

--- a/docs/modules/ROOT/pages/_partials/component-attributes.adoc
+++ b/docs/modules/ROOT/pages/_partials/component-attributes.adoc
@@ -1,6 +1,8 @@
+:git-tag: 0.16.0
+
 ifndef::sourceroot[]
 :sourceroot: https://github.com/apple/servicetalk/blob/master/
 ifdef::is-release-version[]
-:sourceroot: https://github.com/apple/servicetalk/blob/{page-component-version}/
+:sourceroot: https://github.com/apple/servicetalk/blob/{git-tag}/
 endif::[]
 endif::[]

--- a/scripts/update-patch-version-in-antora-components-attributes.sh
+++ b/scripts/update-patch-version-in-antora-components-attributes.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eu
+
+newversion="$1"
+
+if ( echo "$newversion" | grep -q "SNAPSHOT" ); then
+    echo "Expected version to be a release version, not snapshot"
+    exit 1
+fi
+
+if [ "$(echo "$newversion" | tr -Cd '.')" != ".." ]; then
+    echo "Expected semver (eg 1.2.3)"
+    exit 1
+fi
+
+
+find "$(dirname "$0")/.." -name 'component-attributes.adoc' | while read file; do
+
+    cat "$file" | sed "s/^:git-tag: .*/:git-tag: $newversion/" > "$file.tmp"
+
+    mv "$file.tmp" "$file"
+done

--- a/servicetalk-concurrent-api/docs/modules/ROOT/pages/_partials/component-attributes.adoc
+++ b/servicetalk-concurrent-api/docs/modules/ROOT/pages/_partials/component-attributes.adoc
@@ -1,6 +1,8 @@
+:git-tag: 0.16.0
+
 ifndef::sourceroot[]
 :sourceroot: https://github.com/apple/servicetalk/blob/master/
 ifdef::is-release-version[]
-:sourceroot: https://github.com/apple/servicetalk/blob/{page-component-version}/
+:sourceroot: https://github.com/apple/servicetalk/blob/{git-tag}/
 endif::[]
 endif::[]

--- a/servicetalk-data-jackson-jersey/docs/modules/ROOT/pages/_partials/component-attributes.adoc
+++ b/servicetalk-data-jackson-jersey/docs/modules/ROOT/pages/_partials/component-attributes.adoc
@@ -1,6 +1,8 @@
+:git-tag: 0.16.0
+
 ifndef::sourceroot[]
 :sourceroot: https://github.com/apple/servicetalk/blob/master/
 ifdef::is-release-version[]
-:sourceroot: https://github.com/apple/servicetalk/blob/{page-component-version}/
+:sourceroot: https://github.com/apple/servicetalk/blob/{git-tag}/
 endif::[]
 endif::[]

--- a/servicetalk-examples/docs/modules/ROOT/pages/_partials/component-attributes.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/_partials/component-attributes.adoc
@@ -1,6 +1,8 @@
+:git-tag: 0.16.0
+
 ifndef::sourceroot[]
 :sourceroot: https://github.com/apple/servicetalk/blob/master/
 ifdef::is-release-version[]
-:sourceroot: https://github.com/apple/servicetalk/blob/{page-component-version}/
+:sourceroot: https://github.com/apple/servicetalk/blob/{git-tag}/
 endif::[]
 endif::[]

--- a/servicetalk-http-api/docs/modules/ROOT/pages/_partials/component-attributes.adoc
+++ b/servicetalk-http-api/docs/modules/ROOT/pages/_partials/component-attributes.adoc
@@ -1,6 +1,8 @@
+:git-tag: 0.16.0
+
 ifndef::sourceroot[]
 :sourceroot: https://github.com/apple/servicetalk/blob/master/
 ifdef::is-release-version[]
-:sourceroot: https://github.com/apple/servicetalk/blob/{page-component-version}/
+:sourceroot: https://github.com/apple/servicetalk/blob/{git-tag}/
 endif::[]
 endif::[]

--- a/servicetalk-http-router-jersey/docs/modules/ROOT/pages/_partials/component-attributes.adoc
+++ b/servicetalk-http-router-jersey/docs/modules/ROOT/pages/_partials/component-attributes.adoc
@@ -1,6 +1,8 @@
+:git-tag: 0.16.0
+
 ifndef::sourceroot[]
 :sourceroot: https://github.com/apple/servicetalk/blob/master/
 ifdef::is-release-version[]
-:sourceroot: https://github.com/apple/servicetalk/blob/{page-component-version}/
+:sourceroot: https://github.com/apple/servicetalk/blob/{git-tag}/
 endif::[]
 endif::[]

--- a/servicetalk-http-security-jersey/docs/modules/ROOT/pages/_partials/component-attributes.adoc
+++ b/servicetalk-http-security-jersey/docs/modules/ROOT/pages/_partials/component-attributes.adoc
@@ -1,6 +1,8 @@
+:git-tag: 0.16.0
+
 ifndef::sourceroot[]
 :sourceroot: https://github.com/apple/servicetalk/blob/master/
 ifdef::is-release-version[]
-:sourceroot: https://github.com/apple/servicetalk/blob/{page-component-version}/
+:sourceroot: https://github.com/apple/servicetalk/blob/{git-tag}/
 endif::[]
 endif::[]


### PR DESCRIPTION
Motivation:

Previously, release docs attempted to link to a git tag that was missing the
patch version, which would have let to broken links. We need to link to the
correct git tag, which includes the patch vesion.

Modifications:

Add `git-tag` attribute to antora modules, and use it for linking to source
for releases.
Add a script for the release process that updates this attribute.

Results:

Generated release docs link to correct git tag.