### PR TITLE
Add unit test to verify TLSv1.3 support

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/Tls13Test.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/Tls13Test.java
@@ -69,7 +69,7 @@ public class Tls13Test {
 
     @Test
     public void requiredCipher() throws Exception {
-        try(ServerContext serverContext = HttpServers.forAddress(localAddress(0))
+        try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
                 .enableSsl(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
                 .protocols(TLS1_3)
                 .ciphers(singletonList(TLS1_3_REQUIRED_CIPHER))


### PR DESCRIPTION
Motivation:
We support TLSv1.3 via JDK11's SSLEngineImpl and also via netty-tcnative, but we
don't test this capability.

Modifications:
- Add a test to verify TLSv1.3 with the required cipher.

Result:
TLSv1.3 behavior is verified.