### PR TITLE
Fix inconsistent version for `servicetalk-grpc-netty`

### DIFF
--- a/servicetalk-grpc-netty/gradle.properties
+++ b/servicetalk-grpc-netty/gradle.properties
@@ -15,6 +15,6 @@
 #
 
 group=io.servicetalk
-version=0.16.0-SNAPSHOT
+version=0.17.0-SNAPSHOT
 
 protobufVersion=3.9.0


### PR DESCRIPTION
Motivation:

`servicetalk-grpc-netty` has inconsistent version with other modules,
that causes build errors when you use `servicetalk` as
`--include-build`.

Modifications:

- Bump `servicetalk-grpc-netty` version from `0.16.0-SNAPSHOT` to
`0.17.0-SNAPSHOT`;

Result:

No build errors when use `servicetalk` as `--include-build`.