### PR TITLE
Improve accuracy of `HttpExecutionStrategies#difference` for Jersey router

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
@@ -117,15 +117,11 @@ public final class HttpExecutionStrategies {
     public static HttpExecutionStrategy difference(final Executor fallback,
                                                    final HttpExecutionStrategy left,
                                                    final HttpExecutionStrategy right) {
-        if (left.equals(right)) {
-            // No difference, so no offloading is required.
+        if (left.equals(right) || right == noOffloadsStrategy()) {
             return null;
         }
         if (left == noOffloadsStrategy()) {
             return right;
-        }
-        if (left != noOffloadsStrategy() && right == noOffloadsStrategy()) {
-            return left;
         }
         if (right.executor() != null && right.executor() != left.executor() && right.executor() != fallback) {
             // Since the original offloads were done on a different executor, we need to offload again.

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpExecutionStrategiesTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpExecutionStrategiesTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpExecutionStrategies.difference;
+import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -53,6 +54,24 @@ public class HttpExecutionStrategiesTest {
         Executor executor = mock(Executor.class);
         HttpExecutionStrategy result = difference(executor, strat, strat);
         assertThat("Unexpected diff.", result, is(nullValue()));
+    }
+
+    @Test
+    public void diffRightNoOffload() {
+        Executor fallback = mock(Executor.class);
+        HttpExecutionStrategy strat1 = customStrategyBuilder().offloadReceiveData().build();
+        HttpExecutionStrategy strat2 = noOffloadsStrategy();
+        HttpExecutionStrategy result = difference(fallback, strat1, strat2);
+        assertThat("Unexpected diff.", result, is(nullValue()));
+    }
+
+    @Test
+    public void diffLeftNoOffload() {
+        Executor fallback = mock(Executor.class);
+        HttpExecutionStrategy strat1 = noOffloadsStrategy();
+        HttpExecutionStrategy strat2 = customStrategyBuilder().offloadReceiveData().build();
+        HttpExecutionStrategy result = difference(fallback, strat1, strat2);
+        assertThat("Unexpected diff.", result, is(sameInstance(strat2)));
     }
 
     @Test

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/EndpointEnhancingRequestFilter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/EndpointEnhancingRequestFilter.java
@@ -483,18 +483,14 @@ final class EndpointEnhancingRequestFilter implements ContainerRequestFilter {
 
     // Variant of HttpExecutionStrategies#difference which is geared towards router logic
     @Nullable
-    public static HttpExecutionStrategy difference(final Executor fallback,
+    private static HttpExecutionStrategy difference(final Executor fallback,
                                                    final HttpExecutionStrategy left,
                                                    final HttpExecutionStrategy right) {
-        if (left.equals(right)) {
-            // No difference, so no offloading is required.
+        if (left.equals(right) || right == noOffloadsStrategy()) {
             return null;
         }
         if (left == noOffloadsStrategy()) {
             return right;
-        }
-        if (left != noOffloadsStrategy() && right == noOffloadsStrategy()) {
-            return null;
         }
 
         final Executor rightExecutor = right.executor();


### PR DESCRIPTION
__Motivation__

`HttpExecutionStrategies#difference` may compute that offloading is necessary when it actually is not, leading to unwanted overhead.

__Modifications__

Implement these rules:

a) if `right` specifies an `Executor` different than `left` -> `right` executor must be used
b) if `left` offloads more than `right` -> no extra offloads needed
c) if `left` offloads less than `right` -> no extra offloads needed because `left` can be trusted to have computed a safe enough offloading strategy
d) if `left` offloads none but `right` does -> `right` offloads must be used
e) if `left` offloads but `right` does not -> no extra offloads needed

For b) and c) "offloads more" and "offloads less" have been currently interpreted as "offloads differently".

__Results__

Less unnecessary offloads.