### PR TITLE
Declare character encoding in responses returned from fallback service

### DIFF
--- a/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/DefaultFallbackServiceStreaming.java
+++ b/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/DefaultFallbackServiceStreaming.java
@@ -24,7 +24,7 @@ import io.servicetalk.http.api.StreamingHttpService;
 
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
-import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
+import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN_UTF_8;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpResponseStatus.NOT_FOUND;
 
@@ -42,7 +42,7 @@ final class DefaultFallbackServiceStreaming implements StreamingHttpService {
                                                 final StreamingHttpResponseFactory factory) {
         final StreamingHttpResponse response = factory.newResponse(NOT_FOUND).version(request.version());
         response.headers().set(CONTENT_LENGTH, ZERO)
-                .set(CONTENT_TYPE, TEXT_PLAIN);
+                .set(CONTENT_TYPE, TEXT_PLAIN_UTF_8);
         // TODO(derek): Set keepalive once we have an isKeepAlive helper method.
         return Single.succeeded(response);
     }

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/DefaultFallbackServiceTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/DefaultFallbackServiceTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
-import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
+import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN_UTF_8;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseStatus.NOT_FOUND;
@@ -42,6 +42,6 @@ public class DefaultFallbackServiceTest extends BaseHttpPredicateRouterBuilderTe
         assertEquals(HTTP_1_1, response.version());
         assertEquals(NOT_FOUND, response.status());
         assertEquals(ZERO, response.headers().get(CONTENT_LENGTH));
-        assertEquals(TEXT_PLAIN, response.headers().get(CONTENT_TYPE));
+        assertEquals(TEXT_PLAIN_UTF_8, response.headers().get(CONTENT_TYPE));
     }
 }


### PR DESCRIPTION
Motivation:

Currently `DefaultFallbackServiceStreaming` returns response without specifying the charset parameter in the `Content-Type` header. This would confuse the client when it needs to parse the payload. Extra response handling logic is needed on client side to either abort parsing or guess the character encoding.

Modifications:

- Set charset to UTF-8 in the `Content-Type` header.

Result:

Character encoding is specified explicitly.