### PR TITLE
Make `H2ParentConnectionContext.activeChildChannels` counter atomic

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -52,6 +52,7 @@ import java.util.concurrent.Delayed;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
@@ -72,6 +73,8 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
     private static final ClosedChannelException CLOSED_HANDLER_REMOVED =
             unknownStackTrace(new ClosedChannelException(), H2ClientParentConnectionContext.class,
                     "handlerRemoved(..)");
+    private static final AtomicIntegerFieldUpdater<H2ParentConnectionContext> activeChildChannelsUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(H2ParentConnectionContext.class, "activeChildChannels");
     private static final Logger LOGGER = LoggerFactory.getLogger(H2ClientParentConnectionContext.class);
     private static final ScheduledFuture<?> GRACEFUL_CLOSE_PING_PENDING = new NoopScheduledFuture();
     private static final ScheduledFuture<?> GRACEFUL_CLOSE_PING_ACK_RECV = new NoopScheduledFuture();
@@ -86,7 +89,7 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
     private SSLSession sslSession;
     @Nullable
     private ScheduledFuture<?> gracefulCloseTimeoutFuture;
-    private int activeChildChannels;
+    private volatile int activeChildChannels;
 
     H2ParentConnectionContext(Channel channel, BufferAllocator allocator,
                               Executor executor, FlushStrategy flushStrategy,
@@ -214,10 +217,9 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
     }
 
     final void trackActiveStream(Channel streamChannel) {
-        assert channel().eventLoop().inEventLoop(); // the state is currently not thread safe
-        ++activeChildChannels;
+        activeChildChannelsUpdater.incrementAndGet(this);
         streamChannel.closeFuture().addListener(future1 -> {
-            --activeChildChannels;
+            activeChildChannelsUpdater.decrementAndGet(this);
             tryFinishGracefulClose();
         });
     }


### PR DESCRIPTION
Motivation:

Tests in `H2PriorKnowledgeFeatureParityTest` sometimes fail with
`AssertionError` because `H2ParentConnectionContext.trackActiveStream`
has an assertion that it is executed on `EventLoop`. However, this code
could be executed on a subscriber's thread. Therefore, we have to make
`activeChildChannels` counter atomic to keep correct counting.

Modifications:

- Remove assertion from `H2ParentConnectionContext.trackActiveStream`;
- Use AtomicIntegerFieldUpdater to increment/decrement value of
`H2ParentConnectionContext.activeChildChannels`;

Result:

No flaky tests in `H2PriorKnowledgeFeatureParityTest`.