### PR TITLE
Revert 0c4280dcc59dd2a8c21f29ddf12f04a1e85c4141

### DIFF
--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableDirectByteBuf.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableDirectByteBuf.java
@@ -33,16 +33,6 @@ final class UnreleasableDirectByteBuf extends UnpooledDirectByteBuf {
     }
 
     @Override
-    protected void freeDirect(ByteBuffer buffer) {
-        // Do nothing!
-        // In the event a Buffer's capacity needs to be adjusted (e.g. attempting to writeBytes may cause a resize)
-        // Netty may attempt to reclaim the old memory. Since ServiceTalk doesn't expose reference counting to reclaim
-        // memory it maybe the case that the application has a reference to the old memory on a different thread. If
-        // the application dereferences the memory that is force-freed by Netty this will lead to undefined behavior.
-        // In summary we don't want Netty to deallocate any memory and instead we want to rely upon the GC.
-    }
-
-    @Override
     public ByteBuf asReadOnly() {
         return Unpooled.unreleasableBuffer(super.asReadOnly());
     }

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableUnsafeDirectByteBuf.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableUnsafeDirectByteBuf.java
@@ -32,16 +32,6 @@ class UnreleasableUnsafeDirectByteBuf extends UnpooledUnsafeDirectByteBuf {
     }
 
     @Override
-    protected final void freeDirect(ByteBuffer buffer) {
-        // Do nothing!
-        // In the event a Buffer's capacity needs to be adjusted (e.g. attempting to writeBytes may cause a resize)
-        // Netty may attempt to reclaim the old memory. Since ServiceTalk doesn't expose reference counting to reclaim
-        // memory it maybe the case that the application has a reference to the old memory on a different thread. If
-        // the application dereferences the memory that is force-freed by Netty this will lead to undefined behavior.
-        // In summary we don't want Netty to deallocate any memory and instead we want to rely upon the GC.
-    }
-
-    @Override
     public final ByteBuf asReadOnly() {
         return Unpooled.unreleasableBuffer(super.asReadOnly());
     }


### PR DESCRIPTION
Motivation:
0c4280dcc59dd2a8c21f29ddf12f04a1e85c4141 attempted to avoid reclaiming of old
memory when resized for cases where the memory maybe shared by multiple threads.
However modifying a Buffer accross mulitiple threads may lead to visibility
issues where the reference to the new array maybe visible before the memory is
copied into the array, and in general requires external synchornization.

Modificiations:
- Revert the freeDirect(ByteBuffer) override introduced in
0c4280dcc59dd2a8c21f29ddf12f04a1e85c4141

Result:
We can reclaim intermediate memory from resize operations again.