### PR TITLE
Protocol emits payload boundary event

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -73,7 +73,7 @@ import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
 import static io.servicetalk.http.netty.HeaderUtils.LAST_CHUNK_PREDICATE;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
 import static io.servicetalk.transport.netty.internal.ChannelSet.CHANNEL_CLOSEABLE_KEY;
-import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
+import static io.servicetalk.transport.netty.internal.CloseHandler.H2_PROTOCOL_CLOSE_HANDLER;
 import static java.util.Objects.requireNonNull;
 
 final class H2ClientParentConnectionContext extends H2ParentConnectionContext implements NettyConnectionContext {
@@ -241,7 +241,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext im
                     parentContext.trackActiveStream(streamChannel);
                     streamChannel.pipeline().addLast(new H2ToStH1ClientDuplexHandler(waitForSslHandshake,
                             parentContext.executionContext().bufferAllocator(), headersFactory,
-                            UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
+                            H2_PROTOCOL_CLOSE_HANDLER));
                     DefaultNettyConnection<Object, Object> nettyConnection =
                             DefaultNettyConnection.initChildChannel(streamChannel,
                                     parentContext.executionContext().bufferAllocator(),
@@ -249,7 +249,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext im
                                     new TerminalPredicate<>(LAST_CHUNK_PREDICATE),
                                     // Http2StreamChannel is not of type SocketChannel. Also Netty will manage the half
                                     // closure based upon stream state.
-                                    UNSUPPORTED_PROTOCOL_CLOSE_HANDLER,
+                                    H2_PROTOCOL_CLOSE_HANDLER,
                                     parentContext.flushStrategyHolder.currentStrategy(),
                                     parentContext.executionContext().executionStrategy(),
                                     parentContext.sslSession());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -240,7 +240,8 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext im
                     Http2StreamChannel streamChannel = future.getNow();
                     parentContext.trackActiveStream(streamChannel);
                     streamChannel.pipeline().addLast(new H2ToStH1ClientDuplexHandler(waitForSslHandshake,
-                            parentContext.executionContext().bufferAllocator(), headersFactory));
+                            parentContext.executionContext().bufferAllocator(), headersFactory,
+                            UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
                     DefaultNettyConnection<Object, Object> nettyConnection =
                             DefaultNettyConnection.initChildChannel(streamChannel,
                                     parentContext.executionContext().bufferAllocator(),

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -31,6 +31,7 @@ import io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer;
 import io.servicetalk.transport.api.ConnectionAcceptor;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
+import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.servicetalk.transport.netty.internal.DefaultNettyConnection;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.NettyConnection.TerminalPredicate;
@@ -134,7 +135,8 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                                 // Netty To ServiceTalk type conversion
                                 streamChannel.pipeline().addLast(new H2ToStH1ServerDuplexHandler(
                                         connection.executionContext().bufferAllocator(),
-                                        h2ServerConfig.headersFactory()));
+                                        h2ServerConfig.headersFactory(),
+                                        CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
 
                                 // ServiceTalk <-> Netty netty utilities
                                 DefaultNettyConnection<Object, Object> streamConnection =

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -31,7 +31,6 @@ import io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer;
 import io.servicetalk.transport.api.ConnectionAcceptor;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
-import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.servicetalk.transport.netty.internal.DefaultNettyConnection;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.NettyConnection.TerminalPredicate;
@@ -51,7 +50,7 @@ import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.http.netty.HeaderUtils.LAST_CHUNK_PREDICATE;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
 import static io.servicetalk.transport.netty.internal.ChannelSet.CHANNEL_CLOSEABLE_KEY;
-import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
+import static io.servicetalk.transport.netty.internal.CloseHandler.H2_PROTOCOL_CLOSE_HANDLER;
 import static java.util.Objects.requireNonNull;
 
 final class H2ServerParentConnectionContext extends H2ParentConnectionContext implements ServerContext {
@@ -136,7 +135,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                                 streamChannel.pipeline().addLast(new H2ToStH1ServerDuplexHandler(
                                         connection.executionContext().bufferAllocator(),
                                         h2ServerConfig.headersFactory(),
-                                        CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
+                                        H2_PROTOCOL_CLOSE_HANDLER));
 
                                 // ServiceTalk <-> Netty netty utilities
                                 DefaultNettyConnection<Object, Object> streamConnection =
@@ -146,7 +145,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                                                 new TerminalPredicate<>(LAST_CHUNK_PREDICATE),
                                                 // Http2StreamChannel is not of type SocketChannel. Also Netty will
                                                 // manage the half closure based upon stream state.
-                                                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER,
+                                                H2_PROTOCOL_CLOSE_HANDLER,
                                                 // TODO(scott): after flushStrategy is no longer on the connection
                                                 // level we can use DefaultNettyConnection.initChannel instead of this
                                                 // custom method.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -67,7 +67,6 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (msg instanceof HttpRequestMetaData) {
-            closeHandler.protocolPayloadBeginOutbound(ctx);
             HttpRequestMetaData metaData = (HttpRequestMetaData) msg;
             HttpHeaders h1Headers = metaData.headers();
             CharSequence host = h1Headers.getAndRemove(HOST);
@@ -105,7 +104,6 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
             Http2Headers h2Headers = headersFrame.headers();
             final HttpResponseStatus httpStatus;
             if (!readHeaders) {
-                closeHandler.protocolPayloadBeginInbound(ctx);
                 CharSequence status = h2Headers.getAndRemove(STATUS.value());
                 if (status == null) {
                     throw new IllegalArgumentException("a response must have " + STATUS + " header");
@@ -139,7 +137,6 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
                 } else {
                     ctx.fireChannelRead(h2HeadersToH1HeadersClient(h2Headers, null));
                 }
-                closeHandler.protocolPayloadEndInbound(ctx);
             } else if (httpStatus == null) {
                 throw new IllegalArgumentException("a response must have " + STATUS + " header");
             } else {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
@@ -62,7 +62,6 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (msg instanceof HttpResponseMetaData) {
-            closeHandler.protocolPayloadBeginOutbound(ctx);
             HttpResponseMetaData metaData = (HttpResponseMetaData) msg;
             HttpHeaders h1Headers = metaData.headers();
             Http2Headers h2Headers = h1HeadersToH2Headers(h1Headers);
@@ -85,7 +84,6 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
             final HttpRequestMethod httpMethod;
             final String path;
             if (!readHeaders) {
-                closeHandler.protocolPayloadBeginInbound(ctx);
                 CharSequence method = h2Headers.getAndRemove(METHOD.value());
                 CharSequence pathSequence = h2Headers.getAndRemove(PATH.value());
                 if (pathSequence == null || method == null) {
@@ -106,7 +104,6 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
                 } else {
                     ctx.fireChannelRead(h2TrailersToH1TrailersServer(h2Headers));
                 }
-                closeHandler.protocolPayloadEndInbound(ctx);
             } else if (httpMethod == null) {
                 throw new IllegalArgumentException("a request must have " + METHOD + " and " +
                         PATH + " headers");

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectEncoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectEncoder.java
@@ -185,12 +185,13 @@ abstract class HttpObjectEncoder<T extends HttpMetaData> extends ChannelOutbound
                 }
             }
         } else if (msg instanceof HttpHeaders) {
+            closeHandler.protocolPayloadEndOutbound(ctx);
             promise.addListener(f -> {
                 if (f.isSuccess()) {
                     // Only writes of the last payload that have been successfully written and flushed should emit
                     // events. A CloseHandler should not get into a completed state on a failed write so that it can
                     // abort and close the Channel when appropriate.
-                    closeHandler.protocolPayloadEndOutbound(ctx);
+                    closeHandler.protocolPayloadEndOutboundSuccess(ctx);
                 }
             });
             final int oldState = state;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
@@ -28,11 +28,8 @@ import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.netty.NettyHttpServer.NettyHttpServerConnection;
 import io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer;
 import io.servicetalk.transport.api.IoExecutor;
-import io.servicetalk.transport.netty.internal.CloseHandler;
 
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -129,23 +126,7 @@ public class FlushStrategyOnServerTest {
 
         final ReadOnlyHttpServerConfig config = new HttpServerConfig().asReadOnly();
         serverConnection = initChannel(channel, httpExecutionContext, config,
-                new TcpServerChannelInitializer(config.tcpConfig()) {
-                    @Override
-                    public void init(final Channel channel) {
-                        super.init(channel);
-                        channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
-                            @Override
-                            public void userEventTriggered(final ChannelHandlerContext ctx,
-                                                           final Object evt) throws Exception {
-                                if (evt == CloseHandler.ProtocolPayloadEndEvent.OUTBOUND) {
-                                    // Mute payload boundary events for this test with repeated read
-                                    return;
-                                }
-                                super.userEventTriggered(ctx, evt);
-                            }
-                        });
-                    }
-                }, service, true,
+                new TcpServerChannelInitializer(config.tcpConfig()), service, true,
                 UNSUPPORTED_PROTOCOL_CLOSE_HANDLER)
                 .toFuture().get();
         serverConnection.process(true);

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
@@ -32,6 +32,7 @@ import javax.annotation.Nullable;
 public abstract class CloseHandler {
 
     public static final CloseHandler UNSUPPORTED_PROTOCOL_CLOSE_HANDLER = new UnsupportedProtocolHandler();
+    public static final CloseHandler H2_PROTOCOL_CLOSE_HANDLER = new H2ProtocolHandler();
 
     /**
      * New {@link CloseHandler} instance.
@@ -267,6 +268,64 @@ public abstract class CloseHandler {
 
         @Override
         public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx) {
+        }
+
+        @Override
+        public void protocolPayloadEndOutboundSuccess(final ChannelHandlerContext ctx) {
+        }
+
+        @Override
+        public void protocolClosingInbound(final ChannelHandlerContext ctx) {
+        }
+
+        @Override
+        public void protocolClosingOutbound(final ChannelHandlerContext ctx) {
+        }
+    }
+
+    private static final class H2ProtocolHandler extends CloseHandler {
+
+        @Override
+        void registerEventHandler(final Channel channel, final Consumer<CloseEvent> eventHandler) {
+        }
+
+        @Override
+        void channelClosedInbound(final ChannelHandlerContext ctx) {
+        }
+
+        @Override
+        void channelClosedOutbound(final ChannelHandlerContext ctx) {
+        }
+
+        @Override
+        void closeChannelInbound(final Channel channel) {
+            channel.close();
+        }
+
+        @Override
+        void closeChannelOutbound(final Channel channel) {
+            channel.close();
+        }
+
+        @Override
+        void userClosing(final Channel channel) {
+            channel.close();
+        }
+
+        @Override
+        public void protocolPayloadBeginInbound(final ChannelHandlerContext ctx) {
+        }
+
+        @Override
+        public void protocolPayloadEndInbound(final ChannelHandlerContext ctx) {
+        }
+
+        @Override
+        public void protocolPayloadBeginOutbound(final ChannelHandlerContext ctx) {
+        }
+
+        @Override
+        public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx) {
             ctx.pipeline().fireUserEventTriggered(ProtocolPayloadEndEvent.OUTBOUND);
         }
 
@@ -286,11 +345,11 @@ public abstract class CloseHandler {
     /**
      * Netty UserEvent to indicate the end of a payload was observed at the transport.
      */
-    public static final class ProtocolPayloadEndEvent {
+    static final class ProtocolPayloadEndEvent {
         /**
          * Netty UserEvent instance to indicate an outbound end of payload.
          */
-        public static final ProtocolPayloadEndEvent OUTBOUND = new ProtocolPayloadEndEvent();
+        static final ProtocolPayloadEndEvent OUTBOUND = new ProtocolPayloadEndEvent();
 
         private ProtocolPayloadEndEvent() {
             // No instances.

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
@@ -78,6 +78,13 @@ public abstract class CloseHandler {
     public abstract void protocolPayloadEndOutbound(ChannelHandlerContext ctx);
 
     /**
+     * Signal end of outbound payload, once successfully written to the {@link Channel}.
+     *
+     * @param ctx {@link ChannelHandlerContext}
+     */
+    public abstract void protocolPayloadEndOutboundSuccess(ChannelHandlerContext ctx);
+
+    /**
      * Signal inbound close command observed, to be emitted from the {@link EventLoop} for the {@link Channel}.
      *
      * @param ctx {@link ChannelHandlerContext}
@@ -260,6 +267,11 @@ public abstract class CloseHandler {
 
         @Override
         public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx) {
+            ctx.pipeline().fireUserEventTriggered(ProtocolPayloadEndEvent.OUTBOUND);
+        }
+
+        @Override
+        public void protocolPayloadEndOutboundSuccess(final ChannelHandlerContext ctx) {
         }
 
         @Override
@@ -268,6 +280,20 @@ public abstract class CloseHandler {
 
         @Override
         public void protocolClosingOutbound(final ChannelHandlerContext ctx) {
+        }
+    }
+
+    /**
+     * Netty UserEvent to indicate the end of a payload was observed at the transport.
+     */
+    public static final class ProtocolPayloadEndEvent {
+        /**
+         * Netty UserEvent instance to indicate an outbound end of payload.
+         */
+        public static final ProtocolPayloadEndEvent OUTBOUND = new ProtocolPayloadEndEvent();
+
+        private ProtocolPayloadEndEvent() {
+            // No instances.
         }
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -464,7 +464,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
          * <p>
          * Calling {@link #close(Throwable)} after {@link #closeGracefully()} will be ignored.
          * <p>
-         * This is event is expected be called from the eventloop.
+         * This event is expected be called from the eventloop.
          */
         void closeGracefully();
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -34,7 +34,6 @@ import io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent;
 import io.servicetalk.transport.netty.internal.CloseHandler.CloseEventObservedException;
 import io.servicetalk.transport.netty.internal.WriteStreamSubscriber.AbortedFirstWrite;
 
-import io.netty.channel.AbstractChannel;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
@@ -426,7 +425,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
             // never notify the write writeSubscriber of the inactive event. So if the channel is inactive we notify
             // the writeSubscriber.
             if (!channel().isActive()) {
-                newWritableListener.channelClosed(CLOSED_FAIL_ACTIVE);
+                newWritableListener.close(CLOSED_FAIL_ACTIVE);
                 return false;
             }
             return true;
@@ -472,7 +471,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
          * <p>
          * This is event is expected be called from the eventloop.
          */
-        void protocolPayloadComplete();
+        void closeGracefully();
 
         /**
          * Notification that the channel has been closed.
@@ -482,17 +481,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
          *
          * @param closedException the exception which describes the close rational.
          */
-        void channelClosed(Throwable closedException);
-
-        /**
-         * Notification that the channel outbound path has been closed.
-         * <p>
-         * This may indicate a write failed and was implicitly closed by the {@link AbstractChannel} or a {@link
-         * CloseHandler} performing a graceful or forced close. This methods will always be called from the event loop.
-         */
-        default void channelClosedOutbound() {
-            // Do nothing
-        }
+        void close(Throwable closedException);
     }
 
     private static final class NoopWritableListener implements WritableListener {
@@ -501,11 +490,11 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
         }
 
         @Override
-        public void protocolPayloadComplete() {
+        public void closeGracefully() {
         }
 
         @Override
-        public void channelClosed(Throwable closedException) {
+        public void close(Throwable closedException) {
         }
     }
 
@@ -574,10 +563,10 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
         @Override
         public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
             if (evt == CloseHandler.ProtocolPayloadEndEvent.OUTBOUND) {
-                connection.writableListener.protocolPayloadComplete();
+                connection.writableListener.closeGracefully();
             } else if (evt == ChannelOutputShutdownEvent.INSTANCE) {
                 connection.closeHandler.channelClosedOutbound(ctx);
-                connection.writableListener.channelClosedOutbound();
+                connection.writableListener.close(CLOSED_CHANNEL_INACTIVE);
             } else if (evt == ChannelInputShutdownReadComplete.INSTANCE) {
                 // Notify close handler first to enhance error reporting
                 connection.closeHandler.channelClosedInbound(ctx);
@@ -612,7 +601,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
         @Override
         public void channelInactive(ChannelHandlerContext ctx) {
             tryFailSubscriber(CLOSED_CHANNEL_INACTIVE);
-            connection.writableListener.channelClosed(CLOSED_CHANNEL_INACTIVE);
+            connection.writableListener.close(CLOSED_CHANNEL_INACTIVE);
             connection.nettyChannelPublisher.channelInboundClosed();
         }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -459,15 +459,10 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
         void channelWritable();
 
         /**
-         * Notifies the end of payload was observed at the transport (not necessarily flushed).
+         * Close the channel after the pending writes complete.
          *
          * <p>
-         * This helps coordinate state between the writer and the codec/transport. Even if the writing source may not
-         * have completed from a Reactive Streams perspective, it means that as far as the codec and transport is
-         * concerned it considers the write is complete and no further writes can happen. Closing of the transport after
-         * receiving this event should not be considered a write error since the final buffer was written and
-         * potentially flushed. A failed write promise after observing this event however indicates the end of payload
-         * marker may not have been written correctly and should result in an error.
+         * Calling {@link #close(Throwable)} after {@link #closeGracefully()} will be ignored.
          * <p>
          * This is event is expected be called from the eventloop.
          */

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
@@ -163,6 +163,13 @@ class RequestResponseCloseHandler extends CloseHandler {
 
     @Override
     public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx) {
+        if (isClient || has(state, CLOSING)) {
+            ctx.pipeline().fireUserEventTriggered(ProtocolPayloadEndEvent.OUTBOUND);
+        }
+    }
+
+    @Override
+    public void protocolPayloadEndOutboundSuccess(final ChannelHandlerContext ctx) {
         assert ctx.executor().inEventLoop();
         state = unset(state, WRITE);
         if (has(state, CLOSING)) {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteSingleSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteSingleSubscriber.java
@@ -79,7 +79,7 @@ final class WriteSingleSubscriber implements SingleSource.Subscriber<Object>, De
         if (terminatedUpdater.compareAndSet(this, AWAITING_RESULT, TERMINATED)) {
             notifyError(t);
         } else {
-            LOGGER.error("Failed to fail subscriber after permature close of the WriteListener.");
+            LOGGER.error("Ignoring emitted error as the listener is already closed.", t);
         }
     }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteSingleSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteSingleSubscriber.java
@@ -70,7 +70,7 @@ final class WriteSingleSubscriber implements SingleSource.Subscriber<Object>, De
                 }
             });
         } else {
-            LOGGER.error("Failed to write data after permature close of the WriteListener.");
+            LOGGER.error("Ignoring write {} as the listener is already closed.", result);
         }
     }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteSingleSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteSingleSubscriber.java
@@ -74,6 +74,11 @@ final class WriteSingleSubscriber implements SingleSource.Subscriber<Object>, De
     }
 
     @Override
+    public void protocolPayloadComplete() {
+        // No op.
+    }
+
+    @Override
     public void channelClosed(Throwable closedException) {
         // Because the subscriber is terminated "out of band" make sure we cancel any work which may (at some later
         // time) invoke a write associated with this subscriber.

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteSingleSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteSingleSubscriber.java
@@ -74,12 +74,12 @@ final class WriteSingleSubscriber implements SingleSource.Subscriber<Object>, De
     }
 
     @Override
-    public void protocolPayloadComplete() {
+    public void closeGracefully() {
         // No op.
     }
 
     @Override
-    public void channelClosed(Throwable closedException) {
+    public void close(Throwable closedException) {
         // Because the subscriber is terminated "out of band" make sure we cancel any work which may (at some later
         // time) invoke a write associated with this subscriber.
         sequentialCancellable.cancel();

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -139,7 +139,7 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
              * Write1 (Thread1) -> Write2 (Eventloop)
              *
              * If Thread1 != this channels Eventloop then Write2 may happen before Write1 as a write from the eventloop
-              * will skip the task queue and directly send the write on the pipeline.
+             * will skip the task queue and directly send the write on the pipeline.
              */
             enqueueWrites = true;
         }
@@ -187,6 +187,11 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
     public void channelWritable() {
         assert eventLoop.inEventLoop();
         requestMoreIfRequired(subscription);
+    }
+
+    @Override
+    public void protocolPayloadComplete() {
+        onComplete();
     }
 
     @Override
@@ -281,7 +286,7 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
 
         void sourceTerminated(@Nullable Throwable cause) {
             assert eventLoop.inEventLoop();
-            if (hasFlag(SUBSCRIBER_TERMINATED)) {
+            if (hasFlag(SUBSCRIBER_TERMINATED) || hasFlag(SOURCE_TERMINATED)) {
                 // We have terminated prematurely perhaps due to write failure.
                 return;
             }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
@@ -41,6 +41,7 @@ import org.junit.rules.Timeout;
 import org.mockito.ArgumentCaptor;
 
 import java.nio.channels.ClosedChannelException;
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -432,7 +433,8 @@ public class DefaultNettyConnectionTest {
         for (Buffer item : items) {
             verify(requestNSupplier).onItemWrite(eq(item), anyLong(), anyLong());
         }
-        verify(requestNSupplier, times(1 + items.length + channelWritabilityChangedCount))
+        final boolean hasTrailers = Arrays.stream(items).anyMatch(p -> p == TRAILER);
+        verify(requestNSupplier, times((hasTrailers ? 0 : 1) + items.length + channelWritabilityChangedCount))
                 .requestNFor(anyLong());
     }
 
@@ -551,6 +553,7 @@ public class DefaultNettyConnectionTest {
         channel.pipeline().fireChannelInactive();
         publisher.onComplete();
 
+        channel.close();
         writeListener.verifyCompletion();
     }
 }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
@@ -29,7 +29,10 @@ import io.servicetalk.concurrent.api.TestPublisherSubscriber;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.transport.netty.internal.NettyConnection.TerminalPredicate;
 
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.Before;
 import org.junit.Rule;
@@ -76,6 +79,8 @@ import static org.mockito.Mockito.when;
 
 public class DefaultNettyConnectionTest {
 
+    private static final String TRAILER_MSG = "Trailer";
+    private static final Buffer TRAILER = DEFAULT_ALLOCATOR.fromAscii(TRAILER_MSG);
     private TestPublisher<Buffer> publisher;
     @Rule
     public final LegacyMockedCompletableListenerRule writeListener = new LegacyMockedCompletableListenerRule();
@@ -85,7 +90,6 @@ public class DefaultNettyConnectionTest {
     public final LegacyMockedCompletableListenerRule closeListener = new LegacyMockedCompletableListenerRule();
     @Rule
     public final Timeout timeout = new ServiceTalkTestTimeout();
-
     private final TestPublisherSubscriber<Buffer> subscriber = new TestPublisherSubscriber<>();
     private BufferAllocator allocator;
     private EmbeddedChannel channel;
@@ -114,16 +118,31 @@ public class DefaultNettyConnectionTest {
             return true;
         });
         conn = DefaultNettyConnection.<Buffer, Buffer>initChannel(channel, allocator, executor, terminalPredicate,
-                closeHandler, defaultFlushStrategy(), channel2 -> { }, OFFLOAD_ALL_STRATEGY)
+                closeHandler, defaultFlushStrategy(), trailerProtocolEndEventEmitter(), OFFLOAD_ALL_STRATEGY)
                 .toFuture().get();
         publisher = new TestPublisher<>();
     }
 
+    private ChannelInitializer trailerProtocolEndEventEmitter() {
+        return ch -> ch.pipeline()
+                .addLast(new ChannelOutboundHandlerAdapter() {
+                    @Override
+                    public void write(final ChannelHandlerContext ctx,
+                                      final Object msg,
+                                      final ChannelPromise promise) {
+                        if (msg == TRAILER) {
+                            ctx.pipeline().fireUserEventTriggered(CloseHandler.ProtocolPayloadEndEvent.OUTBOUND);
+                        }
+                        ctx.write(msg, promise);
+                    }
+                });
+    }
+
     @Test
     public void testWritePublisher() {
-        writeListener.listen(conn.write(from(newBuffer("Hello1"), newBuffer("Hello2"))))
+        writeListener.listen(conn.write(from(newBuffer("Hello1"), newBuffer("Hello2"), TRAILER)))
                 .verifyCompletion();
-        pollChannelAndVerifyWrites("Hello1", "Hello2");
+        pollChannelAndVerifyWrites("Hello1", "Hello2", TRAILER_MSG);
     }
 
     @Test
@@ -277,9 +296,10 @@ public class DefaultNettyConnectionTest {
         writeListener.listen(conn.write(publisher));
         assertThat("Unexpected write active state.", conn.isWriteActive(), is(true));
         publisher.onNext(newBuffer("Hello"));
+        publisher.onNext(TRAILER);
         publisher.onComplete();
         writeListener.verifyCompletion();
-        pollChannelAndVerifyWrites("Hello");
+        pollChannelAndVerifyWrites("Hello", TRAILER_MSG);
         assertThat("Unexpected write active state.", conn.isWriteActive(), is(false));
     }
 
@@ -308,34 +328,36 @@ public class DefaultNettyConnectionTest {
         requestNext = 1;
         changeWritability(true);
         publisher.onNext(hello2);
+        publisher.onNext(TRAILER);
         publisher.onComplete();
-        pollChannelAndVerifyWrites("Hello2");
-        verifyPredictorCalled(1, hello1, hello2);
+        pollChannelAndVerifyWrites("Hello2", TRAILER_MSG);
+        verifyPredictorCalled(1, hello1, hello2, TRAILER);
         writeListener.verifyCompletion();
     }
 
     @Test
     public void testUpdateFlushStrategy() {
-        writeListener.listen(conn.write(from(newBuffer("Hello"))));
+        writeListener.listen(conn.write(from(newBuffer("Hello"), TRAILER)));
         writeListener.verifyCompletion();
-        pollChannelAndVerifyWrites("Hello"); // Flush on each (default)
+        pollChannelAndVerifyWrites("Hello", TRAILER_MSG); // Flush on each (default)
 
         writeListener.reset();
-        Cancellable c = conn.updateFlushStrategy((old, __) -> batchFlush(2, never()));
+        Cancellable c = conn.updateFlushStrategy((old, __) -> batchFlush(3, never()));
         writeListener.listen(conn.write(publisher));
         publisher.onNext(newBuffer("Hello1"));
         pollChannelAndVerifyWrites(); // No flush
         publisher.onNext(newBuffer("Hello2"));
-        pollChannelAndVerifyWrites("Hello1", "Hello2"); // Batch flush of 2
+        publisher.onNext(TRAILER);
+        pollChannelAndVerifyWrites("Hello1", "Hello2", TRAILER_MSG); // Batch flush of 2
         publisher.onComplete();
         writeListener.verifyCompletion();
 
         c.cancel();
 
         writeListener.reset();
-        writeListener.listen(conn.write(from(newBuffer("Hello3"))));
+        writeListener.listen(conn.write(from(newBuffer("Hello3"), TRAILER)));
         writeListener.verifyCompletion();
-        pollChannelAndVerifyWrites("Hello3"); // Reverted to flush on each
+        pollChannelAndVerifyWrites("Hello3", TRAILER_MSG); // Reverted to flush on each
     }
 
     @Test
@@ -358,6 +380,7 @@ public class DefaultNettyConnectionTest {
         Buffer hello2 = newBuffer("Hello2");
         publisher.onNext(hello1);
         publisher.onNext(hello2);
+        publisher.onNext(TRAILER);
         closeListener.listen(conn.closeAsync());
         assertThat(channel.isOpen(), is(false));
         writeListener.verifyFailure(ClosedChannelException.class);
@@ -499,5 +522,35 @@ public class DefaultNettyConnectionTest {
         toSource(conn.read()).subscribe(subscriber);
         assertThat(subscriber.takeError(), instanceOf(ClosedChannelException.class));
         conn.onClose().toFuture().get();
+    }
+
+    @Test
+    public void testChannelCloseBeforeWriteComplete() {
+        writeListener.listen(conn.write(publisher));
+        Buffer hello1 = newBuffer("Hello1");
+        publisher.onNext(hello1);
+        publisher.onNext(TRAILER);
+        pollChannelAndVerifyWrites("Hello1", TRAILER_MSG);
+
+        channel.pipeline().fireChannelInactive();
+        channel.close();
+        publisher.onComplete();
+
+        writeListener.verifyCompletion();
+    }
+
+    @Test
+    public void testChannelCloseAfterWriteComplete() {
+        writeListener.listen(conn.write(publisher));
+        Buffer hello1 = newBuffer("Hello1");
+        publisher.onNext(hello1);
+        publisher.onNext(TRAILER);
+
+        pollChannelAndVerifyWrites("Hello1", TRAILER_MSG);
+
+        channel.pipeline().fireChannelInactive();
+        publisher.onComplete();
+
+        writeListener.verifyCompletion();
     }
 }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteSingleSubscriberTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteSingleSubscriberTest.java
@@ -16,9 +16,11 @@
 package io.servicetalk.transport.netty.internal;
 
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -76,9 +78,12 @@ public class WriteSingleSubscriberTest extends AbstractWriteTest {
         assertThat("Message not written.", channel.readOutbound(), is("Hello"));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testCloseGracefullyBeforeWrite() {
         WriteSingleSubscriber listener = new WriteSingleSubscriber(channel, completableSubscriber, closeHandler);
+        final ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
         listener.closeGracefully();
+        verify(completableSubscriber).onError(captor.capture());
+        assertThat(captor.getValue(), instanceOf(IllegalStateException.class));
     }
 }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberTest.java
@@ -146,7 +146,7 @@ public class WriteStreamSubscriberTest extends AbstractWriteTest {
 
     @Test
     public void onNextAfterChannelClose() {
-        subscriber.channelClosed(new ClosedChannelException());
+        subscriber.close(new ClosedChannelException());
         subscriber.onNext("Hello");
         channel.runPendingTasks();
         assertThat("Unexpected message(s) written.", channel.outboundMessages(), is(empty()));


### PR DESCRIPTION
__Motivation__

WriteStreamSubscriber is not aware of payload boundaries, hence when a Channel becomes suddenly inactive (closed or output shutdown) it could only assume the write failed. In case of H2 the codec would perfom an output shutdown after observing and emitting trailers. This output shutdown would race with write publisher completion and occasionally result in WriteStreamSubscriber failing the write with an error even though it actually completed normally.

__Modifications__

- H1/H2 codecs emit payload boundaries via CloseHandler
- CloseHandler triggers a new UserEvent on outbound payload end
- DefaultNettyConnection intercepts above event and notifies WriteListener (WriteStreamSubscriber)
- WriteStreamSubscriber responds to 2 triggers for write source stream completion

__Result__

Writes no longer fail due to race between closure of write publisher and H2 end of stream