### PR TITLE
Minor updates to reactive-streams adapter

### DIFF
--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/ReactiveStreamsAdaptersTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/ReactiveStreamsAdaptersTest.java
@@ -95,8 +95,7 @@ public class ReactiveStreamsAdaptersTest {
     @Test
     public void toRSFromSourceSuccess() {
         PublisherSource<Integer> source = s -> s.onSubscribe(new ScalarValueSubscription<>(1, s));
-        Subscriber<Integer> subscriber = toRSPublisherFromSourceAndSubscribe(source);
-        verifyRSSuccess(subscriber);
+        verifyRSSuccess(toRSPublisherFromSourceAndSubscribe(source));
     }
 
     private void verifyRSSuccess(final Subscriber<Integer> subscriber) {


### PR DESCRIPTION
__Motivation__

As part of reviewing https://github.com/apple/servicetalk/pull/904 following issues were observed in `ReactiveStreamsAdapters`:

- One method Javadoc had a typo linking to the wrong class.
- Name of internal classes were not consistently indicating the intent.
- Internal class `PublisherToRSPublisher` is redundant, we can instead use `PublisherSourceToRSPublisher`

__Modification__

- Fixed javadoc
- Renamed classes to follow [Rs, St]To[Rs, St][Publisher, Subscriber, Subscription] format
- Inlined a variable in the test.

__Result__

Better readability for `ReactiveStreamsAdapters`