### PR TITLE
Fix missed titles in Antora docs

### DIFF
--- a/docs/modules/ROOT/pages/programming-paradigms.adoc
+++ b/docs/modules/ROOT/pages/programming-paradigms.adoc
@@ -6,7 +6,8 @@ ifndef::env-github[]
 ifndef::source-root[:source-root: https://github.com/apple/servicetalk/blob/{page-origin-refname}]
 endif::[]
 
-== Programming Paradigms
+= Programming Paradigms
+
 When developing a new application it may not be clear if the complexity of asynchronous control flow is justified.
 Initially the scale may be relatively small, but over time the scale may grow. The scaling or response size
 characteristics may not be uniform for all APIs offered by the application (e.g. health check vs file serving).
@@ -15,27 +16,27 @@ complexity of asynchronous control flow in these cases. This can dramatically lo
 compared with most non-blocking I/O frameworks and avoid "application re-write" if scaling/data size characteristics
 change over time.
 
-=== Blocking vs Synchronous
+== Blocking vs Synchronous
 ServiceTalk APIs may use the term "blocking" in areas where the APIs may be identified as "synchronous". "blocking" in
 this context is meant to declare that the API "may block" the calling thread. This is done because there is no general
 way to determine if a method will return synchronously or block the calling thread, and "blocking" is the least common
 denominator.
 
 [#blocking-and-aggregated]
-=== Blocking and Aggregated
+== Blocking and Aggregated
 This API paradigm is similar to concepts from `java.io` and generally blocks the calling thread until all I/O is
 completed. The result is aggregated into a single object (e.g.
 link:https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#readAllLines-java.nio.file.Path-[Files.readAllLines]
 ).
 
-=== Blocking and Streaming
+== Blocking and Streaming
 This API paradigm is similar to concepts from `java.io` and generally blocks the calling thread until I/O is
 flushed/received. The result can be provided/processed in a streaming fashion (e.g.
 link:https://docs.oracle.com/javase/8/docs/api/java/io/InputStream.html[InputStream] or
 link:https://docs.oracle.com/javase/8/docs/api/java/io/OutputStream.html[OutputStream]) however processing each chunk of
 the stream may also block the calling thread.
 
-=== Asynchronous and Aggregated
+== Asynchronous and Aggregated
 This API paradigm performs I/O asynchronously (e.g. the calling thread is not blocked) and the user is notified when all
 the I/O is complete. ServiceTalk provides a link:https://www.reactive-streams.org[ReactiveStreams] compatible
 xref:{page-version}@servicetalk-concurrent-api::asynchronous-primitives.adoc[Asynchronous primitives] such as
@@ -46,7 +47,7 @@ link:https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionSt
 link:https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html[CompletableFuture] with
 function composition.
 
-=== Asynchronous and Streaming
+== Asynchronous and Streaming
 This API paradigm performs I/O asynchronously (e.g. the calling thread is not blocked) and the user can provide/process
 the I/O in chunks (as opposed to in a single `Object`). ServiceTalk provides
 link:https://www.reactive-streams.org[ReactiveStreams] compatible

--- a/servicetalk-examples/docs/modules/ROOT/pages/grpc/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/grpc/index.adoc
@@ -6,7 +6,7 @@ ifndef::env-github[]
 ifndef::source-root[:source-root: https://github.com/apple/servicetalk/blob/{page-origin-refname}]
 endif::[]
 
-== gRPC Examples
+= gRPC Examples
 
 The link:{source-root}/servicetalk-examples/grpc[`grpc`] folder contains examples for
 link:https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md[the gRPC application protocol]. We provide
@@ -14,18 +14,18 @@ implementations for the examples proto services provided by
 link:https://github.com/grpc/grpc/tree/master/examples/protos[gRPC].
 
 [#HelloWorld]
-=== Hello World
+== Hello World
 
 Implementation for the link:https://github.com/grpc/grpc/blob/master/examples/protos/helloworld.proto[gRPC hello world example].
 
-==== Asynchronous
+=== Asynchronous
 
 This example demonstrates asynchronous request processing for the hello world API using the
 link:{source-root}/servicetalk-examples/grpc/helloworld/src/main/java/io/servicetalk/examples/grpc/helloworld/async/HelloWorldServer.java[HelloWorldServer]
 and a
 link:{source-root}/servicetalk-examples/grpc/helloworld/src/main/java/io/servicetalk/examples/grpc/helloworld/async/HelloWorldClient.java[HelloWorldClient]
 
-==== Blocking
+=== Blocking
 
 This example demonstrates blocking request processing for the hello world API using the
 link:{source-root}/servicetalk-examples/grpc/helloworld/src/main/java/io/servicetalk/examples/grpc/helloworld/blocking/BlockingHelloWorldServer.java[BlockingHelloWorldServer]
@@ -33,11 +33,11 @@ and a
 link:{source-root}/servicetalk-examples/grpc/helloworld/src/main/java/io/servicetalk/examples/grpc/helloworld/blocking/BlockingHelloWorldClient.java[BlockingHelloWorldClient]
 
 [#route-guide]
-=== Route guide
+== Route guide
 
 Implementation for the link:https://github.com/grpc/grpc/blob/master/examples/protos/route_guide.proto[gRPC route guide example].
 
-==== Asynchronous
+=== Asynchronous
 
 Asynchronous processing for different APIs in the link:https://github.com/grpc/grpc/blob/master/examples/protos/route_guide.proto[route guide service]
 are demonstrated using the link:{source-root}/servicetalk-examples/grpc/routeguide/src/main/java/io/servicetalk/examples/grpc/routeguide/async/RouteGuideServer.java[RouteGuideServer]
@@ -56,7 +56,7 @@ xref:{page-version}@servicetalk::programming-paradigms.adoc#asynchronous-and-str
 `recordRoute` API that uses the
 xref:{page-version}@servicetalk::programming-paradigms.adoc#asynchronous-and-streaming[bi-directional streaming programming paradigm].
 
-==== Blocking
+=== Blocking
 
 Blocking processing for different APIs in the link:https://github.com/grpc/grpc/blob/master/examples/protos/route_guide.proto[route guide service]
 are demonstrated using the link:{source-root}/servicetalk-examples/grpc/routeguide/src/main/java/io/servicetalk/examples/grpc/routeguide/blocking/BlockingRouteGuideServer.java[BlockingRouteGuideServer]
@@ -74,4 +74,3 @@ xref:{page-version}@servicetalk::programming-paradigms.adoc#asynchronous-and-str
 * link:{source-root}/servicetalk-examples/grpc/routeguide/src/main/java/io/servicetalk/examples/grpc/routeguide/blocking/streaming/BlockingRouteGuideStreamingClient.java[BlockingRouteGuideStreamingClient] -
 `recordRoute` API that uses the
 xref:{page-version}@servicetalk::programming-paradigms.adoc#asynchronous-and-streaming[bi-directional streaming programming paradigm].
-

--- a/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
@@ -6,17 +6,17 @@ ifndef::env-github[]
 ifndef::source-root[:source-root: https://github.com/apple/servicetalk/blob/{page-origin-refname}]
 endif::[]
 
-== HTTP Examples
+= HTTP Examples
 
 The link:{source-root}/servicetalk-examples/http[`http`]
 folder contains examples for the https://tools.ietf.org/html/rfc7231[HTTP] protocol.
 
 [#HelloWorld]
-=== Hello World
+== Hello World
 
 An obligatory "Hello World" example for HTTP.
 
-==== Asynchronous + Aggregated
+=== Asynchronous + Aggregated
 
 This example demonstrates asynchronous request processing where the payload body is aggregated into a single object
 instead of a stream.
@@ -28,7 +28,7 @@ link:{source-root}/servicetalk-examples/http/helloworld/src/main/java/io/service
 * link:{source-root}/servicetalk-examples/http/helloworld/src/main/java/io/servicetalk/examples/http/helloworld/async/HelloWorldUrlClient.java[HelloWorldUrlClient] - a client that sends a `GET` request to the
 specified URL in absolute-form and receives the response as a single content.
 
-==== Asynchronous + Streaming
+=== Asynchronous + Streaming
 
 This example demonstrates asynchronous request processing where the payload body is a stream.
 
@@ -41,7 +41,7 @@ body as a stream of buffers.
 `GET` request to the specified URL in absolute-form and receives the response payload body as a stream of buffers.
 
 [#blocking-aggregated]
-==== Blocking + Aggregated
+=== Blocking + Aggregated
 
 This example demonstrates blocking request processing where the payload body is aggregated into a single object. The
 APIs will block if content is requested but there is no content available.
@@ -54,7 +54,7 @@ object.
 * link:{source-root}/servicetalk-examples/http/helloworld/src/main/java/io/servicetalk/examples/http/helloworld/blocking/BlockingHelloWorldUrlClient.java[BlockingHelloWorldUrlClient] - a client that sends a `GET`
 request to the specified URL in absolute-form and receives the response payload body as one aggregated object.
 
-==== Blocking + Streaming
+=== Blocking + Streaming
 
 This example demonstrates blocking request processing where the payload body is a blocking iterable stream.
 
@@ -68,7 +68,7 @@ client that sends a `GET` request to the specified URL in absolute-form and rece
 blocking iterable stream of buffers.
 
 [#Serialization]
-=== Serialization
+== Serialization
 
 A similar to "Hello World" examples, which demonstrate
 link:{source-root}/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/async[asynchronous-aggregated],
@@ -81,13 +81,13 @@ Client sends a `POST` request with a JSON payload link:{source-root}/servicetalk
 with `Content-Type: application/json` and link:{source-root}/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/PojoResponse.java[MyPojo] as a payload.
 
 [#JAXRS]
-=== JAX-RS
+== JAX-RS
 
 ServiceTalk provides a JAX-RS implementation that can plugin to ServiceTalk APIs.
 This example demonstrates how to use these APIs, and how different API variations (e.g. asynchronous/blocking and
 aggregated/streaming) are exposed.
 
-==== Hello world
+=== Hello world
 
 A simple "Hello World" example built using JAX-RS.
 
@@ -106,7 +106,7 @@ More examples of how to use the resource can be found in the
 link:{source-root}/servicetalk-examples/http/jaxrs/src/main/java/io/servicetalk/examples/http/jaxrs/HelloWorldJaxRsResource.java[HelloWorldJaxRsResource] javadocs.
 
 [#MetaData]
-=== MetaData
+== MetaData
 
 This example demonstrates some of the basic functionality of the
 link:{source-root}/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpMetaData.java[HttpMetaData] classes:
@@ -125,12 +125,12 @@ NOTE: This example uses the link:#blocking-aggregated[blocking + aggregated] API
 across all the HTTP APIs.
 
 [#HTTP2]
-=== HTTP/2
+== HTTP/2
 
 These examples demonstrate how users can configure link:https://tools.ietf.org/html/rfc7540[HTTP/2] transport in
 ServiceTalk.
 
-==== HTTP/2 with Prior-Knowledge
+=== HTTP/2 with Prior-Knowledge
 
 This example demonstrates how to configure using
 link:https://tools.ietf.org/html/rfc7540#section-3.4[HTTP/2 transport with Prior-Knowledge] for HTTP clients and servers:
@@ -140,7 +140,7 @@ A server that uses HTTP/2 with Prior Knowledge.
 - link:{source-root}/servicetalk-examples/http/http2/src/main/java/io/servicetalk/examples/http/http2/priorknowledge/Http2PriorKnowledgeClient.java[Http2PriorKnowledgeClient] -
 A client that uses HTTP/2 with Prior Knowledge.
 
-==== HTTP/2 via ALPN for secure connections
+=== HTTP/2 via ALPN for secure connections
 
 For secure TLS connections link:https://tools.ietf.org/html/rfc7301[ALPN extension] could be used to negotiate the
 communication protocol:
@@ -160,7 +160,7 @@ link:https://www.eclipse.org/jetty/documentation/current/alpn-chapter.html[anoth
 NOTE: These examples use the link:#blocking-aggregated[blocking + aggregated] API for demonstration purposes, as the
 builder API is the same across all the HTTP APIs.
 
-=== Service Composition
+== Service Composition
 
 An advanced example which demonstrates a composition of various ServiceTalks services in one application.
 For more information see xref:http/service-composition.adoc[Service Composition].


### PR DESCRIPTION
Motivation:

When the page is missing a 1st level header Antora can not infer a page
title and puts `Untitled` instead.

Modifications:

- Decrease level of headers on `Programming Paradigms`,
`HTTP Examples`, and `gRPC Examples` pages;

Result:

Antora correctly generates titles for `Programming Paradigms`,
`HTTP Examples`, and `gRPC Examples` pages.

---
For example, see https://apple.github.io/servicetalk/servicetalk-examples/0.19/http/index.html
Antora generates `Untitled :: ServiceTalk Docs` for tabs in the browser.