### PR TITLE
Align javax artifacts with Jersey 2.29.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,13 +24,13 @@ jsr305Version=3.0.2
 log4jVersion=2.12.1
 slf4jVersion=1.7.28
 
-javaxAnnotationsApiVersion=1.3.2
-javaxActivationVersion=1.2.0
-javaxJaxbApiVersion=2.3.1
+javaxAnnotationsApiVersion=1.3.5
+javaxActivationVersion=1.2.1
+javaxJaxbApiVersion=2.3.2
 javaxJaxbCoreVersion=2.3.0.1
 javaxJaxbImplVersion=2.3.2
 
-jaxRsVersion=2.1
+jaxRsVersion=2.1.6
 jerseyVersion=2.29.1
 jsonUnitVersion=2.8.1
 

--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -40,7 +40,7 @@ dependencies {
   testImplementation "io.grpc:grpc-stub:$grpcVersion"
   testImplementation "io.netty:netty-transport-native-unix-common:$nettyVersion"
   testImplementation "io.netty:netty-tcnative-boringssl-static:$tcnativeVersion"
-  testImplementation "javax.annotation:javax.annotation-api:$javaxAnnotationsApiVersion"
+  testImplementation "jakarta.annotation:jakarta.annotation-api:$javaxAnnotationsApiVersion"
   testImplementation "junit:junit:$junitVersion"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"

--- a/servicetalk-http-router-jersey-internal/build.gradle
+++ b/servicetalk-http-router-jersey-internal/build.gradle
@@ -18,7 +18,7 @@ apply plugin: "servicetalk-library"
 
 dependencies {
   api project(":servicetalk-http-api")
-  api "javax.ws.rs:javax.ws.rs-api:$jaxRsVersion"
+  api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxRsVersion"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api-internal")

--- a/servicetalk-http-router-jersey/build.gradle
+++ b/servicetalk-http-router-jersey/build.gradle
@@ -18,7 +18,7 @@ apply plugin: "servicetalk-library"
 
 dependencies {
   api project(":servicetalk-http-api")
-  api "javax.ws.rs:javax.ws.rs-api:$jaxRsVersion"
+  api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxRsVersion"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api-internal")
@@ -27,10 +27,10 @@ dependencies {
   implementation project(":servicetalk-http-router-jersey-internal")
   implementation project(":servicetalk-http-utils")
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "com.sun.activation:javax.activation:$javaxActivationVersion"
+  implementation "com.sun.activation:jakarta.activation:$javaxActivationVersion"
   implementation "com.sun.xml.bind:jaxb-core:$javaxJaxbCoreVersion"
   implementation "com.sun.xml.bind:jaxb-impl:$javaxJaxbImplVersion"
-  implementation "javax.xml.bind:jaxb-api:$javaxJaxbApiVersion"
+  implementation "jakarta.xml.bind:jakarta.xml.bind-api:$javaxJaxbApiVersion"
   implementation "org.glassfish.jersey.core:jersey-server:$jerseyVersion"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/servicetalk-http-security-jersey/build.gradle
+++ b/servicetalk-http-security-jersey/build.gradle
@@ -17,7 +17,7 @@
 apply plugin: "servicetalk-library"
 
 dependencies {
-  api "javax.ws.rs:javax.ws.rs-api:$jaxRsVersion"
+  api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxRsVersion"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api")


### PR DESCRIPTION
__Motivation__

Jersey has recently switched several `javax` dependencies to their `jakarta` counterparts, but we have not followed this change in our dependencies and thus are now bringing the two variants transitively.

Note that these artifacts have different coordinates but their contents are *for now* the same, so this has no impact on code.

__Modifications__

Align `javax`/`jakarta` dependencies with Jersey to avoid bringing redundant transitive dependencies.

__Results__

Convergence with Jersey dependencies.