### PR TITLE
Do not compare request methods and response statuses by reference

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
@@ -65,7 +65,7 @@ final class GrpcUtils {
     }
 
     static void initRequest(final HttpRequestMetaData request) {
-        assert request.method() == POST;
+        assert POST.equals(request.method());
         final HttpHeaders headers = request.headers();
         headers.set(USER_AGENT, GRPC_USER_AGENT);
         headers.set(TE, TRAILERS);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
@@ -44,6 +44,7 @@ import static io.servicetalk.http.api.HttpExecutionStrategies.OFFLOAD_RECEIVE_ME
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_0;
+import static io.servicetalk.http.api.HttpRequestMethod.HEAD;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.StreamingHttpResponses.newTransportResponse;
 import static java.lang.Thread.currentThread;
@@ -106,7 +107,7 @@ final class BlockingStreamingToStreamingService extends AbstractServiceAdapterHo
                                     // breaks our HttpResponseDecoder
                                     // TODO(jayv) we can provide an optimized PayloadWriter for HEAD response that
                                     // immediately completes on sendMeta() and disallows further writes or trailers
-                                    request.method() != HttpRequestMethod.HEAD) {
+                                    !HEAD.equals(request.method())) {
                                 // this is likely not supported in http/1.0 and it is possible that a response has
                                 // neither header and the connection close indicates the end of the response.
                                 // https://tools.ietf.org/html/rfc7230#section-3.3.3

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -747,7 +747,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
             HttpRequestMetaData req = (HttpRequestMetaData) message;
             // Note that we are using ServiceTalk constants for HttpRequestMethod here, and assume the decoders will
             // also use ServiceTalk constants which allows us to use reference check here:
-            if (req.method() == GET &&
+            if (GET.equals(req.method()) &&
                     h.contains(SEC_WEBSOCKET_KEY1) &&
                     h.contains(SEC_WEBSOCKET_KEY2)) {
                 return 8;

--- a/servicetalk-http-security-jersey/src/test/java/io/servicetalk/http/security/auth/basic/jersey/AbstractBasicAuthSecurityContextFilterTest.java
+++ b/servicetalk-http-security-jersey/src/test/java/io/servicetalk/http/security/auth/basic/jersey/AbstractBasicAuthSecurityContextFilterTest.java
@@ -198,6 +198,6 @@ public abstract class AbstractBasicAuthSecurityContextFilterTest {
         final HttpResponse res = httpClient.request(req);
         assertThat(res.status(), is(expectedStatus));
 
-        return res.status() == OK ? res.payloadBody().toString(UTF_8) : null;
+        return OK.equals(res.status()) ? res.payloadBody().toString(UTF_8) : null;
     }
 }


### PR DESCRIPTION
Motivation:

`HttpRequestMethod` and `HttpResponseStatus` are classes with static
constants, not enums. We should use `equals` to compare them. Otherwise,
users' implementation of these classes won't work correctly.

Modifications:

- Replace all `==` and `!=` for `HttpRequestMetaData.method()` and
`HttpResponseMetaData.status()` with `equals`;

Result:

Correct comparison of `HttpRequestMethod` and `HttpResponseStatus`
objects.