### PR TITLE
Make "project communication" guideline more discoverable

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -78,9 +78,3 @@ Please be sure to include:
 ==== Security issues
 To report a security issue, please DO NOT start by filing a public issue; instead send a
 private email to link:mailto:servicetalk-security@group.apple.com[servicetalk-security@group.apple.com].
-
-== Project Communication
-We encourage your participation asking questions and helping improve the ServiceTalk project.
-link:https://github.com/apple/servicetalk/issues[Github issues] and
-link:https://github.com/apple/servicetalk/pulls[pull requests] are the primary mechanisms of
-participation and communication for ServiceTalk.

--- a/README.adoc
+++ b/README.adoc
@@ -137,3 +137,9 @@ $ idea .
 ----
 $ open servicetalk.ipr
 ----
+
+== Project Communication
+We encourage your participation asking questions and helping improve the ServiceTalk project.
+link:https://github.com/apple/servicetalk/issues[Github issues] and
+link:https://github.com/apple/servicetalk/pulls[pull requests] are the primary mechanisms of
+participation and communication for ServiceTalk.


### PR DESCRIPTION
__Motivation__

We encourage people to use GitHub issues for communication with project maintainers but the information is arguably hidden in `CONTRIBUTING.adoc`.

__Modification__

Move `Project Communication` section to the `README.adoc`

__Result__

Users have a better view of how they are expected to communicate with project maintainers.