### PR TITLE
Add `checkstyleRoot` as a dependency for composite's `build` and `check`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,10 +86,12 @@ task test {
 }
 
 task check {
+  dependsOn checkstyleRoot
   dependsOn findTasks('check')
 }
 
 task build {
+  dependsOn checkstyleRoot
   dependsOn findTasks('build')
 }
 


### PR DESCRIPTION
Motivation:

`./gradlew build` and `./gradlew check` for the composite build doesn't
run the `checkstyleRoot` task defined for the root composite project.
As a result, we missed copyright validation for `scripts/` folder.

Modifications:

- Add `checkstyleRoot` as a dependency for composite's `build` and
`check` tasks;

Result:

Always run checkstyle validation for composite root project when we run
`build` or `check` tasks.