### PR TITLE
Run protoc:buildExecutable task right after `compileJava`

### DIFF
--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -68,7 +68,7 @@ exit1
     outputFile.executable = true
   }
 }
-classes.finalizedBy(buildExecutable)
+tasks.compileJava.finalizedBy(buildExecutable)
 
 publishing {
   publications {


### PR DESCRIPTION
Motivation:

Currently, `:servicetalk-grpc-protoc:buildExecutable` task runs after
`classes` task. `classes` task depends on `compileJava`. Therefore,
when we do `./gradlew clean compileJava` it doesn't trigger
`:servicetalk-grpc-protoc:buildExecutable` and grpc examples compilation
fails.

Modifications:

- Finalize `:servicetalk-grpc-protoc:compileJava` task by `buildExecutable`;

Result:

`./gradlew clean compileJava` works fine.

Follow up for #823