### PR TITLE
BlockingUtils should not assume the cause of ExecutionException is not null #870

### DIFF
--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThrowableUtil.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThrowableUtil.java
@@ -58,4 +58,13 @@ public final class ThrowableUtil {
         }
         return false;
     }
+
+    /**
+     * Gets not null cause of original exception or the original exception.
+     * @param original {@link Throwable} original exception.
+     * @return {@link Throwable#getCause()} if it is not null, or original
+     */
+    public static Throwable getCause(Throwable original) {
+       return (original.getCause() != null) ? original.getCause() : original;
+    }
 }

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThrowableUtil.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThrowableUtil.java
@@ -58,13 +58,4 @@ public final class ThrowableUtil {
         }
         return false;
     }
-
-    /**
-     * Gets not null cause of original exception or the original exception.
-     * @param original {@link Throwable} original exception.
-     * @return {@link Throwable#getCause()} if it is not null, or original
-     */
-    public static Throwable getCause(Throwable original) {
-       return (original.getCause() != null) ? original.getCause() : original;
-    }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingUtils.java
@@ -22,7 +22,6 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.SubscribableCompletable;
 import io.servicetalk.concurrent.api.internal.SubscribableSingle;
 import io.servicetalk.concurrent.internal.ThreadInterruptingCancellable;
-import io.servicetalk.concurrent.internal.ThrowableUtil;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -98,7 +97,7 @@ final class BlockingUtils {
             future.cancel(false);
             throw e;
         } catch (ExecutionException e) {
-            return throwException(ThrowableUtil.getCause(e));
+            return throwException(executionExceptionCause(e));
         }
     }
 
@@ -151,7 +150,7 @@ final class BlockingUtils {
         try {
             return source.toFuture().get();
         } catch (final ExecutionException e) {
-            return throwException(ThrowableUtil.getCause(e));
+            return throwException(executionExceptionCause(e));
         }
     }
 
@@ -161,7 +160,11 @@ final class BlockingUtils {
         try {
             source.toFuture().get();
         } catch (final ExecutionException e) {
-            throwException(ThrowableUtil.getCause(e));
+            throwException(executionExceptionCause(e));
         }
+    }
+
+    private static Throwable executionExceptionCause(ExecutionException original) {
+        return (original.getCause() != null) ? original.getCause() : original;
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingUtils.java
@@ -22,6 +22,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.SubscribableCompletable;
 import io.servicetalk.concurrent.api.internal.SubscribableSingle;
 import io.servicetalk.concurrent.internal.ThreadInterruptingCancellable;
+import io.servicetalk.concurrent.internal.ThrowableUtil;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -97,7 +98,7 @@ final class BlockingUtils {
             future.cancel(false);
             throw e;
         } catch (ExecutionException e) {
-            return throwException(e.getCause());
+            return throwException(ThrowableUtil.getCause(e));
         }
     }
 
@@ -150,7 +151,7 @@ final class BlockingUtils {
         try {
             return source.toFuture().get();
         } catch (final ExecutionException e) {
-            return throwException(e.getCause());
+            return throwException(ThrowableUtil.getCause(e));
         }
     }
 
@@ -160,7 +161,7 @@ final class BlockingUtils {
         try {
             source.toFuture().get();
         } catch (final ExecutionException e) {
-            throwException(e.getCause());
+            throwException(ThrowableUtil.getCause(e));
         }
     }
 }


### PR DESCRIPTION
__Motivation__

BlockingUtils should not assume the cause of ExecutionException is not null.

__Modifications__

Add method `BlockingUtils.executionExceptionCause` that returns nonnull
cause or original throwable.

__Result__

Fixes #870.