### PR TITLE
Rename `HttpServiceContext.streamingBlockingResponseFactory()`

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServiceContext.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServiceContext.java
@@ -90,7 +90,7 @@ public abstract class HttpServiceContext implements ConnectionContext {
      *
      * @return {@link BlockingStreamingHttpResponseFactory} associated with this {@link HttpServiceContext}.
      */
-    protected final BlockingStreamingHttpResponseFactory streamingBlockingResponseFactory() {
+    protected final BlockingStreamingHttpResponseFactory blockingStreamingResponseFactory() {
         return blockingFactory;
     }
 }


### PR DESCRIPTION
Motivation:

We always use `BlockingStreaming*` prefix instead of `StreamingBlocking*`.

Modification:

- Rename `HttpServiceContext.streamingBlockingResponseFactory()` to
`HttpServiceContext.blockingStreamingResponseFactory()`;

Result:

Consistent naming.