### PR TITLE
Remove APIs for unsupported features.

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
@@ -186,8 +186,8 @@ final class DefaultGrpcClientCallFactory implements GrpcClientCallFactory {
     }
 
     private GrpcMessageEncoding getMessageEncoding(final GrpcClientMetadata metadata) {
-        GrpcMessageEncoding messageEncoding = metadata.messageEncoding();
-        return messageEncoding == null ? None : messageEncoding;
+        // compression not yet supported.
+        return None;
     }
 
     private <Req> HttpRequest newAggregatedRequest(final GrpcClientMetadata metadata, final Req rawReq,

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientMetadata.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientMetadata.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.grpc.api;
 
-import java.time.Duration;
 import javax.annotation.Nullable;
 
 import static java.util.Objects.requireNonNull;
@@ -45,10 +44,5 @@ public class DefaultGrpcClientMetadata extends DefaultGrpcMetadata implements Gr
     @Override
     public void strategy(final GrpcExecutionStrategy strategy) {
         this.strategy = requireNonNull(strategy);
-    }
-
-    @Override
-    public void deadline(final Duration deadline) {
-        super.deadline(deadline);
     }
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcMetadata.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcMetadata.java
@@ -15,19 +15,11 @@
  */
 package io.servicetalk.grpc.api;
 
-import java.time.Duration;
-import javax.annotation.Nullable;
-
 import static java.util.Objects.requireNonNull;
 
 class DefaultGrpcMetadata implements GrpcMetadata {
 
     private final String path;
-    private boolean compressed;
-    @Nullable
-    private GrpcMessageEncoding messageEncoding;
-    @Nullable
-    private Duration deadline;
 
     DefaultGrpcMetadata(final String path) {
         this.path = requireNonNull(path);
@@ -36,36 +28,5 @@ class DefaultGrpcMetadata implements GrpcMetadata {
     @Override
     public String path() {
         return path;
-    }
-
-    @Override
-    public boolean isCompressed() {
-        return compressed;
-    }
-
-    @Override
-    public void compressed(final boolean compressed) {
-        this.compressed = compressed;
-    }
-
-    @Nullable
-    @Override
-    public GrpcMessageEncoding messageEncoding() {
-        return messageEncoding;
-    }
-
-    @Override
-    public void messageEncoding(final GrpcMessageEncoding messageEncoding) {
-        this.messageEncoding = requireNonNull(messageEncoding);
-    }
-
-    @Nullable
-    @Override
-    public Duration deadline() {
-        return deadline;
-    }
-
-    void deadline(final Duration deadline) {
-        this.deadline = requireNonNull(deadline);
     }
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientMetadata.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientMetadata.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.grpc.api;
 
-import java.time.Duration;
 import javax.annotation.Nullable;
 
 /**
@@ -41,13 +40,4 @@ public interface GrpcClientMetadata extends GrpcMetadata {
      * <a href="https://www.grpc.io">gRPC</a> method.
      */
     void strategy(GrpcExecutionStrategy strategy);
-
-    /**
-     * Sets the <a href="https://grpc.io/blog/deadlines/">gRPC deadline</a> for the associated
-     * <a href="https://www.grpc.io">gRPC</a> method.
-     *
-     * @param deadline The <a href="https://grpc.io/blog/deadlines/">gRPC deadline</a> for the associated
-     * <a href="https://www.grpc.io">gRPC</a> method.
-     */
-    void deadline(Duration deadline);
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMessageEncoding.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMessageEncoding.java
@@ -21,10 +21,7 @@ package io.servicetalk.grpc.api;
  */
 public enum GrpcMessageEncoding {
 
-    None("identity"),
-    Gzip("gzip"),
-    Zlib("zlib"),
-    Snappy("snappy");
+    None("identity");
 
     private final String encoding;
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMetadata.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMetadata.java
@@ -15,9 +15,6 @@
  */
 package io.servicetalk.grpc.api;
 
-import java.time.Duration;
-import javax.annotation.Nullable;
-
 /**
  * Metadata for a <a href="https://www.grpc.io">gRPC</a> call.
  */
@@ -29,45 +26,4 @@ public interface GrpcMetadata {
      * @return The path for the associated <a href="https://www.grpc.io">gRPC</a> method.
      */
     String path();
-
-    /**
-     * Returns {@code true} if the associated message is to be sent compressed.
-     *
-     * @return {@code true} if the associated message is to be sent compressed.
-     */
-    boolean isCompressed();
-
-    /**
-     * The associated message will be sent compressed if {@code compressed} is {@code true}.
-     *
-     * @param compressed {@code true} if the associated message is to be sent compressed.
-     */
-    void compressed(boolean compressed);
-
-    /**
-     * Returns {@code GrpcMessageEncoding} for any message that is to be sent {@link #isCompressed() compressed}.
-     * {@code null} if none specified.
-     *
-     * @return {@code GrpcMessageEncoding} for any message that is to be sent {@link #isCompressed() compressed}.
-     * {@code null} if none specified.
-     */
-    @Nullable
-    GrpcMessageEncoding messageEncoding();
-
-    /**
-     * Sets {@code GrpcMessageEncoding} for any message that is to be sent {@link #isCompressed() compressed}.
-     *
-     * @param messageEncoding {@code GrpcMessageEncoding} for any message that is to be sent
-     * {@link #isCompressed() compressed}.
-     */
-    void messageEncoding(GrpcMessageEncoding messageEncoding);
-
-    /**
-     * Returns a <a href="https://grpc.io/blog/deadlines/">gRPC deadline</a>, if set for the associated RPC method.
-     *
-     * @return {@link Duration} representing the <a href="https://grpc.io/blog/deadlines/">gRPC deadline</a> or
-     * {@code null} if none exists.
-     */
-    @Nullable
-    Duration deadline();
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
@@ -35,10 +35,7 @@ import java.util.Base64;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.grpc.api.GrpcMessageEncoding.Gzip;
 import static io.servicetalk.grpc.api.GrpcMessageEncoding.None;
-import static io.servicetalk.grpc.api.GrpcMessageEncoding.Snappy;
-import static io.servicetalk.grpc.api.GrpcMessageEncoding.Zlib;
 import static io.servicetalk.http.api.CharSequences.contentEqualsIgnoreCase;
 import static io.servicetalk.http.api.CharSequences.newAsciiString;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
@@ -121,16 +118,7 @@ final class GrpcUtils {
         // identity is a special header for no compression
         if (encoding != null && !contentEqualsIgnoreCase(encoding, IDENTITY)) {
             String lowercaseEncoding = encoding.toString().toLowerCase();
-            switch (lowercaseEncoding) {
-                case "gzip":
-                    return Gzip;
-                case "zlib":
-                    return Zlib;
-                case "snappy":
-                    return Snappy;
-                default:
-                    throw new SerializationException("Compression " + lowercaseEncoding + " not supported");
-            }
+            throw new SerializationException("Compression " + lowercaseEncoding + " not supported");
         } else {
             return None;
         }

--- a/servicetalk-grpc-protobuf/src/main/java/io/servicetalk/grpc/protobuf/ProtoBufSerializationProviderBuilder.java
+++ b/servicetalk-grpc-protobuf/src/main/java/io/servicetalk/grpc/protobuf/ProtoBufSerializationProviderBuilder.java
@@ -123,9 +123,8 @@ public final class ProtoBufSerializationProviderBuilder {
             if (serializersForType == null) {
                 throw new SerializationException("Unknown class to serialize: " + type.getName());
             }
-            GrpcMessageEncoding messageEncoding = metadata.messageEncoding();
             @SuppressWarnings("unchecked")
-            HttpSerializer<T> httpSerializer = serializersForType.get(messageEncoding == null ? None : messageEncoding);
+            HttpSerializer<T> httpSerializer = serializersForType.get(None); // compression not yet supported.
             return httpSerializer;
         }
 


### PR DESCRIPTION
__Motivation__

Compression and deadline are not yet supported but we have them in the API.
We do not intend to support these features in the near term so we should not allow users to use APIs that are not supported.

__Modification__

Remove these methods from the APIs.

__Result__

APIs that are not going to be implemented in the near future are not exposed to users.