### PR TITLE
add docker setup for running quality tasks separately

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,13 @@ buildscript {
   }
 }
 
+if (!repositories) {
+  repositories {
+    jcenter()
+    maven { url "https://plugins.gradle.org/m2/" }
+  }
+}
+
 // Composite builds do not correctly substitute test fixtures dependencies
 // because they target a custom configuration (namely: testFixturesRuntime).
 // We work around this problem by replacing test fixtures artifact dependencies

--- a/docker/docker-compose.centos7.java11.yaml
+++ b/docker/docker-compose.centos7.java11.yaml
@@ -34,6 +34,9 @@ services:
   test:
     image: servicetalk:centos-7-1.11
 
+  quality:
+    image: servicetalk:centos-7-1.11
+
   publish-snapshot:
     image: servicetalk:centos-7-1.11
 

--- a/docker/docker-compose.centos7.java8.yaml
+++ b/docker/docker-compose.centos7.java8.yaml
@@ -34,6 +34,9 @@ services:
   test:
     image: servicetalk:centos-7-1.8
 
+  quality:
+    image: servicetalk:centos-7-1.8
+
   publish-snapshot:
     image: servicetalk:centos-7-1.8
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -41,21 +41,28 @@ services:
     depends_on: [runtime-setup]
     environment:
       - CI
-    command: bash -cl "./gradlew clean build && cd docs/generation && ./gradlew -S validateLocalSite"
+    command: bash -cl "./gradlew --no-daemon clean build && cd docs/generation && ./gradlew -S validateLocalSite"
 
   check:
     << : *common
     depends_on: [runtime-setup]
     environment:
       - CI
-    command: bash -cl "./gradlew clean check"
+    command: bash -cl "./gradlew --no-daemon clean check"
 
   test:
     << : *common
     depends_on: [runtime-setup]
     environment:
       - CI
-    command: bash -cl "./gradlew clean test"
+    command: bash -cl "./gradlew --no-daemon clean test"
+
+  quality:
+    << : *common
+    depends_on: [runtime-setup]
+    environment:
+      - CI
+    command: bash -cl "./gradlew --no-daemon clean quality"
 
   publish-snapshot:
     << : *common
@@ -64,7 +71,7 @@ services:
       - CI
       - BINTRAY_USER
       - BINTRAY_KEY
-    command: bash -cl "./gradlew clean check && ./gradlew bintrayUpload"
+    command: bash -cl "./gradlew --no-daemon clean check && ./gradlew --no-daemon bintrayUpload"
 
   publish-release:
     << : *common
@@ -73,7 +80,7 @@ services:
       - CI
       - BINTRAY_USER
       - BINTRAY_KEY
-    command: bash -cl "./gradlew clean check && ./gradlew bintrayUpload -PreleaseBuild=true"
+    command: bash -cl "./gradlew --no-daemon clean check && ./gradlew --no-daemon bintrayUpload -PreleaseBuild=true"
 
   shell:
     << : *common


### PR DESCRIPTION
motivation: improve build times

changes:
* add quality docker-compose task that calls into the grad;e build quality task
* add conditional repositories stanza to the build script as its required by checkstyleRoot
* add --no-deamon on all docker build tasks as thre is no point using a daemon when in a docker container