### PR TITLE
Adhere http api response status error code names to rfc standards

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponseFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponseFactory.java
@@ -47,28 +47,28 @@ import static io.servicetalk.http.api.HttpResponseStatus.NOT_MODIFIED;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpResponseStatus.PARTIAL_CONTENT;
+import static io.servicetalk.http.api.HttpResponseStatus.PAYLOAD_TOO_LARGE;
 import static io.servicetalk.http.api.HttpResponseStatus.PAYMENT_REQUIRED;
 import static io.servicetalk.http.api.HttpResponseStatus.PERMANENT_REDIRECT;
 import static io.servicetalk.http.api.HttpResponseStatus.PRECONDITION_FAILED;
 import static io.servicetalk.http.api.HttpResponseStatus.PRECONDITION_REQUIRED;
 import static io.servicetalk.http.api.HttpResponseStatus.PROCESSING;
 import static io.servicetalk.http.api.HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED;
-import static io.servicetalk.http.api.HttpResponseStatus.REQUESTED_RANGE_NOT_SATISFIABLE;
-import static io.servicetalk.http.api.HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE;
+import static io.servicetalk.http.api.HttpResponseStatus.RANGE_NOT_SATISFIABLE;
 import static io.servicetalk.http.api.HttpResponseStatus.REQUEST_HEADER_FIELDS_TOO_LARGE;
 import static io.servicetalk.http.api.HttpResponseStatus.REQUEST_TIMEOUT;
-import static io.servicetalk.http.api.HttpResponseStatus.REQUEST_URI_TOO_LONG;
 import static io.servicetalk.http.api.HttpResponseStatus.RESET_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.SEE_OTHER;
 import static io.servicetalk.http.api.HttpResponseStatus.SERVICE_UNAVAILABLE;
 import static io.servicetalk.http.api.HttpResponseStatus.SWITCHING_PROTOCOLS;
 import static io.servicetalk.http.api.HttpResponseStatus.TEMPORARY_REDIRECT;
+import static io.servicetalk.http.api.HttpResponseStatus.TOO_EARLY;
 import static io.servicetalk.http.api.HttpResponseStatus.TOO_MANY_REQUESTS;
 import static io.servicetalk.http.api.HttpResponseStatus.UNAUTHORIZED;
-import static io.servicetalk.http.api.HttpResponseStatus.UNORDERED_COLLECTION;
 import static io.servicetalk.http.api.HttpResponseStatus.UNPROCESSABLE_ENTITY;
 import static io.servicetalk.http.api.HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE;
 import static io.servicetalk.http.api.HttpResponseStatus.UPGRADE_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatus.URI_TOO_LONG;
 import static io.servicetalk.http.api.HttpResponseStatus.USE_PROXY;
 import static io.servicetalk.http.api.HttpResponseStatus.VARIANT_ALSO_NEGOTIATES;
 
@@ -340,19 +340,19 @@ public interface BlockingStreamingHttpResponseFactory {
     }
 
     /**
-     * Create a new {@link HttpResponseStatus#REQUEST_ENTITY_TOO_LARGE} response.
-     * @return a new {@link HttpResponseStatus#REQUEST_ENTITY_TOO_LARGE} response.
+     * Create a new {@link HttpResponseStatus#PAYLOAD_TOO_LARGE} response.
+     * @return a new {@link HttpResponseStatus#PAYLOAD_TOO_LARGE} response.
      */
-    default BlockingStreamingHttpResponse requestEntityTooLarge() {
-        return newResponse(REQUEST_ENTITY_TOO_LARGE);
+    default BlockingStreamingHttpResponse payloadTooLarge() {
+        return newResponse(PAYLOAD_TOO_LARGE);
     }
 
     /**
-     * Create a new {@link HttpResponseStatus#REQUEST_URI_TOO_LONG} response.
-     * @return a new {@link HttpResponseStatus#REQUEST_URI_TOO_LONG} response.
+     * Create a new {@link HttpResponseStatus#URI_TOO_LONG} response.
+     * @return a new {@link HttpResponseStatus#URI_TOO_LONG} response.
      */
-    default BlockingStreamingHttpResponse requestUriTooLong() {
-        return newResponse(REQUEST_URI_TOO_LONG);
+    default BlockingStreamingHttpResponse uriTooLong() {
+        return newResponse(URI_TOO_LONG);
     }
 
     /**
@@ -364,11 +364,11 @@ public interface BlockingStreamingHttpResponseFactory {
     }
 
     /**
-     * Create a new {@link HttpResponseStatus#REQUESTED_RANGE_NOT_SATISFIABLE} response.
-     * @return a new {@link HttpResponseStatus#REQUESTED_RANGE_NOT_SATISFIABLE} response.
+     * Create a new {@link HttpResponseStatus#RANGE_NOT_SATISFIABLE} response.
+     * @return a new {@link HttpResponseStatus#RANGE_NOT_SATISFIABLE} response.
      */
-    default BlockingStreamingHttpResponse requestedRangeNotSatisfiable() {
-        return newResponse(REQUESTED_RANGE_NOT_SATISFIABLE);
+    default BlockingStreamingHttpResponse rangeNotSatisfiable() {
+        return newResponse(RANGE_NOT_SATISFIABLE);
     }
 
     /**
@@ -412,11 +412,11 @@ public interface BlockingStreamingHttpResponseFactory {
     }
 
     /**
-     * Create a new {@link HttpResponseStatus#UNORDERED_COLLECTION} response.
-     * @return a new {@link HttpResponseStatus#UNORDERED_COLLECTION} response.
+     * Create a new {@link HttpResponseStatus#TOO_EARLY} response.
+     * @return a new {@link HttpResponseStatus#TOO_EARLY} response.
      */
-    default BlockingStreamingHttpResponse unorderedCollection() {
-        return newResponse(UNORDERED_COLLECTION);
+    default BlockingStreamingHttpResponse tooEarly() {
+        return newResponse(TOO_EARLY);
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponseFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponseFactory.java
@@ -47,28 +47,28 @@ import static io.servicetalk.http.api.HttpResponseStatus.NOT_MODIFIED;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpResponseStatus.PARTIAL_CONTENT;
+import static io.servicetalk.http.api.HttpResponseStatus.PAYLOAD_TOO_LARGE;
 import static io.servicetalk.http.api.HttpResponseStatus.PAYMENT_REQUIRED;
 import static io.servicetalk.http.api.HttpResponseStatus.PERMANENT_REDIRECT;
 import static io.servicetalk.http.api.HttpResponseStatus.PRECONDITION_FAILED;
 import static io.servicetalk.http.api.HttpResponseStatus.PRECONDITION_REQUIRED;
 import static io.servicetalk.http.api.HttpResponseStatus.PROCESSING;
 import static io.servicetalk.http.api.HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED;
-import static io.servicetalk.http.api.HttpResponseStatus.REQUESTED_RANGE_NOT_SATISFIABLE;
-import static io.servicetalk.http.api.HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE;
+import static io.servicetalk.http.api.HttpResponseStatus.RANGE_NOT_SATISFIABLE;
 import static io.servicetalk.http.api.HttpResponseStatus.REQUEST_HEADER_FIELDS_TOO_LARGE;
 import static io.servicetalk.http.api.HttpResponseStatus.REQUEST_TIMEOUT;
-import static io.servicetalk.http.api.HttpResponseStatus.REQUEST_URI_TOO_LONG;
 import static io.servicetalk.http.api.HttpResponseStatus.RESET_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.SEE_OTHER;
 import static io.servicetalk.http.api.HttpResponseStatus.SERVICE_UNAVAILABLE;
 import static io.servicetalk.http.api.HttpResponseStatus.SWITCHING_PROTOCOLS;
 import static io.servicetalk.http.api.HttpResponseStatus.TEMPORARY_REDIRECT;
+import static io.servicetalk.http.api.HttpResponseStatus.TOO_EARLY;
 import static io.servicetalk.http.api.HttpResponseStatus.TOO_MANY_REQUESTS;
 import static io.servicetalk.http.api.HttpResponseStatus.UNAUTHORIZED;
-import static io.servicetalk.http.api.HttpResponseStatus.UNORDERED_COLLECTION;
 import static io.servicetalk.http.api.HttpResponseStatus.UNPROCESSABLE_ENTITY;
 import static io.servicetalk.http.api.HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE;
 import static io.servicetalk.http.api.HttpResponseStatus.UPGRADE_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatus.URI_TOO_LONG;
 import static io.servicetalk.http.api.HttpResponseStatus.USE_PROXY;
 import static io.servicetalk.http.api.HttpResponseStatus.VARIANT_ALSO_NEGOTIATES;
 
@@ -340,19 +340,19 @@ public interface HttpResponseFactory {
     }
 
     /**
-     * Create a new {@link HttpResponseStatus#REQUEST_ENTITY_TOO_LARGE} response.
-     * @return a new {@link HttpResponseStatus#REQUEST_ENTITY_TOO_LARGE} response.
+     * Create a new {@link HttpResponseStatus#PAYLOAD_TOO_LARGE} response.
+     * @return a new {@link HttpResponseStatus#PAYLOAD_TOO_LARGE} response.
      */
-    default HttpResponse requestEntityTooLarge() {
-        return newResponse(REQUEST_ENTITY_TOO_LARGE);
+    default HttpResponse payloadTooLarge() {
+        return newResponse(PAYLOAD_TOO_LARGE);
     }
 
     /**
-     * Create a new {@link HttpResponseStatus#REQUEST_URI_TOO_LONG} response.
-     * @return a new {@link HttpResponseStatus#REQUEST_URI_TOO_LONG} response.
+     * Create a new {@link HttpResponseStatus#URI_TOO_LONG} response.
+     * @return a new {@link HttpResponseStatus#URI_TOO_LONG} response.
      */
-    default HttpResponse requestUriTooLong() {
-        return newResponse(REQUEST_URI_TOO_LONG);
+    default HttpResponse uriTooLong() {
+        return newResponse(URI_TOO_LONG);
     }
 
     /**
@@ -364,11 +364,11 @@ public interface HttpResponseFactory {
     }
 
     /**
-     * Create a new {@link HttpResponseStatus#REQUESTED_RANGE_NOT_SATISFIABLE} response.
-     * @return a new {@link HttpResponseStatus#REQUESTED_RANGE_NOT_SATISFIABLE} response.
+     * Create a new {@link HttpResponseStatus#RANGE_NOT_SATISFIABLE} response.
+     * @return a new {@link HttpResponseStatus#RANGE_NOT_SATISFIABLE} response.
      */
-    default HttpResponse requestedRangeNotSatisfiable() {
-        return newResponse(REQUESTED_RANGE_NOT_SATISFIABLE);
+    default HttpResponse rangeNotSatisfiable() {
+        return newResponse(RANGE_NOT_SATISFIABLE);
     }
 
     /**
@@ -412,11 +412,11 @@ public interface HttpResponseFactory {
     }
 
     /**
-     * Create a new {@link HttpResponseStatus#UNORDERED_COLLECTION} response.
-     * @return a new {@link HttpResponseStatus#UNORDERED_COLLECTION} response.
+     * Create a new {@link HttpResponseStatus#TOO_EARLY} response.
+     * @return a new {@link HttpResponseStatus#TOO_EARLY} response.
      */
-    default HttpResponse unorderedCollection() {
-        return newResponse(UNORDERED_COLLECTION);
+    default HttpResponse tooEarly() {
+        return newResponse(TOO_EARLY);
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponseStatus.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponseStatus.java
@@ -277,19 +277,19 @@ public final class HttpResponseStatus {
     public static final HttpResponseStatus PRECONDITION_FAILED = new HttpResponseStatus(412, "Precondition Failed");
 
     /**
-     * 413 Request Entity Too Large
+     * 413 Payload Too Large
      *
      * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.11">RFC7231, section 6.5.11</a>
      */
-    public static final HttpResponseStatus REQUEST_ENTITY_TOO_LARGE = new HttpResponseStatus(413,
-            "Request Entity Too Large");
+    public static final HttpResponseStatus PAYLOAD_TOO_LARGE = new HttpResponseStatus(413,
+            "Payload Too Large");
 
     /**
-     * 414 Request-URI Too Long
+     * 414 URI Too Long
      *
      * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.12">RFC7231, section 6.5.12</a>
      */
-    public static final HttpResponseStatus REQUEST_URI_TOO_LONG = new HttpResponseStatus(414, "Request-URI Too Long");
+    public static final HttpResponseStatus URI_TOO_LONG = new HttpResponseStatus(414, "URI Too Long");
 
     /**
      * 415 Unsupported Media Type
@@ -300,12 +300,12 @@ public final class HttpResponseStatus {
             "Unsupported Media Type");
 
     /**
-     * 416 Requested Range Not Satisfiable
+     * 416 Range Not Satisfiable
      *
      * @see <a href="https://tools.ietf.org/html/rfc7233#section-4.4">RFC7233, section 4.4</a>
      */
-    public static final HttpResponseStatus REQUESTED_RANGE_NOT_SATISFIABLE = new HttpResponseStatus(416,
-            "Requested Range Not Satisfiable");
+    public static final HttpResponseStatus RANGE_NOT_SATISFIABLE = new HttpResponseStatus(416,
+            "Range Not Satisfiable");
 
     /**
      * 417 Expectation Failed
@@ -343,12 +343,11 @@ public final class HttpResponseStatus {
     public static final HttpResponseStatus FAILED_DEPENDENCY = new HttpResponseStatus(424, "Failed Dependency");
 
     /**
-     * 425 Unordered Collection
+     * 425 Too Early
      *
-     * @see <a href="https://tools.ietf.org/html/draft-ietf-webdav-ordering-protocol-00#section-11.1">
-     *     RFC3648 draft version 00, section 11.1</a>
+     * @see <a href="https://tools.ietf.org/html/rfc8470#section-5.2">RFC8470, section 5.2</a>
      */
-    public static final HttpResponseStatus UNORDERED_COLLECTION = new HttpResponseStatus(425, "Unordered Collection");
+    public static final HttpResponseStatus TOO_EARLY = new HttpResponseStatus(425, "Too Early");
 
     /**
      * 426 Upgrade Required
@@ -588,13 +587,13 @@ public final class HttpResponseStatus {
             case 412:
                 return PRECONDITION_FAILED;
             case 413:
-                return REQUEST_ENTITY_TOO_LARGE;
+                return PAYLOAD_TOO_LARGE;
             case 414:
-                return REQUEST_URI_TOO_LONG;
+                return URI_TOO_LONG;
             case 415:
                 return UNSUPPORTED_MEDIA_TYPE;
             case 416:
-                return REQUESTED_RANGE_NOT_SATISFIABLE;
+                return RANGE_NOT_SATISFIABLE;
             case 417:
                 return EXPECTATION_FAILED;
             case 421:
@@ -606,7 +605,7 @@ public final class HttpResponseStatus {
             case 424:
                 return FAILED_DEPENDENCY;
             case 425:
-                return UNORDERED_COLLECTION;
+                return TOO_EARLY;
             case 426:
                 return UPGRADE_REQUIRED;
             case 428:

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpResponseFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpResponseFactory.java
@@ -47,28 +47,28 @@ import static io.servicetalk.http.api.HttpResponseStatus.NOT_MODIFIED;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpResponseStatus.PARTIAL_CONTENT;
+import static io.servicetalk.http.api.HttpResponseStatus.PAYLOAD_TOO_LARGE;
 import static io.servicetalk.http.api.HttpResponseStatus.PAYMENT_REQUIRED;
 import static io.servicetalk.http.api.HttpResponseStatus.PERMANENT_REDIRECT;
 import static io.servicetalk.http.api.HttpResponseStatus.PRECONDITION_FAILED;
 import static io.servicetalk.http.api.HttpResponseStatus.PRECONDITION_REQUIRED;
 import static io.servicetalk.http.api.HttpResponseStatus.PROCESSING;
 import static io.servicetalk.http.api.HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED;
-import static io.servicetalk.http.api.HttpResponseStatus.REQUESTED_RANGE_NOT_SATISFIABLE;
-import static io.servicetalk.http.api.HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE;
+import static io.servicetalk.http.api.HttpResponseStatus.RANGE_NOT_SATISFIABLE;
 import static io.servicetalk.http.api.HttpResponseStatus.REQUEST_HEADER_FIELDS_TOO_LARGE;
 import static io.servicetalk.http.api.HttpResponseStatus.REQUEST_TIMEOUT;
-import static io.servicetalk.http.api.HttpResponseStatus.REQUEST_URI_TOO_LONG;
 import static io.servicetalk.http.api.HttpResponseStatus.RESET_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.SEE_OTHER;
 import static io.servicetalk.http.api.HttpResponseStatus.SERVICE_UNAVAILABLE;
 import static io.servicetalk.http.api.HttpResponseStatus.SWITCHING_PROTOCOLS;
 import static io.servicetalk.http.api.HttpResponseStatus.TEMPORARY_REDIRECT;
+import static io.servicetalk.http.api.HttpResponseStatus.TOO_EARLY;
 import static io.servicetalk.http.api.HttpResponseStatus.TOO_MANY_REQUESTS;
 import static io.servicetalk.http.api.HttpResponseStatus.UNAUTHORIZED;
-import static io.servicetalk.http.api.HttpResponseStatus.UNORDERED_COLLECTION;
 import static io.servicetalk.http.api.HttpResponseStatus.UNPROCESSABLE_ENTITY;
 import static io.servicetalk.http.api.HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE;
 import static io.servicetalk.http.api.HttpResponseStatus.UPGRADE_REQUIRED;
+import static io.servicetalk.http.api.HttpResponseStatus.URI_TOO_LONG;
 import static io.servicetalk.http.api.HttpResponseStatus.USE_PROXY;
 import static io.servicetalk.http.api.HttpResponseStatus.VARIANT_ALSO_NEGOTIATES;
 
@@ -340,19 +340,19 @@ public interface StreamingHttpResponseFactory {
     }
 
     /**
-     * Create a new {@link HttpResponseStatus#REQUEST_ENTITY_TOO_LARGE} response.
-     * @return a new {@link HttpResponseStatus#REQUEST_ENTITY_TOO_LARGE} response.
+     * Create a new {@link HttpResponseStatus#PAYLOAD_TOO_LARGE} response.
+     * @return a new {@link HttpResponseStatus#PAYLOAD_TOO_LARGE} response.
      */
-    default StreamingHttpResponse requestEntityTooLarge() {
-        return newResponse(REQUEST_ENTITY_TOO_LARGE);
+    default StreamingHttpResponse payloadTooLarge() {
+        return newResponse(PAYLOAD_TOO_LARGE);
     }
 
     /**
-     * Create a new {@link HttpResponseStatus#REQUEST_URI_TOO_LONG} response.
-     * @return a new {@link HttpResponseStatus#REQUEST_URI_TOO_LONG} response.
+     * Create a new {@link HttpResponseStatus#URI_TOO_LONG} response.
+     * @return a new {@link HttpResponseStatus#URI_TOO_LONG} response.
      */
-    default StreamingHttpResponse requestUriTooLong() {
-        return newResponse(REQUEST_URI_TOO_LONG);
+    default StreamingHttpResponse uriTooLong() {
+        return newResponse(URI_TOO_LONG);
     }
 
     /**
@@ -364,11 +364,11 @@ public interface StreamingHttpResponseFactory {
     }
 
     /**
-     * Create a new {@link HttpResponseStatus#REQUESTED_RANGE_NOT_SATISFIABLE} response.
-     * @return a new {@link HttpResponseStatus#REQUESTED_RANGE_NOT_SATISFIABLE} response.
+     * Create a new {@link HttpResponseStatus#RANGE_NOT_SATISFIABLE} response.
+     * @return a new {@link HttpResponseStatus#RANGE_NOT_SATISFIABLE} response.
      */
-    default StreamingHttpResponse requestedRangeNotSatisfiable() {
-        return newResponse(REQUESTED_RANGE_NOT_SATISFIABLE);
+    default StreamingHttpResponse rangeNotSatisfiable() {
+        return newResponse(RANGE_NOT_SATISFIABLE);
     }
 
     /**
@@ -412,11 +412,11 @@ public interface StreamingHttpResponseFactory {
     }
 
     /**
-     * Create a new {@link HttpResponseStatus#UNORDERED_COLLECTION} response.
-     * @return a new {@link HttpResponseStatus#UNORDERED_COLLECTION} response.
+     * Create a new {@link HttpResponseStatus#TOO_EARLY} response.
+     * @return a new {@link HttpResponseStatus#TOO_EARLY} response.
      */
-    default StreamingHttpResponse unorderedCollection() {
-        return newResponse(UNORDERED_COLLECTION);
+    default StreamingHttpResponse tooEarly() {
+        return newResponse(TOO_EARLY);
     }
 
     /**


### PR DESCRIPTION
Motivation:

`http-api` `HttpResponseStatus` error codes 413, 414, 416, 425 do not
follow the most recent standards, defined by:
https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
therefore we should update the `HttpResponseStatus` error code names.

Modifications:

- update the following fields in `HttpResponseStatus`:
  - 413 `REQUEST_ENTITY_TOO_LARGE` to `PAYLOAD_TOO_LARGE`.
  - 414 `REQUEST_URI_TOO_LONG` to `URI_TOO_LONG`.
  - 416 `REQUESTED_RANGE_NOT_SATISFIABLE` to `RANGE_NOT_SATISFIABLE`.
  - 425 `UNORDERED_COLLECTION` to `TOO_EARLY`.

- update `private static HttpResponseStatus valueOf(int)` to return
  the updated `HttpResponseStatus` for 413, 414, 416, 425.

- update `HttpResponseFactory` to create the updated error codes.

- update `BlockingStreamingHttpResponseFactory` to create the updated
  error codes.

- update `StreamingHttpResponseFactory` to create the updated error
  codes.

Result:

follow up with: #888, #884

`HttpResponseStatus` error code names follows the most recent standards.