### PR TITLE
Verify if the `master` branch exists before checking out in release.sh

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -56,8 +56,11 @@ else
 fi
 
 $git fetch -p
-$git branch -D master
-$git checkout --track origin/master
+if $git rev-parse --quiet --verify master > /dev/null; then
+    $git checkout master
+else
+    $git checkout --track origin/master
+fi
 $git pull
 $git log -n1
 


### PR DESCRIPTION
Motivation:

If we cleaned up workspace on CI, it does not have local `master`
branch and fails release with an error.

Modifications:

- Verify if the `master` branch exists before checking out in release.sh;

Result:

`release.sh` checks out to `master` branch without errors.