### PR TITLE
Reduce allocation in `HttpObjectDecoder.findCRLF`

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -740,7 +740,7 @@ public final class HeaderUtils {
      * @param value the character to validate.
      */
     private static void validateHeaderNameToken(final byte value) {
-        if (value >= 0 && value <= 32 || value < 0) {
+        if (value <= 32) {
             throw new IllegalArgumentException("invalid token detected: " + value);
         }
         switch (value) {


### PR DESCRIPTION
Motivation:

`HttpObjectDecoder.findCRLF` method uses `ByteBuf.indexOf` to find a
`LF` byte. `indexOf` will create a new `ByteProcessor` internally to
find requested byte value. We may utilize the existing static
`io.netty.util.ByteProcessor.FIND_LF` instead.

Modifications:

- Implement `findLF` method that uses static `ByteProcessor.FIND_LF`;
- Remove unnecessary second argument from `getContentLength` method;
- Simplify condition in `HeaderUtils.validateHeaderNameToken`;
- Add test what verifies `HttpObjectDecoder` can parse request without
payload body and trailers;

Result:

Less object allocations in `HttpObjectDecoder`.