### PR TITLE
Enable host verification by default for Http clients

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -616,7 +616,7 @@ public class ProtocolCompatibilityTest {
         final GrpcClientBuilder<InetSocketAddress, InetSocketAddress> builder =
                 GrpcClients.forResolvedAddress((InetSocketAddress) serverAddress).h2PriorKnowledge(true);
         if (ssl) {
-            builder.secure().provider(OPENSSL)
+            builder.secure().disableHostnameVerification().provider(OPENSSL)
                     .applicationProtocolNegotiation(ALPN, NO_ADVERTISE, ACCEPT, ALPN_SUPPORTED_PROTOCOLS)
                     .trustManager(DefaultTestCerts::loadServerPem).commit();
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -151,7 +151,8 @@ public abstract class AbstractNettyHttpServerTest {
 
         final SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> clientBuilder = newClientBuilder();
         if (sslEnabled) {
-            clientBuilder.secure().trustManager(DefaultTestCerts::loadMutualAuthCaPem).commit();
+            clientBuilder.secure().disableHostnameVerification()
+                    .trustManager(DefaultTestCerts::loadMutualAuthCaPem).commit();
         }
         httpClient = clientBuilder.ioExecutor(clientIoExecutor)
                 .executionStrategy(defaultStrategy(clientExecutor)).buildStreaming();

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
@@ -104,6 +104,7 @@ public abstract class AbstractTcpServerTest {
             ClientSecurityConfig securityConfig = new ClientSecurityConfig(serverHostAndPort.hostName(),
                     serverHostAndPort.port());
             securityConfig.trustManager(DefaultTestCerts::loadMutualAuthCaPem);
+            securityConfig.disableHostnameVerification();
             tcpClientConfig.secure(securityConfig.asReadOnly());
         }
         return tcpClientConfig;

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ClientSecurityConfigurator.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ClientSecurityConfigurator.java
@@ -57,6 +57,8 @@ public interface ClientSecurityConfigurator extends SecurityConfigurator {
      * Determines what algorithm to use for hostname verification.
      *
      * @param hostNameVerificationAlgorithm The algorithm to use when verifying the host name.
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#jssenames">
+     * Supported algorithm names</a>.
      * @return {@code this}.
      * @see SSLParameters#setEndpointIdentificationAlgorithm(String)
      */
@@ -66,6 +68,8 @@ public interface ClientSecurityConfigurator extends SecurityConfigurator {
      * Determines what algorithm to use for hostname verification.
      *
      * @param hostNameVerificationAlgorithm The algorithm to use when verifying the host name.
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#jssenames">
+     * Supported algorithm names</a>.
      * @param hostNameVerificationHost the host name used to verify the
      * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
      * @return {@code this}.
@@ -78,6 +82,8 @@ public interface ClientSecurityConfigurator extends SecurityConfigurator {
      * Determines what algorithm to use for hostname verification.
      *
      * @param hostNameVerificationAlgorithm The algorithm to use when verifying the host name.
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#jssenames">
+     * Supported algorithm names</a>.
      * @param hostNameVerificationHost the host name used to verify the
      * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
      * @param hostNameVerificationPort The port which maybe used to verify the

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ReadOnlyClientSecurityConfig.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ReadOnlyClientSecurityConfig.java
@@ -24,7 +24,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class ReadOnlyClientSecurityConfig extends ReadOnlySecurityConfig {
     @Nullable
-    protected String hostnameVerificationAlgorithm;
+    protected String hostnameVerificationAlgorithm = "HTTPS";
     @Nullable
     protected String hostNameVerificationHost;
     /**


### PR DESCRIPTION
__Motivation__

Our intent currently is to enable host verification by default for HTTP clients but we did not specify a verification algorithm by default which leads to disabling this verification.

__Modification__

Use a default hostname verification algorithm which can be updated using builder options.

__Result__

Host verification is enabled by default.