### PR TITLE
Update Jackson to 2.9.9.2

### DIFF
--- a/servicetalk-bom-internal/gradle.properties
+++ b/servicetalk-bom-internal/gradle.properties
@@ -42,7 +42,7 @@ mockitoCoreVersion=2.19.0
 reactiveStreamsVersion=1.0.2
 rxJavaVersion=2.1.13
 jcToolsVersion=2.1.2
-jacksonVersion=2.9.9.1
+jacksonVersion=2.9.9.2
 
 openTracingVersion=0.31.0
 


### PR DESCRIPTION
__Motivation__

Two deserialization attacks have been fixed in the latest version of Jackson [1]

__Modifications__

Update Jackson to micro-patched version 2.9.9.2

__Results__

More secure deserialization.

[1] https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9#micro-patches