### PR TITLE
Remove build.gradle comment about extracting version

### DIFF
--- a/servicetalk-grpc-protobuf/build.gradle
+++ b/servicetalk-grpc-protobuf/build.gradle
@@ -49,8 +49,6 @@ dependencies {
   testImplementation "org.mockito:mockito-core"
 }
 
-// Versions for managed dependencies are not available as properties so we retrieve it from a concrete dependency
-// Attempts to extract from configurations lead to transitive dependency failures.
 def protobufVersion = "3.9.0"
 
 protobuf {


### PR DESCRIPTION
Motivation:
There was an attempt to extract a managed dependency version from the set of
resolved dependencies. This approach didn't work in this specific situation so
the version is hard coded. Now the comment is confusing and should be removed.

Modifications:
- Remove the comment which no longer applies

Result:
Less confusing comments.