### PR TITLE
Enable h2 builder options for gRPC server

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -54,6 +54,32 @@ public abstract class GrpcServerBuilder {
     public abstract GrpcServerBuilder headersFactory(HttpHeadersFactory headersFactory);
 
     /**
+     * Set the {@link HttpHeadersFactory} to use when HTTP/2 is used.
+     *
+     * @param headersFactory the {@link HttpHeadersFactory} to use when HTTP/2 is used.
+     * @return {@code this}.
+     */
+    public abstract GrpcServerBuilder h2HeadersFactory(HttpHeadersFactory headersFactory);
+
+    /**
+     * Enable HTTP/2 via
+     * <a href="https://tools.ietf.org/html/rfc7540#section-3.4">Prior Knowledge</a>.
+     * @param h2PriorKnowledge {@code true} to enable HTTP/2 via
+     * <a href="https://tools.ietf.org/html/rfc7540#section-3.4">Prior Knowledge</a>.
+     *
+     * @return {@code this}.
+     */
+    public abstract GrpcServerBuilder h2PriorKnowledge(boolean h2PriorKnowledge);
+
+    /**
+     * Set the name of the frame logger when HTTP/2 is used.
+     *
+     * @param h2FrameLogger the name of the frame logger, or {@code null} to disable.
+     * @return {@code this}.
+     */
+    public abstract GrpcServerBuilder h2FrameLogger(@Nullable String h2FrameLogger);
+
+    /**
      * Set how long to wait (in milliseconds) for a client to close the connection (if no keep-alive is set) before the
      * server will close the connection.
      *

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -61,6 +61,24 @@ final class DefaultGrpcServerBuilder extends GrpcServerBuilder implements Server
     }
 
     @Override
+    public GrpcServerBuilder h2HeadersFactory(final HttpHeadersFactory headersFactory) {
+        httpServerBuilder.h2HeadersFactory(headersFactory);
+        return this;
+    }
+
+    @Override
+    public GrpcServerBuilder h2PriorKnowledge(final boolean h2PriorKnowledge) {
+        httpServerBuilder.h2PriorKnowledge(h2PriorKnowledge);
+        return this;
+    }
+
+    @Override
+    public GrpcServerBuilder h2FrameLogger(@Nullable final String h2FrameLogger) {
+        httpServerBuilder.h2FrameLogger(h2FrameLogger);
+        return this;
+    }
+
+    @Override
     public GrpcServerBuilder clientCloseTimeout(final long clientCloseTimeoutMs) {
         httpServerBuilder.clientCloseTimeout(clientCloseTimeoutMs);
         return this;


### PR DESCRIPTION
__Motivation__

HTTP servers now supports h2 with prior knowledge, we should support the same for gRPC servers.

__Modification__

Provide the h2 builder options in gRPC server builder.

__Result__

h2 prior knowledge is supported for gRPC servers