### PR TITLE
Spotbugs exclusion for JDK flow

### DIFF
--- a/servicetalk-concurrent-jdkflow/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-concurrent-jdkflow/gradle/spotbugs/main-exclusions.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<FindBugsFilter>
+  <!-- JDK flow Subscriber#onNext is not marked as @Nullable but our Subscriber is -->
+  <Match>
+    <Class name="io.servicetalk.concurrent.jdkflow.JdkFlowAdapters$FlowToStSubscriber"/>
+    <Method name="onNext"/>
+    <Parameter name="next"/>
+    <Bug pattern="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE"/>
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
__Motivation__

ServiceTalk `Subscriber` allows passing `null` values in `onNext` but JDK flow does not provide any guidance hence defaulting to non-null. Spotbugs does not like this inconsistency but does not complain consistently (ironically 🙂)

__Modification__

As this is an expected situation for the JDK flow adapter, add a spotbugs exclusion.

__Result__

Spotbugs does not complain for this intentional inconsistency.