### PR TITLE
Parse headers with no whitespaces

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -565,7 +565,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                 throw new IllegalArgumentException("unable to find colon");
             }
         }
-        if (nonControlIndex <= valueStart) {
+        if (nonControlIndex < valueStart) {
             headers.add(name, emptyAsciiString());
         } else {
             valueStart = buffer.forEachByte(valueStart, nonControlIndex - valueStart + 1, FIND_NON_LINEAR_WHITESPACE);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -544,23 +544,24 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         //                     ; obsolete line folding
         //                     ; see Section 3.2.4
         final int nonControlIndex = lfIndex - 2;
-        int headerStart = buffer.forEachByte(buffer.readerIndex(), nonControlIndex - buffer.readerIndex(),
+        final int headerStart = buffer.forEachByte(buffer.readerIndex(), nonControlIndex - buffer.readerIndex(),
                 FIND_NON_LINEAR_WHITESPACE);
         if (headerStart < 0) {
             throw new IllegalArgumentException("unable to find start of header name");
         }
 
-        int headerEnd = buffer.forEachByte(headerStart + 1, nonControlIndex - headerStart,
+        final int headerEnd = buffer.forEachByte(headerStart + 1, nonControlIndex - headerStart,
                 FIND_COLON_OR_WHITE_SPACE);
         if (headerEnd < 0) {
             throw new IllegalArgumentException("unable to find end of header name");
         }
+        // We assume the allocator will not leak memory, and so we retain + slice to avoid copying data.
+        final CharSequence name = newAsciiString(newBufferFrom(
+                buffer.retainedSlice(headerStart, headerEnd - headerStart)));
 
         int valueStart = headerEnd + 1;
-        // We assume the allocator will not leak memory, and so we retain + slice to avoid copying data.
-        CharSequence name = newAsciiString(newBufferFrom(buffer.retainedSlice(headerStart, headerEnd - headerStart)));
         if (buffer.getByte(headerEnd) != COLON_BYTE) {
-            valueStart = buffer.forEachByte(headerEnd + 1, nonControlIndex - headerEnd, FIND_COLON);
+            valueStart = buffer.forEachByte(headerEnd + 1, nonControlIndex - headerEnd, FIND_COLON) + 1;
             if (valueStart < 0) {
                 throw new IllegalArgumentException("unable to find colon");
             }
@@ -568,16 +569,17 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         if (nonControlIndex <= valueStart) {
             headers.add(name, emptyAsciiString());
         } else {
-            valueStart = buffer.forEachByte(valueStart + 1, nonControlIndex - valueStart, FIND_NON_LINEAR_WHITESPACE);
+            valueStart = buffer.forEachByte(valueStart, nonControlIndex - valueStart + 1, FIND_NON_LINEAR_WHITESPACE);
             // Find End Of String
-            int valueEnd;
+            final int valueEnd;
             if (valueStart < 0 || (valueEnd = buffer.forEachByteDesc(valueStart, lfIndex - valueStart - 1,
                     FIND_NON_LINEAR_WHITESPACE)) < 0) {
                 headers.add(name, emptyAsciiString());
             } else {
                 // We assume the allocator will not leak memory, and so we retain + slice to avoid copying data.
-                headers.add(name, newAsciiString(newBufferFrom(
-                        buffer.retainedSlice(valueStart, valueEnd - valueStart + 1))));
+                final CharSequence value = newAsciiString(newBufferFrom(
+                        buffer.retainedSlice(valueStart, valueEnd - valueStart + 1)));
+                headers.add(name, value);
             }
         }
         // Consume the header line bytes from the buffer.

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
@@ -137,6 +137,7 @@ public class HttpRequestDecoderTest {
                 "   User-Agent   :unit-test" + "\r\n" +
                 "Empty:" + "\r\n" +
                 "EmptyWhitespace:   " + "\r\n" +
+                "SingleCharacterNoWhiteSpace: a" + "\r\n" +
                 "Content-Length:   " + content.length + "   " + "\r\n" + "\r\n").getBytes(US_ASCII);
         assertTrue(channel.writeInbound(wrappedBuffer(beforeContentBytes)));
         assertTrue(channel.writeInbound(wrappedBuffer(content)));
@@ -462,6 +463,7 @@ public class HttpRequestDecoderTest {
         if (headers.contains("Empty")) {
             assertSingleHeaderValue(headers, "Empty", "");
             assertSingleHeaderValue(headers, "EmptyWhitespace", "");
+            assertSingleHeaderValue(headers, "SingleCharacterNoWhiteSpace", "a");
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
@@ -119,6 +119,7 @@ public class HttpRequestDecoderTest {
         byte[] beforeContentBytes = ("GET /some/path?foo=bar&baz=yyy HTTP/1.1" + "\r\n" +
                 "Connection:keep-alive" + "\r\n" +
                 "User-Agent:unit-test" + "\r\n" +
+                "SingleCharacterNoWhiteSpace:a" + "\r\n" +
                 "Content-Length:" + content.length + "\r\n" + "\r\n").getBytes(US_ASCII);
         assertTrue(channel.writeInbound(wrappedBuffer(beforeContentBytes)));
         assertTrue(channel.writeInbound(wrappedBuffer(content)));
@@ -463,6 +464,8 @@ public class HttpRequestDecoderTest {
         if (headers.contains("Empty")) {
             assertSingleHeaderValue(headers, "Empty", "");
             assertSingleHeaderValue(headers, "EmptyWhitespace", "");
+        }
+        if (headers.contains("SingleCharacterNoWhiteSpace")) {
             assertSingleHeaderValue(headers, "SingleCharacterNoWhiteSpace", "a");
         }
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
@@ -144,6 +144,7 @@ public class HttpResponseDecoderTest {
                 "   Server   :unit-test" + "\r\n" +
                 "Empty:" + "\r\n" +
                 "EmptyWhitespace:   " + "\r\n" +
+                "SingleCharacterNoWhiteSpace: a" + "\r\n" +
                 "Content-Length:   " + content.length + "   " + "\r\n" + "\r\n").getBytes(US_ASCII);
         assertTrue(channel.writeInbound(wrappedBuffer(beforeContentBytes)));
         assertTrue(channel.writeInbound(wrappedBuffer(content)));
@@ -464,6 +465,7 @@ public class HttpResponseDecoderTest {
         if (headers.contains("Empty")) {
             assertSingleHeaderValue(headers, "Empty", "");
             assertSingleHeaderValue(headers, "EmptyWhitespace", "");
+            assertSingleHeaderValue(headers, "SingleCharacterNoWhiteSpace", "a");
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
@@ -126,6 +126,7 @@ public class HttpResponseDecoderTest {
         byte[] beforeContentBytes = ("HTTP/1.1 200 OK" + "\r\n" +
                 "Connection:keep-alive" + "\r\n" +
                 "Server:unit-test" + "\r\n" +
+                "SingleCharacterNoWhiteSpace:a" + "\r\n" +
                 "Content-Length:" + content.length + "\r\n" + "\r\n").getBytes(US_ASCII);
         assertTrue(channel.writeInbound(wrappedBuffer(beforeContentBytes)));
         assertTrue(channel.writeInbound(wrappedBuffer(content)));
@@ -465,6 +466,8 @@ public class HttpResponseDecoderTest {
         if (headers.contains("Empty")) {
             assertSingleHeaderValue(headers, "Empty", "");
             assertSingleHeaderValue(headers, "EmptyWhitespace", "");
+        }
+        if (headers.contains("SingleCharacterNoWhiteSpace")) {
             assertSingleHeaderValue(headers, "SingleCharacterNoWhiteSpace", "a");
         }
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
@@ -119,6 +119,40 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
+    public void contentLengthNoTrailersHeaderNoWhiteSpace() {
+        EmbeddedChannel channel = newEmbeddedChannel();
+        byte[] content = new byte[128];
+        ThreadLocalRandom.current().nextBytes(content);
+        byte[] beforeContentBytes = ("HTTP/1.1 200 OK" + "\r\n" +
+                "Connection:keep-alive" + "\r\n" +
+                "Server:unit-test" + "\r\n" +
+                "Content-Length:" + content.length + "\r\n" + "\r\n").getBytes(US_ASCII);
+        assertTrue(channel.writeInbound(wrappedBuffer(beforeContentBytes)));
+        assertTrue(channel.writeInbound(wrappedBuffer(content)));
+
+        validateHttpResponse(channel, content.length);
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    @Test
+    public void contentLengthNoTrailersHeaderMixedWhiteSpace() {
+        EmbeddedChannel channel = newEmbeddedChannel();
+        byte[] content = new byte[128];
+        ThreadLocalRandom.current().nextBytes(content);
+        byte[] beforeContentBytes = ("HTTP/1.1 200 OK" + "\r\n" +
+                "Connection   :keep-alive" + "\r\n" +
+                "   Server   :unit-test" + "\r\n" +
+                "Empty:" + "\r\n" +
+                "EmptyWhitespace:   " + "\r\n" +
+                "Content-Length:   " + content.length + "   " + "\r\n" + "\r\n").getBytes(US_ASCII);
+        assertTrue(channel.writeInbound(wrappedBuffer(beforeContentBytes)));
+        assertTrue(channel.writeInbound(wrappedBuffer(content)));
+
+        validateHttpResponse(channel, content.length);
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    @Test
     public void chunkedNoTrailers() {
         EmbeddedChannel channel = newEmbeddedChannel();
         byte[] content = new byte[128];
@@ -427,6 +461,10 @@ public class HttpResponseDecoderTest {
     private static void assertStandardHeaders(HttpHeaders headers) {
         assertSingleHeaderValue(headers, CONNECTION, KEEP_ALIVE);
         assertSingleHeaderValue(headers, "seRver", "unit-test");
+        if (headers.contains("Empty")) {
+            assertSingleHeaderValue(headers, "Empty", "");
+            assertSingleHeaderValue(headers, "EmptyWhitespace", "");
+        }
     }
 
     private static EmbeddedChannel newEmbeddedChannel() {


### PR DESCRIPTION
Motivation:

The whitespace between the `:` and a header value is optional [1] but we
consider it as required [2] hence skip a character after the `:`. As a result,
a header value may miss the first character.

[1] https://tools.ietf.org/html/rfc7230#section-3.2
[2] `header-field = field-name ":" OWS field-value OWS`

Modifications:

- Do not skip a character after `:`;
- Add more tests for headers with no whitespace and for mixed
whitespaces;

Result:

Headers parser does not skip the first value character when there is no
whitespace after `:`.

Resolves #854 