### PR TITLE
Do not ignore NettyHttpServerConnectionAcceptorTest.testAcceptConnection

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionAcceptorTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionAcceptorTest.java
@@ -26,7 +26,6 @@ import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.transport.api.ConnectionAcceptor;
 import io.servicetalk.transport.api.ConnectionContext;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -131,7 +130,6 @@ public class NettyHttpServerConnectionAcceptorTest extends AbstractNettyHttpServ
         return parameters;
     }
 
-    @Ignore("Flaky on CI: https://github.com/apple/servicetalk/issues/452")
     @Test
     public void testAcceptConnection() throws Exception {
         try {


### PR DESCRIPTION
Motivation:

This test was known as flaky. Most likely, the main issue was a
concurrency bug in `SequentialSubscription` that was resolved in #640.

Modifications:

- Remove `@Ignore` annotation from
`NettyHttpServerConnectionAcceptorTest.testAcceptConnection`;

Result:

We will track if the issue with
`NettyHttpServerConnectionAcceptorTest.testAcceptConnection` is already
resolved.

---
This is related to #452. I can not reproduce the problem locally. Let's enable
this test and track on CI.