### PR TITLE
Publishing of docs didn't update SNAPSHOT versions.

### DIFF
--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -81,7 +81,7 @@ if [ ! -z "$version" ]; then
 fi
 
 pushd gh-pages
-# Do not override older javadoc with anotra's placeholder:
+# Do not override older javadoc with Antora's placeholder:
 git diff --name-only | grep 'javadoc/index.html' | grep -v $version | grep -v SNAPSHOT | xargs git checkout --
 
 git add * .nojekyll

--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -71,6 +71,8 @@ git worktree add gh-pages gh-pages
 touch gh-pages/.nojekyll
 \cp -r $DOCS_FOLDER/* gh-pages
 echo "Copy javadoc to gh-pages/servicetalk/SNAPSHOT"
+# Avoid accumulating old javadocs for classes that have been moved, renamed or deleted.
+rm -rf gh-pages/servicetalk/SNAPSHOT/javadoc
 \cp -r $JAVADOC_FOLDER gh-pages/servicetalk/SNAPSHOT
 if [ ! -z "$version" ]; then
     echo "Copy javadoc to gh-pages/servicetalk/$version"
@@ -79,10 +81,7 @@ fi
 
 pushd gh-pages
 # Do not override older javadoc with anotra's placeholder:
-for file in $(git diff --name-only | grep -v "servicetalk/SNAPSHOT/javadoc/index.html" | \
-  grep -v "servicetalk/$version/javadoc/index.html"); do
-    git checkout -- $file
-done
+git diff --name-only | grep 'javadoc/index.html' | xargs git checkout --
 
 git add * .nojekyll
 if [ -z "$version" ]; then
@@ -94,8 +93,10 @@ fi
 git push docs gh-pages
 popd
 
-rm -rf gh-pages
-git worktree prune
+# Cleanup gh-pages state for future runs based on remote
+git worktree remove gh-pages
+# above takes care of removal: rm -rf gh-pages
+git branch -D gh-pages
 
 if [ -z "$version" ]; then
     echo "Docs website for the SNAPSHOT version successfully updated"

--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -76,12 +76,13 @@ rm -rf gh-pages/servicetalk/SNAPSHOT/javadoc
 \cp -r $JAVADOC_FOLDER gh-pages/servicetalk/SNAPSHOT
 if [ ! -z "$version" ]; then
     echo "Copy javadoc to gh-pages/servicetalk/$version"
+    rm -rf gh-pages/servicetalk/$version/javadoc
     \cp -r $JAVADOC_FOLDER gh-pages/servicetalk/$version
 fi
 
 pushd gh-pages
 # Do not override older javadoc with anotra's placeholder:
-git diff --name-only | grep 'javadoc/index.html' | xargs git checkout --
+git diff --name-only | grep 'javadoc/index.html' | grep -v $version | grep -v SNAPSHOT | xargs git checkout --
 
 git add * .nojekyll
 if [ -z "$version" ]; then


### PR DESCRIPTION
__Motivation__

A prior fix to avoid overwriting javadoc indexes for older versions with the antora placeholders introduced an issue where SNAPSHOT docs were no longer being updated.

__Modifications__

- Change the approach to filtering which ensure only the javadocs indices are reset
- Fix an issue with javadocs for SNAPSHOT not cleaning up older versions of removed or renamed classes

__Result__

Correct docs.