### PR TITLE
Fix evaluation order in HeaderUtils.hasContentType

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -653,10 +653,10 @@ public final class HeaderUtils {
         }
 
         if (UTF_8.equals(expectedCharset) &&
-                (contentEqualsIgnoreCase(expectedContentType, TEXT_PLAIN) &&
+                ((contentEqualsIgnoreCase(expectedContentType, TEXT_PLAIN) &&
                         contentEqualsIgnoreCase(contentTypeHeader, TEXT_PLAIN_UTF_8)) ||
                 (contentEqualsIgnoreCase(expectedContentType, APPLICATION_X_WWW_FORM_URLENCODED) &&
-                        contentEqualsIgnoreCase(contentTypeHeader, APPLICATION_X_WWW_FORM_URLENCODED_UTF_8))) {
+                        contentEqualsIgnoreCase(contentTypeHeader, APPLICATION_X_WWW_FORM_URLENCODED_UTF_8)))) {
             return true;
         }
 

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
@@ -32,6 +32,7 @@ import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
 import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN_UTF_8;
 import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_16;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -61,6 +62,10 @@ public class HeaderUtilsTest {
         assertTrue(HeaderUtils.hasContentType(
                 headersWithContentType(APPLICATION_X_WWW_FORM_URLENCODED_UTF_8),
                 APPLICATION_X_WWW_FORM_URLENCODED, UTF_8));
+
+        assertFalse(HeaderUtils.hasContentType(
+                headersWithContentType(APPLICATION_X_WWW_FORM_URLENCODED_UTF_8),
+                APPLICATION_X_WWW_FORM_URLENCODED, UTF_16));
 
         assertTrue(HeaderUtils.hasContentType(
                 headersWithContentType(of("text/plain")), TEXT_PLAIN, null));


### PR DESCRIPTION
Motivation:

Currently `HeaderUtils.hasContentType` returns true if headers contain `application/x-www-form-urlencoded; charset=UTF-8`, no matter what the expected charset is. This causes `FormUrlEncodedHttpDeserializer` with UTF-16 charset attempting to deserialize UTF-8 encoded payload.

Modifications:

- Fix evaluation order in `HeaderUtils.hasContentType`

Result:

Method behaves as expected.