### PR TITLE
Refactor check content type http api

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultClassHttpDeserializer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultClassHttpDeserializer.java
@@ -18,12 +18,11 @@ package io.servicetalk.http.api;
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.BlockingIterable;
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.serialization.api.SerializationException;
 import io.servicetalk.serialization.api.Serializer;
 
 import java.util.function.Predicate;
 
-import static io.servicetalk.http.api.HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER;
+import static io.servicetalk.http.api.HeaderUtils.checkContentType;
 
 /**
  * A {@link HttpDeserializer} that can deserialize to a {@link Class} of type {@link T}.
@@ -46,27 +45,20 @@ final class DefaultClassHttpDeserializer<T> implements HttpDeserializer<T> {
 
     @Override
     public T deserialize(final HttpHeaders headers, final Buffer payload) {
-        checkContentType(headers);
+        checkContentType(headers, checkContentType);
         return serializer.deserializeAggregatedSingle(payload, type);
     }
 
     @Override
     public BlockingIterable<T> deserialize(final HttpHeaders headers,
                                            final BlockingIterable<Buffer> payload) {
-        checkContentType(headers);
+        checkContentType(headers, checkContentType);
         return serializer.deserialize(payload, type);
     }
 
     @Override
     public Publisher<T> deserialize(final HttpHeaders headers, final Publisher<Buffer> payload) {
-        checkContentType(headers);
+        checkContentType(headers, checkContentType);
         return serializer.deserialize(payload, type);
-    }
-
-    private void checkContentType(final HttpHeaders headers) {
-        if (!checkContentType.test(headers)) {
-            throw new SerializationException("Unexpected headers, can not deserialize. Headers: "
-                    + headers.toString(DEFAULT_DEBUG_HEADER_FILTER));
-        }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultTypeHttpDeserializer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultTypeHttpDeserializer.java
@@ -18,13 +18,12 @@ package io.servicetalk.http.api;
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.BlockingIterable;
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.serialization.api.SerializationException;
 import io.servicetalk.serialization.api.Serializer;
 import io.servicetalk.serialization.api.TypeHolder;
 
 import java.util.function.Predicate;
 
-import static io.servicetalk.http.api.HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER;
+import static io.servicetalk.http.api.HeaderUtils.checkContentType;
 
 /**
  * A {@link HttpDeserializer} that can deserialize a {@link TypeHolder} of type {@link T}.
@@ -47,27 +46,20 @@ final class DefaultTypeHttpDeserializer<T> implements HttpDeserializer<T> {
 
     @Override
     public T deserialize(final HttpHeaders headers, final Buffer payload) {
-        checkContentType(headers);
+        checkContentType(headers, checkContentType);
         return serializer.deserializeAggregatedSingle(payload, type);
     }
 
     @Override
     public BlockingIterable<T> deserialize(final HttpHeaders headers,
                                            final BlockingIterable<Buffer> payload) {
-        checkContentType(headers);
+        checkContentType(headers, checkContentType);
         return serializer.deserialize(payload, type);
     }
 
     @Override
     public Publisher<T> deserialize(final HttpHeaders headers, final Publisher<Buffer> payload) {
-        checkContentType(headers);
+        checkContentType(headers, checkContentType);
         return serializer.deserialize(payload, type);
-    }
-
-    private void checkContentType(final HttpHeaders headers) {
-        if (!checkContentType.test(headers)) {
-            throw new SerializationException("Unexpected headers, can not deserialize. Headers: "
-                    + headers.toString(DEFAULT_DEBUG_HEADER_FILTER));
-        }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FormUrlEncodedHttpDeserializer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FormUrlEncodedHttpDeserializer.java
@@ -19,7 +19,6 @@ import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.BlockingIterable;
 import io.servicetalk.concurrent.BlockingIterator;
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.serialization.api.SerializationException;
 
 import java.nio.charset.Charset;
 import java.util.List;
@@ -29,7 +28,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.http.api.HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER;
+import static io.servicetalk.http.api.HeaderUtils.checkContentType;
 import static io.servicetalk.http.api.HeaderUtils.hasContentType;
 import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED;
 import static io.servicetalk.http.api.QueryStringDecoder.decodeParams;
@@ -53,14 +52,14 @@ final class FormUrlEncodedHttpDeserializer implements HttpDeserializer<Map<Strin
 
     @Override
     public Map<String, List<String>> deserialize(final HttpHeaders headers, final Buffer payload) {
-        checkContentType(headers);
+        checkContentType(headers, checkContentType);
         return deserialize(payload);
     }
 
     @Override
     public BlockingIterable<Map<String, List<String>>> deserialize(final HttpHeaders headers,
                                                                    final BlockingIterable<Buffer> payload) {
-        checkContentType(headers);
+        checkContentType(headers, checkContentType);
         return () -> {
             final BlockingIterator<Buffer> iterator = payload.iterator();
             return new BlockingIterator<Map<String, List<String>>>() {
@@ -95,15 +94,8 @@ final class FormUrlEncodedHttpDeserializer implements HttpDeserializer<Map<Strin
     @Override
     public Publisher<Map<String, List<String>>> deserialize(final HttpHeaders headers,
                                                             final Publisher<Buffer> payload) {
-        checkContentType(headers);
+        checkContentType(headers, checkContentType);
         return payload.map(this::deserialize);
-    }
-
-    private void checkContentType(final HttpHeaders headers) {
-        if (!checkContentType.test(headers)) {
-            throw new SerializationException("Unexpected headers, can not deserialize. Headers: "
-                    + headers.toString(DEFAULT_DEBUG_HEADER_FILTER));
-        }
     }
 
     private Map<String, List<String>> deserialize(@Nullable final Buffer buffer) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.ByteProcessor;
+import io.servicetalk.serialization.api.SerializationException;
 
 import java.nio.charset.Charset;
 import java.util.Iterator;
@@ -23,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.function.BiFunction;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
@@ -680,6 +682,19 @@ public final class HeaderUtils {
         }
         return pattern.matcher(contentTypeHeader.subSequence(expectedContentType.length(), contentTypeHeader.length()))
                 .matches();
+    }
+
+    /**
+     * Checks if the provider headers contain a {@code Content-Type} header that satisfies the supplied predicate.
+     *
+     * @param headers the {@link HttpHeaders} instance
+     * @param contentTypePredicate the content type predicate
+     */
+    static void checkContentType(final HttpHeaders headers, Predicate<HttpHeaders> contentTypePredicate) {
+        if (!contentTypePredicate.test(headers)) {
+            throw new SerializationException("Unexpected headers, can not deserialize. Headers: "
+                    + headers.toString(DEFAULT_DEBUG_HEADER_FILTER));
+        }
     }
 
     private static Pattern compileCharsetRegex(String charsetName) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpStringDeserializer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpStringDeserializer.java
@@ -19,7 +19,6 @@ import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.BlockingIterable;
 import io.servicetalk.concurrent.BlockingIterator;
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.serialization.api.SerializationException;
 
 import java.nio.charset.Charset;
 import java.util.concurrent.TimeUnit;
@@ -27,7 +26,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.http.api.HeaderUtils.DEFAULT_DEBUG_HEADER_FILTER;
+import static io.servicetalk.http.api.HeaderUtils.checkContentType;
 import static io.servicetalk.http.api.HeaderUtils.hasContentType;
 import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -49,13 +48,13 @@ final class HttpStringDeserializer implements HttpDeserializer<String> {
 
     @Override
     public String deserialize(final HttpHeaders headers, final Buffer payload) {
-        checkContentType(headers);
+        checkContentType(headers, checkContentType);
         return payload.toString(charset);
     }
 
     @Override
     public BlockingIterable<String> deserialize(final HttpHeaders headers, final BlockingIterable<Buffer> payload) {
-        checkContentType(headers);
+        checkContentType(headers, checkContentType);
         return () -> {
             final BlockingIterator<Buffer> iterator = payload.iterator();
             return new BlockingIterator<String>() {
@@ -89,19 +88,12 @@ final class HttpStringDeserializer implements HttpDeserializer<String> {
 
     @Override
     public Publisher<String> deserialize(final HttpHeaders headers, final Publisher<Buffer> payload) {
-        checkContentType(headers);
+        checkContentType(headers, checkContentType);
         return payload.map(this::toString);
     }
 
     @Nullable
     private String toString(@Nullable Buffer buffer) {
         return buffer == null ? null : buffer.toString(charset);
-    }
-
-    private void checkContentType(final HttpHeaders headers) {
-        if (!checkContentType.test(headers)) {
-            throw new SerializationException("Unexpected headers, can not deserialize. Headers: "
-                    + headers.toString(DEFAULT_DEBUG_HEADER_FILTER));
-        }
     }
 }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
@@ -44,7 +44,6 @@ import static java.nio.charset.StandardCharsets.UTF_16;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -156,14 +155,12 @@ public class HeaderUtilsTest {
         final Predicate<HttpHeaders> jsonContentTypeValidator =
                 headers -> headers.contains(CONTENT_TYPE, APPLICATION_JSON);
 
+        checkContentType(headersWithContentType(APPLICATION_JSON), jsonContentTypeValidator);
+
         expectedException.expect(instanceOf(SerializationException.class));
         expectedException.expectMessage(containsString(invalidContentType));
 
         checkContentType(headersWithContentType(of(invalidContentType)), jsonContentTypeValidator);
-
-        expectedException.expect(nullValue());
-
-        checkContentType(headersWithContentType(APPLICATION_JSON), jsonContentTypeValidator);
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Currently there is duplication in checkContentType in:
 - `DefaultClassHttpDeserializer`
 - `DefaultTypeHttpDeserializer`
 - `FormUrlEncodedHttpDeserializer`
 - `HttpStringDeserializer`
where `checkContentType` method is identical in all classes.

Modifications:

- Remove `checkContentType` from `DefaultClassHttpDeserializer`
- Remove `checkContentType` from `DefaultTypeHttpDeserializer`
- Remove `checkContentType` from `FormUrlEncodedHttpDeserializer`
- Remove `checkContentType` from `HttpStringDeserializer`
- Add `checkContentType(HttpHeaders, Predicate<HttpHeaders>)` to
  `HeaderUtils`
- Replace calls to `checkContentType(headers)` with calls to
  `HeaderUtils.checkContentType(headers, checkContentType)`
  in all 4 HttpDeserializers

Result:

Less code duplication.
Resolves: #886
