### PR TITLE
Update Jackson to 2.9.9.3

### DIFF
--- a/servicetalk-bom-internal/gradle.properties
+++ b/servicetalk-bom-internal/gradle.properties
@@ -42,7 +42,7 @@ mockitoCoreVersion=2.19.0
 reactiveStreamsVersion=1.0.2
 rxJavaVersion=2.1.13
 jcToolsVersion=2.1.2
-jacksonVersion=2.9.9.2
+jacksonVersion=2.9.9.3
 
 openTracingVersion=0.31.0
 


### PR DESCRIPTION
__Motivation__

A regression has been introduced in 2.9.9.2 and fixed in 2.9.9.3

See: https://github.com/FasterXML/jackson-databind/issues/2395