### PR TITLE
Use `AddressUtils.localAddress` in tests where it was missed

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ErrorHandlingTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ErrorHandlingTest.java
@@ -68,6 +68,7 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseabl
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.concurrent.internal.PlatformDependent.throwException;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -219,7 +220,7 @@ public class ErrorHandlingTest {
             default:
                 throw new IllegalArgumentException("Unknown mode: " + testMode);
         }
-        serverContext = GrpcServers.forPort(0).appendHttpServiceFilter(serviceFilterFactory)
+        serverContext = GrpcServers.forAddress(localAddress(0)).appendHttpServiceFilter(serviceFilterFactory)
                 .listenAndAwait(serviceFactory);
         GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
                 GrpcClients.forAddress(serverHostAndPort(serverContext)).appendHttpClientFilter(clientFilterFactory);

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -89,6 +89,7 @@ import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy
 import static io.servicetalk.test.resources.DefaultTestCerts.loadServerKey;
 import static io.servicetalk.test.resources.DefaultTestCerts.loadServerPem;
 import static io.servicetalk.transport.api.SecurityConfigurator.SslProvider.OPENSSL;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static java.util.Collections.singleton;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
@@ -620,7 +621,7 @@ public class ProtocolCompatibilityTest {
     }
 
     private static GrpcServerBuilder serviceTalkServerBuilder(final ErrorMode errorMode, final boolean ssl) {
-        final GrpcServerBuilder serverBuilder = GrpcServers.forPort(0)
+        final GrpcServerBuilder serverBuilder = GrpcServers.forAddress(localAddress(0))
                 .appendHttpServiceFilter(service -> new StreamingHttpServiceFilter(service) {
                     @Override
                     public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
@@ -893,7 +894,7 @@ public class ProtocolCompatibilityTest {
     }
 
     private static TestServerContext grpcJavaServer(final ErrorMode errorMode, final boolean ssl) throws Exception {
-        final NettyServerBuilder builder = NettyServerBuilder.forPort(0);
+        final NettyServerBuilder builder = NettyServerBuilder.forAddress(localAddress(0));
         if (ssl) {
             builder.useTransportSecurity(loadServerPem(), loadServerKey());
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BasicAuthStrategyInfluencerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BasicAuthStrategyInfluencerTest.java
@@ -59,6 +59,7 @@ import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
 import static io.servicetalk.http.api.HttpHeaderNames.AUTHORIZATION;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.util.Base64.getEncoder;
@@ -131,7 +132,7 @@ public class BasicAuthStrategyInfluencerTest {
 
     private BlockingHttpClient setup(boolean noOffloadsInfluence) throws Exception {
         ioExecutor = NettyIoExecutors.createIoExecutor(new DefaultThreadFactory(IO_EXECUTOR_NAME_PREFIX));
-        HttpServerBuilder serverBuilder = HttpServers.forPort(0);
+        HttpServerBuilder serverBuilder = HttpServers.forAddress(localAddress(0));
         when(credentialsVerifier.apply(anyString(), anyString())).thenReturn(succeeded("success"));
         when(credentialsVerifier.closeAsync()).thenReturn(completed());
         when(credentialsVerifier.closeAsyncGracefully()).thenReturn(completed());

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryFilterTest.java
@@ -57,8 +57,7 @@ import javax.net.ssl.SSLSession;
 
 import static io.servicetalk.concurrent.api.Processors.newCompletableProcessor;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
-import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
-import static io.servicetalk.http.netty.HttpServers.forPort;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -72,8 +71,9 @@ public class ConnectionFactoryFilterTest {
     private BlockingHttpClient client;
 
     public ConnectionFactoryFilterTest() throws Exception {
-        serverContext = forPort(0).listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
-        clientBuilder = forSingleAddress(serverHostAndPort(serverContext));
+        serverContext = HttpServers.forAddress(localAddress(0))
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
+        clientBuilder = HttpClients.forSingleAddress(serverHostAndPort(serverContext));
     }
 
     @After

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExecutionStrategyInContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExecutionStrategyInContextTest.java
@@ -30,7 +30,6 @@ import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
-import io.servicetalk.transport.netty.internal.AddressUtils;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -49,7 +48,8 @@ import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
-import static io.servicetalk.http.netty.HttpServers.forPort;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ExecutionStrategyInContextTest {
@@ -230,14 +230,14 @@ public class ExecutionStrategyInContextTest {
     private SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> initClientAndServer(
             Function<HttpServerBuilder, Single<ServerContext>> serverStarter, boolean customStrategy)
             throws Exception {
-        HttpServerBuilder serverBuilder = forPort(0);
+        HttpServerBuilder serverBuilder = HttpServers.forAddress(localAddress(0));
         if (customStrategy) {
             expectedServerStrategy = customStrategyBuilder().build();
             serverBuilder.executionStrategy(expectedServerStrategy);
         }
         context = serverStarter.apply(serverBuilder).toFuture().get();
         SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
-                forSingleAddress(AddressUtils.serverHostAndPort(context));
+                forSingleAddress(serverHostAndPort(context));
         if (customStrategy) {
             expectedClientStrategy = customStrategyBuilder().build();
             clientBuilder.executionStrategy(expectedClientStrategy);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulCloseTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulCloseTest.java
@@ -24,7 +24,6 @@ import io.servicetalk.http.api.StatelessTrailersTransformer;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.transport.api.ServerContext;
-import io.servicetalk.transport.netty.internal.AddressUtils;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.After;
@@ -41,6 +40,8 @@ import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.DefaultHttpHeadersFactory.INSTANCE;
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -61,7 +62,7 @@ public class GracefulCloseTest {
 
     @SuppressWarnings("unchecked")
     public GracefulCloseTest(final TrailerAddType trailerAddType) throws Exception {
-        context = HttpServers.forPort(0).listenStreamingAndAwait((ctx, request, responseFactory) -> {
+        context = HttpServers.forAddress(localAddress(0)).listenStreamingAndAwait((ctx, request, responseFactory) -> {
             StreamingHttpResponse resp = responseFactory.ok().payloadBody(from("Hello"), textSerializer());
             switch (trailerAddType) {
                 case Regular:
@@ -76,7 +77,7 @@ public class GracefulCloseTest {
             }
             return succeeded(resp);
         });
-        client = HttpClients.forSingleAddress(AddressUtils.serverHostAndPort(context)).buildStreaming();
+        client = HttpClients.forSingleAddress(serverHostAndPort(context)).buildStreaming();
     }
 
     @Parameterized.Parameters(name = "{index} - trailer type: {0}")

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProxyTest.java
@@ -30,6 +30,7 @@ import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.hamcrest.Matchers.is;
@@ -54,7 +55,7 @@ public class HttpProxyTest {
 
     public void startProxy() throws Exception {
         final HttpClient proxyClient = HttpClients.forMultiAddressUrl().build();
-        final ServerContext serverContext = HttpServers.forPort(0)
+        final ServerContext serverContext = HttpServers.forAddress(localAddress(0))
                 .listenAndAwait((ctx, request, responseFactory) -> {
                     proxyRequestCount.incrementAndGet();
                     return proxyClient.request(request);
@@ -63,7 +64,7 @@ public class HttpProxyTest {
     }
 
     public void startServer() throws Exception {
-        final ServerContext serverContext = HttpServers.forPort(0)
+        final ServerContext serverContext = HttpServers.forAddress(localAddress(0))
                 .listenAndAwait((ctx, request, responseFactory) -> succeeded(responseFactory.ok()
                         .payloadBody("host: " + request.headers().get(HOST), textSerializer())));
         serverPort = serverHostAndPort(serverContext).port();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
@@ -44,6 +44,7 @@ import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -137,7 +138,7 @@ public class HttpsProxyTest {
     }
 
     public void startServer() throws Exception {
-        final ServerContext serverContext = HttpServers.forPort(0)
+        final ServerContext serverContext = HttpServers.forAddress(localAddress(0))
                 .secure().commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
                 .listenAndAwait((ctx, request, responseFactory) -> succeeded(responseFactory.ok()
                         .payloadBody("host: " + request.headers().get(HOST), textSerializer())));


### PR DESCRIPTION
Motivation:

We should never start a server for all interfaces (0.0.0.0) in tests,
because in some environments additional permissions may be required.
Servers should use loopback address only in tests and we provide a
utility that creates it with random port.

Modifications:

- Use `AddressUtils.localAddress` in tests where it was missed;

Result:

Servers in tests do not start using `0.0.0.0` interface.