### PR TITLE
Add trailers after gRPC `BlockingStreamingRoute` response

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
@@ -110,7 +110,7 @@ final class GrpcUtils {
         setStatus(trailers, STATUS_OK, null, allocator);
     }
 
-    static void setStatus(final HttpHeaders trailers, final GrpcStatus status, final @Nullable Status details,
+    static void setStatus(final HttpHeaders trailers, final GrpcStatus status, @Nullable final Status details,
                           final BufferAllocator allocator) {
         trailers.set(GRPC_STATUS_CODE_TRAILER, valueOf(status.code().value()));
         if (status.description() != null) {
@@ -125,11 +125,9 @@ final class GrpcUtils {
     static void setStatus(final HttpHeaders trailers, final Throwable cause, final BufferAllocator allocator) {
         if (cause instanceof GrpcStatusException) {
             GrpcStatusException grpcStatusException = (GrpcStatusException) cause;
-            GrpcUtils.setStatus(trailers, grpcStatusException.status(), grpcStatusException.applicationStatus(),
-                    allocator);
+            setStatus(trailers, grpcStatusException.status(), grpcStatusException.applicationStatus(), allocator);
         } else {
-            GrpcUtils.setStatus(trailers, GrpcStatus.fromCodeValue(GrpcStatusCode.UNKNOWN.value()), null,
-                    allocator);
+            setStatus(trailers, GrpcStatus.fromCodeValue(GrpcStatusCode.UNKNOWN.value()), null, allocator);
         }
     }
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
@@ -88,7 +88,7 @@ final class GrpcUtils {
     static HttpResponse newResponse(final HttpResponseFactory responseFactory, final BufferAllocator allocator) {
         final HttpResponse response = responseFactory.ok();
         initResponse(response);
-        setStatus(response.trailers(), STATUS_OK, null, allocator);
+        setStatusOk(response.trailers(), allocator);
         return response;
     }
 
@@ -104,6 +104,10 @@ final class GrpcUtils {
         StreamingHttpResponse response = newResponse(responseFactory, null, null, allocator);
         response.transformRaw(new ErrorUpdater(cause, allocator));
         return response;
+    }
+
+    static void setStatusOk(final HttpHeaders trailers, final BufferAllocator allocator) {
+        setStatus(trailers, STATUS_OK, null, allocator);
     }
 
     static void setStatus(final HttpHeaders trailers, final GrpcStatus status, final @Nullable Status details,


### PR DESCRIPTION
Motivation:

gRPC protocol requires a server to send trailers after the response
payload body to notify a client about the status of this response
processing. We add trailers for all service APIs except
`BlockingStreamingRoute` when service responds successfully.

Modifications:

- Add trailers with `grpc-status: 0` if `BlockingStreamingRoute`
responds without errors;

Result:

Server sends a complete response with trailers from
`BlockingStreamingRoute`.