### PR TITLE
Disallow space after header name and colon

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
@@ -101,9 +101,9 @@ public class HttpRequestDecoderTest {
         byte[] content = new byte[128];
         ThreadLocalRandom.current().nextBytes(content);
         byte[] beforeContentBytes = ("GET /some/path?foo=bar&baz=yyy HTTP/1.1" + "\r\n" +
-                " Connection :  keep-alive " + "\r\n" +
-                "  User-Agent  :        unit-test        " + "\r\n" +
-                "   Content-Length  : " + content.length + "\r\n" + "\r\n").getBytes(US_ASCII);
+                " Connection:  keep-alive " + "\r\n" +
+                "  User-Agent:        unit-test        " + "\r\n" +
+                "   Content-Length: " + content.length + "\r\n" + "\r\n").getBytes(US_ASCII);
         assertTrue(channel.writeInbound(wrappedBuffer(beforeContentBytes)));
         assertTrue(channel.writeInbound(wrappedBuffer(content)));
 
@@ -134,8 +134,8 @@ public class HttpRequestDecoderTest {
         byte[] content = new byte[128];
         ThreadLocalRandom.current().nextBytes(content);
         byte[] beforeContentBytes = ("GET /some/path?foo=bar&baz=yyy HTTP/1.1" + "\r\n" +
-                "Connection   :keep-alive" + "\r\n" +
-                "   User-Agent   :unit-test" + "\r\n" +
+                "Connection:keep-alive" + "\r\n" +
+                "   User-Agent:unit-test" + "\r\n" +
                 "Empty:" + "\r\n" +
                 "EmptyWhitespace:   " + "\r\n" +
                 "SingleCharacterNoWhiteSpace: a" + "\r\n" +
@@ -327,6 +327,21 @@ public class HttpRequestDecoderTest {
         expectedException.expect(instanceOf(DecoderException.class));
         expectedException.expectCause(instanceOf(IllegalArgumentException.class));
         channel.writeInbound(wrappedBuffer(content));
+    }
+
+    @Test(expected = DecoderException.class)
+    public void testWhitespaceNotAllowedBetweenHeaderFieldNameAndColon() {
+        EmbeddedChannel channel = newEmbeddedChannel();
+        try {
+            byte[] beforeContentBytes = ("GET /some/path HTTP/1.1\r\n" +
+                    "Transfer-Encoding : chunked\r\n" +
+                    "Host: servicetalk.io\r\n\r\n").getBytes(US_ASCII);
+
+            assertTrue(channel.writeInbound(wrappedBuffer(beforeContentBytes)));
+            channel.readInbound();
+        } finally {
+            channel.finishAndReleaseAll();
+        }
     }
 
     @Test(expected = DecoderException.class)

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
@@ -108,9 +108,9 @@ public class HttpResponseDecoderTest {
         byte[] content = new byte[128];
         ThreadLocalRandom.current().nextBytes(content);
         byte[] beforeContentBytes = ("HTTP/1.1 200 OK" + "\r\n" +
-                " Connection :  keep-alive " + "\r\n" +
-                "  Server  :        unit-test        " + "\r\n" +
-                "   Content-Length  : " + content.length + "\r\n" + "\r\n").getBytes(US_ASCII);
+                " Connection:  keep-alive " + "\r\n" +
+                "  Server:        unit-test        " + "\r\n" +
+                "   Content-Length: " + content.length + "\r\n" + "\r\n").getBytes(US_ASCII);
         assertTrue(channel.writeInbound(wrappedBuffer(beforeContentBytes)));
         assertTrue(channel.writeInbound(wrappedBuffer(content)));
 
@@ -141,8 +141,8 @@ public class HttpResponseDecoderTest {
         byte[] content = new byte[128];
         ThreadLocalRandom.current().nextBytes(content);
         byte[] beforeContentBytes = ("HTTP/1.1 200 OK" + "\r\n" +
-                "Connection   :keep-alive" + "\r\n" +
-                "   Server   :unit-test" + "\r\n" +
+                "Connection:keep-alive" + "\r\n" +
+                "   Server:unit-test" + "\r\n" +
                 "Empty:" + "\r\n" +
                 "EmptyWhitespace:   " + "\r\n" +
                 "SingleCharacterNoWhiteSpace: a" + "\r\n" +
@@ -351,6 +351,21 @@ public class HttpResponseDecoderTest {
         HttpHeaders lastChunk = channel.readInbound();
         assertTrue(lastChunk.isEmpty());
         assertFalse(channel.finishAndReleaseAll());
+    }
+
+    @Test(expected = DecoderException.class)
+    public void testWhitespaceNotAllowedBetweenHeaderFieldNameAndColon() {
+        EmbeddedChannel channel = newEmbeddedChannel();
+        try {
+            byte[] beforeContentBytes = ("HTTP/1.1 200 OK\r\n" +
+                    "Transfer-Encoding : chunked\r\n" +
+                    "Host: servicetalk.io\r\n\r\n").getBytes(US_ASCII);
+
+            assertTrue(channel.writeInbound(wrappedBuffer(beforeContentBytes)));
+            channel.readInbound();
+        } finally {
+            channel.finishAndReleaseAll();
+        }
     }
 
     @Test


### PR DESCRIPTION
Motivation:
https://tools.ietf.org/html/rfc7230#section-3.2.4 specifies that spaces are
prohibited between the end of the header-name and the colon. Our header parsing
is currently liberal and allows a space. This may leave us vulnerable to HTTP
request smuggling.

Modifications:
- HttpObjectDecoder should prevent white space before the colon when paring
  header-name field

Result:
HTTP/1.x header parsing follows
https://tools.ietf.org/html/rfc7230#section-3.2.4