### PR TITLE
Refresh Jersey router doc wrt HttpExecutionStrategies

### DIFF
--- a/servicetalk-http-router-jersey/docs/modules/ROOT/pages/evolve-to-async.adoc
+++ b/servicetalk-http-router-jersey/docs/modules/ROOT/pages/evolve-to-async.adoc
@@ -1,5 +1,4 @@
 include::ROOT:partial$component-attributes.adoc[]
-
 = Evolving to asynchronous
 
 Evolution to full asynchronous routes is elaborated xref:servicetalk-http-api::evolve-to-async.adoc[here].

--- a/servicetalk-http-router-jersey/docs/modules/ROOT/pages/index.adoc
+++ b/servicetalk-http-router-jersey/docs/modules/ROOT/pages/index.adoc
@@ -408,10 +408,8 @@ the Jersey router, as demonstrated here:
 [source,java]
 ----
 HttpServers.forPort(8080)
-    .listenStreamingAndAwait(
-            new HttpJerseyRouterBuilder()
-                    .executionStrategy(HttpExecutionStrategies.defaultStrategy(executor))
-                    .build(jaxrsApplication))
+    .executionStrategy(HttpExecutionStrategies.defaultStrategy(executor))
+    .listenStreamingAndAwait(new HttpJerseyRouterBuilder().build(jaxrsApplication))
     .awaitShutdown();
 ----
 
@@ -465,10 +463,8 @@ bootstrap code and followed by one JAX-RS resource method:
 [source,java]
 ----
 HttpServers.forPort(8080)
-    .listenStreamingAndAwait(
-            new HttpJerseyRouterBuilder()
-                    .executionStrategy(HttpExecutionStrategies.noOffloadsStrategy())
-                    .build(jaxrsApplication))
+    .executionStrategy(HttpExecutionStrategies.noOffloadsStrategy())
+    .listenStreamingAndAwait(new HttpJerseyRouterBuilder().build(jaxrsApplication))
     .awaitShutdown();
 
 @NoOffloadsRouteExecutionStrategy
@@ -485,7 +481,11 @@ public class HelloWorldJaxRsResource {
 
 Notice how `HttpExecutionStrategies.noOffloadsStrategy()` and
 `@NoOffloadsRouteExecutionStrategy` are used conjointly to ensure that
-the requests will be fully handled on I/O threads.
+offloading will be completely disabled and that the requests will be fully handled on I/O threads.
+
+WARNING: Disabling offloading should only be done when it is certain that no blocking code will be invoked.
+Request handling in Jersey follows a complicated and dynamic path, so unexpected blocking can occur in non-user code.
+Be sure to thoroughly test the routes for which you intend to disable offloading.
 
 These different options combined together yield different effects at
 different level of the application code. The following table details


### PR DESCRIPTION
__Motivation__

Jersey doc  is out of date. For example, "Execution Strategies" section refers to the old API (sets HttpExecutionStrategy on router builder instead of the server builder).

__Modifications__

- Update code samples,
- Add admonition about disabling offloading.

__Results__

More informed users.