### PR TITLE
Correctly override all methods in `MultiAddressHttpClientBuilder`

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -131,6 +131,16 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
     public abstract MultiAddressHttpClientBuilder<U, R> unresolvedAddressToHost(
             Function<U, CharSequence> unresolvedAddressToHostFunction);
 
+    @Override
+    public abstract MultiAddressHttpClientBuilder<U, R> appendClientFilter(StreamingHttpClientFilterFactory factory);
+
+    @Override
+    public MultiAddressHttpClientBuilder<U, R> appendClientFilter(final Predicate<StreamingHttpRequest> predicate,
+                                                                  final StreamingHttpClientFilterFactory factory) {
+        super.appendClientFilter(predicate, factory);
+        return this;
+    }
+
     /**
      * Append the filter to the chain of filters used to decorate the {@link StreamingHttpClient} created by this
      * builder for a given {@code UnresolvedAddress}.


### PR DESCRIPTION
__Motivation__

`MultiAddressHttpClientBuilder` does not override `appendClientFactory` methods from `HttpClientBuilder` which exposes a package private class `HttpClientBuilder` in these methods.

__Modification__

Override the methods and appropriately change the return type.

__Result__

No leaking of package private class and correct return types.