### PR TITLE
Improve JDK version management for CI with jabba

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,10 +36,12 @@ RUN yum install -y \
 
 ENV LANG en_US.UTF-8
 
-ARG java_version=adopt@1.8.192-12
+# `java_version` should be 1.x where x indicates the major JDK version, eg. 8, 11, etc.
+ARG java_version=1.8
 ENV JAVA_VERSION $java_version
 # installing java with jabba
-RUN curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | JABBA_COMMAND="install $JAVA_VERSION -o /jdk" bash
-
+RUN curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash
+RUN echo ". /root/.bashrc ; jabba ls-remote adopt@ --latest=minor | grep @$JAVA_VERSION" | bash > /root/.jabba-jdk
+RUN echo ". /root/.bashrc ; jabba install $(cat /root/.jabba-jdk) -o /jdk" | bash
 RUN echo 'export JAVA_HOME="/jdk"' >> ~/.bashrc
 RUN echo 'PATH=/jdk/bin:$PATH' >> ~/.bashrc

--- a/docker/docker-compose.centos7.java11.yaml
+++ b/docker/docker-compose.centos7.java11.yaml
@@ -23,7 +23,8 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "openjdk@1.11.0-2"
+        # `java_version` should be 1.x where x indicates the major JDK version, eg. 8, 11, etc.
+        java_version : "1.11"
 
   build:
     image: servicetalk:centos-7-1.11

--- a/docker/docker-compose.centos7.java8.yaml
+++ b/docker/docker-compose.centos7.java8.yaml
@@ -23,7 +23,8 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "adopt@1.8.192-12"
+        # `java_version` should be 1.x where x indicates the major JDK version, eg. 8, 11, etc.
+        java_version : "1.8"
 
   build:
     image: servicetalk:centos-7-1.8


### PR DESCRIPTION
__Motivation__

Currently the JDK version is hardcoded, this leads to CI running with outdated JDKs over time.
This change improves the Dockerfile such that the latest version is installed.

__Modifications__

- change `java_version` to indicate the major version
- Docker queries jabba to find the latest matching `java_version` from AdoptOpenJDK and installs it

__Result__

The JDK used by CI is always up to date.