### PR TITLE
Add http headers values to serialization exception message

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultClassHttpDeserializer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultClassHttpDeserializer.java
@@ -64,7 +64,7 @@ final class DefaultClassHttpDeserializer<T> implements HttpDeserializer<T> {
     private void checkContentType(final HttpHeaders headers) {
         if (!checkContentType.test(headers)) {
             throw new SerializationException("Unexpected headers, can not deserialize. Headers: "
-                    + headers.toString());
+                    + headers.toString(HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER));
         }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultClassHttpDeserializer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultClassHttpDeserializer.java
@@ -23,6 +23,8 @@ import io.servicetalk.serialization.api.Serializer;
 
 import java.util.function.Predicate;
 
+import static io.servicetalk.http.api.HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER;
+
 /**
  * A {@link HttpDeserializer} that can deserialize to a {@link Class} of type {@link T}.
  *
@@ -64,7 +66,7 @@ final class DefaultClassHttpDeserializer<T> implements HttpDeserializer<T> {
     private void checkContentType(final HttpHeaders headers) {
         if (!checkContentType.test(headers)) {
             throw new SerializationException("Unexpected headers, can not deserialize. Headers: "
-                    + headers.toString(HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER));
+                    + headers.toString(DEFAULT_DEBUG_HEADER_FILTER));
         }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultTypeHttpDeserializer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultTypeHttpDeserializer.java
@@ -24,6 +24,8 @@ import io.servicetalk.serialization.api.TypeHolder;
 
 import java.util.function.Predicate;
 
+import static io.servicetalk.http.api.HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER;
+
 /**
  * A {@link HttpDeserializer} that can deserialize a {@link TypeHolder} of type {@link T}.
  *
@@ -65,7 +67,7 @@ final class DefaultTypeHttpDeserializer<T> implements HttpDeserializer<T> {
     private void checkContentType(final HttpHeaders headers) {
         if (!checkContentType.test(headers)) {
             throw new SerializationException("Unexpected headers, can not deserialize. Headers: "
-                    + headers.toString(HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER));
+                    + headers.toString(DEFAULT_DEBUG_HEADER_FILTER));
         }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultTypeHttpDeserializer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultTypeHttpDeserializer.java
@@ -65,7 +65,7 @@ final class DefaultTypeHttpDeserializer<T> implements HttpDeserializer<T> {
     private void checkContentType(final HttpHeaders headers) {
         if (!checkContentType.test(headers)) {
             throw new SerializationException("Unexpected headers, can not deserialize. Headers: "
-                    + headers.toString());
+                    + headers.toString(HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER));
         }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FormUrlEncodedHttpDeserializer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FormUrlEncodedHttpDeserializer.java
@@ -101,7 +101,7 @@ final class FormUrlEncodedHttpDeserializer implements HttpDeserializer<Map<Strin
     private void checkContentType(final HttpHeaders headers) {
         if (!checkContentType.test(headers)) {
             throw new SerializationException("Unexpected headers, can not deserialize. Headers: "
-                    + headers.toString());
+                    + headers.toString(HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER));
         }
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FormUrlEncodedHttpDeserializer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FormUrlEncodedHttpDeserializer.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.http.api.HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER;
 import static io.servicetalk.http.api.HeaderUtils.hasContentType;
 import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED;
 import static io.servicetalk.http.api.QueryStringDecoder.decodeParams;
@@ -101,7 +102,7 @@ final class FormUrlEncodedHttpDeserializer implements HttpDeserializer<Map<Strin
     private void checkContentType(final HttpHeaders headers) {
         if (!checkContentType.test(headers)) {
             throw new SerializationException("Unexpected headers, can not deserialize. Headers: "
-                    + headers.toString(HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER));
+                    + headers.toString(DEFAULT_DEBUG_HEADER_FILTER));
         }
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -18,9 +18,13 @@ package io.servicetalk.http.api;
 import io.servicetalk.buffer.api.ByteProcessor;
 
 import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
@@ -60,16 +64,16 @@ public final class HeaderUtils {
     static final int HASH_CODE_SEED = 0xc2b2ae35;
     public static final BiFunction<? super CharSequence, ? super CharSequence, CharSequence> DEFAULT_HEADER_FILTER =
             (k, v) -> "<filtered>";
+    private static final Set<CharSequence> DEFAULT_DEBUG_HEADER_NAMES = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(CONTENT_TYPE, CONTENT_LENGTH, TRANSFER_ENCODING)));
     static final BiFunction<? super CharSequence, ? super CharSequence, CharSequence>
             DEFAULT_DEBUG_HEADER_FILTER = (key, value) -> {
-                switch (key.toString()) {
-                    case "content-type":
-                    case "content-length":
-                    case "transfer-encoding":
+                for (CharSequence headerName : DEFAULT_DEBUG_HEADER_NAMES) {
+                    if (CharSequences.contentEqualsIgnoreCase(key, headerName)) {
                         return value;
-                    default:
-                        return "<filtered>";
+                    }
                 }
+                return "<filtered>";
             };
     private static final ByteProcessor HEADER_NAME_VALIDATOR = value -> {
         validateHeaderNameToken(value);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -60,7 +60,7 @@ public final class HeaderUtils {
     static final int HASH_CODE_SEED = 0xc2b2ae35;
     public static final BiFunction<? super CharSequence, ? super CharSequence, CharSequence> DEFAULT_HEADER_FILTER =
             (k, v) -> "<filtered>";
-    public static final BiFunction<? super CharSequence, ? super CharSequence, CharSequence>
+    static final BiFunction<? super CharSequence, ? super CharSequence, CharSequence>
             DEFAULT_DEBUG_HEADER_FILTER = (key, value) -> {
                 switch (key.toString()) {
                     case "content-type":

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -60,6 +60,17 @@ public final class HeaderUtils {
     static final int HASH_CODE_SEED = 0xc2b2ae35;
     public static final BiFunction<? super CharSequence, ? super CharSequence, CharSequence> DEFAULT_HEADER_FILTER =
             (k, v) -> "<filtered>";
+    public static final BiFunction<? super CharSequence, ? super CharSequence, CharSequence>
+            DEFAULT_DEBUG_HEADER_FILTER = (key, value) -> {
+                switch (key.toString()) {
+                    case "content-type":
+                    case "content-length":
+                    case "transfer-encoding":
+                        return value;
+                    default:
+                        return "<filtered>";
+                }
+            };
     private static final ByteProcessor HEADER_NAME_VALIDATOR = value -> {
         validateHeaderNameToken(value);
         return true;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -18,13 +18,10 @@ package io.servicetalk.http.api;
 import io.servicetalk.buffer.api.ByteProcessor;
 
 import java.nio.charset.Charset;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
@@ -48,6 +45,7 @@ import static java.lang.Math.min;
 import static java.lang.System.lineSeparator;
 import static java.nio.charset.Charset.availableCharsets;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static java.util.regex.Pattern.compile;
@@ -64,12 +62,12 @@ public final class HeaderUtils {
     static final int HASH_CODE_SEED = 0xc2b2ae35;
     public static final BiFunction<? super CharSequence, ? super CharSequence, CharSequence> DEFAULT_HEADER_FILTER =
             (k, v) -> "<filtered>";
-    private static final Set<CharSequence> DEFAULT_DEBUG_HEADER_NAMES = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(CONTENT_TYPE, CONTENT_LENGTH, TRANSFER_ENCODING)));
-    static final BiFunction<? super CharSequence, ? super CharSequence, CharSequence>
-            DEFAULT_DEBUG_HEADER_FILTER = (key, value) -> {
+    private static final List<CharSequence> DEFAULT_DEBUG_HEADER_NAMES = asList(CONTENT_TYPE, CONTENT_LENGTH,
+            TRANSFER_ENCODING);
+    static final BiFunction<? super CharSequence, ? super CharSequence, CharSequence> DEFAULT_DEBUG_HEADER_FILTER =
+            (key, value) -> {
                 for (CharSequence headerName : DEFAULT_DEBUG_HEADER_NAMES) {
-                    if (CharSequences.contentEqualsIgnoreCase(key, headerName)) {
+                    if (contentEqualsIgnoreCase(key, headerName)) {
                         return value;
                     }
                 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpStringDeserializer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpStringDeserializer.java
@@ -100,7 +100,7 @@ final class HttpStringDeserializer implements HttpDeserializer<String> {
     private void checkContentType(final HttpHeaders headers) {
         if (!checkContentType.test(headers)) {
             throw new SerializationException("Unexpected headers, can not deserialize. Headers: "
-                    + headers.toString());
+                    + headers.toString(HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER));
         }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpStringDeserializer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpStringDeserializer.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.http.api.HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER;
 import static io.servicetalk.http.api.HeaderUtils.hasContentType;
 import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -100,7 +101,7 @@ final class HttpStringDeserializer implements HttpDeserializer<String> {
     private void checkContentType(final HttpHeaders headers) {
         if (!checkContentType.test(headers)) {
             throw new SerializationException("Unexpected headers, can not deserialize. Headers: "
-                    + headers.toString(HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER));
+                    + headers.toString(DEFAULT_DEBUG_HEADER_FILTER));
         }
     }
 }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/FormUrlEncodedHttpDeserializerTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/FormUrlEncodedHttpDeserializerTest.java
@@ -33,7 +33,9 @@ import static io.servicetalk.buffer.api.EmptyBuffer.EMPTY_BUFFER;
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
 import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.rules.ExpectedException.none;
@@ -82,13 +84,11 @@ public class FormUrlEncodedHttpDeserializerTest {
         final FormUrlEncodedHttpDeserializer deserializer = FormUrlEncodedHttpDeserializer.UTF8;
 
         final HttpHeaders headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders();
-        headers.set(CONTENT_TYPE, "invalid/content/type");
-
-        final String expectedMessage = "Unexpected headers, can not deserialize. Headers: DefaultHttpHeaders" +
-                "[content-type: " + headers.get(CONTENT_TYPE) + "]";
+        final String invalidContentType = "invalid/content/type";
+        headers.set(CONTENT_TYPE, invalidContentType);
 
         expectedException.expect(instanceOf(SerializationException.class));
-        expectedException.expectMessage(expectedMessage);
+        expectedException.expectMessage(containsString(invalidContentType));
 
         deserializer.deserialize(headers, EMPTY_BUFFER);
     }
@@ -98,14 +98,15 @@ public class FormUrlEncodedHttpDeserializerTest {
         final FormUrlEncodedHttpDeserializer deserializer = FormUrlEncodedHttpDeserializer.UTF8;
 
         final HttpHeaders headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders();
-        headers.set(CONTENT_TYPE, "invalid/content/type");
-        headers.set(HttpHeaderNames.HOST, "some/host");
-
-        final String expectedMessage = "Unexpected headers, can not deserialize. Headers: DefaultHttpHeaders[host: " +
-                "<filtered>\ncontent-type: " + headers.get(CONTENT_TYPE) + "]";
+        final String invalidContentType = "invalid/content/type";
+        final String someHost = "some/host";
+        headers.set(CONTENT_TYPE, invalidContentType);
+        headers.set(HttpHeaderNames.HOST, someHost);
 
         expectedException.expect(instanceOf(SerializationException.class));
-        expectedException.expectMessage(expectedMessage);
+        expectedException.expectMessage(containsString(invalidContentType));
+        expectedException.expectMessage(containsString("<filtered>"));
+        expectedException.expectMessage(not(containsString(someHost)));
 
         deserializer.deserialize(headers, EMPTY_BUFFER);
     }
@@ -116,10 +117,7 @@ public class FormUrlEncodedHttpDeserializerTest {
 
         final HttpHeaders headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders();
 
-        final String expectedMessage = "Unexpected headers, can not deserialize. Headers: DefaultHttpHeaders[]";
-
         expectedException.expect(instanceOf(SerializationException.class));
-        expectedException.expectMessage(expectedMessage);
 
         deserializer.deserialize(headers, EMPTY_BUFFER);
     }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/FormUrlEncodedHttpDeserializerTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/FormUrlEncodedHttpDeserializerTest.java
@@ -84,7 +84,42 @@ public class FormUrlEncodedHttpDeserializerTest {
         final HttpHeaders headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders();
         headers.set(CONTENT_TYPE, "invalid/content/type");
 
+        final String expectedMessage = "Unexpected headers, can not deserialize. Headers: DefaultHttpHeaders" +
+                "[content-type: " + headers.get(CONTENT_TYPE) + "]";
+
         expectedException.expect(instanceOf(SerializationException.class));
+        expectedException.expectMessage(expectedMessage);
+
+        deserializer.deserialize(headers, EMPTY_BUFFER);
+    }
+
+    @Test
+    public void invalidContentTypeThrowsAndMasksAdditionalHeadersValues() {
+        final FormUrlEncodedHttpDeserializer deserializer = FormUrlEncodedHttpDeserializer.UTF8;
+
+        final HttpHeaders headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders();
+        headers.set(CONTENT_TYPE, "invalid/content/type");
+        headers.set(HttpHeaderNames.HOST, "some/host");
+
+        final String expectedMessage = "Unexpected headers, can not deserialize. Headers: DefaultHttpHeaders[host: " +
+                "<filtered>\ncontent-type: " + headers.get(CONTENT_TYPE) + "]";
+
+        expectedException.expect(instanceOf(SerializationException.class));
+        expectedException.expectMessage(expectedMessage);
+
+        deserializer.deserialize(headers, EMPTY_BUFFER);
+    }
+
+    @Test
+    public void missingContentTypeThrows() {
+        final FormUrlEncodedHttpDeserializer deserializer = FormUrlEncodedHttpDeserializer.UTF8;
+
+        final HttpHeaders headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders();
+
+        final String expectedMessage = "Unexpected headers, can not deserialize. Headers: DefaultHttpHeaders[]";
+
+        expectedException.expect(instanceOf(SerializationException.class));
+        expectedException.expectMessage(expectedMessage);
 
         deserializer.deserialize(headers, EMPTY_BUFFER);
     }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
@@ -23,12 +23,15 @@ import java.nio.charset.CharsetEncoder;
 
 import static io.netty.util.AsciiString.of;
 import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
+import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
+import static io.servicetalk.http.api.HttpHeaderNames.ORIGIN;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_JSON;
 import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED;
 import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED_UTF_8;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
+import static io.servicetalk.http.api.HttpHeaderValues.GZIP;
 import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
 import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN_UTF_8;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -39,6 +42,17 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class HeaderUtilsTest {
+    @Test
+    public void DEFAULT_DEBUG_HEADER_FILTER() {
+        assertEquals(APPLICATION_JSON, HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER.apply(CONTENT_TYPE, APPLICATION_JSON));
+
+        assertEquals("3495", HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER.apply(CONTENT_LENGTH, "3495"));
+
+        assertEquals(GZIP, HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER.apply(TRANSFER_ENCODING, GZIP));
+
+        assertEquals("<filtered>", HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER.apply(ORIGIN, "some/origin"));
+    }
+
     @Test
     public void hasContentType() {
         assertFalse(HeaderUtils.hasContentType(

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
@@ -31,7 +31,6 @@ import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_JSON;
 import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED;
 import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED_UTF_8;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
-import static io.servicetalk.http.api.HttpHeaderValues.GZIP;
 import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
 import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN_UTF_8;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -43,12 +42,14 @@ import static org.junit.Assert.assertTrue;
 
 public class HeaderUtilsTest {
     @Test
-    public void DEFAULT_DEBUG_HEADER_FILTER() {
+    public void defaultDebugHeaderFilter() {
         assertEquals(APPLICATION_JSON, HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER.apply(CONTENT_TYPE, APPLICATION_JSON));
 
         assertEquals("3495", HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER.apply(CONTENT_LENGTH, "3495"));
 
-        assertEquals(GZIP, HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER.apply(TRANSFER_ENCODING, GZIP));
+        assertEquals(CHUNKED, HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER.apply(TRANSFER_ENCODING, CHUNKED));
+
+        assertEquals(CHUNKED, HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER.apply("TrAnsFeR-eNcOdiNg", CHUNKED));
 
         assertEquals("<filtered>", HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER.apply(ORIGIN, "some/origin"));
     }


### PR DESCRIPTION
Motivation:

When users attempt to deserialize a response that has the wrong content-type, they receive an exception that lists all the headers, but with `<filtered>` as the value, making it hard to diagnose.

Modifications:

- Add a new debug filter `DEFAULT_DEBUG_HEADER_FILTER` to the class `HeaderUtils`.
- Modify the following classes [`DefaultClassHttpDeserializer`, `DefaultTypeHttpDeserializer`, `FormUrlEncodedHttpDeserializer`, `HttpStringDeserializer`] and change the method `checkContentType` to call `headers.toString(DEFAULT_DEBUG_HEADER_FILTER)`.
- Add tests to cover the new SerializationException messages.

Result:

Better debugging info in `SerializationException` when attempting to deserialize invalid
`content-type`.

Fixes #878