### PR TITLE
Upgrade to netty 4.1.39.Final which fixes http2 security issues

### DIFF
--- a/servicetalk-bom-internal/gradle.properties
+++ b/servicetalk-bom-internal/gradle.properties
@@ -17,7 +17,7 @@
 group=io.servicetalk
 version=0.17.0-SNAPSHOT
 
-nettyVersion=4.1.38.Final
+nettyVersion=4.1.39.Final
 tcnativeVersion=2.0.25.Final
 jsr305Version=3.0.2
 


### PR DESCRIPTION
Motivation:

A new netty version was released

Modifications:

Update version

Result:

Use latest netty version