### PR TITLE
WriteStreamSubscriber and WriteListener cleanup

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -73,7 +73,7 @@ import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
 import static io.servicetalk.http.netty.HeaderUtils.LAST_CHUNK_PREDICATE;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
 import static io.servicetalk.transport.netty.internal.ChannelSet.CHANNEL_CLOSEABLE_KEY;
-import static io.servicetalk.transport.netty.internal.CloseHandler.H2_PROTOCOL_CLOSE_HANDLER;
+import static io.servicetalk.transport.netty.internal.CloseHandler.PROTOCOL_OUTBOUND_CLOSE_HANDLER;
 import static java.util.Objects.requireNonNull;
 
 final class H2ClientParentConnectionContext extends H2ParentConnectionContext implements NettyConnectionContext {
@@ -241,7 +241,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext im
                     parentContext.trackActiveStream(streamChannel);
                     streamChannel.pipeline().addLast(new H2ToStH1ClientDuplexHandler(waitForSslHandshake,
                             parentContext.executionContext().bufferAllocator(), headersFactory,
-                            H2_PROTOCOL_CLOSE_HANDLER));
+                            PROTOCOL_OUTBOUND_CLOSE_HANDLER));
                     DefaultNettyConnection<Object, Object> nettyConnection =
                             DefaultNettyConnection.initChildChannel(streamChannel,
                                     parentContext.executionContext().bufferAllocator(),
@@ -249,7 +249,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext im
                                     new TerminalPredicate<>(LAST_CHUNK_PREDICATE),
                                     // Http2StreamChannel is not of type SocketChannel. Also Netty will manage the half
                                     // closure based upon stream state.
-                                    H2_PROTOCOL_CLOSE_HANDLER,
+                                    PROTOCOL_OUTBOUND_CLOSE_HANDLER,
                                     parentContext.flushStrategyHolder.currentStrategy(),
                                     parentContext.executionContext().executionStrategy(),
                                     parentContext.sslSession());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -50,7 +50,7 @@ import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.http.netty.HeaderUtils.LAST_CHUNK_PREDICATE;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
 import static io.servicetalk.transport.netty.internal.ChannelSet.CHANNEL_CLOSEABLE_KEY;
-import static io.servicetalk.transport.netty.internal.CloseHandler.H2_PROTOCOL_CLOSE_HANDLER;
+import static io.servicetalk.transport.netty.internal.CloseHandler.PROTOCOL_OUTBOUND_CLOSE_HANDLER;
 import static java.util.Objects.requireNonNull;
 
 final class H2ServerParentConnectionContext extends H2ParentConnectionContext implements ServerContext {
@@ -135,7 +135,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                                 streamChannel.pipeline().addLast(new H2ToStH1ServerDuplexHandler(
                                         connection.executionContext().bufferAllocator(),
                                         h2ServerConfig.headersFactory(),
-                                        H2_PROTOCOL_CLOSE_HANDLER));
+                                        PROTOCOL_OUTBOUND_CLOSE_HANDLER));
 
                                 // ServiceTalk <-> Netty netty utilities
                                 DefaultNettyConnection<Object, Object> streamConnection =
@@ -145,7 +145,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                                                 new TerminalPredicate<>(LAST_CHUNK_PREDICATE),
                                                 // Http2StreamChannel is not of type SocketChannel. Also Netty will
                                                 // manage the half closure based upon stream state.
-                                                H2_PROTOCOL_CLOSE_HANDLER,
+                                                PROTOCOL_OUTBOUND_CLOSE_HANDLER,
                                                 // TODO(scott): after flushStrategy is no longer on the connection
                                                 // level we can use DefaultNettyConnection.initChannel instead of this
                                                 // custom method.

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
@@ -32,7 +32,7 @@ import javax.annotation.Nullable;
 public abstract class CloseHandler {
 
     public static final CloseHandler UNSUPPORTED_PROTOCOL_CLOSE_HANDLER = new UnsupportedProtocolHandler();
-    public static final CloseHandler H2_PROTOCOL_CLOSE_HANDLER = new H2ProtocolHandler();
+    public static final CloseHandler PROTOCOL_OUTBOUND_CLOSE_HANDLER = new ProtocolOutboundCloseEventHandler();
 
     /**
      * New {@link CloseHandler} instance.
@@ -283,7 +283,7 @@ public abstract class CloseHandler {
         }
     }
 
-    private static final class H2ProtocolHandler extends CloseHandler {
+    private static final class ProtocolOutboundCloseEventHandler extends CloseHandler {
 
         @Override
         void registerEventHandler(final Channel channel, final Consumer<CloseEvent> eventHandler) {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -79,7 +79,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultNettyConnection.class);
 
-    private static final TerminalPredicate PIPELINE_UNSUPPORTED_PREDICATE = new TerminalPredicate();
+    private static final TerminalPredicate PIPELINE_UNSUPPORTED_PREDICATE = new TerminalPredicate<>();
 
     private static final ChannelOutboundListener PLACE_HOLDER_OUTBOUND_LISTENER = new NoopChannelOutboundListener();
     private static final ChannelOutboundListener SINGLE_ITEM_OUTBOUND_LISTENER = new NoopChannelOutboundListener();
@@ -90,8 +90,9 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
             unknownStackTrace(new ClosedChannelException(), DefaultNettyConnection.class, "failIfWriteActive(..)");
     private static final ClosedChannelException CLOSED_HANDLER_REMOVED =
             unknownStackTrace(new ClosedChannelException(), NettyToStChannelInboundHandler.class, "handlerRemoved(..)");
-    private static final AtomicReferenceFieldUpdater<DefaultNettyConnection, ChannelOutboundListener> writableListenerUpdater =
-            newUpdater(DefaultNettyConnection.class, ChannelOutboundListener.class, "channelOutboundListener");
+    private static final AtomicReferenceFieldUpdater<DefaultNettyConnection, ChannelOutboundListener>
+            writableListenerUpdater = newUpdater(DefaultNettyConnection.class, ChannelOutboundListener.class,
+                                                 "channelOutboundListener");
 
     private final TerminalPredicate<Read> terminalMsgPredicate;
     private final CloseHandler closeHandler;

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -81,8 +81,8 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
 
     private static final TerminalPredicate PIPELINE_UNSUPPORTED_PREDICATE = new TerminalPredicate();
 
-    private static final WritableListener PLACE_HOLDER_WRITABLE_LISTENER = new NoopWritableListener();
-    private static final WritableListener SINGLE_ITEM_WRITABLE_LISTENER = new NoopWritableListener();
+    private static final ChannelOutboundListener PLACE_HOLDER_OUTBOUND_LISTENER = new NoopChannelOutboundListener();
+    private static final ChannelOutboundListener SINGLE_ITEM_OUTBOUND_LISTENER = new NoopChannelOutboundListener();
 
     private static final ClosedChannelException CLOSED_CHANNEL_INACTIVE = unknownStackTrace(
             new ClosedChannelException(), NettyToStChannelInboundHandler.class, "channelInactive(..)");
@@ -90,8 +90,8 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
             unknownStackTrace(new ClosedChannelException(), DefaultNettyConnection.class, "failIfWriteActive(..)");
     private static final ClosedChannelException CLOSED_HANDLER_REMOVED =
             unknownStackTrace(new ClosedChannelException(), NettyToStChannelInboundHandler.class, "handlerRemoved(..)");
-    private static final AtomicReferenceFieldUpdater<DefaultNettyConnection, WritableListener> writableListenerUpdater =
-            newUpdater(DefaultNettyConnection.class, WritableListener.class, "writableListener");
+    private static final AtomicReferenceFieldUpdater<DefaultNettyConnection, ChannelOutboundListener> writableListenerUpdater =
+            newUpdater(DefaultNettyConnection.class, ChannelOutboundListener.class, "channelOutboundListener");
 
     private final TerminalPredicate<Read> terminalMsgPredicate;
     private final CloseHandler closeHandler;
@@ -102,7 +102,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     private final CompletableSource.Processor onClosing;
     private final SingleSource.Processor<Throwable, Throwable> transportError = newSingleProcessor();
     private final FlushStrategyHolder flushStrategyHolder;
-    private volatile WritableListener writableListener = PLACE_HOLDER_WRITABLE_LISTENER;
+    private volatile ChannelOutboundListener channelOutboundListener = PLACE_HOLDER_OUTBOUND_LISTENER;
     /**
      * Potentially contains more information when a protocol or channel level close event was observed.
      * <p>
@@ -295,7 +295,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     }
 
     private void cleanupOnWriteTerminated() {
-        writableListener = PLACE_HOLDER_WRITABLE_LISTENER;
+        channelOutboundListener = PLACE_HOLDER_OUTBOUND_LISTENER;
     }
 
     @Override
@@ -347,8 +347,8 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     public Completable writeAndFlush(Write write) {
         requireNonNull(write);
         return cleanupStateWhenDone(new NettyFutureCompletable(() -> {
-            if (writableListenerUpdater.compareAndSet(DefaultNettyConnection.this, PLACE_HOLDER_WRITABLE_LISTENER,
-                    SINGLE_ITEM_WRITABLE_LISTENER)) {
+            if (writableListenerUpdater.compareAndSet(DefaultNettyConnection.this, PLACE_HOLDER_OUTBOUND_LISTENER,
+                    SINGLE_ITEM_OUTBOUND_LISTENER)) {
                 return channel().writeAndFlush(write);
             }
             return channel().newFailedFuture(
@@ -362,7 +362,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
      * @return {@code true} if a write is already active.
      */
     boolean isWriteActive() {
-        return writableListener != PLACE_HOLDER_WRITABLE_LISTENER;
+        return channelOutboundListener != PLACE_HOLDER_OUTBOUND_LISTENER;
     }
 
     @Override
@@ -419,13 +419,13 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
         return completable.beforeFinally(this::cleanupOnWriteTerminated);
     }
 
-    private boolean failIfWriteActive(WritableListener newWritableListener, Subscriber subscriber) {
-        if (writableListenerUpdater.compareAndSet(this, PLACE_HOLDER_WRITABLE_LISTENER, newWritableListener)) {
+    private boolean failIfWriteActive(ChannelOutboundListener newChannelOutboundListener, Subscriber subscriber) {
+        if (writableListenerUpdater.compareAndSet(this, PLACE_HOLDER_OUTBOUND_LISTENER, newChannelOutboundListener)) {
             // It is possible that we have set the writeSubscriber, then the channel becomes inactive, and we will
             // never notify the write writeSubscriber of the inactive event. So if the channel is inactive we notify
             // the writeSubscriber.
             if (!channel().isActive()) {
-                newWritableListener.close(CLOSED_FAIL_ACTIVE);
+                newChannelOutboundListener.channelClosed(CLOSED_FAIL_ACTIVE);
                 return false;
             }
             return true;
@@ -450,7 +450,11 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
         return fromSource(transportError).publishOn(executionContext().executor());
     }
 
-    interface WritableListener {
+    /**
+     * An interface which provides methods that are invoked when outbound channel events occur. The implementors of
+     * this interface are effectively "listening" to these events via method calls.
+     */
+    interface ChannelOutboundListener {
         /**
          * Notification that the writability of the channel has changed.
          * <p>
@@ -459,37 +463,34 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
         void channelWritable();
 
         /**
-         * Close the channel after the pending writes complete.
-         *
+         * Notification that the channel's outbound side has been closed and will no longer accept writes.s
          * <p>
-         * Calling {@link #close(Throwable)} after {@link #closeGracefully()} will be ignored.
-         * <p>
-         * This event is expected be called from the eventloop.
+         * Always called from the event loop thread.
          */
-        void closeGracefully();
+        void channelOutboundClosed();
 
         /**
          * Notification that the channel has been closed.
          * <p>
-         * This may not always be called from the event loop. For example if the channel is closed when a new write
-         * happens then this method will be called from the writer thread.
+         * This may not always be called from the event loop thread. For example if the channel is closed when a new
+         * write happens then this method will be called from the writer thread.
          *
          * @param closedException the exception which describes the close rational.
          */
-        void close(Throwable closedException);
+        void channelClosed(Throwable closedException);
     }
 
-    private static final class NoopWritableListener implements WritableListener {
+    private static final class NoopChannelOutboundListener implements ChannelOutboundListener {
         @Override
         public void channelWritable() {
         }
 
         @Override
-        public void closeGracefully() {
+        public void channelOutboundClosed() {
         }
 
         @Override
-        public void close(Throwable closedException) {
+        public void channelClosed(Throwable closedException) {
         }
     }
 
@@ -516,7 +517,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
         @Override
         public void channelWritabilityChanged(ChannelHandlerContext ctx) {
             if (ctx.channel().isWritable()) {
-                connection.writableListener.channelWritable();
+                connection.channelOutboundListener.channelWritable();
             } else if (connection.flushStrategyHolder.currentStrategy().shouldFlushOnUnwritable()) {
                 ctx.flush();
             }
@@ -558,10 +559,10 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
         @Override
         public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
             if (evt == CloseHandler.ProtocolPayloadEndEvent.OUTBOUND) {
-                connection.writableListener.closeGracefully();
+                connection.channelOutboundListener.channelOutboundClosed();
             } else if (evt == ChannelOutputShutdownEvent.INSTANCE) {
                 connection.closeHandler.channelClosedOutbound(ctx);
-                connection.writableListener.close(CLOSED_CHANNEL_INACTIVE);
+                connection.channelOutboundListener.channelClosed(CLOSED_CHANNEL_INACTIVE);
             } else if (evt == ChannelInputShutdownReadComplete.INSTANCE) {
                 // Notify close handler first to enhance error reporting
                 connection.closeHandler.channelClosedInbound(ctx);
@@ -596,7 +597,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
         @Override
         public void channelInactive(ChannelHandlerContext ctx) {
             tryFailSubscriber(CLOSED_CHANNEL_INACTIVE);
-            connection.writableListener.close(CLOSED_CHANNEL_INACTIVE);
+            connection.channelOutboundListener.channelClosed(CLOSED_CHANNEL_INACTIVE);
             connection.nettyChannelPublisher.channelInboundClosed();
         }
 

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
@@ -131,7 +131,7 @@ public class DefaultNettyConnectionTest {
                     public void write(final ChannelHandlerContext ctx,
                                       final Object msg,
                                       final ChannelPromise promise) {
-                        if (msg.equals(TRAILER)) {
+                        if (TRAILER.equals(msg)) {
                             ctx.pipeline().fireUserEventTriggered(CloseHandler.ProtocolPayloadEndEvent.OUTBOUND);
                         }
                         ctx.write(msg, promise);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteSingleSubscriberTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteSingleSubscriberTest.java
@@ -60,7 +60,7 @@ public class WriteSingleSubscriberTest extends AbstractWriteTest {
     public void testCloseGracefully() {
         WriteSingleSubscriber listener = new WriteSingleSubscriber(channel, completableSubscriber, closeHandler);
         listener.onSuccess("Hello");
-        listener.closeGracefully();
+        listener.channelOutboundClosed();
         channel.flushOutbound();
         verify(completableSubscriber).onComplete();
         verifyZeroInteractions(closeHandler);
@@ -72,7 +72,7 @@ public class WriteSingleSubscriberTest extends AbstractWriteTest {
         WriteSingleSubscriber listener = new WriteSingleSubscriber(channel, completableSubscriber, closeHandler);
         listener.onSuccess("Hello");
         channel.flushOutbound();
-        listener.closeGracefully();
+        listener.channelOutboundClosed();
         verify(completableSubscriber).onComplete();
         verifyZeroInteractions(closeHandler);
         assertThat("Message not written.", channel.readOutbound(), is("Hello"));
@@ -82,7 +82,7 @@ public class WriteSingleSubscriberTest extends AbstractWriteTest {
     public void testCloseGracefullyBeforeWrite() {
         WriteSingleSubscriber listener = new WriteSingleSubscriber(channel, completableSubscriber, closeHandler);
         final ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
-        listener.closeGracefully();
+        listener.channelOutboundClosed();
         verify(completableSubscriber).onError(captor.capture());
         assertThat(captor.getValue(), instanceOf(IllegalStateException.class));
     }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberTest.java
@@ -146,7 +146,7 @@ public class WriteStreamSubscriberTest extends AbstractWriteTest {
 
     @Test
     public void onNextAfterChannelClose() {
-        subscriber.close(new ClosedChannelException());
+        subscriber.channelClosed(new ClosedChannelException());
         subscriber.onNext("Hello");
         channel.runPendingTasks();
         assertThat("Unexpected message(s) written.", channel.outboundMessages(), is(empty()));


### PR DESCRIPTION
Motivation:
The WriteListener interface has grown over time and its naming conventions have
become less clear. For example "closeGracefully" implies that some action is
expected to be taken to account for pending writes, but in reality this is just
a notification that the transport's outbound side has been closed and should be
interpreted accordingly by the implementation.

Modifications:
- Rename WritableListener to ChannelOutboundListener. Rename method names on
this interface to indicate they are notification of channel events and
implementations can react however they need to.
- DefaultNettyConnectionTest writes a static buffer, but doesn't duplicate() on
each use. The test now duplicates the buffer to avoid shared indexes.
- Avoid forcing error logs from WriteSingleSubscriber because the async
control flow has already been completed and the additional noise/overhead of the
log may not be necessary.

Result:
More clarity around ChannelOutboundListener interfaces and implementations.