### PR TITLE
Validate javadoc as part of the `quality` task

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
@@ -216,6 +216,9 @@ final class ProjectUtils {
         if (tasks.findByName("spotbugs")) {
           dependsOn tasks.spotbugs
         }
+        if (tasks.findByName("javadoc")) {  // verifies that javadoc generates without errors
+          dependsOn tasks.javadoc
+        }
       }
     }
   }


### PR DESCRIPTION
Motivation:

We currently do not validate that javadoc generates without errors, like
broken links. We can discover that type of problems only after the
release, when we publish documentation.

Modifications:

- Add `javadoc` as a sub-task of the `quality` task that we run for PRB;

Result:

PRB `quality` job also verifies that javadoc does not have errors.