### PR TITLE
Update gRPC `ProtocolCompatibilityTest`

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -50,6 +50,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import io.grpc.ManagedChannel;
 import io.grpc.Server;
 import io.grpc.Status;
+import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
@@ -465,10 +466,10 @@ public class ProtocolCompatibilityTest {
             ));
             streamingResponse.toFuture().get();
         } catch (ExecutionException e) {
-            Throwable cause = e.getCause();
+            final Throwable cause = e.getCause();
             if (cause instanceof StatusRuntimeException) {
-                StatusRuntimeException sre = (StatusRuntimeException) cause;
-                Status.Code code = sre.getStatus().getCode();
+                final StatusRuntimeException sre = (StatusRuntimeException) cause;
+                final Code code = sre.getStatus().getCode();
                 assertEquals("Unexpected grpc error code: " + code, code, CANCELLED);
             } else {
                 cause.printStackTrace();


### PR DESCRIPTION
__Motivation__

`ProtocolCompatibilityTest` checks for a scenario when users throw a `GrpcStatusException` from within an operator from the response stream. The expectation is that the status should correctly be propagated to the client. Additionally the testcase also emits exception while reading the request `Publisher`. From a general gRPC transport implementation point of view, exception while reading data from socket is ambiguous w.r.t the usage of this data, i.e. whether it is expected to be used for the response or not. Hence, ST can not convert this exception to relevant headers in the response. Instead ST closes the related H2 stream and sends this error down on the `Publisher`. If the read is transformed to a response ST also converts this error to relevant gRPC trailers. However, there is a race between H2 stream reset and write of trailers (containing the error information). In cases when there is no offloading, we would write trailers first and then close the channel, however, when there is offloading involved we will mostly close the H2 stream first.
We should modify the test to follow the above behavior.

__Modification__

- Split the test for the above mentioned scenarios into 2 tests; with and without offloading.
- Split the validations to have different runs for scalar and streaming to simplify debugging.

__Result__

More appropriate test coverage.