### PR TITLE
Allow default deserializers to handle payload without specified encoding

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -668,14 +668,15 @@ public final class HeaderUtils {
         }
 
         if (UTF_8.equals(expectedCharset)) {
+            if (!hasCharset(contentTypeHeader)) {
+                return true;
+            }
             if (contentEqualsIgnoreCase(expectedContentType, TEXT_PLAIN) &&
-                    (contentEqualsIgnoreCase(contentTypeHeader, TEXT_PLAIN_UTF_8) ||
-                            !hasCharset(contentTypeHeader))) {
+                    contentEqualsIgnoreCase(contentTypeHeader, TEXT_PLAIN_UTF_8)) {
                 return true;
             }
             if (contentEqualsIgnoreCase(expectedContentType, APPLICATION_X_WWW_FORM_URLENCODED) &&
-                    (contentEqualsIgnoreCase(contentTypeHeader, APPLICATION_X_WWW_FORM_URLENCODED_UTF_8) ||
-                            !hasCharset(contentTypeHeader))) {
+                    contentEqualsIgnoreCase(contentTypeHeader, APPLICATION_X_WWW_FORM_URLENCODED_UTF_8)) {
                 return true;
             }
         }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -36,11 +36,7 @@ import static io.servicetalk.http.api.CharSequences.regionMatches;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
-import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED;
-import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED_UTF_8;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
-import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
-import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN_UTF_8;
 import static io.servicetalk.http.api.NetUtils.isValidIpV4Address;
 import static io.servicetalk.http.api.NetUtils.isValidIpV6Address;
 import static java.lang.Math.min;
@@ -669,15 +665,13 @@ public final class HeaderUtils {
         }
 
         if (UTF_8.equals(expectedCharset)) {
+            if (contentTypeHeader.length() == expectedContentType.length()) {
+                return true;
+            }
+            if (regionMatches(contentTypeHeader, true, expectedContentType.length(), "; charset=UTF-8", 0, 15)) {
+                return true;
+            }
             if (!hasCharset(contentTypeHeader)) {
-                return true;
-            }
-            if (contentEqualsIgnoreCase(expectedContentType, TEXT_PLAIN) &&
-                    contentEqualsIgnoreCase(contentTypeHeader, TEXT_PLAIN_UTF_8)) {
-                return true;
-            }
-            if (contentEqualsIgnoreCase(expectedContentType, APPLICATION_X_WWW_FORM_URLENCODED) &&
-                    contentEqualsIgnoreCase(contentTypeHeader, APPLICATION_X_WWW_FORM_URLENCODED_UTF_8)) {
                 return true;
             }
         }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -80,6 +80,7 @@ public final class HeaderUtils {
         return true;
     };
 
+    private static final Pattern HAS_CHARSET_PATTERN = compile(".+;\\s*charset=.+", CASE_INSENSITIVE);
     private static final Map<Charset, Pattern> CHARSET_PATTERNS;
 
     static {
@@ -708,7 +709,7 @@ public final class HeaderUtils {
     }
 
     private static boolean hasCharset(final CharSequence contentTypeHeader) {
-        return contentTypeHeader.toString().contains("charset=");
+        return HAS_CHARSET_PATTERN.matcher(contentTypeHeader).matches();
     }
 
     private static void validateCookieTokenAndHeaderName0(final CharSequence key) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -667,12 +667,17 @@ public final class HeaderUtils {
             return false;
         }
 
-        if (UTF_8.equals(expectedCharset) &&
-                ((contentEqualsIgnoreCase(expectedContentType, TEXT_PLAIN) &&
-                        contentEqualsIgnoreCase(contentTypeHeader, TEXT_PLAIN_UTF_8)) ||
-                (contentEqualsIgnoreCase(expectedContentType, APPLICATION_X_WWW_FORM_URLENCODED) &&
-                        contentEqualsIgnoreCase(contentTypeHeader, APPLICATION_X_WWW_FORM_URLENCODED_UTF_8)))) {
-            return true;
+        if (UTF_8.equals(expectedCharset)) {
+            if (contentEqualsIgnoreCase(expectedContentType, TEXT_PLAIN) &&
+                    (contentEqualsIgnoreCase(contentTypeHeader, TEXT_PLAIN_UTF_8) ||
+                            !hasCharset(contentTypeHeader))) {
+                return true;
+            }
+            if (contentEqualsIgnoreCase(expectedContentType, APPLICATION_X_WWW_FORM_URLENCODED) &&
+                    (contentEqualsIgnoreCase(contentTypeHeader, APPLICATION_X_WWW_FORM_URLENCODED_UTF_8) ||
+                            !hasCharset(contentTypeHeader))) {
+                return true;
+            }
         }
 
         // None of the fastlane shortcuts have bitten -> use a regex to try to match the charset param wherever it is
@@ -699,6 +704,10 @@ public final class HeaderUtils {
 
     private static Pattern compileCharsetRegex(String charsetName) {
         return compile(".*;\\s*charset=\"?" + quote(charsetName) + "\"?\\s*(;.*|$)", CASE_INSENSITIVE);
+    }
+
+    private static boolean hasCharset(final CharSequence contentTypeHeader) {
+        return contentTypeHeader.toString().contains("charset=");
     }
 
     private static void validateCookieTokenAndHeaderName0(final CharSequence key) {

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
@@ -121,6 +121,10 @@ public class HeaderUtilsTest {
                 headersWithContentType(of("text/plain;id=\"ABC@host.com\";charset=\"UTF-8\";total=2")),
                 TEXT_PLAIN, UTF_8));
 
+        assertFalse(HeaderUtils.hasContentType(
+                headersWithContentType(of("text/plain;id=\"ABC@host.com\";Charset=\"UTF-16\";total=2")),
+                TEXT_PLAIN, UTF_8));
+
         assertTrue(HeaderUtils.hasContentType(
                 headersWithContentType(of("text/plain;id=\"ABC@host.com\";total=2")),
                 TEXT_PLAIN, UTF_8));

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
@@ -110,6 +110,12 @@ public class HeaderUtilsTest {
                 headersWithContentType(of("text/plain")), TEXT_PLAIN, null));
 
         assertTrue(HeaderUtils.hasContentType(
+                headersWithContentType(of("Text/Plain")), TEXT_PLAIN, null));
+
+        assertTrue(HeaderUtils.hasContentType(
+                headersWithContentType(of("Text/Plain")), TEXT_PLAIN, UTF_8));
+
+        assertTrue(HeaderUtils.hasContentType(
                 headersWithContentType(of("text/plain;id=\"ABC@host.com\";charset=\"us-ascii\";total=2")),
                 TEXT_PLAIN, null));
 

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
@@ -142,8 +142,14 @@ public class HeaderUtilsTest {
         assertTrue(HeaderUtils.hasContentType(
                 headersWithContentType(of("image/png")), of("image/png"), null));
 
+        assertTrue(HeaderUtils.hasContentType(
+                headersWithContentType(of("image/png")), of("image/png"), UTF_8));
+
         assertFalse(HeaderUtils.hasContentType(
                 headersWithContentType(of("image/png")), APPLICATION_X_WWW_FORM_URLENCODED, null));
+
+        assertFalse(HeaderUtils.hasContentType(
+                headersWithContentType(of("image/png")), APPLICATION_X_WWW_FORM_URLENCODED, UTF_8));
 
         assertTrue(HeaderUtils.hasContentType(
                 headersWithContentType(of("image/png;charset=unknown-charset")), of("image/png"), null));

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
@@ -78,14 +78,25 @@ public class HeaderUtilsTest {
         assertFalse(HeaderUtils.hasContentType(
                 headersWithContentType(TEXT_PLAIN), APPLICATION_JSON, null));
 
-        assertFalse(HeaderUtils.hasContentType(
+        assertTrue(HeaderUtils.hasContentType(
                 headersWithContentType(TEXT_PLAIN), TEXT_PLAIN, UTF_8));
+
+        assertFalse(HeaderUtils.hasContentType(
+                headersWithContentType(TEXT_PLAIN), TEXT_PLAIN, UTF_16));
 
         assertTrue(HeaderUtils.hasContentType(
                 headersWithContentType(TEXT_PLAIN_UTF_8), TEXT_PLAIN, UTF_8));
 
         assertFalse(HeaderUtils.hasContentType(
                 headersWithContentType(TEXT_PLAIN_UTF_8), TEXT_PLAIN, US_ASCII));
+
+        assertTrue(HeaderUtils.hasContentType(
+                headersWithContentType(APPLICATION_X_WWW_FORM_URLENCODED),
+                APPLICATION_X_WWW_FORM_URLENCODED, UTF_8));
+
+        assertFalse(HeaderUtils.hasContentType(
+                headersWithContentType(APPLICATION_X_WWW_FORM_URLENCODED),
+                APPLICATION_X_WWW_FORM_URLENCODED, UTF_16));
 
         assertTrue(HeaderUtils.hasContentType(
                 headersWithContentType(APPLICATION_X_WWW_FORM_URLENCODED_UTF_8),
@@ -109,6 +120,14 @@ public class HeaderUtilsTest {
         assertTrue(HeaderUtils.hasContentType(
                 headersWithContentType(of("text/plain;id=\"ABC@host.com\";charset=\"UTF-8\";total=2")),
                 TEXT_PLAIN, UTF_8));
+
+        assertTrue(HeaderUtils.hasContentType(
+                headersWithContentType(of("text/plain;id=\"ABC@host.com\";total=2")),
+                TEXT_PLAIN, UTF_8));
+
+        assertFalse(HeaderUtils.hasContentType(
+                headersWithContentType(of("text/plain;id=\"ABC@host.com\";total=2")),
+                TEXT_PLAIN, UTF_16));
 
         assertTrue(HeaderUtils.hasContentType(
                 headersWithContentType(of("text/plain; charset=\"us-ascii\"")), TEXT_PLAIN, null));


### PR DESCRIPTION
Motivation:

Many existing services don't include charset in `Content-Type` header.
Therefore it would be convenient to have a default (UTF-8) deserializer
that can handle payload if charset is UTF-8 or no charset is specified.

Modifications:

- Add a rule to `hasContentType` method to accept no charset case when
  the expected charset is UTF-8.

Result:

The default `textDeserializer` and `formUrlEncodedDeserializer` can
deserialize payload of request/response with no charset in
`Content-Type` header.