### PR TITLE
Enable publish to maven central via Sonatype

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -71,9 +71,17 @@ services:
       - CI
       - BINTRAY_USER
       - BINTRAY_KEY
+      - ORG_GRADLE_PROJECT_signingKey
+      - ORG_GRADLE_PROJECT_signingPassword
+      - SONATYPE_USER
+      - SONATYPE_TOKEN
     command: >
       bash -cl "./gradlew --no-daemon --parallel --max-workers=4 clean check &&
       ./gradlew --no-daemon bintrayUpload"
+
+# Don't run `publish` task on `publish-snapshot` for now ^^ replace with below command later.
+#      bash -cl "./gradlew --no-daemon --parallel --max-workers=4 clean check &&
+#      ./gradlew --no-daemon publish bintrayUpload"
 
   publish-release:
     << : *common
@@ -82,9 +90,13 @@ services:
       - CI
       - BINTRAY_USER
       - BINTRAY_KEY
+      - ORG_GRADLE_PROJECT_signingKey
+      - ORG_GRADLE_PROJECT_signingPassword
+      - SONATYPE_USER
+      - SONATYPE_TOKEN
     command: >
       bash -cl "./gradlew --no-daemon --parallel --max-workers=4 -PreleaseBuild=true clean check &&
-      ./gradlew --no-daemon -PreleaseBuild=true bintrayUpload"
+      ./gradlew --no-daemon -PreleaseBuild=true publish bintrayUpload"
 
   shell:
     << : *common


### PR DESCRIPTION
__Motivation__

Directly publishing to sonatype maven central gives us more control over the artifacts to be promoted to central.

__Modifications__

- add POM metadata as required by maven central
- add signing of artifacts as per maven central requirements
- update Docker Compose to pass PGP and Sonatype credentials from the ENV

__Result__

Gradle can now publish to maven central.