### PR TITLE
Change schema for slf4j docs links from `https` to `http`

### DIFF
--- a/docs/generation/gradle/validateSite.gradle
+++ b/docs/generation/gradle/validateSite.gradle
@@ -22,7 +22,7 @@ if (!repositories) {
 
 // links that are allowed to be http rather than https
 def httpLinks = [
-    //"http://somedomain.tld/someoptionalpath"
+    "http://www.slf4j.org/"
 ]
 
 // links to exclude from validation (for example because they require authentication)

--- a/docs/modules/ROOT/pages/performance.adoc
+++ b/docs/modules/ROOT/pages/performance.adoc
@@ -490,7 +490,7 @@ HttpClients.forSingleAddress("localhost", 8080)
 In traditional sequential programming where each request gets its own dedicated thread Java users may rely upon
 `ThreadLocal` to implicitly pass state across API boundaries. This is a convenient feature to take care of cross
 cutting concerns that do not have corresponding provisions throughout all layers of APIs (e.g.
-link:https://www.slf4j.org/manual.html#mdc[MDC], auth, etc...). However when moving to an asynchronous execution model
+link:http://www.slf4j.org/manual.html#mdc[MDC], auth, etc...). However when moving to an asynchronous execution model
 you are no longer guaranteed to be the sole occupant of a thread over the lifetime of your request/response processing,
 and therefore `ThreadLocal` is not directly usable in the same way. For this reason ServiceTalk offers
 xref:servicetalk-concurrent-api::async-context.adoc[`AsyncContext`] which provides a static API similar to what

--- a/servicetalk-concurrent-api/docs/modules/ROOT/pages/async-context.adoc
+++ b/servicetalk-concurrent-api/docs/modules/ROOT/pages/async-context.adoc
@@ -30,7 +30,7 @@ public static Single<Resposne> authenticate(Single<Response> responseSingle) {
 
 ServiceTalk is a fully asynchronous framework and therefore multiple requests may be multiplexed on the same thread.
 Also depending on the application's threading model a single request may be processed on different threads. This means
-that `ThreadLocal` and derivatives such as https://www.slf4j.org/manual.html#mdc[`MDC`] would not work as expected. To
+that `ThreadLocal` and derivatives such as http://www.slf4j.org/manual.html#mdc[`MDC`] would not work as expected. To
 overcome this limitation, we provide an `AsyncContext` which hooks into the internal async machinery to make sure
 thread local context data is propagated along with the request.
 
@@ -48,7 +48,7 @@ API has a few benefits:
 asynchronous execution and also share threads for processing different requests. For example the
 link:https://github.com/opentracing/opentracing-java/blob/master/opentracing-api/src/main/java/io/opentracing/Tracer.java[OpenTracing APIs]
 and the
-link:https://www.slf4j.org/api/org/slf4j/MDC.html[MDC APIs] assume state is stored in some static structure.
+link:http://www.slf4j.org/api/org/slf4j/MDC.html[MDC APIs] assume state is stored in some static structure.
 * API is decoupled from application data APIs
 ** A use case for `AsyncContext` is to retain distributed tracing state. This state maybe useful across different APIs
 and maybe burdensome to account for this state in every API (e.g. gRPC and generated code). It also maybe error prone to


### PR DESCRIPTION
Motivation:

slf4j announced that they turn off SSL support for their docs website,
all links redirect to `http` now. `validateLocalSite` fail PRB because
the previous links respond with 302.

Modifications:

- Change schema for slf4j docs links from `https` to `http`;
- Add `www.slf4j.org` to the list of allowed http resources;

Result:

`validateLocalSite` validates new slf4j links.