### PR TITLE
Enable Gradle 5 module metadata

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+enableFeaturePreview("GRADLE_METADATA")
+
 rootProject.name = "servicetalk"
 
 include "servicetalk-annotations",


### PR DESCRIPTION
__Motivation__

ServiceTalk publishes test fixtures modules, which can be used from Gradle either via:

1) the `testFixtures(...)` dependency capacity modifier within the same build or in composite builds,
2) regular dependencies using the `test-fixtures` classifier.

Unfortunately:

1) doesn't work for a disconnected Gradle build [0] unless metadata are published [1],
2) doesn't work with composite builds, Gradle fails to resolve the dependency as provided by ServiceTalk.

So enabling the publication of Gradle metadata seems the only way out.

__Modification__

Enable the `GRADLE_METADATA` feature preview.

__Results__

All Gradle builds can use ServiceTalk's test fixtures.

[0] i.e. not a composite with ServiceTalk's project
[1] https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures
[2] https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md