### PR TITLE
gRPC-server should return `UNIMPLEMENTED` when route is not found

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -32,7 +32,6 @@ import io.servicetalk.grpc.api.GrpcRoutes.ResponseStreamingRoute;
 import io.servicetalk.grpc.api.GrpcRoutes.Route;
 import io.servicetalk.grpc.api.GrpcRoutes.StreamingRoute;
 import io.servicetalk.grpc.api.GrpcServiceFactory.ServerBinder;
-import io.servicetalk.grpc.api.GrpcUtils.GrpcStatusUpdater;
 import io.servicetalk.http.api.BlockingHttpService;
 import io.servicetalk.http.api.BlockingStreamingHttpRequest;
 import io.servicetalk.http.api.BlockingStreamingHttpServerResponse;
@@ -94,9 +93,9 @@ final class GrpcRouter {
 
     private static final GrpcStatus STATUS_UNIMPLEMENTED = fromCodeValue(UNIMPLEMENTED.value());
     private static final StreamingHttpService NOT_FOUND_SERVICE = (ctx, request, responseFactory) -> {
-        final StreamingHttpResponse response = responseFactory.ok();
+        final StreamingHttpResponse response = newResponse(responseFactory, STATUS_UNIMPLEMENTED,
+                ctx.executionContext().bufferAllocator());
         response.version(request.version());
-        response.transformRaw(new GrpcStatusUpdater(ctx.executionContext().bufferAllocator(), STATUS_UNIMPLEMENTED));
         return succeeded(response);
     };
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -67,6 +67,8 @@ import static io.servicetalk.grpc.api.GrpcRouteConversions.toRequestStreamingRou
 import static io.servicetalk.grpc.api.GrpcRouteConversions.toResponseStreamingRoute;
 import static io.servicetalk.grpc.api.GrpcRouteConversions.toRoute;
 import static io.servicetalk.grpc.api.GrpcRouteConversions.toStreaming;
+import static io.servicetalk.grpc.api.GrpcStatus.fromCodeValue;
+import static io.servicetalk.grpc.api.GrpcStatusCode.UNIMPLEMENTED;
 import static io.servicetalk.grpc.api.GrpcUtils.newErrorResponse;
 import static io.servicetalk.grpc.api.GrpcUtils.newResponse;
 import static io.servicetalk.grpc.api.GrpcUtils.readGrpcMessageEncoding;
@@ -90,8 +92,8 @@ final class GrpcRouter {
     private final Map<String, RouteProvider> blockingRoutes;
     private final Map<String, RouteProvider> blockingStreamingRoutes;
 
-    private static final GrpcStatus STATUS_UNIMPLEMENTED = GrpcStatus.fromCodeValue(GrpcStatusCode.OK.value());
-    private static final StreamingHttpService notFound = (ctx, request, responseFactory) -> {
+    private static final GrpcStatus STATUS_UNIMPLEMENTED = fromCodeValue(UNIMPLEMENTED.value());
+    private static final StreamingHttpService NOT_FOUND_SERVICE = (ctx, request, responseFactory) -> {
         final StreamingHttpResponse response = responseFactory.ok();
         response.version(request.version());
         response.transformRaw(new GrpcStatusUpdater(ctx.executionContext().bufferAllocator(), STATUS_UNIMPLEMENTED));
@@ -124,7 +126,7 @@ final class GrpcRouter {
                                                         final StreamingHttpResponseFactory responseFactory) {
                 final StreamingHttpService service;
                 if (!POST.equals(request.method()) || (service = allRoutes.get(request.path())) == null) {
-                    return notFound.handle(ctx, request, responseFactory);
+                    return NOT_FOUND_SERVICE.handle(ctx, request, responseFactory);
                 } else {
                     return service.handle(ctx, request, responseFactory);
                 }


### PR DESCRIPTION
Motivation:

When gRPC-server doesn't have a requested route it should respond
with an error status `UNIMPLEMENTED` to propagate the error to the
client.

Modifications:

- Change `NOT_FOUND_SERVICE` to return `UNIMPLEMENTED` grpc-status;
- Add required `content-type` header for not-found response;
- Add a test to verify that client throws `GrpcStatusException`
when it requests a route that is not registered on the server;

Result:

Client throws `GrpcStatusException` when it requests a route that
is not registered on the server.