### PR TITLE
Don't configure sonatype repo if another repository is already configured

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -102,14 +102,18 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
             }
           }
         }
-        repositories {
-          maven {
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-            url = project.isReleaseBuild ? releasesRepoUrl : snapshotsRepoUrl
-            credentials {
-              username = System.getenv("SONATYPE_USER")
-              password = System.getenv("SONATYPE_TOKEN")
+
+        if (!repositories) {
+          repositories {
+            maven {
+              name = "sonatype"
+              def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+              def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
+              url = project.isReleaseBuild ? releasesRepoUrl : snapshotsRepoUrl
+              credentials {
+                username = System.getenv("SONATYPE_USER")
+                password = System.getenv("SONATYPE_TOKEN")
+              }
             }
           }
         }


### PR DESCRIPTION
Motivation:

For cases when publishing repositories are configured by the environment
we should not configure sonatype repo.

Modifications:

- Configure `sonatype` publishing repo only if no other repos are
configured;
- Name for this `sonatype` repo;

Result:

`sonatype` publishing repo will be configured only if there are no other
repos.