### PR TITLE
Generated gRPC interfaces should be annotated as `@FunctionalInterface`

### DIFF
--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   testImplementation project(":servicetalk-grpc-protobuf")
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-utils-internal")
+  testImplementation project(":servicetalk-grpc-protoc")
   testImplementation "io.grpc:grpc-core:$grpcVersion"
   testImplementation("io.grpc:grpc-netty:$grpcVersion") {
     exclude group: "io.netty"

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/protoc/GeneratorTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/protoc/GeneratorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.protoc;
+
+import io.servicetalk.grpc.netty.TesterProto.Tester;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static io.servicetalk.grpc.protoc.Words.Blocking;
+import static io.servicetalk.grpc.protoc.Words.Rpc;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class GeneratorTest {
+
+    @Test
+    public void testGeneratedFunctionalInterfaces() {
+
+        final List<Class<?>> generatedRpcInterfaces = stream(Tester.class.getDeclaredClasses())
+                .filter(declaredClass -> declaredClass.getAnnotation(FunctionalInterface.class) != null
+                        && !declaredClass.getSimpleName().startsWith(Blocking)
+                        && declaredClass.getSimpleName().endsWith(Rpc))
+                .collect(toList());
+
+        final List<Class<?>> generatedBlockingRpcInterfaces = stream(Tester.class.getDeclaredClasses())
+                .filter(declaredClass -> declaredClass.getAnnotation(FunctionalInterface.class) != null
+                        && declaredClass.getSimpleName().startsWith(Blocking)
+                        && declaredClass.getSimpleName().endsWith(Rpc))
+                .collect(toList());
+
+        assertThat(generatedRpcInterfaces.size(), is(4));
+        assertThat(generatedRpcInterfaces.size(), is(generatedBlockingRpcInterfaces.size()));
+    }
+}

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
@@ -229,6 +229,7 @@ final class Generator {
             final FieldSpec.Builder pathSpecBuilder = FieldSpec.builder(String.class, RPC_PATH, PUBLIC, STATIC, FINAL)
                     .initializer("$S", context.methodPath(state.serviceProto, methodProto));
             final TypeSpec.Builder interfaceSpecBuilder = interfaceBuilder(name)
+                    .addAnnotation(FunctionalInterface.class)
                     .addModifiers(PUBLIC)
                     .addField(pathSpecBuilder.build())
                     .addMethod(newRpcMethodSpec(methodProto, EnumSet.of(INTERFACE),
@@ -252,6 +253,7 @@ final class Generator {
             final FieldSpec.Builder pathSpecBuilder = FieldSpec.builder(String.class, RPC_PATH, PUBLIC, STATIC, FINAL);
             pathSpecBuilder.initializer("$T.$L", rpcInterface.className, RPC_PATH);
             final TypeSpec.Builder interfaceSpecBuilder = interfaceBuilder(name)
+                    .addAnnotation(FunctionalInterface.class)
                     .addModifiers(PUBLIC)
                     .addField(pathSpecBuilder.build())
                     .addMethod(newRpcMethodSpec(methodProto, EnumSet.of(BLOCKING, INTERFACE),


### PR DESCRIPTION
Generated gRPC RPC interfaces should be annotated as `@FunctionalInterface` #908

Motivation:

Generated gRPC RPC interfaces should be annotated as `@FunctionalInterface` #908

Modifications:

- Add `@FunctionalInterface` to generated interfaces as part of the method addServiceRpcInterfaces():

Result:

Fixes #908