### PR TITLE
Add missing version

### DIFF
--- a/servicetalk-opentracing-log4j2/build.gradle
+++ b/servicetalk-opentracing-log4j2/build.gradle
@@ -24,7 +24,7 @@ dependencies {
   implementation project(":servicetalk-opentracing-inmemory-api")
   implementation project(":servicetalk-opentracing-asynccontext")
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "org.apache.logging.log4j:log4j-api"
+  implementation "org.apache.logging.log4j:log4j-api:$log4jVersion"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation testFixtures(project(":servicetalk-log4j2-mdc-utils"))


### PR DESCRIPTION
__Motivation__

For some reason Gradle is find with artifacts without versions. Unfortunately it leads to producing POM files that are broken.

__Modification__

Add missing version in servicetalk-opentracing-log4j2.

__Results__

Usable servicetalk-opentracing-log4j2 artifact.