### PR TITLE
Publish javadoc as part of the docs website

### DIFF
--- a/docs/generation/gradle/buildSite.gradle
+++ b/docs/generation/gradle/buildSite.gradle
@@ -75,39 +75,3 @@ task buildRemoteSite(type: NodeTask) { task ->
     println("Generated remote site at: file://$outputDir/index.html")
   }
 }
-
-task publishRemoteSite(type: Exec) {
-  // important to run this as a self-contained CI step with GitHub deploy key,
-  // hence no task dependency on `buildRemoteSite`
-
-  executable = "bash"
-
-  args = [
-      "-c",
-      """
-      set -xe
-
-      BRANCH_NAME=\$(git symbolic-ref -q HEAD)
-      BRANCH_NAME=\${BRANCH_NAME##refs/heads/}
-      GIT_AUTHOR=\$(git --no-pager show -s --format='%an <%ae>' HEAD)
-      if ( ! git remote get-url docs ); then
-        git remote add docs git@github.com:apple/servicetalk.git
-      fi
-      git fetch docs +gh-pages:gh-pages
-      git worktree add gh-pages gh-pages
-      cd gh-pages
-
-      rm -rf *
-      touch .nojekyll
-      cp -r ../.out/remote/* .
-      git add * .nojekyll
-
-      git commit --author="\$GIT_AUTHOR" -m "Publish docsite"
-      git push docs gh-pages
-
-      cd ..
-      rm -rf gh-pages
-      git worktree prune
-    """.stripIndent()
-  ]
-}

--- a/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
+++ b/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
@@ -31,3 +31,4 @@ include::{page-version}@servicetalk-http-router-jersey:ROOT:partial$nav-versione
 ** xref:{page-version}@servicetalk-data-jackson-jersey::index.adoc[Data Jackson Jersey]
 * xref:{page-version}@servicetalk::CONTRIBUTING.adoc[Contributing]
 * xref:{page-version}@servicetalk::CODE_OF_CONDUCT.adoc[Code of Conduct]
+* xref:{page-version}@servicetalk::javadoc/index.adoc[Javadoc]

--- a/docs/modules/ROOT/pages/javadoc/index.adoc
+++ b/docs/modules/ROOT/pages/javadoc/index.adoc
@@ -1,0 +1,3 @@
+= Javadoc placeholder
+
+This page should be replaced by the actual javadoc.

--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -eu
+
+cd "$(dirname "$0")"
+cd ..
+
+version=""
+DOCS_FOLDER="docs/generation/.out/remote"
+JAVADOC_FOLDER="build/javadoc"
+BRANCH_NAME=$(git symbolic-ref -q HEAD)
+BRANCH_NAME=${BRANCH_NAME##refs/heads/}
+GIT_AUTHOR=$(git --no-pager show -s --format='%an <%ae>' HEAD)
+
+function usage() {
+cat << EOF
+Run as:
+publish-docs.sh - to update the SNAPSHOT version of docs website only
+publish-docs.sh {release_version} - to publish docs for a new release version and update the SNAPSHOT version
+EOF
+}
+
+if [ "$#" -eq "0" ]; then
+    echo "Publishing docs website for the SNAPSHOT version only"
+elif [ "$#" -eq "1" ]; then
+    version="$1"
+    if ( echo "$version" | grep -Eqv "^\d+\.\d+$" ); then
+        echo "Release version should match 'major.minor' pattern"
+        exit 1
+    fi
+    echo "Publishing docs website for the release version $version"
+else
+    usage
+    exit 1
+fi
+
+echo ""
+
+echo "Generate docs website"
+pushd docs/generation
+./gradlew --no-daemon clean validateRemoteSite
+popd
+echo "Docs website generated, see ./$DOCS_FOLDER"
+
+echo "Generate javadoc"
+./gradlew --no-daemon javadocAll
+echo "Javadoc generated, see ./$JAVADOC_FOLDER"
+``
+if ( ! git remote get-url docs ); then
+  git remote add docs git@github.com:apple/servicetalk.git
+fi
+
+git fetch docs +gh-pages:gh-pages
+git worktree add gh-pages gh-pages
+
+touch gh-pages/.nojekyll
+\cp -r $DOCS_FOLDER/* gh-pages
+echo "Copy javadoc to gh-pages/servicetalk/SNAPSHOT"
+\cp -r $JAVADOC_FOLDER gh-pages/servicetalk/SNAPSHOT
+if [ ! -z "$version" ]; then
+    echo "Copy javadoc to gh-pages/servicetalk/$version"
+    \cp -r $JAVADOC_FOLDER gh-pages/servicetalk/$version
+fi
+
+pushd gh-pages
+git add * .nojekyll
+if [ -z "$version" ]; then
+    git commit --author="$GIT_AUTHOR" -m "Update SNAPSHOT doc website"
+else
+    git commit --author="$GIT_AUTHOR" -m "Publish docs website $version"
+fi
+
+git push docs gh-pages
+popd
+
+rm -rf gh-pages
+git worktree prune
+
+if [ -z "$version" ]; then
+    echo "Docs website for the SNAPSHOT version successfully updated"
+else
+    echo "Docs website for the release version $version successfully published"
+fi


### PR DESCRIPTION
Motivation:

Current docs website does not contain javadoc.

Modifications:

- Add `publish-docs.sh` script that published docs website and javadoc;
- Remote `publishRemoteSite` gradlew's task because it is replaced by
`publish-docs.sh` script;
- Add a placeholder adoc for antora that will be replaced by the
actual javadoc html;
- Add a link to the javadoc at navigation bar;

Result:

Javadoc is published as part of the docs website.