### PR TITLE
Add Google Analytics and HTML meta data

### DIFF
--- a/docs/generation/site-remote.yml
+++ b/docs/generation/site-remote.yml
@@ -18,6 +18,8 @@ runtime:
   cache_dir: .out/cache
 site:
   title: ServiceTalk Docs
+  keys:
+    google_analytics: 'UA-151504011-1'
   start_page: servicetalk::index.adoc
 content:
   # ordered alphabetically by component name (as specified in components' antora.yml)

--- a/docs/generation/supplemental-ui/partials/head-meta.hbs
+++ b/docs/generation/supplemental-ui/partials/head-meta.hbs
@@ -1,1 +1,3 @@
+<meta name="description" content="ServiceTalk is a JVM network application framework with APIs tailored to specific protocols (e.g. HTTP/1.x, HTTP/2.x, etc…​) and supports multiple programming paradigms.">
+<meta name="keywords" content="servicetalk, java, reactive, reactive-streams, microservices, framework, http, http2, rpc, grpc, netty">
 <link rel="stylesheet" href="{{uiRootPath}}/css/site-extra.css">

--- a/docs/generation/supplemental-ui/partials/head-scripts.hbs
+++ b/docs/generation/supplemental-ui/partials/head-scripts.hbs
@@ -1,0 +1,4 @@
+{{#if site.keys.googleAnalytics}}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{site.keys.googleAnalytics}}"></script>
+<script>function gtag(){dataLayer.push(arguments)};window.dataLayer=window.dataLayer||[];gtag('js',new Date());gtag('config','{{site.keys.googleAnalytics}}')</script>
+{{/if}}

--- a/servicetalk-gradle-plugin-internal/src/main/resources/io/servicetalk/gradle/plugin/internal/checkstyle/global-suppressions.xml
+++ b/servicetalk-gradle-plugin-internal/src/main/resources/io/servicetalk/gradle/plugin/internal/checkstyle/global-suppressions.xml
@@ -40,4 +40,5 @@
   <!-- docs -->
   <suppress checks="LineLength" files="docs[\\/]generation[\\/]package-lock.json"/>
   <suppress checks="LineLength" files="docs[\\/]modules[\\/]ROOT[\\/]pages[\\/].*\.adoc"/>
+  <suppress checks="LineLength" files="docs[\\/]generation[\\/]supplemental-ui[\\/]partials[\\/].*\.hbs"/>
 </suppressions>


### PR DESCRIPTION
Motivation:

Monitor which documentation pages are useful for users and improve
documentation website for search engines.

Modification:

- Add Google Analytics script;
- Add HTML metadata: description and keyworks;
- Suppress `LineLength` rule violation for antora's partials;

Result:

Enabled Google Analytics, description for the docs website and keywords.