### PR TITLE
Sync files in the root folder with docs pages

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -45,17 +45,18 @@ This code of conduct applies both within project spaces and in public spaces whe
 individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
-contacting a project maintainer at link:mailto:servicetalk-conduct@group.apple.com[servicetalk-conduct@group.apple.com]. All complaints will be reviewed and
-investigated and will result in a response that is deemed necessary and appropriate to the
-circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter
-of an incident.
+contacting a project maintainer at link:mailto:servicetalk-conduct@group.apple.com[servicetalk-conduct@group.apple.com].
+All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate
+to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
-_This policy is adapted from the Contributor Code of Conduct https://contributor-covenant.org/version/1/3/0/[version 1.3.0]._
+_This policy is adapted from the Contributor Code of Conduct
+https://contributor-covenant.org/version/1/3/0/[version 1.3.0]._
 
 [discrete]
 === Reporting
 
-A working group of community members is committed to promptly addressing any link:mailto:servicetalk-conduct@group.apple.com[reported issues].
+A working group of community members is committed to promptly addressing any
+link:mailto:servicetalk-conduct@group.apple.com[reported issues].
 Working group members are volunteers appointed by the project lead, with a
 preference for individuals with varied backgrounds and perspectives. Membership is expected
 to change regularly, and may grow or shrink.

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -16,8 +16,8 @@ get involved. Pull requests to update and expand this guide are welcome.
 
 == Before you get started
 === Community Guidelines
-We want the ServiceTalk community to be as welcoming and inclusive as possible, and have adopted a xref:CODE_OF_CONDUCT.adoc[Code of Conduct]
-that we ask all community members to read and observe.
+We want the ServiceTalk community to be as welcoming and inclusive as possible, and have adopted a
+xref:CODE_OF_CONDUCT.adoc[Code of Conduct] that we ask all community members to read and observe.
 
 === Project Licensing
 By submitting a pull request, you represent that you have the right to license your contribution to Apple and the
@@ -34,8 +34,9 @@ adding individuals in this role will be formalized in the future.
 == Contributing
 === Opening a Pull Request
 We love pull requests! For minor changes, feel free to open up a PR directly. For larger feature development and any
-changes that may require community discussion, we ask that you discuss your ideas on a link:https://github.com/apple/servicetalk/issues[github issue]
-prior to opening a PR, and then reference that issue within your PR comment.
+changes that may require community discussion, we ask that you discuss your ideas on a
+link:https://github.com/apple/servicetalk/issues[github issue] prior to opening a PR, and then reference that issue
+within your PR comment.
 
 CI will run tests against the PR and post the status back to github.
 
@@ -71,8 +72,8 @@ Please be sure to include:
 * Java version, output of `java -version`
 * Contextual information (e.g. what you were trying to achieve with ServiceTalk)
 * Simplest possible steps to reproduce
-** A pull request with a failing test case is preferred, but it's fine to paste the test case into the issue description.
-* Anything else that might be relevant in your opinion, such as network configuration.
+** A pull request with a failing test case is preferred, but it's fine to paste the test case into the issue description
+* Anything else that might be relevant in your opinion, such as network configuration
 
 ==== Security issues
 To report a security issue, please DO NOT start by filing a public issue; instead send a

--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,8 @@ See the link:https://docs.servicetalk.io/[ServiceTalk docs] for more information
 
 == Getting Started
 
-All ServiceTalk released artifacts are available in link:https://repo1.maven.org/maven2/io/servicetalk/[the Maven central repository].
+All ServiceTalk released artifacts are available in
+link:https://repo1.maven.org/maven2/io/servicetalk/[the Maven central repository].
 
 The easiest way to get started is to add ServiceTalk's bill-of-material (BOM) dependency to your project's build.
 
@@ -49,29 +50,33 @@ enableFeaturePreview("IMPROVED_POM_SUPPORT") // <2>
 
 With this in place, you can add the ServiceTalk module dependencies you need without specifying their versions.
 
-Refer to the link:https://docs.servicetalk.io/[ServiceTalk docs] for various examples that will get you started with the different features of ServiceTalk.
+Refer to the link:https://docs.servicetalk.io/[ServiceTalk docs] for various examples that will get you started with the
+different features of ServiceTalk.
 
-NOTE: Builds of the development version are available
-      in link:https://oss.sonatype.org/content/repositories/snapshots/io/servicetalk/[Sonatype's snapshots Maven repository].
+NOTE: Builds of the development version are available in
+link:https://oss.sonatype.org/content/repositories/snapshots/io/servicetalk/[Sonatype's snapshots Maven repository].
 
 === Contributor Setup
 
 IMPORTANT: If you're intending to contribute to ServiceTalk,
            make sure to first read the xref:CONTRIBUTING.adoc[contribution guidelines].
 
-ServiceTalk uses link:https://gradle.org[Gradle] as its build tool and only requires JDK 8 or higher to be pre-installed.
-ServiceTalk ships with the Gradle Wrapper, which means that there is no need to install Gradle on your machine beforehand.
+ServiceTalk uses link:https://gradle.org[Gradle] as its build tool and only requires JDK 8 or higher to be
+pre-installed. ServiceTalk ships with the Gradle Wrapper, which means that there is no need to install Gradle on your
+machine beforehand.
 
 ==== File Encoding
 
 ServiceTalk's source code is UTF-8 encoded: make sure your filesystem supports it before attempting to build
 the project. Setting the `JAVA_TOOL_OPTIONS` env var to `-Dfile.encoding=UTF-8` should help building the project in
-non-UTF-8 environments. Editors and IDEs must also support UTF-8 in order to successfully edit ServiceTalk's source code.
+non-UTF-8 environments. Editors and IDEs must also support UTF-8 in order to successfully edit ServiceTalk's source
+code.
 
 ==== Gradle Repositories
 
 ServiceTalk's build produces custom Gradle plugins and thus has regular (i.e. non-`buildscript`) dependencies
-on other plugins. This is the reason why the repositories that are provided if none are configured globally are the following:
+on other plugins. This is the reason why the repositories that are provided if none are configured globally are the
+following:
 
 [source,groovy]
 ----
@@ -93,7 +98,8 @@ If you have defined repositories or repository mirrors in your global Gradle con
 the build will detect them and attempt to inherit `buildscript` repositories into the main `repositories`
 of the sub-projects that produce custom Gradle plugins.
 
-NOTE: This inheritance mechanism can be disabled by setting a Gradle property: `-PdisableInheritBuildscriptRepositories`
+NOTE: This inheritance mechanism can be disabled by setting a Gradle property: +
+      `-PdisableInheritBuildscriptRepositories`.
 
 ==== Build Commands
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -53,8 +53,8 @@ With this in place, you can add the ServiceTalk module dependencies you need wit
 Refer to the link:https://docs.servicetalk.io/[ServiceTalk docs] for various examples that will get you started with the
 different features of ServiceTalk.
 
-NOTE: Builds of the development version are available
-      in link:https://oss.sonatype.org/content/repositories/snapshots/io/servicetalk/[Sonatype's snapshots Maven repository].
+NOTE: Builds of the development version are available in
+link:https://oss.sonatype.org/content/repositories/snapshots/io/servicetalk/[Sonatype's snapshots Maven repository].
 
 === Contributor Setup
 
@@ -65,9 +65,43 @@ ServiceTalk uses link:https://gradle.org[Gradle] as its build tool and only requ
 pre-installed. ServiceTalk ships with the Gradle Wrapper, which means that there is no need to install Gradle on your
 machine beforehand.
 
-IMPORTANT: ServiceTalk's source code is UTF-8 encoded: make sure your filesystem supports it before attempting to build
+==== File Encoding
+
+ServiceTalk's source code is UTF-8 encoded: make sure your filesystem supports it before attempting to build
 the project. Setting the `JAVA_TOOL_OPTIONS` env var to `-Dfile.encoding=UTF-8` should help building the project in
-non-UTF-8 environments. Editors and IDEs must also support UTF-8 in order to successfully edit ServiceTalk's source code.
+non-UTF-8 environments. Editors and IDEs must also support UTF-8 in order to successfully edit ServiceTalk's source
+code.
+
+==== Gradle Repositories
+
+ServiceTalk's build produces custom Gradle plugins and thus has regular (i.e. non-`buildscript`) dependencies
+on other plugins. This is the reason why the repositories that are provided if none are configured globally are the
+following:
+
+[source,groovy]
+----
+allprojects {
+  buildscript {
+    repositories {
+      jcenter()
+      maven { url "https://plugins.gradle.org/m2/" }
+    }
+  }
+  repositories {
+    jcenter()
+    maven { url "https://plugins.gradle.org/m2/" }
+  }
+}
+----
+
+If you have defined repositories or repository mirrors in your global Gradle config (`~/.gradle/init.gradle`),
+the build will detect them and attempt to inherit `buildscript` repositories into the main `repositories`
+of the sub-projects that produce custom Gradle plugins.
+
+NOTE: This inheritance mechanism can be disabled by setting a Gradle property: +
+      `-PdisableInheritBuildscriptRepositories`.
+
+==== Build Commands
 
 You should be able to run the following command to build ServiceTalk:
 


### PR DESCRIPTION
Motivation:

The documentation generation approach currently involves copying files
from the root directory. We need to sync them until we have automated
solution. See #712 for more information.

Modifications:

- Sync `README.adoc`, `CONTRIBUTING.adoc`, and `CODE_OF_CONDUCT.adoc`
with files in `docs/modules/ROOT/pages`;

Result:

Docs synced.