### PR TITLE
Move `netty-buffer` to api dependency configuration

### DIFF
--- a/servicetalk-buffer-netty/build.gradle
+++ b/servicetalk-buffer-netty/build.gradle
@@ -18,11 +18,11 @@ apply plugin: "servicetalk-library"
 
 dependencies {
   api project(":servicetalk-buffer-api")
+  api "io.netty:netty-buffer:$nettyVersion"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-internal")
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "io.netty:netty-buffer:$nettyVersion"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation project(":servicetalk-test-resources")


### PR DESCRIPTION
Motivation:

`BufferUtil` exposes classes from `io.netty.buffer` package as a public
API, but we do not bring `io.netty:netty-buffer` dependency to the
`compile` scope.

Modifications:

- Move `netty-buffer` from `implementation` to `api` dependency
configuration;

Result:

Users won't have compile errors if they use `BufferUtil` in their code.