### PR TITLE
Clarify the gRPC docs

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -23,6 +23,7 @@ ServiceTalk addresses these challenges and includes support for multiple
 xref:{page-version}@servicetalk::programming-paradigms.adoc[Programming Paradigms]. It accomplishes this by building
 on a fully asynchronous non-blocking I/O core and taking care of the threading model complexities internally.
 
+[#DesignPhilosophy]
 == Design Philosophy
 
 ServiceTalk has many different goals driven from the improvement opportunities provided by Netty. Despite ServiceTalk's

--- a/servicetalk-grpc-api/docs/modules/ROOT/pages/index.adoc
+++ b/servicetalk-grpc-api/docs/modules/ROOT/pages/index.adoc
@@ -16,16 +16,18 @@ xref:{page-version}@servicetalk::performance.adoc[peformance tested].
 A design philosophy for ServiceTalk is
 xref:{page-version}@servicetalk::index.adoc#cross-protocol-api-symmetry[cross protocol API symmetry] which means that
 all protocols supported by ServiceTalk should have same constructs and follow the same design principles. We acknowledge
-that link:https://github.com/grpc/grpc-java[grpc-java] implements the gRPC protocol for the JVM and is used
-extensively. However, our
-xref:{page-version}@servicetalk::index.adoc#design-philosophy[design philosophies] are different than
-link:https://github.com/grpc/grpc-java[grpc-java] and we support the underlying
-link:https://tools.ietf.org/html/rfc7540[HTTP/2] protocol using link:https://netty.io[Netty]. Also, as part of developing
-Netty, we collaborated with the link:https://github.com/grpc/grpc-java[grpc-java] team to implement
-link:https://tools.ietf.org/html/rfc7540[HTTP/2] in Netty enabling us both to share this common protocol implementation.
-Considering the above, implementing the
-link:https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md[gRPC wire protocol] is a relatively lower investment
-for us while giving us the benefits of following our design philosophies consistently across all protocols.
+that link:https://github.com/grpc/grpc-java[grpc-java] implements the
+link:https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md[gRPC wire protocol] for the JVM and is used
+extensively. However, our xref:{page-version}@servicetalk::index.adoc#design-philosophy[design philosophies] are
+different than
+link:https://github.com/grpc/grpc-java[grpc-java] and ServiceTalk also provides
+link:https://tools.ietf.org/html/rfc7540[HTTP/2] directly for users. The
+link:https://github.com/grpc/grpc-java[grpc-java] team and the ServiceTalk team collaborated to bring
+link:https://tools.ietf.org/html/rfc7540[HTTP/2] support to Netty, and both share the same underlying protocol
+implementation. Once you have link:https://tools.ietf.org/html/rfc7540[HTTP/2] support the investment to support the
+link:https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md[gRPC wire protocol] is relatively small but it
+enables ServiceTalk users to benefit from our
+xref:{page-version}@servicetalk::index.adoc#DesignPhilosophy[design philosophy] consistently across all protocols.
 
 == Overview
 gRPC support in ServiceTalk implements the


### PR DESCRIPTION
Motivation:
Minor rewording of gRPC docs to clarify the HTTP/2, grpc-java, and Netty relationship.