### PR TITLE
gRPC clients do not provide `ExecutionContext`

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/BlockingGrpcClient.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/BlockingGrpcClient.java
@@ -30,4 +30,14 @@ public interface BlockingGrpcClient<Client extends GrpcClient> extends GracefulA
      * @return This {@link BlockingGrpcClient} as a {@link Client}.
      */
     Client asClient();
+
+    /**
+     * Get the {@link GrpcExecutionContext} used during construction of this object.
+     * <p>
+     * Note that the {@link GrpcExecutionContext#ioExecutor()} will not necessarily be associated with a specific thread
+     * unless that was how this object was built.
+     *
+     * @return the {@link GrpcExecutionContext} used during construction of this object.
+     */
+    GrpcExecutionContext executionContext();
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
@@ -40,9 +40,11 @@ import static java.util.Objects.requireNonNull;
 
 final class DefaultGrpcClientCallFactory implements GrpcClientCallFactory {
     private final StreamingHttpClient streamingHttpClient;
+    private final GrpcExecutionContext executionContext;
 
     DefaultGrpcClientCallFactory(final StreamingHttpClient streamingHttpClient) {
         this.streamingHttpClient = requireNonNull(streamingHttpClient);
+        executionContext = new DefaultGrpcExecutionContext(streamingHttpClient.executionContext());
     }
 
     @Override
@@ -169,6 +171,11 @@ final class DefaultGrpcClientCallFactory implements GrpcClientCallFactory {
         BlockingStreamingClientCall<Req, Resp> streamingClientCall =
                 newBlockingStreamingCall(serializationProvider, requestClass, responseClass);
         return (metadata, request) -> streamingClientCall.request(metadata, singletonBlockingIterable(request));
+    }
+
+    @Override
+    public GrpcExecutionContext executionContext() {
+        return executionContext;
     }
 
     @Override

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcExecutionContext.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcExecutionContext.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.api;
+
+import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.transport.api.ExecutionContext;
+import io.servicetalk.transport.api.IoExecutor;
+
+import static java.util.Objects.requireNonNull;
+
+final class DefaultGrpcExecutionContext implements GrpcExecutionContext {
+    private final ExecutionContext delegate;
+    private final GrpcExecutionStrategy strategy;
+
+    DefaultGrpcExecutionContext(HttpExecutionContext httpExecutionContext) {
+        delegate = requireNonNull(httpExecutionContext);
+        HttpExecutionStrategy httpExecutionStrategy = httpExecutionContext.executionStrategy();
+        strategy = httpExecutionStrategy instanceof GrpcExecutionStrategy ?
+                (GrpcExecutionStrategy) httpExecutionStrategy : new DefaultGrpcExecutionStrategy(httpExecutionStrategy);
+    }
+
+    @Override
+    public BufferAllocator bufferAllocator() {
+        return delegate.bufferAllocator();
+    }
+
+    @Override
+    public IoExecutor ioExecutor() {
+        return delegate.ioExecutor();
+    }
+
+    @Override
+    public Executor executor() {
+        return delegate.executor();
+    }
+
+    @Override
+    public GrpcExecutionStrategy executionStrategy() {
+        return strategy;
+    }
+}

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcServiceContext.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcServiceContext.java
@@ -16,8 +16,8 @@
 package io.servicetalk.grpc.api;
 
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.transport.api.ConnectionContext;
-import io.servicetalk.transport.api.ExecutionContext;
 
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
@@ -28,10 +28,12 @@ import static java.util.Objects.requireNonNull;
 final class DefaultGrpcServiceContext extends DefaultGrpcMetadata implements GrpcServiceContext {
 
     private final ConnectionContext connectionContext;
+    private final GrpcExecutionContext executionContext;
 
-    DefaultGrpcServiceContext(final String path, final ConnectionContext connectionContext) {
+    DefaultGrpcServiceContext(final String path, final HttpServiceContext httpServiceContext) {
         super(path);
-        this.connectionContext = requireNonNull(connectionContext);
+        connectionContext = requireNonNull(httpServiceContext);
+        executionContext = new DefaultGrpcExecutionContext(httpServiceContext.executionContext());
     }
 
     @Override
@@ -51,8 +53,8 @@ final class DefaultGrpcServiceContext extends DefaultGrpcMetadata implements Grp
     }
 
     @Override
-    public ExecutionContext executionContext() {
-        return connectionContext.executionContext();
+    public GrpcExecutionContext executionContext() {
+        return executionContext;
     }
 
     @Override

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/FilterableGrpcClient.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/FilterableGrpcClient.java
@@ -15,13 +15,20 @@
  */
 package io.servicetalk.grpc.api;
 
-import io.servicetalk.transport.api.ConnectionContext;
+import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 
 /**
- * A <a href="https://www.grpc.io">gRPC</a> service context.
+ * A client to a <a href="https://www.grpc.io">gRPC</a> service that supports filtering.
  */
-public interface GrpcServiceContext extends ConnectionContext, GrpcMetadata {
+public interface FilterableGrpcClient extends ListenableAsyncCloseable {
 
-    @Override
+    /**
+     * Get the {@link GrpcExecutionContext} used during construction of this object.
+     * <p>
+     * Note that the {@link GrpcExecutionContext#ioExecutor()} will not necessarily be associated with a specific thread
+     * unless that was how this object was built.
+     *
+     * @return the {@link GrpcExecutionContext} used during construction of this object.
+     */
     GrpcExecutionContext executionContext();
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClient.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClient.java
@@ -18,6 +18,8 @@ package io.servicetalk.grpc.api;
 import io.servicetalk.concurrent.GracefulAutoCloseable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 
+import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
+
 /**
  * A client to a <a href="https://www.grpc.io">gRPC</a> service.
  *
@@ -32,4 +34,19 @@ public interface GrpcClient<BlockingClient extends BlockingGrpcClient>
      * @return This {@link GrpcClient} as a {@link BlockingClient}.
      */
     BlockingClient asBlockingClient();
+
+    /**
+     * Get the {@link GrpcExecutionContext} used during construction of this object.
+     * <p>
+     * Note that the {@link GrpcExecutionContext#ioExecutor()} will not necessarily be associated with a specific thread
+     * unless that was how this object was built.
+     *
+     * @return the {@link GrpcExecutionContext} used during construction of this object.
+     */
+    GrpcExecutionContext executionContext();
+
+    @Override
+    default void close() throws Exception {
+        awaitTermination(closeAsync().toFuture());
+    }
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -21,7 +21,6 @@ import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.LoadBalancerFactory;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
-import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
@@ -155,7 +154,7 @@ public abstract class GrpcClientBuilder<U, R>
      * @return A <a href="https://www.grpc.io">gRPC</a> client.
      */
     public final <Client extends GrpcClient<?>,
-            Filter extends FilterableClient, FilterableClient extends ListenableAsyncCloseable & AutoCloseable,
+            Filter extends FilterableClient, FilterableClient extends FilterableGrpcClient,
             FilterFactory extends GrpcClientFilterFactory<Filter, FilterableClient>> Client
     build(GrpcClientFactory<Client, ?, Filter, FilterableClient, FilterFactory> clientFactory) {
         return clientFactory.newClientForCallFactory(newGrpcClientCallFactory());
@@ -174,7 +173,7 @@ public abstract class GrpcClientBuilder<U, R>
      * @return A blocking <a href="https://www.grpc.io">gRPC</a> client.
      */
     public final <BlockingClient extends BlockingGrpcClient<?>,
-            Filter extends FilterableClient, FilterableClient extends ListenableAsyncCloseable & AutoCloseable,
+            Filter extends FilterableClient, FilterableClient extends FilterableGrpcClient,
             FilterFactory extends GrpcClientFilterFactory<Filter, FilterableClient>> BlockingClient
     buildBlocking(GrpcClientFactory<?, BlockingClient, Filter, FilterableClient, FilterFactory> clientFactory) {
         return clientFactory.newBlockingClientForCallFactory(newGrpcClientCallFactory());
@@ -191,7 +190,7 @@ public abstract class GrpcClientBuilder<U, R>
         return new MultiClientBuilder() {
             @Override
             public <Client extends GrpcClient<?>,
-                    Filter extends FilterableClient, FilterableClient extends ListenableAsyncCloseable & AutoCloseable,
+                    Filter extends FilterableClient, FilterableClient extends FilterableGrpcClient,
                     FilterFactory extends GrpcClientFilterFactory<Filter, FilterableClient>> Client
             build(final GrpcClientFactory<Client, ?, Filter, FilterableClient, FilterFactory> clientFactory) {
                 return clientFactory.newClient(callFactory);
@@ -199,7 +198,7 @@ public abstract class GrpcClientBuilder<U, R>
 
             @Override
             public <BlockingClient extends BlockingGrpcClient<?>,
-                    Filter extends FilterableClient, FilterableClient extends ListenableAsyncCloseable & AutoCloseable,
+                    Filter extends FilterableClient, FilterableClient extends FilterableGrpcClient,
                     FilterFactory extends GrpcClientFilterFactory<Filter, FilterableClient>> BlockingClient
             buildBlocking(
                     final GrpcClientFactory<?, BlockingClient, Filter, FilterableClient, FilterFactory> clientFactory) {
@@ -293,7 +292,7 @@ public abstract class GrpcClientBuilder<U, R>
          * @return A <a href="https://www.grpc.io">gRPC</a> client.
          */
         <Client extends GrpcClient<?>,
-                Filter extends FilterableClient, FilterableClient extends ListenableAsyncCloseable & AutoCloseable,
+                Filter extends FilterableClient, FilterableClient extends FilterableGrpcClient,
                 FilterFactory extends GrpcClientFilterFactory<Filter, FilterableClient>> Client
         build(GrpcClientFactory<Client, ?, Filter, FilterableClient, FilterFactory> clientFactory);
 
@@ -310,7 +309,7 @@ public abstract class GrpcClientBuilder<U, R>
          * @return A blocking <a href="https://www.grpc.io">gRPC</a> client.
          */
         <BlockingClient extends BlockingGrpcClient<?>,
-                Filter extends FilterableClient, FilterableClient extends ListenableAsyncCloseable & AutoCloseable,
+                Filter extends FilterableClient, FilterableClient extends FilterableGrpcClient,
                 FilterFactory extends GrpcClientFilterFactory<Filter, FilterableClient>> BlockingClient
         buildBlocking(GrpcClientFactory<?, BlockingClient, Filter, FilterableClient, FilterFactory> clientFactory);
     }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientCallFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientCallFactory.java
@@ -139,6 +139,16 @@ public interface GrpcClientCallFactory extends ListenableAsyncCloseable {
                                      Class<Resp> responseClass);
 
     /**
+     * Get the {@link GrpcExecutionContext} used during construction of this object.
+     * <p>
+     * Note that the {@link GrpcExecutionContext#ioExecutor()} will not necessarily be associated with a specific thread
+     * unless that was how this object was built.
+     *
+     * @return the {@link GrpcExecutionContext} used during construction of this object.
+     */
+    GrpcExecutionContext executionContext();
+
+    /**
      * Creates a new {@link GrpcClientCallFactory} using the passed {@link StreamingHttpClient}.
      *
      * @param httpClient {@link StreamingHttpClient} to use. The returned {@link GrpcClientCallFactory} will own the

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientFactory.java
@@ -15,8 +15,6 @@
  */
 package io.servicetalk.grpc.api;
 
-import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
-
 import javax.annotation.Nullable;
 
 import static java.util.Objects.requireNonNull;
@@ -35,7 +33,7 @@ import static java.util.Objects.requireNonNull;
  */
 public abstract class GrpcClientFactory<Client extends GrpcClient<BlockingClient>,
         BlockingClient extends BlockingGrpcClient<Client>,
-        Filter extends FilterableClient, FilterableClient extends ListenableAsyncCloseable & AutoCloseable,
+        Filter extends FilterableClient, FilterableClient extends FilterableGrpcClient,
         FilterFactory extends GrpcClientFilterFactory<Filter, FilterableClient>> {
 
     @Nullable

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientFilterFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientFilterFactory.java
@@ -21,7 +21,8 @@ package io.servicetalk.grpc.api;
  * @param <Filter> Type for client filter
  * @param <FilterableClient> Type of filterable client.
  */
-public interface GrpcClientFilterFactory<Filter extends FilterableClient, FilterableClient> {
+public interface GrpcClientFilterFactory<Filter extends FilterableClient,
+        FilterableClient extends FilterableGrpcClient> {
 
     /**
      * Create a {@link Filter} using the provided {@link Filter}.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionContext.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionContext.java
@@ -15,13 +15,18 @@
  */
 package io.servicetalk.grpc.api;
 
-import io.servicetalk.transport.api.ConnectionContext;
+import io.servicetalk.transport.api.ExecutionContext;
 
 /**
- * A <a href="https://www.grpc.io">gRPC</a> service context.
+ * An extension of {@link ExecutionContext} for <a href="https://www.grpc.io">gRPC</a>.
  */
-public interface GrpcServiceContext extends ConnectionContext, GrpcMetadata {
+public interface GrpcExecutionContext extends ExecutionContext {
 
+    /**
+     * Returns the {@link GrpcExecutionStrategy} associated with this context.
+     *
+     * @return The {@link GrpcExecutionStrategy} associated with this context.
+     */
     @Override
-    GrpcExecutionContext executionContext();
+    GrpcExecutionStrategy executionStrategy();
 }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -22,6 +22,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.SpScPublisherProcessor;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.grpc.api.GrpcClientBuilder;
+import io.servicetalk.grpc.api.GrpcExecutionContext;
 import io.servicetalk.grpc.api.GrpcExecutionStrategy;
 import io.servicetalk.grpc.api.GrpcServerBuilder;
 import io.servicetalk.grpc.api.GrpcServiceContext;
@@ -769,6 +770,11 @@ public class ProtocolCompatibilityTest {
                 CompatGrpc.newStub(channel) : CompatGrpc.newStub(channel).withCompression(compression);
 
         return new CompatClient() {
+            @Override
+            public GrpcExecutionContext executionContext() {
+                throw new UnsupportedOperationException();
+            }
+
             @Override
             public Publisher<CompatResponse> bidirectionalStreamingCall(final Publisher<CompatRequest> request) {
                 final SpScPublisherProcessor<CompatResponse> processor = new SpScPublisherProcessor<>(3);

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Types.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Types.java
@@ -43,6 +43,8 @@ final class Types {
     static final ClassName GrpcClientCallFactory = bestGuess(grpcApiPkg + ".GrpcClientCallFactory");
     static final ClassName GrpcClientFactory = bestGuess(grpcApiPkg + ".GrpcClientFactory");
     static final ClassName GrpcClientFilterFactory = bestGuess(grpcApiPkg + ".GrpcClientFilterFactory");
+    static final ClassName FilterableGrpcClient = bestGuess(grpcApiPkg + ".FilterableGrpcClient");
+    static final ClassName GrpcExecutionContext = bestGuess(grpcApiPkg + ".GrpcExecutionContext");
     static final ClassName GrpcExecutionStrategy = bestGuess(grpcApiPkg + ".GrpcExecutionStrategy");
     static final ClassName GrpcPayloadWriter = bestGuess(grpcApiPkg + ".GrpcPayloadWriter");
     static final ClassName GrpcRoutes = bestGuess(grpcApiPkg + ".GrpcRoutes");

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Words.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Words.java
@@ -25,6 +25,7 @@ final class Words {
     static final String closeAsync = close + "Async";
     static final String closeAsyncGracefully = closeAsync + "Gracefully";
     static final String closeGracefully = close + "Gracefully";
+    static final String executionContext = "executionContext";
     static final String ctx = "ctx";
     static final String delegate = "delegate";
     static final String existing = "existing";


### PR DESCRIPTION
__Motivation__

HTTP clients provides a way to fetch the `ExecutionContext` with which the client was created. This was missed for gRPC.

__Modification__

- Add `executionContext()` method for `GrpcClient` and `BlockingGrpcClient`.
- In order for the generated clients to provide this information, we need to provide the same in `GrpcClientCallFactory`.
- For generated clients that delegate to filters, in order to provide this information, we need to make it as part of generated filterable clients. Generated filterable clients were not using any interface which made it hard to add this new method. Added a new interface `FilterableGrpcClient` which provides contract for filterable clients.
- Generated filterable clients (and filters) were incorrectly having the blocking `close()` method,which is not carried over to the new `FilterableGrpcClient` interface.

__Result__

Parity between HTTP and gRPC clients.