### PR TITLE
Move RPC paths to generated RPC interfaces

### DIFF
--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Words.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Words.java
@@ -50,6 +50,7 @@ final class Words {
     static final String Rpc = "Rpc";
     static final String To = "To";
     static final String INSTANCE = "INSTANCE";
+    static final String RPC_PATH = "PATH";
 
     private Words() {
         // no instance


### PR DESCRIPTION
__Motivation__

gRPC generated code uses an `Enum` to define all RPC paths. It is convenient to have all paths together but they are detached from the actual RPC methods for which the paths are defined.

__Modification__

- Remove `RpcPaths` `Enum` from generated code.
- Generate a `PATH` constant for all individual RPC interfaces.
- Async interfaces defines the `PATH` constant with the actual path `String`.
- Blocking interfaces define the `PATH` constant which referr to the async `PATH` constant.

__Result__

RPC paths are attached to the associate RPC interfaces.