### PR TITLE
Reduce contention on host selection cursor incr

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -258,7 +258,7 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends ListenableA
             return failed(NO_ACTIVE_HOSTS_SELECT_CNX_EXCEPTION);
         }
 
-        final int cursor = indexUpdater.getAndUpdate(this, i -> (++i & Integer.MAX_VALUE)) % activeHosts.size();
+        final int cursor = (indexUpdater.getAndIncrement(this) & Integer.MAX_VALUE) % activeHosts.size();
         final Host<ResolvedAddress, C> host = activeHosts.get(cursor);
         assert host != null : "Host can't be null.";
         assert host.address != null : "Host address can't be null.";


### PR DESCRIPTION
__Motivation__

The round-robin host selection cursor atomic increment showed up in some profiles taking up to 4% CPU. It was implemented using JDK Atomic getAndUpdate() with a lambda to increment and protect for overflow. We can take advantage of the hardware atomic increment instruction with far less perf hit under contention and guard for overflow on return. The previous implementation bounces back and forth between the Java lambda execution and the CPU cache subsystem on repeated failed CASes for this value shared by all client threads.

__Modifications__

Switch the JDK Atomic getAndUpdate() to getAndIncrement() and move the overlow protection outside.

__Result__

Reduce performance hit under contention.