### PR TITLE
Fix release build

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -80,7 +80,9 @@ services:
       - CI
       - BINTRAY_USER
       - BINTRAY_KEY
-    command: bash -cl "./gradlew --no-daemon clean check && ./gradlew --no-daemon bintrayUpload -PreleaseBuild=true"
+    command: >
+      bash -cl "./gradlew --no-daemon -PreleaseBuild=true clean check &&
+      ./gradlew --no-daemon -PreleaseBuild=true bintrayUpload"
 
   shell:
     << : *common

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
@@ -96,6 +96,20 @@ final class ProjectUtils {
     }
   }
 
+  static void enforceProjectVersionScheme(Project project) {
+    def endsWithSnapshot = project.version.toString().toUpperCase().endsWith("-SNAPSHOT")
+    if (project.ext.isReleaseBuild) {
+      if (endsWithSnapshot) {
+        throw new GradleException("Project version for a release build must not contain a '-SNAPSHOT' suffix")
+      }
+    } else if (!endsWithSnapshot) {
+      if (!project.parent) {
+        project.logger.quiet("Adding missing '-SNAPSHOT' suffix to project version $project.version for non-release build.")
+      }
+      project.version += "-SNAPSHOT"
+    }
+  }
+
   static void addManifestAttributes(Project project, Manifest manifest) {
     manifest.attributes("Built-JDK": System.getProperty("java.version"),
         "Specification-Title": project.name,

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkCorePlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkCorePlugin.groovy
@@ -16,7 +16,6 @@
 package io.servicetalk.gradle.plugin.internal
 
 import com.jfrog.bintray.gradle.tasks.BintrayUploadTask
-import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.XmlProvider
@@ -28,6 +27,7 @@ import org.gradle.api.publish.maven.internal.artifact.FileBasedMavenArtifact
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.addBuildContextExtensions
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.appendNodes
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.copyResource
+import static io.servicetalk.gradle.plugin.internal.ProjectUtils.enforceProjectVersionScheme
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.enforceUtf8FileSystem
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.locateBuildLevelConfigFile
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.writeToFile
@@ -38,6 +38,7 @@ class ServiceTalkCorePlugin implements Plugin<Project> {
   void apply(Project project, boolean publishesArtifacts = true) {
     enforceUtf8FileSystem()
     addBuildContextExtensions project
+    enforceProjectVersionScheme project
     applyCheckstylePlugin project
     applyIdeaPlugin project
 
@@ -138,17 +139,6 @@ class ServiceTalkCorePlugin implements Plugin<Project> {
   private static void applyBintrayPlugin(Project project) {
     project.configure(project) {
       pluginManager.apply("com.jfrog.bintray")
-
-      def endsWithSnapshot = project.version.toString().toUpperCase().endsWith("-SNAPSHOT")
-      if (project.ext.isReleaseBuild) {
-        if (endsWithSnapshot) {
-          throw new GradleException("Project version for a release build must not contain a '-SNAPSHOT' suffix")
-        }
-      } else {
-        if (!endsWithSnapshot) {
-          project.version += "-SNAPSHOT"
-        }
-      }
 
       // bintray publishing information
       def bintrayUser = System.getenv("BINTRAY_USER")


### PR DESCRIPTION
__Motivation__

Currently the release process runs two Gradle commands, with only one of them having the `releaseBuild` flag set.

This enables the logic that automatically adds "-SNAPSHOT" to kick in, leading to resource files generated with the wrong version number.

__Modifications__

- Set the `releaseBuild` flag for all Gradle commands used at release time.
- Improve the logic that auto adds "-SNAPSHOT" so it logs when it kicks in and also applies to all sub-projects.

__Results__

Release builds do not contain snasphot versions.