### PR TITLE
Dont use deprecated Http2StreamChannelBootstrap.open0(...) method

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -60,7 +60,6 @@ import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http2.DefaultHttp2GoAwayFrame;
 import io.netty.handler.codec.http2.DefaultHttp2PingFrame;
 import io.netty.handler.codec.http2.Http2GoAwayFrame;
-import io.netty.handler.codec.http2.Http2MultiplexCodec;
 import io.netty.handler.codec.http2.Http2PingFrame;
 import io.netty.handler.codec.http2.Http2SettingsAckFrame;
 import io.netty.handler.codec.http2.Http2SettingsFrame;
@@ -171,7 +170,7 @@ final class H2ClientParentConnectionContext extends NettyChannelListenableAsyncC
                     parentChannelInitializer = new H2ParentClientConnection(connection, subscriber,
                             delayedCancellable,
                             NettyPipelineSslUtils.isSslEnabled(pipeline),
-                            pipeline.lastContext(), config.h2HeadersFactory(), reqRespFactory);
+                            config.h2HeadersFactory(), reqRespFactory);
                 } catch (Throwable cause) {
                     channel.close();
                     subscriber.onSubscribe(IGNORE_CANCEL);
@@ -302,7 +301,6 @@ final class H2ClientParentConnectionContext extends NettyChannelListenableAsyncC
     private static final class H2ParentClientConnection extends ChannelInboundHandlerAdapter implements
                                                                                              Http2ParentConnection {
         private final Http2StreamChannelBootstrap bs;
-        private final ChannelHandlerContext http2MultiplexCodecContext;
         private final boolean waitForSslHandshake;
         private final H2ClientParentConnectionContext connection;
         private final DelayedCancellable delayedCancellable;
@@ -316,15 +314,12 @@ final class H2ClientParentConnectionContext extends NettyChannelListenableAsyncC
                                  Subscriber<? super Http2ParentConnection> subscriber,
                                  DelayedCancellable delayedCancellable,
                                  boolean waitForSslHandshake,
-                                 ChannelHandlerContext http2MultiplexCodecContext,
                                  HttpHeadersFactory headersFactory,
                                  StreamingHttpRequestResponseFactory reqRespFactory) {
-            assert http2MultiplexCodecContext.handler() instanceof Http2MultiplexCodec;
             this.connection = connection;
             this.subscriber = requireNonNull(subscriber);
             this.delayedCancellable = delayedCancellable;
             this.waitForSslHandshake = waitForSslHandshake;
-            this.http2MultiplexCodecContext = requireNonNull(http2MultiplexCodecContext);
             this.headersFactory = requireNonNull(headersFactory);
             this.reqRespFactory = requireNonNull(reqRespFactory);
             bs = new Http2StreamChannelBootstrap(connection.channel());
@@ -466,11 +461,7 @@ final class H2ClientParentConnectionContext extends NettyChannelListenableAsyncC
                     try {
                         final EventExecutor e = connection.channel().eventLoop();
                         promise = e.newPromise();
-                        if (e.inEventLoop()) {
-                            bs.open0(http2MultiplexCodecContext, promise);
-                        } else {
-                            e.execute(() -> bs.open0(http2MultiplexCodecContext, promise));
-                        }
+                        bs.open(promise);
                         sequentialCancellable = new SequentialCancellable(() -> promise.cancel(true));
                     } catch (Throwable cause) {
                         deliverTerminalFromSource(subscriber, cause);


### PR DESCRIPTION
Motivation:

Http2StreamChannelBootstrap.open0(...) will be deprecated in the next netty release, so we should not use it.

See https://github.com/netty/netty/pull/9372.

Modifications:

- Replace open0(...) with open(...)

Result:

Do not use deprecated method