### PR TITLE
Move internal dependencies to `implementation` gradle-configuration

### DIFF
--- a/servicetalk-grpc-api/build.gradle
+++ b/servicetalk-grpc-api/build.gradle
@@ -31,12 +31,12 @@ apply plugin: "servicetalk-library"
 dependencies {
   implementation "io.servicetalk:servicetalk-bom-internal:$project.version"
 
-  api "io.servicetalk:servicetalk-annotations:$project.version"
   api "io.servicetalk:servicetalk-http-api:$project.version"
   api "io.servicetalk:servicetalk-concurrent-api:$project.version"
-  api "io.servicetalk:servicetalk-concurrent-internal:$project.version"
   api "com.google.api.grpc:proto-google-common-protos"
 
+  implementation "io.servicetalk:servicetalk-annotations:$project.version"
+  implementation "io.servicetalk:servicetalk-concurrent-internal:$project.version"
   implementation "io.servicetalk:servicetalk-concurrent-api-internal:$project.version"
   implementation "org.slf4j:slf4j-api"
   implementation "com.google.code.findbugs:jsr305"

--- a/servicetalk-grpc-api/gradle.properties
+++ b/servicetalk-grpc-api/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+# Copyright © 2019 Apple Inc. and the ServiceTalk project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -31,13 +31,11 @@ apply plugin: "servicetalk-library"
 dependencies {
   implementation "io.servicetalk:servicetalk-bom-internal:$project.version"
 
-  api "io.servicetalk:servicetalk-annotations:$project.version"
-  api "io.servicetalk:servicetalk-concurrent-api:$project.version"
   api "io.servicetalk:servicetalk-grpc-api:$project.version"
-  api "io.servicetalk:servicetalk-http-api:$project.version"
   api "io.servicetalk:servicetalk-http-netty:$project.version"
-  api "io.servicetalk:servicetalk-transport-netty-internal:$project.version"
 
+  implementation "io.servicetalk:servicetalk-annotations:$project.version"
+  implementation "io.servicetalk:servicetalk-transport-netty-internal:$project.version"
   implementation "org.slf4j:slf4j-api"
   implementation "com.google.code.findbugs:jsr305"
 

--- a/servicetalk-grpc-netty/gradle.properties
+++ b/servicetalk-grpc-netty/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+# Copyright © 2019 Apple Inc. and the ServiceTalk project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/servicetalk-grpc-protobuf/build.gradle
+++ b/servicetalk-grpc-protobuf/build.gradle
@@ -31,13 +31,11 @@ apply plugin: "servicetalk-library"
 dependencies {
   implementation "io.servicetalk:servicetalk-bom-internal:$project.version"
 
-  api "io.servicetalk:servicetalk-annotations:$project.version"
   api "io.servicetalk:servicetalk-grpc-api:$project.version"
-  api "io.servicetalk:servicetalk-http-api:$project.version"
-  api "io.servicetalk:servicetalk-concurrent-api:$project.version"
   api "com.google.protobuf:protobuf-java"
   api "com.google.api.grpc:proto-google-common-protos"
 
+  implementation "io.servicetalk:servicetalk-annotations:$project.version"
   implementation "org.slf4j:slf4j-api"
   implementation "com.google.code.findbugs:jsr305"
 

--- a/servicetalk-grpc-protobuf/gradle.properties
+++ b/servicetalk-grpc-protobuf/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+# Copyright © 2019 Apple Inc. and the ServiceTalk project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Motivation:

Dependencies with `-internal` suffix and `servicetalk-annotations` are
not part of the public API and should be declared under `implementation`
configuration in gradle.

Modifications:

- Move `*-internal` and `servicetalk-annotations` dependencies from
`api` to `implementation` configuration;
- Do not declare transitive dependencies from `servicetalk-grpc-api`
explicitly;
- Update copyright year;

Result:

No internal API leak.