### PR TITLE
Remove builder methods that return back default values

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/BaseGrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/BaseGrpcClientBuilder.java
@@ -72,15 +72,6 @@ interface BaseGrpcClientBuilder<U, R> {
     BaseGrpcClientBuilder<U, R> enableWireLogging(String loggerName);
 
     /**
-     * Disable previously configured wire-logging for clients created by this builder.
-     * If wire-logging has not been configured before, this method has no effect.
-     *
-     * @return {@code this}.
-     * @see #enableWireLogging(String)
-     */
-    BaseGrpcClientBuilder<U, R> disableWireLogging();
-
-    /**
      * Set the {@link HttpHeadersFactory} to be used for creating {@link HttpHeaders} when decoding responses.
      *
      * @param headersFactory the {@link HttpHeadersFactory} to use.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -68,9 +68,6 @@ public abstract class GrpcClientBuilder<U, R>
     public abstract GrpcClientBuilder<U, R> enableWireLogging(String loggerName);
 
     @Override
-    public abstract GrpcClientBuilder<U, R> disableWireLogging();
-
-    @Override
     public abstract GrpcClientBuilder<U, R> headersFactory(HttpHeadersFactory headersFactory);
 
     @Override

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -183,15 +183,6 @@ public abstract class GrpcServerBuilder {
     public abstract GrpcServerBuilder enableWireLogging(String loggerName);
 
     /**
-     * Disable previously configured wire-logging for this server.
-     * If wire-logging has not been configured before, this method has no effect.
-     *
-     * @return {@code this}.
-     * @see #enableWireLogging(String)
-     */
-    public abstract GrpcServerBuilder disableWireLogging();
-
-    /**
      * Disables automatic consumption of request {@link StreamingHttpRequest#payloadBody() payload body} when it is not
      * consumed by the service.
      * <p>
@@ -206,24 +197,6 @@ public abstract class GrpcServerBuilder {
      * @return {@code this}.
      */
     public abstract GrpcServerBuilder disableDrainingRequestPayloadBody();
-
-    /**
-     * Enables automatic consumption of request {@link StreamingHttpRequest#payloadBody() payload body} when it is not
-     * consumed by the service.
-     * <p>
-     * For <a href="https://tools.ietf.org/html/rfc7230#section-6.3">persistent HTTP connections</a> it is required to
-     * eventually consume the entire request payload to enable reading of the next request. This is required because
-     * requests are pipelined for HTTP/1.1, so if the previous request is not completely read, next request can not be
-     * read from the socket. For cases when there is a possibility that user may forget to consume request payload,
-     * ServiceTalk automatically consumes request payload body. This automatic consumption behavior may create some
-     * overhead and {@link #disableDrainingRequestPayloadBody() can be disabled} when it is guaranteed that all request
-     * paths consumes all request payloads eventually. An example of guaranteed consumption are
-     * {@link HttpRequest non-streaming APIs}.
-     *
-     * @return {@code this}.
-     * @see #disableDrainingRequestPayloadBody()
-     */
-    public abstract GrpcServerBuilder enableDrainingRequestPayloadBody();
 
     /**
      * Append the filter to the chain of filters used to decorate the {@link ConnectionAcceptor} used by this builder.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/SingleAddressGrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/SingleAddressGrpcClientBuilder.java
@@ -54,9 +54,6 @@ interface SingleAddressGrpcClientBuilder<U, R,
     SingleAddressGrpcClientBuilder<U, R, SDE> enableWireLogging(String loggerName);
 
     @Override
-    SingleAddressGrpcClientBuilder<U, R, SDE> disableWireLogging();
-
-    @Override
     SingleAddressGrpcClientBuilder<U, R, SDE> headersFactory(HttpHeadersFactory headersFactory);
 
     @Override

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
@@ -78,12 +78,6 @@ final class DefaultGrpcClientBuilder<U, R> extends GrpcClientBuilder<U, R> {
     }
 
     @Override
-    public GrpcClientBuilder<U, R> disableWireLogging() {
-        httpClientBuilder.disableWireLogging();
-        return this;
-    }
-
-    @Override
     public GrpcClientBuilder<U, R> headersFactory(final HttpHeadersFactory headersFactory) {
         httpClientBuilder.headersFactory(headersFactory);
         return this;

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -135,20 +135,8 @@ final class DefaultGrpcServerBuilder extends GrpcServerBuilder implements Server
     }
 
     @Override
-    public GrpcServerBuilder disableWireLogging() {
-        httpServerBuilder.disableWireLogging();
-        return this;
-    }
-
-    @Override
     public GrpcServerBuilder disableDrainingRequestPayloadBody() {
         httpServerBuilder.disableDrainingRequestPayloadBody();
-        return this;
-    }
-
-    @Override
-    public GrpcServerBuilder enableDrainingRequestPayloadBody() {
-        httpServerBuilder.enableDrainingRequestPayloadBody();
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseHttpBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseHttpBuilder.java
@@ -76,15 +76,6 @@ abstract class BaseHttpBuilder<ResolvedAddress> {
     public abstract BaseHttpBuilder<ResolvedAddress> enableWireLogging(String loggerName);
 
     /**
-     * Disable previously configured wire-logging for connections created by this builder.
-     * If wire-logging has not been configured before, this method has no effect.
-     *
-     * @return {@code this}.
-     * @see #enableWireLogging(String)
-     */
-    public abstract BaseHttpBuilder<ResolvedAddress> disableWireLogging();
-
-    /**
      * Set the {@link HttpHeadersFactory} to be used for creating {@link HttpHeaders} when decoding responses.
      *
      * @param headersFactory the {@link HttpHeadersFactory} to use.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseSingleAddressHttpClientBuilder.java
@@ -44,9 +44,6 @@ abstract class BaseSingleAddressHttpClientBuilder<U, R, SDE extends ServiceDisco
     public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> enableWireLogging(String loggerName);
 
     @Override
-    public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> disableWireLogging();
-
-    @Override
     public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> headersFactory(HttpHeadersFactory headersFactory);
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
@@ -59,9 +59,6 @@ abstract class HttpClientBuilder<U, R, SDE extends ServiceDiscovererEvent<R>> ex
     public abstract HttpClientBuilder<U, R, SDE> enableWireLogging(String loggerName);
 
     @Override
-    public abstract HttpClientBuilder<U, R, SDE> disableWireLogging();
-
-    @Override
     public abstract HttpClientBuilder<U, R, SDE> headersFactory(HttpHeadersFactory headersFactory);
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -197,15 +197,6 @@ public abstract class HttpServerBuilder {
     public abstract HttpServerBuilder enableWireLogging(String loggerName);
 
     /**
-     * Disable previously configured wire-logging for this server.
-     * If wire-logging has not been configured before, this method has no effect.
-     *
-     * @return {@code this}.
-     * @see #enableWireLogging(String)
-     */
-    public abstract HttpServerBuilder disableWireLogging();
-
-    /**
      * Disables automatic consumption of request {@link StreamingHttpRequest#payloadBody() payload body} when it is not
      * consumed by the service.
      * <p>
@@ -221,27 +212,6 @@ public abstract class HttpServerBuilder {
      */
     public final HttpServerBuilder disableDrainingRequestPayloadBody() {
         this.drainRequestPayloadBody = false;
-        return this;
-    }
-
-    /**
-     * Enables automatic consumption of request {@link StreamingHttpRequest#payloadBody() payload body} when it is not
-     * consumed by the service.
-     * <p>
-     * For <a href="https://tools.ietf.org/html/rfc7230#section-6.3">persistent HTTP connections</a> it is required to
-     * eventually consume the entire request payload to enable reading of the next request. This is required because
-     * requests are pipelined for HTTP/1.1, so if the previous request is not completely read, next request can not be
-     * read from the socket. For cases when there is a possibility that user may forget to consume request payload,
-     * ServiceTalk automatically consumes request payload body. This automatic consumption behavior may create some
-     * overhead and {@link #disableDrainingRequestPayloadBody() can be disabled} when it is guaranteed that all request
-     * paths consumes all request payloads eventually. An example of guaranteed consumption are
-     * {@link HttpRequest non-streaming APIs}.
-     *
-     * @return {@code this}.
-     * @see #disableDrainingRequestPayloadBody()
-     */
-    public final HttpServerBuilder enableDrainingRequestPayloadBody() {
-        this.drainRequestPayloadBody = true;
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -61,9 +61,6 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
     public abstract MultiAddressHttpClientBuilder<U, R> enableWireLogging(String loggerName);
 
     @Override
-    public abstract MultiAddressHttpClientBuilder<U, R> disableWireLogging();
-
-    @Override
     public abstract MultiAddressHttpClientBuilder<U, R> headersFactory(HttpHeadersFactory headersFactory);
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
@@ -62,9 +62,6 @@ public abstract class PartitionedHttpClientBuilder<U, R>
     public abstract PartitionedHttpClientBuilder<U, R> enableWireLogging(String loggerName);
 
     @Override
-    public abstract PartitionedHttpClientBuilder<U, R> disableWireLogging();
-
-    @Override
     public abstract PartitionedHttpClientBuilder<U, R> headersFactory(HttpHeadersFactory headersFactory);
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -56,9 +56,6 @@ public abstract class SingleAddressHttpClientBuilder<U, R>
     public abstract SingleAddressHttpClientBuilder<U, R> enableWireLogging(String loggerName);
 
     @Override
-    public abstract SingleAddressHttpClientBuilder<U, R> disableWireLogging();
-
-    @Override
     public abstract SingleAddressHttpClientBuilder<U, R> headersFactory(HttpHeadersFactory headersFactory);
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -141,12 +141,6 @@ final class DefaultHttpServerBuilder extends HttpServerBuilder {
     }
 
     @Override
-    public HttpServerBuilder disableWireLogging() {
-        config.tcpConfig().disableWireLogging();
-        return this;
-    }
-
-    @Override
     public HttpServerBuilder ioExecutor(final IoExecutor ioExecutor) {
         executionContextBuilder.ioExecutor(ioExecutor);
         return this;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -364,12 +364,6 @@ final class DefaultMultiAddressUrlHttpClientBuilder
     }
 
     @Override
-    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> disableWireLogging() {
-        builderTemplate.disableWireLogging();
-        return this;
-    }
-
-    @Override
     public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> headersFactory(
             final HttpHeadersFactory headersFactory) {
         builderTemplate.headersFactory(headersFactory);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -255,12 +255,6 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
     }
 
     @Override
-    public PartitionedHttpClientBuilder<U, R> disableWireLogging() {
-        builderTemplate.disableWireLogging();
-        return this;
-    }
-
-    @Override
     public PartitionedHttpClientBuilder<U, R> headersFactory(final HttpHeadersFactory headersFactory) {
         builderTemplate.headersFactory(headersFactory);
         return this;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -387,12 +387,6 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
     }
 
     @Override
-    public DefaultSingleAddressHttpClientBuilder<U, R> disableWireLogging() {
-        config.tcpClientConfig().disableWireLogging();
-        return this;
-    }
-
-    @Override
     public DefaultSingleAddressHttpClientBuilder<U, R> headersFactory(final HttpHeadersFactory headersFactory) {
         config.headersFactory(headersFactory);
         return this;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionDrainTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionDrainTest.java
@@ -131,33 +131,31 @@ public class NettyHttpServerConnectionDrainTest {
         fail("Request should not complete normally");
     }
 
-    private void closeClient(@Nullable final AutoCloseable client) throws Exception {
+    private static void closeClient(@Nullable final AutoCloseable client) throws Exception {
         if (client != null) {
             client.close();
         }
     }
 
-    private void postLargePayloadAndAssertResponseOk(final BlockingHttpClient client) throws Exception {
+    private static void postLargePayloadAndAssertResponseOk(final BlockingHttpClient client) throws Exception {
         HttpResponse response = client.request(client.post("/").payloadBody(LARGE_TEXT, textSerializer()));
         assertThat(response.payloadBody(textDeserializer()), equalTo("OK"));
     }
 
-    private StreamingHttpService respondOkWithoutReadingRequest(Runnable onRequest) {
+    private static StreamingHttpService respondOkWithoutReadingRequest(Runnable onRequest) {
         return (ctx, request, responseFactory) -> {
             onRequest.run();
             return succeeded(responseFactory.ok().payloadBody(from("OK"), textSerializer()));
         };
     }
 
-    private StreamingHttpService respondOkWithoutReadingRequest() {
+    private static StreamingHttpService respondOkWithoutReadingRequest() {
         return respondOkWithoutReadingRequest(() -> { });
     }
 
-    private ServerContext server(boolean autoDrain, StreamingHttpService handler) throws Exception {
+    private static ServerContext server(boolean autoDrain, StreamingHttpService handler) throws Exception {
         HttpServerBuilder httpServerBuilder = HttpServers.forAddress(AddressUtils.localAddress(0));
-        if (autoDrain) {
-            httpServerBuilder = httpServerBuilder.enableDrainingRequestPayloadBody();
-        } else {
+        if (!autoDrain) {
             httpServerBuilder = httpServerBuilder.disableDrainingRequestPayloadBody();
         }
         ServerContext serverContext = httpServerBuilder

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientConfig.java
@@ -102,18 +102,6 @@ public final class TcpClientConfig extends ReadOnlyTcpClientConfig {
     }
 
     /**
-     * Disable previously configured wire-logging for this client.
-     * If wire-logging has not been configured before, this method has no effect.
-     *
-     * @return {@code this}.
-     * @see #enableWireLogging(String)
-     */
-    public TcpClientConfig disableWireLogging() {
-        wireLoggingInitializer = null;
-        return this;
-    }
-
-    /**
      * Sets {@link FlushStrategy} to use for all connections created by this client.
      *
      * @param flushStrategy {@link FlushStrategy} to use for all connections created by this client.

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
@@ -135,18 +135,6 @@ public final class TcpServerConfig extends ReadOnlyTcpServerConfig {
     }
 
     /**
-     * Disable previously configured wire-logging for this server.
-     * If wire-logging has not been configured before, this method has no effect.
-     *
-     * @return {@code this}.
-     * @see #enableWireLogging(String)
-     */
-    public TcpServerConfig disableWireLogging() {
-        wireLoggingInitializer = null;
-        return this;
-    }
-
-    /**
      * Sets {@link FlushStrategy} to use for all connections accepted by this server.
      *
      * @param flushStrategy {@link FlushStrategy} to use for all connections accepted by this server.


### PR DESCRIPTION
Motivation:

Wire logging is disabled by default and auto-draining is enabled by
default. We have builder methods that change the default values. There
is no need to let users return them back to defaults.

Modifications:

- Remove `disableWireLogging()` method from client and server builders;
- Remove `enableDrainingRequestPayloadBody()` method from server builders;

Result:

Less public methods to maintain.