### PR TITLE
HTTP/1.x and HTTP/2.0 decoder Buffer visibility and data corruption

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseDecoderBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseDecoderBenchmark.java
@@ -83,10 +83,8 @@ public class HttpResponseDecoderBenchmark {
         responseBuffer.writeShort(CRLF_SHORT);
         responseByteBuf = toByteBuf(responseBuffer.slice());
 
-        final HttpResponseDecoder decoder = new HttpResponseDecoder(new ArrayDeque<>(),
-                DefaultHttpHeadersFactory.INSTANCE, 8192, 8192);
-        decoder.setDiscardAfterReads(1);
-        channel = new EmbeddedChannel(decoder);
+        channel = new EmbeddedChannel(new HttpResponseDecoder(new ArrayDeque<>(),
+                DefaultHttpHeadersFactory.INSTANCE, 8192, 8192));
     }
 
     @Benchmark

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/ServiceTalkBufferAllocator.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/ServiceTalkBufferAllocator.java
@@ -45,7 +45,6 @@ final class ServiceTalkBufferAllocator extends AbstractByteBufAllocator implemen
     private final boolean noZeroing;
 
     ServiceTalkBufferAllocator(boolean preferDirect, boolean tryNoZeroing) {
-
         super(preferDirect);
         this.noZeroing = tryNoZeroing && useDirectBufferWithoutZeroing();
     }

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableCompositeByteBuf.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableCompositeByteBuf.java
@@ -24,6 +24,12 @@ final class UnreleasableCompositeByteBuf extends CompositeByteBuf {
 
     UnreleasableCompositeByteBuf(ByteBufAllocator alloc, boolean direct, int maxNumComponents) {
         super(alloc, direct, maxNumComponents);
+        // ServiceTalk buffers are unreleasable. There are some optimizations in Netty which use `refCnt() > 1` to
+        // judge if a ByteBuf maybe shared, and if not shared Netty may assume is is safe to make changes to the
+        // underlying storage (e.g. write reallocation, compact data in place) of the ByteBuf which may lead to
+        // visibility issues across threads and data corruption. We retain() here to imply the ByteBuf maybe shared and
+        // these optimizations are not safe.
+        super.retain();
     }
 
     @Override

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableDirectByteBuf.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableDirectByteBuf.java
@@ -26,10 +26,22 @@ final class UnreleasableDirectByteBuf extends UnpooledDirectByteBuf {
 
     UnreleasableDirectByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
         super(alloc, initialCapacity, maxCapacity);
+        // ServiceTalk buffers are unreleasable. There are some optimizations in Netty which use `refCnt() > 1` to
+        // judge if a ByteBuf maybe shared, and if not shared Netty may assume is is safe to make changes to the
+        // underlying storage (e.g. write reallocation, compact data in place) of the ByteBuf which may lead to
+        // visibility issues across threads and data corruption. We retain() here to imply the ByteBuf maybe shared and
+        // these optimizations are not safe.
+        super.retain();
     }
 
     UnreleasableDirectByteBuf(ByteBufAllocator alloc, ByteBuffer initialBuffer, int maxCapacity) {
         super(alloc, initialBuffer, maxCapacity);
+        // ServiceTalk buffers are unreleasable. There are some optimizations in Netty which use `refCnt() > 1` to
+        // judge if a ByteBuf maybe shared, and if not shared Netty may assume is is safe to make changes to the
+        // underlying storage (e.g. write reallocation, compact data in place) of the ByteBuf which may lead to
+        // visibility issues across threads and data corruption. We retain() here to imply the ByteBuf maybe shared and
+        // these optimizations are not safe.
+        super.retain();
     }
 
     @Override

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableHeapByteBuf.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableHeapByteBuf.java
@@ -24,10 +24,22 @@ class UnreleasableHeapByteBuf extends UnpooledHeapByteBuf {
 
     UnreleasableHeapByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
         super(alloc, initialCapacity, maxCapacity);
+        // ServiceTalk buffers are unreleasable. There are some optimizations in Netty which use `refCnt() > 1` to
+        // judge if a ByteBuf maybe shared, and if not shared Netty may assume is is safe to make changes to the
+        // underlying storage (e.g. write reallocation, compact data in place) of the ByteBuf which may lead to
+        // visibility issues across threads and data corruption. We retain() here to imply the ByteBuf maybe shared and
+        // these optimizations are not safe.
+        super.retain();
     }
 
     UnreleasableHeapByteBuf(ByteBufAllocator alloc, byte[] initialArray, int maxCapacity) {
         super(alloc, initialArray, maxCapacity);
+        // ServiceTalk buffers are unreleasable. There are some optimizations in Netty which use `refCnt() > 1` to
+        // judge if a ByteBuf maybe shared, and if not shared Netty may assume is is safe to make changes to the
+        // underlying storage (e.g. write reallocation, compact data in place) of the ByteBuf which may lead to
+        // visibility issues across threads and data corruption. We retain() here to imply the ByteBuf maybe shared and
+        // these optimizations are not safe.
+        super.retain();
     }
 
     @Override

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableUnsafeDirectByteBuf.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableUnsafeDirectByteBuf.java
@@ -25,10 +25,22 @@ import java.nio.ByteBuffer;
 class UnreleasableUnsafeDirectByteBuf extends UnpooledUnsafeDirectByteBuf {
     UnreleasableUnsafeDirectByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
         super(alloc, initialCapacity, maxCapacity);
+        // ServiceTalk buffers are unreleasable. There are some optimizations in Netty which use `refCnt() > 1` to
+        // judge if a ByteBuf maybe shared, and if not shared Netty may assume is is safe to make changes to the
+        // underlying storage (e.g. write reallocation, compact data in place) of the ByteBuf which may lead to
+        // visibility issues across threads and data corruption. We retain() here to imply the ByteBuf maybe shared and
+        // these optimizations are not safe.
+        super.retain();
     }
 
     UnreleasableUnsafeDirectByteBuf(ByteBufAllocator alloc, ByteBuffer initialBuffer, int maxCapacity) {
         super(alloc, initialBuffer, maxCapacity);
+        // ServiceTalk buffers are unreleasable. There are some optimizations in Netty which use `refCnt() > 1` to
+        // judge if a ByteBuf maybe shared, and if not shared Netty may assume is is safe to make changes to the
+        // underlying storage (e.g. write reallocation, compact data in place) of the ByteBuf which may lead to
+        // visibility issues across threads and data corruption. We retain() here to imply the ByteBuf maybe shared and
+        // these optimizations are not safe.
+        super.retain();
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -409,9 +409,11 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
     }
 
     @Override
-    protected final ByteBuf swapCumulation(ByteBuf cumulation, ByteBufAllocator allocator) {
+    protected final ByteBuf swapAndCopyCumulation(final ByteBufAllocator alloc,
+                                                  final ByteBuf cumulation,
+                                                  final ByteBuf in) {
         final int readerIndex = cumulation.readerIndex();
-        ByteBuf newCumulation = super.swapCumulation(cumulation, allocator);
+        ByteBuf newCumulation = super.swapAndCopyCumulation(alloc, cumulation, in);
         cumulationIndex -= readerIndex - newCumulation.readerIndex();
         return newCumulation;
     }
@@ -525,8 +527,8 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
             cumulationIndex = buffer.writerIndex();
             return false;
         } else {
-            cumulationIndex = i;
             buffer.readerIndex(i);
+            cumulationIndex = i;
             return true;
         }
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
@@ -410,10 +410,8 @@ public class HttpRequestDecoderTest {
     }
 
     private static EmbeddedChannel newEmbeddedChannel() {
-        HttpRequestDecoder decoder = new HttpRequestDecoder(new ArrayDeque<>(),
-                DefaultHttpHeadersFactory.INSTANCE, 8192, 8192);
-        decoder.setDiscardAfterReads(1);
-        return new EmbeddedChannel(decoder);
+        return new EmbeddedChannel(new HttpRequestDecoder(new ArrayDeque<>(),
+                DefaultHttpHeadersFactory.INSTANCE, 8192, 8192));
     }
 
     private static void validateHttpRequest(EmbeddedChannel channel, int expectedContentLength) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
@@ -473,9 +473,7 @@ public class HttpResponseDecoderTest {
     }
 
     private static EmbeddedChannel newEmbeddedChannel() {
-        HttpResponseDecoder decoder = new HttpResponseDecoder(new ArrayDeque<>(), DefaultHttpHeadersFactory.INSTANCE,
-                8192, 8192);
-        decoder.setDiscardAfterReads(1);
-        return new EmbeddedChannel(decoder);
+        return new EmbeddedChannel(new HttpResponseDecoder(new ArrayDeque<>(), DefaultHttpHeadersFactory.INSTANCE,
+                8192, 8192));
     }
 }


### PR DESCRIPTION
Motivation:
ServiceTalk attempts to effectivley disable Netty's reference counting by using
a strategy similar to Netty's `UnreleasableByteBuf` to short circit operations
which attempt to modify the reference count, and therefore prevent the reference
count from reaching zero and prematruley freeing memory. ServiceTalk's
ByteBuf instances will therefore always have a `refCnt() == 1`. However Netty's
ByteToMessageDecoder uses `refCnt() > 1` to determine if the cumulation ByteBuf
maybe shared, and if not it may compact data in place. This compacting data in
place may result in a corrupted view of data from the perspective of offloaded
threads in ServiceTalk, and for example result in failures to decode HTTP/2 data
such as gRPC frames.

ServiceTalk's `ByteToMessageDecoder` uses Netty's
`ByteToMessageDecoder#MERGE_CUMULATOR` to manage accumulation of data. As of
Netty 4.1.43.Final this may result in writing into the `cumulation` ByteBuf such
that a reallocation opearation occurs. This reallocation operation is not done
in a thread safe way and this may result in visibility issues when referencing
the same `Buffer` object from another thread (e.g. when offloading is enabled).
This may result in the applicaiton thread observing an empty `Buffer` if the
reference to the newly allocated memory is visibile before the copy operation is
visible.

Modifications:
- All `ByteBuf` objects generated by `ServiceTalkBufferAllocator` should have a
`refCnt() > 1` to avoid any optimizations which may assume exclusive ownership
of a `ByteBuf` in Netty. This will prevent corrupted content for HTTP/2.x and
gRPC use cases. This may result in more reallocation/copy operations in Netty's
`ByteToMessageDecoder` and there is a Netty PR
https://github.com/netty/netty/pull/9877 intended to improve this behavior.
- ServiceTalk's `ByteToMessageDecoder` should not use
`ByteToMessageDecoder#MERGE_CUMULATOR` and instead use a strategy similar to
https://github.com/netty/netty/pull/9877 to do the accumulation of bytes. It is
also unecessary to attempt to compact the buffer after accumulation has been
attempted, as any compaction can be handled in the accumulation.

Result:
No more decode related visibility issues for HTTP/1.x and no more content
corruption and visibility issues for HTTP/2.0 / gRPC.