### PR TITLE
Do not override older javadoc with anotra's placeholder

### DIFF
--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -78,6 +78,12 @@ if [ ! -z "$version" ]; then
 fi
 
 pushd gh-pages
+# Do not override older javadoc with anotra's placeholder:
+for file in $(git diff --name-only | grep -v "servicetalk/SNAPSHOT/javadoc/index.html" | \
+  grep -v "servicetalk/$version/javadoc/index.html"); do
+    git checkout -- $file
+done
+
 git add * .nojekyll
 if [ -z "$version" ]; then
     git commit --author="$GIT_AUTHOR" -m "Update SNAPSHOT doc website"


### PR DESCRIPTION
Motivation:

When Antora generates a new docs website it overrides `index.html` page
for all existing javadocs with its placeholder. The script should
discard changes of `index.html` for older versions.

Modifications:

- Discard changes of `index.html` files for older javadoc versions;

Result:

Antora does not override javadoc with its placeholder.