### PR TITLE
Security configuration for gRPC client/server

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -28,7 +28,6 @@ import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
-import io.servicetalk.transport.api.ClientSslConfigBuilder;
 import io.servicetalk.transport.api.IoExecutor;
 
 import java.net.SocketOption;
@@ -97,7 +96,7 @@ public abstract class GrpcClientBuilder<U, R>
                                                                    StreamingHttpConnectionFilterFactory factory);
 
     @Override
-    public abstract ClientSslConfigBuilder<? extends GrpcClientBuilder<U, R>> enableSsl();
+    public abstract GrpcClientSecurityConfigurator<U, R> secure();
 
     @Override
     public abstract GrpcClientBuilder<U, R> serviceDiscoverer(

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientSecurityConfigurator.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientSecurityConfigurator.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.api;
+
+import io.servicetalk.transport.api.ClientSecurityConfigurator;
+
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * A {@link ClientSecurityConfigurator} for {@link SingleAddressGrpcClientBuilder}.
+ * @param <U> the type of address before resolution (unresolved address)
+ * @param <R> the type of address after resolution (resolved address)
+ */
+public interface GrpcClientSecurityConfigurator<U, R> extends ClientSecurityConfigurator {
+    /**
+     * Commit configuring client security.
+     *
+     * @return Original {@link GrpcClientBuilder} that initiated the security configuration process.
+     */
+    GrpcClientBuilder<U, R> commit();
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> trustManager(Supplier<InputStream> trustCertChainSupplier);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> trustManager(TrustManagerFactory trustManagerFactory);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> protocols(String... protocols);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> applicationProtocolNegotiation(
+            ApplicationProtocolNegotiation apn, SelectorFailureBehavior selectorBehavior,
+            SelectedListenerFailureBehavior selectedBehavior, Collection<String> supportedProtocols);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> ciphers(Iterable<String> ciphers);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> sessionCacheSize(long sessionCacheSize);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> sessionTimeout(long sessionTimeout);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> provider(SslProvider provider);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> hostnameVerificationAlgorithm(
+            String hostNameVerificationAlgorithm);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationAlgorithm,
+                                                              String hostNameVerificationHost);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationAlgorithm,
+                                                              String hostNameVerificationHost,
+                                                              int hostNameVerificationPort);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationHost);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationHost,
+                                                              int hostNameVerificationPort);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> sniHostname(String sniHostname);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> disableHostnameVerification();
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> keyManager(KeyManagerFactory keyManagerFactory);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> keyManager(Supplier<InputStream> keyCertChainSupplier,
+                                                    Supplier<InputStream> keySupplier);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> keyManager(Supplier<InputStream> keyCertChainSupplier,
+                                                    Supplier<InputStream> keySupplier, String keyPassword);
+}

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -27,16 +27,10 @@ import io.servicetalk.transport.api.ConnectionAcceptor;
 import io.servicetalk.transport.api.ConnectionAcceptorFactory;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
-import io.servicetalk.transport.api.ServerSslConfigBuilder;
-import io.servicetalk.transport.api.SslConfig;
 
-import java.io.InputStream;
 import java.net.SocketOption;
-import java.util.Map;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import javax.annotation.Nullable;
-import javax.net.ssl.KeyManagerFactory;
 
 import static io.servicetalk.concurrent.internal.FutureUtils.awaitResult;
 
@@ -135,64 +129,33 @@ public abstract class GrpcServerBuilder {
     public abstract GrpcServerBuilder backlog(int backlog);
 
     /**
-     * Allows to setup SNI.
-     * You can either use {@link #enableSsl(KeyManagerFactory)}, {@link #enableSsl(Supplier, Supplier)} or this method.
+     * Initiate security configuration for this server. Calling any {@code commit} method on the returned
+     * {@link GrpcServerSecurityConfigurator} will commit the configuration.
+     * <p>
+     * Additionally use {@link #secure(String...)} to define configurations for specific
+     * <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> hostnames. If such configuration is additionally
+     * defined then configuration using this method is used as default if the hostname does not match any of the
+     * specified hostnames.
      *
-     * @param mappings mapping hostnames to the ssl configuration that should be used.
-     * @param defaultConfig the configuration to use if no hostnames matched from {@code mappings}.
-     * @return {@code this}.
-     * @throws IllegalStateException if the {@link SslConfig#keyCertChainSupplier()}, {@link SslConfig#keySupplier()},
-     * or {@link SslConfig#trustCertChainSupplier()} throws when
-     * {@link InputStream#close()} is called.
+     * @return {@link GrpcServerSecurityConfigurator} to configure security for this server. It is
+     * mandatory to call any one of the {@code commit} methods after all configuration is done.
      */
-    public abstract GrpcServerBuilder sniConfig(@Nullable Map<String, SslConfig> mappings, SslConfig defaultConfig);
+    public abstract GrpcServerSecurityConfigurator secure();
 
     /**
-     * Enable SSL/TLS, and return a builder for configuring it. Call {@link ServerSslConfigBuilder#finish()} to
-     * return to configuring the gRPC server.
+     * Initiate security configuration for this server for the passed {@code sniHostnames}.
+     * Calling any {@code commit} method on the returned {@link GrpcServerSecurityConfigurator} will commit the
+     * configuration.
+     * <p>
+     * When using this method, it is mandatory to also define the default configuration using {@link #secure()} which
+     * is used when the hostname does not match any of the specified {@code sniHostnames}.
      *
-     * @param keyManagerFactory an {@link KeyManagerFactory}.
-     * @return an {@link ServerSslConfigBuilder} for configuring SSL/TLS.
+     * @param sniHostnames <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> hostnames for which this
+     * config is being defined.
+     * @return {@link GrpcServerSecurityConfigurator} to configure security for this server. It is
+     * mandatory to call any one of the {@code commit} methods after all configuration is done.
      */
-    public abstract ServerSslConfigBuilder<GrpcServerBuilder> enableSsl(KeyManagerFactory keyManagerFactory);
-
-    /**
-     * Enable SSL/TLS, and return a builder for configuring it. Call {@link ServerSslConfigBuilder#finish()} to
-     * return to configuring the gRPC server.
-     *
-     * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a X.509 certificate chain
-     * in PEM format.
-     * <p>
-     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
-     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
-     * @param keySupplier an {@link Supplier} that will provide an input stream for a KCS#8 private key in PEM format.
-     * <p>
-     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
-     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
-     * @return an {@link ServerSslConfigBuilder} for configuring SSL/TLS.
-     */
-    public abstract ServerSslConfigBuilder<GrpcServerBuilder> enableSsl(Supplier<InputStream> keyCertChainSupplier,
-                                                                        Supplier<InputStream> keySupplier);
-
-    /**
-     * Enable SSL/TLS, and return a builder for configuring it. Call {@link ServerSslConfigBuilder#finish()} to
-     * return to configuring the gRPC server.
-     *
-     * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a X.509 certificate chain
-     * in PEM format.
-     * <p>
-     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
-     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
-     * @param keySupplier an {@link Supplier} that will provide an input stream for a KCS#8 private key in PEM format.
-     * <p>
-     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
-     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
-     * @param keyPassword the password of the {@code keyFile} if it's password-protected.
-     * @return an {@link ServerSslConfigBuilder} for configuring SSL/TLS.
-     */
-    public abstract ServerSslConfigBuilder<GrpcServerBuilder> enableSsl(Supplier<InputStream> keyCertChainSupplier,
-                                                                        Supplier<InputStream> keySupplier,
-                                                                        String keyPassword);
+    public abstract GrpcServerSecurityConfigurator secure(String... sniHostnames);
 
     /**
      * Add a {@link SocketOption} that is applied.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerSecurityConfigurator.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerSecurityConfigurator.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.api;
+
+import io.servicetalk.transport.api.ServerSecurityConfigurator;
+
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * A {@link ServerSecurityConfigurator} for {@link GrpcServerBuilder}.
+ */
+public interface GrpcServerSecurityConfigurator extends ServerSecurityConfigurator {
+    @Override
+    GrpcServerSecurityConfigurator trustManager(Supplier<InputStream> trustCertChainSupplier);
+
+    @Override
+    GrpcServerSecurityConfigurator trustManager(TrustManagerFactory trustManagerFactory);
+
+    @Override
+    GrpcServerSecurityConfigurator protocols(String... protocols);
+
+    @Override
+    GrpcServerSecurityConfigurator applicationProtocolNegotiation(
+            ApplicationProtocolNegotiation apn, SelectorFailureBehavior selectorBehavior,
+            SelectedListenerFailureBehavior selectedBehavior, Collection<String> supportedProtocols);
+
+    @Override
+    GrpcServerSecurityConfigurator ciphers(Iterable<String> ciphers);
+
+    @Override
+    GrpcServerSecurityConfigurator sessionCacheSize(long sessionCacheSize);
+
+    @Override
+    GrpcServerSecurityConfigurator sessionTimeout(long sessionTimeout);
+
+    @Override
+    GrpcServerSecurityConfigurator provider(SslProvider provider);
+
+    @Override
+    GrpcServerSecurityConfigurator clientAuth(ClientAuth clientAuth);
+
+    /**
+     * Commit configuring server security.
+     *
+     * @param keyManagerFactory an {@link KeyManagerFactory}.
+     * @return Original {@link GrpcServerBuilder} that initiated the security configuration process.
+     */
+    GrpcServerBuilder commit(KeyManagerFactory keyManagerFactory);
+
+    /**
+     * Commit configuring server security.
+     *
+     * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a {@code X.509} certificate
+     * chain in {@code PEM} format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a {@code KCS#8} private key in
+     * {@code PEM} format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @return Original {@link GrpcServerBuilder} that initiated the security configuration process.
+     */
+    GrpcServerBuilder commit(Supplier<InputStream> keyCertChainSupplier, Supplier<InputStream> keySupplier);
+
+    /**
+     * Commit configuring server security.
+     *
+     * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a {@code X.509} certificate
+     * chain in {@code PEM} format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a {@code KCS#8} private key in
+     * {@code PEM} format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @param keyPassword the password of the {@code keyFile}.
+     * @return Original {@link GrpcServerBuilder} that initiated the security configuration process.
+     */
+    GrpcServerBuilder commit(Supplier<InputStream> keyCertChainSupplier, Supplier<InputStream> keySupplier,
+                             String keyPassword);
+}

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/SingleAddressGrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/SingleAddressGrpcClientBuilder.java
@@ -28,7 +28,6 @@ import io.servicetalk.http.api.HttpHeadersFactory;
 import io.servicetalk.http.api.StreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
-import io.servicetalk.transport.api.ClientSslConfigBuilder;
 import io.servicetalk.transport.api.IoExecutor;
 
 import java.net.SocketOption;
@@ -110,12 +109,15 @@ interface SingleAddressGrpcClientBuilder<U, R,
                                                                      StreamingHttpConnectionFilterFactory factory);
 
     /**
-     * Enable SSL/TLS, and return a builder for configuring it. Call {@link ClientSslConfigBuilder#finish()} to
-     * return to configuring the gRPC client.
+     * Initiate security configuration for this client. Calling
+     * {@link GrpcClientSecurityConfigurator#commit()} on the returned {@link GrpcClientSecurityConfigurator} will
+     * commit the configuration.
      *
-     * @return an {@link ClientSslConfigBuilder} for configuring SSL/TLS.
+     * @return {@link GrpcClientSecurityConfigurator} to configure security for this client. It is
+     * mandatory to call {@link GrpcClientSecurityConfigurator#commit() commit} after all configuration is
+     * done.
      */
-    ClientSslConfigBuilder<? extends SingleAddressGrpcClientBuilder<U, R, SDE>> enableSsl();
+    GrpcClientSecurityConfigurator<U, R> secure();
 
     /**
      * Set a {@link ServiceDiscoverer} to resolve addresses of remote servers to connect to.

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
@@ -22,15 +22,16 @@ import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.grpc.api.GrpcClientBuilder;
 import io.servicetalk.grpc.api.GrpcClientCallFactory;
+import io.servicetalk.grpc.api.GrpcClientSecurityConfigurator;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpHeadersFactory;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.http.api.SingleAddressHttpClientSecurityConfigurator;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
-import io.servicetalk.transport.api.ClientSslConfigBuilder;
 import io.servicetalk.transport.api.IoExecutor;
 
 import java.net.SocketOption;
@@ -151,8 +152,9 @@ final class DefaultGrpcClientBuilder<U, R> extends GrpcClientBuilder<U, R> {
     }
 
     @Override
-    public ClientSslConfigBuilder<? extends GrpcClientBuilder<U, R>> enableSsl() {
-        throw new UnsupportedOperationException("SSL not yet supported.");
+    public GrpcClientSecurityConfigurator<U, R> secure() {
+        SingleAddressHttpClientSecurityConfigurator<U, R> httpConfigurator = httpClientBuilder.secure();
+        return new DefaultGrpcClientSecurityConfigurator<>(httpConfigurator, this);
     }
 
     @Override

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientSecurityConfigurator.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientSecurityConfigurator.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.netty;
+
+import io.servicetalk.grpc.api.GrpcClientBuilder;
+import io.servicetalk.grpc.api.GrpcClientSecurityConfigurator;
+import io.servicetalk.http.api.SingleAddressHttpClientSecurityConfigurator;
+
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+final class DefaultGrpcClientSecurityConfigurator<U, R> implements GrpcClientSecurityConfigurator<U, R> {
+    private final SingleAddressHttpClientSecurityConfigurator<U, R> delegate;
+    private final GrpcClientBuilder<U, R> original;
+
+    DefaultGrpcClientSecurityConfigurator(final SingleAddressHttpClientSecurityConfigurator<U, R> delegate,
+                                          final GrpcClientBuilder<U, R> original) {
+        this.delegate = delegate;
+        this.original = original;
+    }
+
+    @Override
+    public GrpcClientBuilder<U, R> commit() {
+        delegate.commit();
+        return original;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> trustManager(final Supplier<InputStream> trustCertChainSupplier) {
+        delegate.trustManager(trustCertChainSupplier);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> trustManager(final TrustManagerFactory trustManagerFactory) {
+        delegate.trustManager(trustManagerFactory);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> protocols(final String... protocols) {
+        delegate.protocols(protocols);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> applicationProtocolNegotiation(
+            final ApplicationProtocolNegotiation apn, final SelectorFailureBehavior selectorBehavior,
+            final SelectedListenerFailureBehavior selectedBehavior, final Collection<String> supportedProtocols) {
+        delegate.applicationProtocolNegotiation(apn, selectorBehavior, selectedBehavior, supportedProtocols);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> ciphers(final Iterable<String> ciphers) {
+        delegate.ciphers(ciphers);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> sessionCacheSize(final long sessionCacheSize) {
+        delegate.sessionCacheSize(sessionCacheSize);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> sessionTimeout(final long sessionTimeout) {
+        delegate.sessionTimeout(sessionTimeout);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> provider(final SslProvider provider) {
+        delegate.provider(provider);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> hostnameVerificationAlgorithm(
+            final String hostNameVerificationAlgorithm) {
+        delegate.hostnameVerificationAlgorithm(hostNameVerificationAlgorithm);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> hostnameVerification(final String hostNameVerificationAlgorithm,
+                                                                     final String hostNameVerificationHost) {
+        delegate.hostnameVerification(hostNameVerificationAlgorithm, hostNameVerificationHost);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> hostnameVerification(final String hostNameVerificationAlgorithm,
+                                                                     final String hostNameVerificationHost,
+                                                                     final int hostNameVerificationPort) {
+        delegate.hostnameVerification(hostNameVerificationAlgorithm, hostNameVerificationHost,
+                hostNameVerificationPort);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> hostnameVerification(final String hostNameVerificationHost) {
+        delegate.hostnameVerification(hostNameVerificationHost);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> hostnameVerification(final String hostNameVerificationHost,
+                                                                     final int hostNameVerificationPort) {
+        delegate.hostnameVerification(hostNameVerificationHost, hostNameVerificationPort);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> sniHostname(final String sniHostname) {
+        delegate.sniHostname(sniHostname);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> disableHostnameVerification() {
+        delegate.disableHostnameVerification();
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> keyManager(final KeyManagerFactory keyManagerFactory) {
+        delegate.keyManager(keyManagerFactory);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> keyManager(final Supplier<InputStream> keyCertChainSupplier,
+                                                           final Supplier<InputStream> keySupplier) {
+        delegate.keyManager(keyCertChainSupplier, keySupplier);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> keyManager(final Supplier<InputStream> keyCertChainSupplier,
+                                                           final Supplier<InputStream> keySupplier,
+                                                           final String keyPassword) {
+        delegate.keyManager(keyCertChainSupplier, keySupplier, keyPassword);
+        return this;
+    }
+}

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -18,6 +18,7 @@ package io.servicetalk.grpc.netty;
 import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.grpc.api.GrpcServerBuilder;
+import io.servicetalk.grpc.api.GrpcServerSecurityConfigurator;
 import io.servicetalk.grpc.api.GrpcServiceFactory;
 import io.servicetalk.grpc.api.GrpcServiceFactory.ServerBinder;
 import io.servicetalk.http.api.BlockingHttpService;
@@ -25,6 +26,7 @@ import io.servicetalk.http.api.BlockingStreamingHttpService;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpHeadersFactory;
 import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpServerSecurityConfigurator;
 import io.servicetalk.http.api.HttpService;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpService;
@@ -33,17 +35,11 @@ import io.servicetalk.transport.api.ConnectionAcceptorFactory;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
-import io.servicetalk.transport.api.ServerSslConfigBuilder;
-import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.netty.internal.ExecutionContextBuilder;
 
-import java.io.InputStream;
 import java.net.SocketOption;
-import java.util.Map;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import javax.annotation.Nullable;
-import javax.net.ssl.KeyManagerFactory;
 
 final class DefaultGrpcServerBuilder extends GrpcServerBuilder implements ServerBinder {
 
@@ -115,26 +111,15 @@ final class DefaultGrpcServerBuilder extends GrpcServerBuilder implements Server
     }
 
     @Override
-    public GrpcServerBuilder sniConfig(@Nullable final Map<String, SslConfig> mappings, final SslConfig defaultConfig) {
-        throw new UnsupportedOperationException("SSL not yet supported.");
+    public GrpcServerSecurityConfigurator secure() {
+        HttpServerSecurityConfigurator secure = httpServerBuilder.secure();
+        return new DefaultGrpcServerSecurityConfigurator(secure, this);
     }
 
     @Override
-    public ServerSslConfigBuilder<GrpcServerBuilder> enableSsl(final KeyManagerFactory keyManagerFactory) {
-        throw new UnsupportedOperationException("SSL not yet supported.");
-    }
-
-    @Override
-    public ServerSslConfigBuilder<GrpcServerBuilder> enableSsl(final Supplier<InputStream> keyCertChainSupplier,
-                                                               final Supplier<InputStream> keySupplier) {
-        throw new UnsupportedOperationException("SSL not yet supported.");
-    }
-
-    @Override
-    public ServerSslConfigBuilder<GrpcServerBuilder> enableSsl(final Supplier<InputStream> keyCertChainSupplier,
-                                                               final Supplier<InputStream> keySupplier,
-                                                               final String keyPassword) {
-        throw new UnsupportedOperationException("SSL not yet supported.");
+    public GrpcServerSecurityConfigurator secure(final String... sniHostnames) {
+        HttpServerSecurityConfigurator secure = httpServerBuilder.secure(sniHostnames);
+        return new DefaultGrpcServerSecurityConfigurator(secure, this);
     }
 
     @Override

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerSecurityConfigurator.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerSecurityConfigurator.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.netty;
+
+import io.servicetalk.grpc.api.GrpcServerBuilder;
+import io.servicetalk.grpc.api.GrpcServerSecurityConfigurator;
+import io.servicetalk.http.api.HttpServerSecurityConfigurator;
+
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+final class DefaultGrpcServerSecurityConfigurator implements GrpcServerSecurityConfigurator {
+    private final HttpServerSecurityConfigurator delegate;
+    private final GrpcServerBuilder original;
+
+    DefaultGrpcServerSecurityConfigurator(final HttpServerSecurityConfigurator delegate,
+                                          final GrpcServerBuilder original) {
+        this.delegate = delegate;
+        this.original = original;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator trustManager(final Supplier<InputStream> trustCertChainSupplier) {
+        delegate.trustManager(trustCertChainSupplier);
+        return this;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator trustManager(final TrustManagerFactory trustManagerFactory) {
+        delegate.trustManager(trustManagerFactory);
+        return this;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator protocols(final String... protocols) {
+        delegate.protocols(protocols);
+        return this;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator applicationProtocolNegotiation(
+            final ApplicationProtocolNegotiation apn, final SelectorFailureBehavior selectorBehavior,
+            final SelectedListenerFailureBehavior selectedBehavior, final Collection<String> supportedProtocols) {
+        delegate.applicationProtocolNegotiation(apn, selectorBehavior, selectedBehavior, supportedProtocols);
+        return this;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator ciphers(final Iterable<String> ciphers) {
+        delegate.ciphers(ciphers);
+        return this;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator sessionCacheSize(final long sessionCacheSize) {
+        delegate.sessionCacheSize(sessionCacheSize);
+        return this;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator sessionTimeout(final long sessionTimeout) {
+        delegate.sessionTimeout(sessionTimeout);
+        return this;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator provider(final SslProvider provider) {
+        delegate.provider(provider);
+        return this;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator clientAuth(final ClientAuth clientAuth) {
+        delegate.clientAuth(clientAuth);
+        return this;
+    }
+
+    @Override
+    public GrpcServerBuilder commit(final KeyManagerFactory keyManagerFactory) {
+        delegate.commit(keyManagerFactory);
+        return original;
+    }
+
+    @Override
+    public GrpcServerBuilder commit(final Supplier<InputStream> keyCertChainSupplier,
+                                    final Supplier<InputStream> keySupplier) {
+        delegate.commit(keyCertChainSupplier, keySupplier);
+        return original;
+    }
+
+    @Override
+    public GrpcServerBuilder commit(final Supplier<InputStream> keyCertChainSupplier,
+                                    final Supplier<InputStream> keySupplier, final String keyPassword) {
+        delegate.commit(keyCertChainSupplier, keySupplier, keyPassword);
+        return original;
+    }
+}


### PR DESCRIPTION
__Motivation__

gRPC did not support security configuration as the base configuration abstractions were not usable in this context.
Now, HTTP has more composable configuration primitives which we can use.

__Modification__

Use underlying HTTP abstractions.

__Result__

gRPC client/server can be configured for security.