### PR TITLE
Add recently added new status codes to response factories #889

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponseFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponseFactory.java
@@ -16,11 +16,13 @@
 package io.servicetalk.http.api;
 
 import static io.servicetalk.http.api.HttpResponseStatus.ACCEPTED;
+import static io.servicetalk.http.api.HttpResponseStatus.ALREADY_REPORTED;
 import static io.servicetalk.http.api.HttpResponseStatus.BAD_GATEWAY;
 import static io.servicetalk.http.api.HttpResponseStatus.BAD_REQUEST;
 import static io.servicetalk.http.api.HttpResponseStatus.CONFLICT;
 import static io.servicetalk.http.api.HttpResponseStatus.CONTINUE;
 import static io.servicetalk.http.api.HttpResponseStatus.CREATED;
+import static io.servicetalk.http.api.HttpResponseStatus.EARLY_HINTS;
 import static io.servicetalk.http.api.HttpResponseStatus.EXPECTATION_FAILED;
 import static io.servicetalk.http.api.HttpResponseStatus.FAILED_DEPENDENCY;
 import static io.servicetalk.http.api.HttpResponseStatus.FORBIDDEN;
@@ -28,10 +30,12 @@ import static io.servicetalk.http.api.HttpResponseStatus.FOUND;
 import static io.servicetalk.http.api.HttpResponseStatus.GATEWAY_TIMEOUT;
 import static io.servicetalk.http.api.HttpResponseStatus.GONE;
 import static io.servicetalk.http.api.HttpResponseStatus.HTTP_VERSION_NOT_SUPPORTED;
+import static io.servicetalk.http.api.HttpResponseStatus.IM_USED;
 import static io.servicetalk.http.api.HttpResponseStatus.INSUFFICIENT_STORAGE;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.servicetalk.http.api.HttpResponseStatus.LENGTH_REQUIRED;
 import static io.servicetalk.http.api.HttpResponseStatus.LOCKED;
+import static io.servicetalk.http.api.HttpResponseStatus.LOOP_DETECTED;
 import static io.servicetalk.http.api.HttpResponseStatus.METHOD_NOT_ALLOWED;
 import static io.servicetalk.http.api.HttpResponseStatus.MISDIRECTED_REQUEST;
 import static io.servicetalk.http.api.HttpResponseStatus.MOVED_PERMANENTLY;
@@ -65,6 +69,7 @@ import static io.servicetalk.http.api.HttpResponseStatus.TEMPORARY_REDIRECT;
 import static io.servicetalk.http.api.HttpResponseStatus.TOO_EARLY;
 import static io.servicetalk.http.api.HttpResponseStatus.TOO_MANY_REQUESTS;
 import static io.servicetalk.http.api.HttpResponseStatus.UNAUTHORIZED;
+import static io.servicetalk.http.api.HttpResponseStatus.UNAVAILABLE_FOR_LEGAL_REASONS;
 import static io.servicetalk.http.api.HttpResponseStatus.UNPROCESSABLE_ENTITY;
 import static io.servicetalk.http.api.HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE;
 import static io.servicetalk.http.api.HttpResponseStatus.UPGRADE_REQUIRED;
@@ -105,6 +110,14 @@ public interface BlockingStreamingHttpResponseFactory {
      */
     default BlockingStreamingHttpResponse processing() {
         return newResponse(PROCESSING);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatus#EARLY_HINTS} response.
+     * @return a new {@link HttpResponseStatus#EARLY_HINTS} response.
+     */
+    default BlockingStreamingHttpResponse earlyHints() {
+        return newResponse(EARLY_HINTS);
     }
 
     /**
@@ -169,6 +182,22 @@ public interface BlockingStreamingHttpResponseFactory {
      */
     default BlockingStreamingHttpResponse multiStatus() {
         return newResponse(MULTI_STATUS);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatus#ALREADY_REPORTED} response.
+     * @return a new {@link HttpResponseStatus#ALREADY_REPORTED} response.
+     */
+    default BlockingStreamingHttpResponse alreadyReported() {
+        return newResponse(ALREADY_REPORTED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatus#IM_USED} response.
+     * @return a new {@link HttpResponseStatus#IM_USED} response.
+     */
+    default BlockingStreamingHttpResponse imUsed() {
+        return newResponse(IM_USED);
     }
 
     /**
@@ -452,6 +481,14 @@ public interface BlockingStreamingHttpResponseFactory {
     }
 
     /**
+     * Create a new {@link HttpResponseStatus#UNAVAILABLE_FOR_LEGAL_REASONS} response.
+     * @return a new {@link HttpResponseStatus#UNAVAILABLE_FOR_LEGAL_REASONS} response.
+     */
+    default BlockingStreamingHttpResponse unavailableForLegalReasons() {
+        return newResponse(UNAVAILABLE_FOR_LEGAL_REASONS);
+    }
+
+    /**
      * Create a new {@link HttpResponseStatus#INTERNAL_SERVER_ERROR} response.
      * @return a new {@link HttpResponseStatus#INTERNAL_SERVER_ERROR} response.
      */
@@ -513,6 +550,14 @@ public interface BlockingStreamingHttpResponseFactory {
      */
     default BlockingStreamingHttpResponse insufficientStorage() {
         return newResponse(INSUFFICIENT_STORAGE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatus#LOOP_DETECTED} response.
+     * @return a new {@link HttpResponseStatus#LOOP_DETECTED} response.
+     */
+    default BlockingStreamingHttpResponse loopDetected() {
+        return newResponse(LOOP_DETECTED);
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponseFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponseFactory.java
@@ -16,11 +16,13 @@
 package io.servicetalk.http.api;
 
 import static io.servicetalk.http.api.HttpResponseStatus.ACCEPTED;
+import static io.servicetalk.http.api.HttpResponseStatus.ALREADY_REPORTED;
 import static io.servicetalk.http.api.HttpResponseStatus.BAD_GATEWAY;
 import static io.servicetalk.http.api.HttpResponseStatus.BAD_REQUEST;
 import static io.servicetalk.http.api.HttpResponseStatus.CONFLICT;
 import static io.servicetalk.http.api.HttpResponseStatus.CONTINUE;
 import static io.servicetalk.http.api.HttpResponseStatus.CREATED;
+import static io.servicetalk.http.api.HttpResponseStatus.EARLY_HINTS;
 import static io.servicetalk.http.api.HttpResponseStatus.EXPECTATION_FAILED;
 import static io.servicetalk.http.api.HttpResponseStatus.FAILED_DEPENDENCY;
 import static io.servicetalk.http.api.HttpResponseStatus.FORBIDDEN;
@@ -28,10 +30,12 @@ import static io.servicetalk.http.api.HttpResponseStatus.FOUND;
 import static io.servicetalk.http.api.HttpResponseStatus.GATEWAY_TIMEOUT;
 import static io.servicetalk.http.api.HttpResponseStatus.GONE;
 import static io.servicetalk.http.api.HttpResponseStatus.HTTP_VERSION_NOT_SUPPORTED;
+import static io.servicetalk.http.api.HttpResponseStatus.IM_USED;
 import static io.servicetalk.http.api.HttpResponseStatus.INSUFFICIENT_STORAGE;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.servicetalk.http.api.HttpResponseStatus.LENGTH_REQUIRED;
 import static io.servicetalk.http.api.HttpResponseStatus.LOCKED;
+import static io.servicetalk.http.api.HttpResponseStatus.LOOP_DETECTED;
 import static io.servicetalk.http.api.HttpResponseStatus.METHOD_NOT_ALLOWED;
 import static io.servicetalk.http.api.HttpResponseStatus.MISDIRECTED_REQUEST;
 import static io.servicetalk.http.api.HttpResponseStatus.MOVED_PERMANENTLY;
@@ -65,6 +69,7 @@ import static io.servicetalk.http.api.HttpResponseStatus.TEMPORARY_REDIRECT;
 import static io.servicetalk.http.api.HttpResponseStatus.TOO_EARLY;
 import static io.servicetalk.http.api.HttpResponseStatus.TOO_MANY_REQUESTS;
 import static io.servicetalk.http.api.HttpResponseStatus.UNAUTHORIZED;
+import static io.servicetalk.http.api.HttpResponseStatus.UNAVAILABLE_FOR_LEGAL_REASONS;
 import static io.servicetalk.http.api.HttpResponseStatus.UNPROCESSABLE_ENTITY;
 import static io.servicetalk.http.api.HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE;
 import static io.servicetalk.http.api.HttpResponseStatus.UPGRADE_REQUIRED;
@@ -105,6 +110,14 @@ public interface HttpResponseFactory {
      */
     default HttpResponse processing() {
         return newResponse(PROCESSING);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatus#EARLY_HINTS} response.
+     * @return a new {@link HttpResponseStatus#EARLY_HINTS} response.
+     */
+    default HttpResponse earlyHints() {
+        return newResponse(EARLY_HINTS);
     }
 
     /**
@@ -169,6 +182,22 @@ public interface HttpResponseFactory {
      */
     default HttpResponse multiStatus() {
         return newResponse(MULTI_STATUS);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatus#ALREADY_REPORTED} response.
+     * @return a new {@link HttpResponseStatus#ALREADY_REPORTED} response.
+     */
+    default HttpResponse alreadyReported() {
+        return newResponse(ALREADY_REPORTED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatus#IM_USED} response.
+     * @return a new {@link HttpResponseStatus#IM_USED} response.
+     */
+    default HttpResponse imUsed() {
+        return newResponse(IM_USED);
     }
 
     /**
@@ -452,6 +481,14 @@ public interface HttpResponseFactory {
     }
 
     /**
+     * Create a new {@link HttpResponseStatus#UNAVAILABLE_FOR_LEGAL_REASONS} response.
+     * @return a new {@link HttpResponseStatus#UNAVAILABLE_FOR_LEGAL_REASONS} response.
+     */
+    default HttpResponse unavailableForLegalReasons() {
+        return newResponse(UNAVAILABLE_FOR_LEGAL_REASONS);
+    }
+
+    /**
      * Create a new {@link HttpResponseStatus#INTERNAL_SERVER_ERROR} response.
      * @return a new {@link HttpResponseStatus#INTERNAL_SERVER_ERROR} response.
      */
@@ -513,6 +550,14 @@ public interface HttpResponseFactory {
      */
     default HttpResponse insufficientStorage() {
         return newResponse(INSUFFICIENT_STORAGE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatus#LOOP_DETECTED} response.
+     * @return a new {@link HttpResponseStatus#LOOP_DETECTED} response.
+     */
+    default HttpResponse loopDetected() {
+        return newResponse(LOOP_DETECTED);
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpResponseFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpResponseFactory.java
@@ -16,11 +16,13 @@
 package io.servicetalk.http.api;
 
 import static io.servicetalk.http.api.HttpResponseStatus.ACCEPTED;
+import static io.servicetalk.http.api.HttpResponseStatus.ALREADY_REPORTED;
 import static io.servicetalk.http.api.HttpResponseStatus.BAD_GATEWAY;
 import static io.servicetalk.http.api.HttpResponseStatus.BAD_REQUEST;
 import static io.servicetalk.http.api.HttpResponseStatus.CONFLICT;
 import static io.servicetalk.http.api.HttpResponseStatus.CONTINUE;
 import static io.servicetalk.http.api.HttpResponseStatus.CREATED;
+import static io.servicetalk.http.api.HttpResponseStatus.EARLY_HINTS;
 import static io.servicetalk.http.api.HttpResponseStatus.EXPECTATION_FAILED;
 import static io.servicetalk.http.api.HttpResponseStatus.FAILED_DEPENDENCY;
 import static io.servicetalk.http.api.HttpResponseStatus.FORBIDDEN;
@@ -28,10 +30,12 @@ import static io.servicetalk.http.api.HttpResponseStatus.FOUND;
 import static io.servicetalk.http.api.HttpResponseStatus.GATEWAY_TIMEOUT;
 import static io.servicetalk.http.api.HttpResponseStatus.GONE;
 import static io.servicetalk.http.api.HttpResponseStatus.HTTP_VERSION_NOT_SUPPORTED;
+import static io.servicetalk.http.api.HttpResponseStatus.IM_USED;
 import static io.servicetalk.http.api.HttpResponseStatus.INSUFFICIENT_STORAGE;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.servicetalk.http.api.HttpResponseStatus.LENGTH_REQUIRED;
 import static io.servicetalk.http.api.HttpResponseStatus.LOCKED;
+import static io.servicetalk.http.api.HttpResponseStatus.LOOP_DETECTED;
 import static io.servicetalk.http.api.HttpResponseStatus.METHOD_NOT_ALLOWED;
 import static io.servicetalk.http.api.HttpResponseStatus.MISDIRECTED_REQUEST;
 import static io.servicetalk.http.api.HttpResponseStatus.MOVED_PERMANENTLY;
@@ -65,6 +69,7 @@ import static io.servicetalk.http.api.HttpResponseStatus.TEMPORARY_REDIRECT;
 import static io.servicetalk.http.api.HttpResponseStatus.TOO_EARLY;
 import static io.servicetalk.http.api.HttpResponseStatus.TOO_MANY_REQUESTS;
 import static io.servicetalk.http.api.HttpResponseStatus.UNAUTHORIZED;
+import static io.servicetalk.http.api.HttpResponseStatus.UNAVAILABLE_FOR_LEGAL_REASONS;
 import static io.servicetalk.http.api.HttpResponseStatus.UNPROCESSABLE_ENTITY;
 import static io.servicetalk.http.api.HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE;
 import static io.servicetalk.http.api.HttpResponseStatus.UPGRADE_REQUIRED;
@@ -105,6 +110,14 @@ public interface StreamingHttpResponseFactory {
      */
     default StreamingHttpResponse processing() {
         return newResponse(PROCESSING);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatus#EARLY_HINTS} response.
+     * @return a new {@link HttpResponseStatus#EARLY_HINTS} response.
+     */
+    default StreamingHttpResponse earlyHints() {
+        return newResponse(EARLY_HINTS);
     }
 
     /**
@@ -169,6 +182,22 @@ public interface StreamingHttpResponseFactory {
      */
     default StreamingHttpResponse multiStatus() {
         return newResponse(MULTI_STATUS);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatus#ALREADY_REPORTED} response.
+     * @return a new {@link HttpResponseStatus#ALREADY_REPORTED} response.
+     */
+    default StreamingHttpResponse alreadyReported() {
+        return newResponse(ALREADY_REPORTED);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatus#IM_USED} response.
+     * @return a new {@link HttpResponseStatus#IM_USED} response.
+     */
+    default StreamingHttpResponse imUsed() {
+        return newResponse(IM_USED);
     }
 
     /**
@@ -452,6 +481,14 @@ public interface StreamingHttpResponseFactory {
     }
 
     /**
+     * Create a new {@link HttpResponseStatus#UNAVAILABLE_FOR_LEGAL_REASONS} response.
+     * @return a new {@link HttpResponseStatus#UNAVAILABLE_FOR_LEGAL_REASONS} response.
+     */
+    default StreamingHttpResponse unavailableForLegalReasons() {
+        return newResponse(UNAVAILABLE_FOR_LEGAL_REASONS);
+    }
+
+    /**
      * Create a new {@link HttpResponseStatus#INTERNAL_SERVER_ERROR} response.
      * @return a new {@link HttpResponseStatus#INTERNAL_SERVER_ERROR} response.
      */
@@ -513,6 +550,14 @@ public interface StreamingHttpResponseFactory {
      */
     default StreamingHttpResponse insufficientStorage() {
         return newResponse(INSUFFICIENT_STORAGE);
+    }
+
+    /**
+     * Create a new {@link HttpResponseStatus#LOOP_DETECTED} response.
+     * @return a new {@link HttpResponseStatus#LOOP_DETECTED} response.
+     */
+    default StreamingHttpResponse loopDetected() {
+        return newResponse(LOOP_DETECTED);
     }
 
     /**

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseFactoryStatusCodeTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseFactoryStatusCodeTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.buffer.netty.BufferAllocators;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.http.api.BlockingStreamingHttpResponse;
+import io.servicetalk.http.api.BlockingStreamingHttpResponseFactory;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.HttpResponseFactory;
+import io.servicetalk.http.api.HttpResponseMetaData;
+import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static io.servicetalk.http.api.DefaultHttpHeadersFactory.INSTANCE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+public class HttpResponseFactoryStatusCodeTest {
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+    private static List<HttpResponseStatus> expectedStatuses;
+
+    @BeforeClass
+    public static void before() {
+        expectedStatuses = IntStream.range(100, 600)
+                .mapToObj(code -> HttpResponseStatus.of(Integer.toString(code)))
+                .filter(status -> !"unknown".equals(status.reasonPhrase()))
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    public void testStatusCode() {
+        final HttpResponseFactory httpResponseFactory =
+                new DefaultHttpResponseFactory(INSTANCE, BufferAllocators.DEFAULT_ALLOCATOR);
+
+        List<HttpResponseStatus> actualStatuses =
+                buildHttpStatuses(httpResponseFactory, HttpResponseFactory.class, HttpResponse.class);
+
+        assertThat("unexpected statuses", actualStatuses, containsInAnyOrder(expectedStatuses.toArray()));
+    }
+
+    @Test
+    public void testBlockingStatusCode() {
+
+        final BlockingStreamingHttpResponseFactory blockingStreamingHttpResponseFactory =
+                new DefaultBlockingStreamingHttpResponseFactory(INSTANCE, BufferAllocators.DEFAULT_ALLOCATOR);
+
+        List<HttpResponseStatus> actualStatuses =
+                buildHttpStatuses(blockingStreamingHttpResponseFactory,
+                        BlockingStreamingHttpResponseFactory.class, BlockingStreamingHttpResponse.class);
+
+        assertThat("unexpected statuses", actualStatuses, containsInAnyOrder(expectedStatuses.toArray()));
+    }
+
+    @Test
+    public void testStreamingStatusCode() {
+
+        final StreamingHttpResponseFactory streamingHttpResponseFactory =
+                new DefaultStreamingHttpResponseFactory(INSTANCE, BufferAllocators.DEFAULT_ALLOCATOR);
+
+        List<HttpResponseStatus> actualStatuses =
+                buildHttpStatuses(streamingHttpResponseFactory,
+                        StreamingHttpResponseFactory.class, StreamingHttpResponse.class);
+
+        assertThat("unexpected statuses", actualStatuses, containsInAnyOrder(expectedStatuses.toArray()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T, R extends HttpResponseMetaData> List<HttpResponseStatus> buildHttpStatuses(
+            final T factory, final Class<T> factoryClass, final Class<R> returnType) {
+        return Arrays.stream(factoryClass.getMethods())
+                .filter(method -> method.getParameterCount() == 0 &&
+                        method.getReturnType().equals(returnType))
+                .map(method -> {
+                    try {
+                        return (R) method.invoke(factory);
+                    } catch (IllegalAccessException | InvocationTargetException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .map(HttpResponseMetaData::status)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
Motivation:

Add 5 http status methods for HttpResponseFactory, BlockingStreamingHttpResponseFactory and StreamingHttpResponseFactory

Modifications:

add methods to BlockingStreamingHttpResponseFactory
add methods to HttpResponseFactory
add methods to StreamingHttpResponseFactory
add test HttpResponseFactoryStatusCodeTest

Result:

Fixes #889