### PR TITLE
Handle empty `tags` parameter in antora's `site-remote.yml`

### DIFF
--- a/scripts/manage-antora-remote-versions.sh
+++ b/scripts/manage-antora-remote-versions.sh
@@ -57,12 +57,15 @@ majorminor="${newversion%.*}"
 
 rm -f "$file.tmp"
 cat "$file" | while IFS='' read line; do
-    if ( echo "$line" | grep -q "^      tags: \[.*\]" ); then
-        if (echo "$line" | grep -q "[[ ]${majorminor}.\d" ); then
+    if ( echo "$line" | grep -q "^      tags: \[.*\]$" ); then
+        if ( echo "$line" | grep -q "[[ ]${majorminor}.\d" ); then
             # If major.minor was already in this line, update the patch version
             echo "$line" |
               sed "s/^      tags: \[\(.*[[ ]\)$majorminor\.[^,]*\(.*\)\]$/      tags: [\1$newversion\2]/" \
               >> "$file.tmp"
+        elif ( echo "$line" | grep -q "^      tags: \[[ ]*\]$" ); then
+            # If tags is empty
+            echo "$line" | sed "s/^      tags: \[[ ]*\]$/      tags: [$newversion]/" >> "$file.tmp"
         else
             # If major.minor was not already in this line, add it
             echo "$line" | sed "s/^      tags: \[\(.*\)\]$/      tags: [\1, $newversion]/" >> "$file.tmp"


### PR DESCRIPTION
Motivation:

When we add a new module `tags` has an empty array value in antora's
`site-remote.yml`. Our release.sh script does not handle this case.

Modifications:

- Correctly add a new version number in empty `tags`;

Result:

`release.sh` correctly adds a new version for empty `tags`.