### PR TITLE
Enhancements for performance.adoc

### DIFF
--- a/docs/modules/ROOT/pages/performance.adoc
+++ b/docs/modules/ROOT/pages/performance.adoc
@@ -621,10 +621,10 @@ is wrapped in a link:{source-root}/servicetalk-buffer-api/src/main/java/io/servi
 that maintains read and write indices to prevent reading uninitialized memory. Therefore zeroing of `Buffer`s is not
 necessary and adds considerable overhead while allocating which affects throughput.
 
-ServiceTalk bypasses this zeroing for the default
-link:{source-root}/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/BufferAllocators.java[BufferAllocators]
-on JDK8. On JDK9+ due to the additional protections put in place by the Java Platform Module System, one needs to
-provide additional system properties to take advantage of this optimization.
+ServiceTalk bypasses this zeroing for the default direct
+link:{source-root}/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/BufferAllocators.java[BufferAllocator]
+on JDK8. On JDK9+ due to the additional protections put in place, one needs to provide additional system properties to
+take advantage of this optimization.
 
 To bypass zeroing direct buffers on JDK9+, use:
 
@@ -633,7 +633,7 @@ To bypass zeroing direct buffers on JDK9+, use:
 -Dio.servicetalk.tryReflectionSetAccessible=true
 ----
 
-To bypass zeroing heap buffers in JDK9+, use:
+Bypassing zeroing for heap buffers works only in JDK9+, to enable it use:
 
 [source]
 ----


### PR DESCRIPTION
Motivation:

1. An example for flush strategy changes on the client side sets the
same strategy as the default value.
2. We are missing a section for optimization of memory allocation.

Modifications:

- Update an example of how to alter flush strategy on the client side;
- Add `Skip zero initialization for allocated memory` section;

Result:

Correct example for flush strategy and a new section for disabling
zero initialization.