### PR TITLE
Including docs from the root in the docsite.

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -16,7 +16,7 @@ get involved. Pull requests to update and expand this guide are welcome.
 
 == Before you get started
 === Community Guidelines
-We want the ServiceTalk community to be as welcoming and inclusive as possible, and have adopted a link:CODE_OF_CONDUCT.adoc[Code of Conduct]
+We want the ServiceTalk community to be as welcoming and inclusive as possible, and have adopted a xref:CODE_OF_CONDUCT.adoc[Code of Conduct]
 that we ask all community members to read and observe.
 
 === Project Licensing

--- a/README.adoc
+++ b/README.adoc
@@ -57,7 +57,7 @@ NOTE: Builds of the development version are available
 === Contributor Setup
 
 IMPORTANT: If you're intending to contribute to ServiceTalk,
-           make sure to first read the link:CONTRIBUTING.adoc[contribution guidelines].
+           make sure to first read the xref:CONTRIBUTING.adoc[contribution guidelines].
 
 ServiceTalk uses link:https://gradle.org[Gradle] as its build tool and only requires JDK 8 or higher to be pre-installed.
 ServiceTalk ships with the Gradle Wrapper, which means that there is no need to install Gradle on your machine beforehand.

--- a/docs/generation/gradle/buildSite.gradle
+++ b/docs/generation/gradle/buildSite.gradle
@@ -13,12 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+def servicetalkRoot = "../../"
+
+task copyFilesFromRoot(type: Copy) {
+  from "$servicetalkRoot/README.adoc", "$servicetalkRoot/CONTRIBUTING.adoc", "$servicetalkRoot/CODE_OF_CONDUCT.adoc"
+  into "$servicetalkRoot/docs/modules/ROOT/pages"
+}
+
 task buildLocalSite(type: NodeTask) { task ->
-  dependsOn installAntora
+  dependsOn installAntora, copyFilesFromRoot
 
   def outputDir = file("$buildDir/local")
-
-  def servicetalkRoot = "../../"
 
   inputs.file("site-local.yml")
   inputs.dir("$servicetalkRoot/docs")

--- a/docs/generation/gradle/validateSite.gradle
+++ b/docs/generation/gradle/validateSite.gradle
@@ -6,8 +6,11 @@ def httpLinks = [
 // links to exclude from validation (for example because they require authentication)
 def excludedLinks = [
     //"http://somedomain.tld/someoptionalpath"
-    // Exclude the repo until it's public, otherwise thr 404's fail the validation.
-    "https://github.com/apple/servicetalk"
+    // Exclude the repo (and others) until they're public, otherwise the 404's fail the validation.
+    "https://github.com/apple/servicetalk",
+    "https://oss.sonatype.org/content/repositories/snapshots/io/servicetalk/",
+    "https://repo1.maven.org/maven2/io/servicetalk/",
+    "https://docs.servicetalk.io/"
 ]
 
 configurations {

--- a/docs/generation/site-local.yml
+++ b/docs/generation/site-local.yml
@@ -2,7 +2,7 @@ runtime:
   cache_dir: .cache
 site:
   title: ServiceTalk Docs
-  start_page: servicetalk::index.adoc
+  start_page: servicetalk::README.adoc
 content:
   # ordered alphabetically by component name (as specified in components' antora.yml)
   # to reflect ordering of `site.components` used in .hbs

--- a/docs/generation/site-remote.yml
+++ b/docs/generation/site-remote.yml
@@ -3,7 +3,7 @@ runtime:
 site:
   title: ServiceTalk Docs
   url: https://pages.github.com/apple/servicetalk
-  start_page: servicetalk::index.adoc
+  start_page: servicetalk::README.adoc
 content:
   # ordered alphabetically by component name (as specified in components' antora.yml)
   # to reflect ordering of `site.components` used in .hbs

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -7,5 +7,5 @@
 ** xref:servicetalk-http-router-jersey::index.adoc[Jersey Router]
 ** xref:servicetalk-http-security-jersey::index.adoc[Jersey Security]
 ** xref:servicetalk-data-jackson-jersey::index.adoc[Data Jackson Jersey]
-
-
+* xref:CONTRIBUTING.adoc[Contributing]
+* xref:CODE_OF_CONDUCT.adoc[Code of Conduct]

--- a/docs/modules/ROOT/pages/.gitignore
+++ b/docs/modules/ROOT/pages/.gitignore
@@ -1,0 +1,4 @@
+# Files copied from the root during the doc generation process
+CONTRIBUTING.adoc
+README.adoc
+CODE_OF_CONDUCT.adoc


### PR DESCRIPTION
Motivation:

The root project docs have some value that would be nice to include in the
generated doc site.

Modifications:

Copy adoc files from the root into the Antora module prior to generation.
Remove `index.adoc` (content is all duplicated from `README.adoc`.
Change the start page from `index.adoc` to `README.adoc`.

Results:

There is more useful information in the doc site.