### PR TITLE
Convert Jersey headers to lower case when HTTP/2 is used

### DIFF
--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultContainerResponseWriter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultContainerResponseWriter.java
@@ -248,8 +248,10 @@ final class DefaultContainerResponseWriter implements ContainerResponseWriter {
         }
 
         final HttpHeaders headers = response.headers();
+        // If we use HTTP/2 protocol all headers MUST be in lower case
+        final boolean isH2 = response.version().major() == 2;
         containerResponse.getHeaders().forEach((k, vs) -> vs.forEach(v -> {
-            headers.add(k, v == null ? emptyAsciiString() : asCharSequence(v));
+            headers.add(isH2 ? k.toLowerCase() : k, v == null ? emptyAsciiString() : asCharSequence(v));
         }));
 
         if (!headers.contains(CONTENT_LENGTH)) {


### PR DESCRIPTION
Motivation:

HTTP/2 requires all headers to be in lower case.

Modifications:

- Convert Jersey headers to lower case when HTTP/2 is used;

Result:

Jersey response could be converted to HTTP/2 response.

---
I tried to run tests from `servicetalk-http-router-jersey` with h2 enabled. This is the first issue that bubbled up. Other issues related to how the jersey test suite is written. For example, the test suite expects h1, or `transfer-encoding: chucked` header, or expects that header names are case sensitive. We will need to spend more time on rewriting that tests.
For now, just tested with `HelloWorldJaxRsServer` that it works when h2 is enabled.