### PR TITLE
Remove externally influenced protos

### DIFF
--- a/servicetalk-grpc-protoc/src/test/proto/test_multi.proto
+++ b/servicetalk-grpc-protoc/src/test/proto/test_multi.proto
@@ -1,31 +1,17 @@
-// Copyright 2015, Google Inc.
-// All rights reserved.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Copyright © 2019 Apple Inc. and the ServiceTalk project authors
 //
-//     * Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above
-// copyright notice, this list of conditions and the following disclaimer
-// in the documentation and/or other materials provided with the
-// distribution.
-//     * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 syntax = "proto3";
 
@@ -37,28 +23,24 @@ option java_outer_classname = "HelloWorldProto";
 
 package test.multi;
 
-// The greeting service definition.
-service Greeter {
-    rpc SayHello (UserRequest) returns (HelloReply) {}
-    rpc SayHelloToFromMany (stream UserRequest) returns (stream HelloReply) {}
-    rpc SayHelloToMany (UserRequest) returns (stream HelloReply) {}
-    rpc SayHelloFromMany (stream UserRequest) returns (HelloReply) {}
+service Tester {
+    rpc test (TestRequest) returns (TestReply) {}
+    rpc testBiDiStream (stream TestRequest) returns (stream TestReply) {}
+    rpc testResponseStream (TestRequest) returns (stream TestReply) {}
+    rpc testRequestStream (stream TestRequest) returns (TestReply) {}
 }
 
-// The farewell service definition.
-service Fareweller {
-    rpc SayGoodbye (UserRequest) returns (test.shared.GoodbyeReply) {}
-    rpc GetAllUntils (test.shared.Generic.Empty) returns (stream test.shared.AllUntils) {
+service Tester2 {
+    rpc testShared (TestRequest) returns (test.shared.SharedReply) {}
+    rpc testUntils (test.shared.Generic.Empty) returns (stream test.shared.Untils) {
         option deprecated = true;
     }
 }
 
-// The request message containing the user's name.
-message UserRequest {
+message TestRequest {
     string name = 1;
 }
 
-// The response message containing the greetings
-message HelloReply {
+message TestReply {
     string message = 1;
 }

--- a/servicetalk-grpc-protoc/src/test/proto/test_shared.proto
+++ b/servicetalk-grpc-protoc/src/test/proto/test_shared.proto
@@ -1,38 +1,23 @@
-// Copyright 2015, Google Inc.
-// All rights reserved.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Copyright © 2019 Apple Inc. and the ServiceTalk project authors
 //
-//     * Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above
-// copyright notice, this list of conditions and the following disclaimer
-// in the documentation and/or other materials provided with the
-// distribution.
-//     * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 syntax = "proto3";
 
 package test.shared;
 
-// The response message containing the farewells
-message GoodbyeReply {
+message SharedReply {
     string message = 1;
     enum Until {
         NEXT_TIME = 0;
@@ -42,8 +27,8 @@ message GoodbyeReply {
     int32 old_field = 3 [deprecated=true];
 }
 
-message AllUntils {
-    repeated GoodbyeReply.Until until = 1;
+message Untils {
+    repeated SharedReply.Until until = 1;
 }
 
 message Generic {

--- a/servicetalk-grpc-protoc/src/test/proto/test_single.proto
+++ b/servicetalk-grpc-protoc/src/test/proto/test_single.proto
@@ -1,31 +1,17 @@
-// Copyright 2015, Google Inc.
-// All rights reserved.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Copyright © 2019 Apple Inc. and the ServiceTalk project authors
 //
-//     * Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above
-// copyright notice, this list of conditions and the following disclaimer
-// in the documentation and/or other materials provided with the
-// distribution.
-//     * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 syntax = "proto3";
 
@@ -47,8 +33,8 @@ service Greeter {
 
 // The farewell service definition.
 service Fareweller {
-    rpc SayGoodbye (UserRequest) returns (test.shared.GoodbyeReply) {}
-    rpc GetAllUntils (test.shared.Generic.Empty) returns (stream test.shared.AllUntils) {
+    rpc SayGoodbye (UserRequest) returns (test.shared.SharedReply) {}
+    rpc GetAllUntils (test.shared.Generic.Empty) returns (stream test.shared.Untils) {
         option deprecated = true;
     }
 }


### PR DESCRIPTION
__Motivation__

We should use external proto files when we want to demonstrate some standard. Otherwise we can create a test proto file to use.

__Modification__

Reduce usage of external proto files.

__Result__

Less usage of external proto files.