### PR TITLE
Add local docs site generation and validation to build Docker command

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
     depends_on: [runtime-setup]
     environment:
       - CI
-    command: bash -cl "./gradlew clean build"
+    command: bash -cl "./gradlew clean build && cd docs/generation && ./gradlew -S validateLocalSite"
 
   check:
     << : *common

--- a/docs/generation/build.gradle
+++ b/docs/generation/build.gradle
@@ -1,4 +1,11 @@
 buildscript {
+  if (!repositories) {
+    repositories {
+      jcenter()
+      maven { url "https://plugins.gradle.org/m2/" }
+    }
+  }
+
   ext.isCiBuild = "true" == System.getenv("CI")
   ext.isReleaseBuild = project.hasProperty("releaseBuild")
 
@@ -22,9 +29,7 @@ buildDir = ".out"
 
 node {
   version = "8.12.0" // LTS
-
-  // CI build uses node from docker image
-  download = !isCiBuild
+  download = true
 }
 
 task installAntora(type: NpmTask) {

--- a/docs/generation/gradle/validateSite.gradle
+++ b/docs/generation/gradle/validateSite.gradle
@@ -1,3 +1,9 @@
+if (!repositories) {
+  repositories {
+    jcenter()
+  }
+}
+
 // links that are allowed to be http rather than https
 def httpLinks = [
     //"http://somedomain.tld/someoptionalpath"


### PR DESCRIPTION
__Motivation__

Changes can silently break documentation generation: generating and validating the local doc site at PRB time would catch most issues early.

__Modifications__

Add local docs site generation and validation to `build` Docker command.

__Results__

Broken docs break PRBs.