### PR TITLE
Fix remote documentation generation

### DIFF
--- a/docs/generation/gradle/buildSite.gradle
+++ b/docs/generation/gradle/buildSite.gradle
@@ -16,13 +16,8 @@
 
 def servicetalkRoot = "../../"
 
-task copyFilesFromRoot(type: Copy) {
-  from "$servicetalkRoot/README.adoc", "$servicetalkRoot/CONTRIBUTING.adoc", "$servicetalkRoot/CODE_OF_CONDUCT.adoc"
-  into "$servicetalkRoot/docs/modules/ROOT/pages"
-}
-
 task buildLocalSite(type: NodeTask) { task ->
-  dependsOn installAntora, copyFilesFromRoot
+  dependsOn installAntora
 
   def outputDir = file("$buildDir/local")
 

--- a/docs/generation/gradle/validateSite.gradle
+++ b/docs/generation/gradle/validateSite.gradle
@@ -16,7 +16,8 @@ def excludedLinks = [
     "https://github.com/apple/servicetalk",
     "https://oss.sonatype.org/content/repositories/snapshots/io/servicetalk/",
     "https://repo1.maven.org/maven2/io/servicetalk/",
-    "https://docs.servicetalk.io/"
+    "https://docs.servicetalk.io/",
+    "https://reactivex.io/"
 ]
 
 configurations {

--- a/docs/generation/site-local.yml
+++ b/docs/generation/site-local.yml
@@ -2,7 +2,7 @@ runtime:
   cache_dir: .cache
 site:
   title: ServiceTalk Docs
-  start_page: servicetalk::README.adoc
+  start_page: servicetalk::index.adoc
 content:
   # ordered alphabetically by component name (as specified in components' antora.yml)
   # to reflect ordering of `site.components` used in .hbs

--- a/docs/generation/site-remote.yml
+++ b/docs/generation/site-remote.yml
@@ -2,8 +2,7 @@ runtime:
   cache_dir: .cache
 site:
   title: ServiceTalk Docs
-  url: https://pages.github.com/apple/servicetalk
-  start_page: servicetalk::README.adoc
+  start_page: servicetalk::index.adoc
 content:
   # ordered alphabetically by component name (as specified in components' antora.yml)
   # to reflect ordering of `site.components` used in .hbs

--- a/docs/modules/ROOT/pages/.gitignore
+++ b/docs/modules/ROOT/pages/.gitignore
@@ -1,4 +1,0 @@
-# Files copied from the root during the doc generation process
-CONTRIBUTING.adoc
-README.adoc
-CODE_OF_CONDUCT.adoc

--- a/docs/modules/ROOT/pages/CODE_OF_CONDUCT.adoc
+++ b/docs/modules/ROOT/pages/CODE_OF_CONDUCT.adoc
@@ -1,0 +1,61 @@
+= Code of Conduct
+
+To be a truly great community, ServiceTalk needs to welcome developers from all walks of life,
+with different backgrounds, and with a wide range of experience. A diverse and friendly
+community will have more great ideas, more unique perspectives, and produce more great
+code. We will work diligently to make the ServiceTalk community welcoming to everyone.
+
+To give clarity of what is expected of our members, ServiceTalk has adopted the code of conduct
+defined by https://www.contributor-covenant.org[contributor-covenant.org]. This document is used across many open source
+communities, and we think it articulates our values well. The full text is copied below:
+
+[discrete]
+=== Contributor Code of Conduct v1.3
+
+As contributors and maintainers of this project, and in the interest of fostering an open and
+welcoming community, we pledge to respect all people who contribute through reporting
+issues, posting feature requests, updating documentation, submitting pull requests or patches,
+and other activities.
+
+We are committed to making participation in this project a harassment-free experience for
+everyone, regardless of level of experience, gender, gender identity and expression, sexual
+orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or
+nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of
+Conduct, or to ban temporarily or permanently any contributor for other behaviors that they
+deem inappropriate, threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and
+consistently applying these principles to every aspect of managing this project. Project
+maintainers who do not follow or enforce the Code of Conduct may be permanently removed
+from the project team.
+
+This code of conduct applies both within project spaces and in public spaces when an
+individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
+contacting a project maintainer at link:mailto:servicetalk-conduct@group.apple.com[servicetalk-conduct@group.apple.com]. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and appropriate to the
+circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter
+of an incident.
+
+_This policy is adapted from the Contributor Code of Conduct https://contributor-covenant.org/version/1/3/0/[version 1.3.0]._
+
+[discrete]
+=== Reporting
+
+A working group of community members is committed to promptly addressing any link:mailto:servicetalk-conduct@group.apple.com[reported issues].
+Working group members are volunteers appointed by the project lead, with a
+preference for individuals with varied backgrounds and perspectives. Membership is expected
+to change regularly, and may grow or shrink.

--- a/docs/modules/ROOT/pages/CONTRIBUTING.adoc
+++ b/docs/modules/ROOT/pages/CONTRIBUTING.adoc
@@ -1,0 +1,85 @@
+= Contributing to ServiceTalk
+
+Welcome to the ServiceTalk community, and thank you for contributing! The following guide outlines the basics of how to
+get involved. Pull requests to update and expand this guide are welcome.
+
+==== Table of Contents
+
+* <<Before you get started>>
+** <<Community Guidelines>>
+** <<Project Licensing>>
+** <<Governance and Decision Making>>
+* <<Contributing>>
+** <<Opening a Pull Request>>
+** <<Reporting Issues>>
+* <<Project Communication>>
+
+== Before you get started
+=== Community Guidelines
+We want the ServiceTalk community to be as welcoming and inclusive as possible, and have adopted a xref:CODE_OF_CONDUCT.adoc[Code of Conduct]
+that we ask all community members to read and observe.
+
+=== Project Licensing
+By submitting a pull request, you represent that you have the right to license your contribution to Apple and the
+community, and agree by submitting the patch that your contributions are licensed under the Apache 2.0 license.
+
+=== Governance and Decision Making
+At project launch, ServiceTalk has a light governance structure. The intention is for the community to evolve quickly
+and adopt additional processes as participation grows. Stay tuned, and stay engaged! Your feedback is welcome.
+
+Members of the Apple ServiceTalk team are part of the initial core committers helping review individual contributions;
+you'll see them commenting on your pull requests. Future committers to the open source project, and the process for
+adding individuals in this role will be formalized in the future.
+
+== Contributing
+=== Opening a Pull Request
+We love pull requests! For minor changes, feel free to open up a PR directly. For larger feature development and any
+changes that may require community discussion, we ask that you discuss your ideas on a link:https://github.pie.apple.com/servicetalk/servicetalk/issues[github issue]
+prior to opening a PR, and then reference that issue within your PR comment.
+
+CI will run tests against the PR and post the status back to github.
+
+=== Writing a Patch
+A good ServiceTalk patch is:
+
+- Concise, and contains as few changes as needed to achieve the end result.
+- Tested, ensuring that any tests provided failed before the patch and pass after it.
+- Documented, adding API documentation as needed to cover new functions and properties.
+- Accompanied by a great commit message, using our <<Commit Message Template>>.
+
+=== Checklist
+Please use the following checklist before pushing your commits or issuing a pull request:
+
+- Did you rebase your pull request against the HEAD of the target branch and fix all conflicts?
+- Does your work build without any failure when you run `./gradlew build` from shell?
+- Does your commit message or pull request description follow our <<Commit Message Template>>?
+
+=== Commit Message Template
+We require that your commit messages match our template. The easiest way to do that is to get git
+to help you by explicitly using the template. To do that, `cd` to the root of our repository and run:
+```
+git config commit.template .git.commit.template
+```
+
+=== Reporting Issues
+Issues may be reported through link:https://github.pie.apple.com/servicetalk/servicetalk/issues[github issues].
+
+Please be sure to include:
+
+* The ServiceTalk version
+* The OS version and the output of `uname -a`
+* Java version, output of `java -version`
+* Contextual information (e.g. what you were trying to achieve with ServiceTalk)
+* Simplest possible steps to reproduce
+** A pull request with a failing test case is preferred, but it's fine to paste the test case into the issue description.
+* Anything else that might be relevant in your opinion, such as network configuration.
+
+==== Security issues
+To report a security issue, please DO NOT start by filing a public issue; instead send a
+private email to link:mailto:servicetalk-security@group.apple.com[servicetalk-security@group.apple.com].
+
+== Project Communication
+We encourage your participation asking questions and helping improve the ServiceTalk project.
+link:https://github.pie.apple.com/servicetalk/servicetalk/issues[Github issues] and
+link:https://github.pie.apple.com/servicetalk/servicetalk/pulls[pull requests] are the primary mechanisms of
+participation and communication for ServiceTalk.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,9 +1,97 @@
-include::ROOT:partial$component-attributes.adoc[]
 = ServiceTalk
 
 ServiceTalk is a JVM network application framework with APIs tailored to specific protocols (e.g. HTTP/1.x,
-HTTP/2.x, etc...) and supports multiple xref:introduction.adoc#programming-paradigms[Programming Paradigms].
+HTTP/2.x, etc...) and supports multiple programming paradigms.
 
 It is built on link:https://netty.io[Netty] and is designed to provide most of the performance/scalability benefits of
 Netty for common networking protocols used in service to service communication. ServiceTalk provides server support and
 "smart client" like features such as client-side load balancing and service discovery integration.
+
+See the link:https://docs.servicetalk.io/[ServiceTalk docs] for more information.
+
+== Getting Started
+
+All ServiceTalk released artifacts are available in link:https://repo1.maven.org/maven2/io/servicetalk/[the Maven central repository].
+
+The easiest way to get started is to add ServiceTalk's bill-of-material (BOM) dependency to your project's build.
+
+.Maven, pom/xml
+[source,xml]
+----
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>io.servicetalk</groupId>
+      <artifactId>servicetalk-bom</artifactId>
+      <version>${servicetalk.version}</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+----
+
+.Gradle 5, build.gradle
+[source,groovy]
+----
+implementation platform("io.servicetalk:servicetalk-bom:$serviceTalkVersion")
+----
+
+.Gradle 4
+[source,groovy]
+----
+implementation "io.servicetalk:servicetalk-bom:$serviceTalkVersion" // <1>
+
+enableFeaturePreview("IMPROVED_POM_SUPPORT") // <2>
+----
+<1> in _build.gradle_
+<2> in _settings.gradle_
+
+With this in place, you can add the ServiceTalk module dependencies you need without specifying their versions.
+
+Refer to the link:https://docs.servicetalk.io/[ServiceTalk docs] for various examples that will get you started with the different features of ServiceTalk.
+
+NOTE: Builds of the development version are available
+      in link:https://oss.sonatype.org/content/repositories/snapshots/io/servicetalk/[Sonatype's snapshots Maven repository].
+
+=== Contributor Setup
+
+IMPORTANT: If you're intending to contribute to ServiceTalk,
+           make sure to first read the xref:CONTRIBUTING.adoc[contribution guidelines].
+
+ServiceTalk uses link:https://gradle.org[Gradle] as its build tool and only requires JDK 8 or higher to be pre-installed.
+ServiceTalk ships with the Gradle Wrapper, which means that there is no need to install Gradle on your machine beforehand.
+
+IMPORTANT: ServiceTalk's source code is UTF-8 encoded: make sure your filesystem supports it before attempting to build
+the project. Setting the `JAVA_TOOL_OPTIONS` env var to `-Dfile.encoding=UTF-8` should help building the project in
+non-UTF-8 environments. Editors and IDEs must also support UTF-8 in order to successfully edit ServiceTalk's source code.
+
+You should be able to run the following command to build ServiceTalk:
+
+[source,shell]
+----
+$ ./gradlew build
+----
+
+The supported IDE is link:https://www.jetbrains.com/idea[IntelliJ IDEA].
+In order to generate IntelliJ IDEA project files for ServiceTalk,
+you can run the following command:
+
+[source,shell]
+----
+$ ./gradlew idea
+----
+
+When done, running one of following commands would open ServiceTalk in IntelliJ:
+
+.Generic
+[source,shell]
+----
+$ idea .
+----
+
+.macOS
+[source,shell]
+----
+$ open servicetalk.ipr
+----


### PR DESCRIPTION
Motivation:
Remote documentation generation is broken due to root level documentation not
existing in source control when Antora attempts to check out and generate.

Modifications:
- Add root level documents to source control that are referenced during remote
documentation generation
- move README.adoc to index.adoc because Antora expects the start page to be the
same name for all versions/tags
- Ignore reactivex.io certificate errors

Result:
Remote documentation generation completes.