### PR TITLE
Update README with maven-central info

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-= ServiceTalk
+= ServiceTalk image:https://img.shields.io/maven-central/v/io.servicetalk/servicetalk-annotations?color=blue[Maven Central] image:https://img.shields.io/jenkins/tests/https/ci.servicetalk.io/servicetalk-java8-prb?compact_message[Jenkins tests]
 
 ServiceTalk is a JVM network application framework with APIs tailored to specific protocols (e.g. HTTP/1.x,
 HTTP/2.x, etc...) and supports multiple programming paradigms.
@@ -11,40 +11,9 @@ See the link:https://docs.servicetalk.io/[ServiceTalk docs] for more information
 
 == Getting Started
 
-Currently, all ServiceTalk released artifacts are available in a Bintray repo:
-https://dl.bintray.com/servicetalk/servicetalk/, but will be published to Maven Central
-link:https://github.com/apple/servicetalk/issues/845[soon].
+ServiceTalk releases are available on Maven Central:
 
-This repository must be configured in which ever build tool your project uses (e.g. Maven, Gradle, etc...).
-
-.Maven, pom.xml
-[source,xml]
-----
-<project>
-...
-  <repositories>
-    <repository>
-      <id>bintray-servicetalk</id>
-      <url>https://dl.bintray.com/servicetalk/servicetalk/</url>
-    </repository>
-  </repositories>
-...
-</project>
-----
-
-.Gradle, build.gradle
-[source,groovy]
-----
-repositories {
-  mavenCentral()
-  maven {
-    url  "https://dl.bintray.com/servicetalk/servicetalk/"
-  }
-}
-----
-
-For more information, see Bintray
-link:https://www.jfrog.com/confluence/display/BT/Maven+Repositories[Maven Repositories] docs.
+* http://repo1.maven.org/maven2/io/servicetalk/
 
 Refer to the link:https://docs.servicetalk.io/[ServiceTalk docs] for various examples that will get you started with the
 different features of ServiceTalk.

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-= ServiceTalk image:https://img.shields.io/maven-central/v/io.servicetalk/servicetalk-annotations?color=blue[Maven Central] image:https://img.shields.io/jenkins/tests/https/ci.servicetalk.io/servicetalk-java8-prb?compact_message[Jenkins tests]
+= ServiceTalk image:https://img.shields.io/maven-central/v/io.servicetalk/servicetalk-annotations?color=blue[Maven Central]
 
 ServiceTalk is a JVM network application framework with APIs tailored to specific protocols (e.g. HTTP/1.x,
 HTTP/2.x, etc...) and supports multiple programming paradigms.
@@ -14,6 +14,19 @@ See the link:https://docs.servicetalk.io/[ServiceTalk docs] for more information
 ServiceTalk releases are available on Maven Central:
 
 * http://repo1.maven.org/maven2/io/servicetalk/
+
+For Gradle as well as other build tools that don't download from Maven Central by default, add it to your remote
+repositories. link:https://bintray.com/beta/#/bintray/jcenter/[bintray/jcenter] is an aggregate repository that
+combines Maven Central and other popular repositories.
+
+.Gradle, build.gradle
+[source,groovy]
+----
+repositories {
+  jcenter()
+}
+----
+
 
 Refer to the link:https://docs.servicetalk.io/[ServiceTalk docs] for various examples that will get you started with the
 different features of ServiceTalk.

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,6 @@
-= ServiceTalk image:https://img.shields.io/maven-central/v/io.servicetalk/servicetalk-annotations?color=blue[Maven Central]
+= ServiceTalk
+
+image:https://img.shields.io/maven-central/v/io.servicetalk/servicetalk-annotations?color=blue[Maven Central]
 
 ServiceTalk is a JVM network application framework with APIs tailored to specific protocols (e.g. HTTP/1.x,
 HTTP/2.x, etc...) and supports multiple programming paradigms.
@@ -11,19 +13,16 @@ See the link:https://docs.servicetalk.io/[ServiceTalk docs] for more information
 
 == Getting Started
 
-ServiceTalk releases are available on Maven Central:
+ServiceTalk releases are available on link:http://repo1.maven.org/maven2/io/servicetalk/[Maven Central]
 
-* http://repo1.maven.org/maven2/io/servicetalk/
-
-For Gradle as well as other build tools that don't download from Maven Central by default, add it to your remote
-repositories. link:https://bintray.com/beta/#/bintray/jcenter/[bintray/jcenter] is an aggregate repository that
-combines Maven Central and other popular repositories.
+For Gradle as well as other build tools that don't use Maven Central as default repository, additional configuration is
+required.
 
 .Gradle, build.gradle
 [source,groovy]
 ----
 repositories {
-  jcenter()
+  jcenter() // combines Maven Central and other popular repositories
 }
 ----
 

--- a/README.adoc
+++ b/README.adoc
@@ -13,10 +13,10 @@ See the link:https://docs.servicetalk.io/[ServiceTalk docs] for more information
 
 == Getting Started
 
-ServiceTalk releases are available on link:http://repo1.maven.org/maven2/io/servicetalk/[Maven Central]
+ServiceTalk releases are available on link:http://repo1.maven.org/maven2/io/servicetalk/[Maven Central].
 
-For Gradle as well as other build tools that don't use Maven Central as default repository, additional configuration is
-required.
+For Gradle as well as other build tools that don't use Maven Central as a default repository, additional configuration
+is required.
 
 .Gradle, build.gradle
 [source,groovy]

--- a/servicetalk-grpc-gradle-plugin/README.adoc
+++ b/servicetalk-grpc-gradle-plugin/README.adoc
@@ -7,12 +7,6 @@ Gradle plugin for configuring gRPC client and server code generation.
 [source,groovy]
 ----
 buildscript {
-  repositories {
-    mavenCentral()
-    maven {
-        url  "https://dl.bintray.com/servicetalk/servicetalk/"
-    }
-  }
   dependencies {
     classpath "io.servicetalk:servicetalk-grpc-gradle-plugin:$servicetalkVersion"
   }

--- a/servicetalk-grpc-gradle-plugin/README.adoc
+++ b/servicetalk-grpc-gradle-plugin/README.adoc
@@ -7,6 +7,9 @@ Gradle plugin for configuring gRPC client and server code generation.
 [source,groovy]
 ----
 buildscript {
+  repositories {
+    jcenter()
+  }
   dependencies {
     classpath "io.servicetalk:servicetalk-grpc-gradle-plugin:$servicetalkVersion"
   }


### PR DESCRIPTION
__Motivation__

ServiceTalk is now available through Maven Central.

__Modifications__

- Include coordinates and badge for maven central
- Remove coordinates for Bintray

__Result__

Folks can get artifacts from the default respositories
