### PR TITLE
gRPC filters override configured execution strategy for the route

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouteConversions.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouteConversions.java
@@ -144,7 +144,7 @@ final class GrpcRouteConversions {
                                 grpcPayloadWriter.close();
                             } catch (IOException e) {
                                 if (!concurrentTerminalSubscriber.processOnError(e)) {
-                                    LOGGER.error("Cannot close GrpcPayloadWriter", e);
+                                    LOGGER.error("Failed to close GrpcPayloadWriter", e);
                                 }
                             }
                         }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -200,8 +200,7 @@ final class GrpcRouter {
             return new RouteProviders(allRoutes);
         }
 
-        GrpcExecutionStrategy alreadyRegisteredExecutionStrategy(final String path,
-                                                                 final GrpcExecutionStrategy defaultValue) {
+        GrpcExecutionStrategy executionStrategyFor(final String path, final GrpcExecutionStrategy defaultValue) {
             return executionStrategies.getOrDefault(path, defaultValue);
         }
 
@@ -216,7 +215,7 @@ final class GrpcRouter {
                 mergeRoutes(streamingRoutes, builder.streamingRoutes);
                 mergeRoutes(blockingRoutes, builder.blockingRoutes);
                 mergeRoutes(blockingStreamingRoutes, builder.blockingStreamingRoutes);
-                executionStrategies.putAll(executionStrategies);
+                executionStrategies.putAll(builder.executionStrategies);
             }
             return new Builder(routes, streamingRoutes, blockingRoutes, blockingStreamingRoutes, executionStrategies);
         }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -200,9 +200,8 @@ final class GrpcRouter {
             return new RouteProviders(allRoutes);
         }
 
-        @Nullable
-        GrpcExecutionStrategy executionStrategyFor(final String path) {
-            return executionStrategies.get(path);
+        GrpcExecutionStrategy executionStrategyFor(final String path, final GrpcExecutionStrategy defaultValue) {
+            return executionStrategies.getOrDefault(path, defaultValue);
         }
 
         static GrpcRouter.Builder merge(final GrpcRouter.Builder... builders) {

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -200,8 +200,9 @@ final class GrpcRouter {
             return new RouteProviders(allRoutes);
         }
 
-        GrpcExecutionStrategy executionStrategyFor(final String path, final GrpcExecutionStrategy defaultValue) {
-            return executionStrategies.getOrDefault(path, defaultValue);
+        @Nullable
+        GrpcExecutionStrategy executionStrategyFor(final String path) {
+            return executionStrategies.get(path);
         }
 
         static GrpcRouter.Builder merge(final GrpcRouter.Builder... builders) {

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
@@ -30,8 +30,6 @@ import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.ServerContext;
 
 import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import javax.annotation.Nullable;
@@ -160,12 +158,10 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
 
     static GrpcRoutes<?> merge(GrpcRoutes<?>... allRoutes) {
         final GrpcRouter.Builder[] builders = new GrpcRouter.Builder[allRoutes.length];
-        final Map<String, GrpcExecutionStrategy> executionStrategies = new HashMap<>();
         final Set<String> errors = new TreeSet<>();
         for (int i = 0; i < allRoutes.length; i++) {
-            final GrpcRoutes<?> route = allRoutes[i];
-            builders[i] = route.routeBuilder;
-            errors.addAll(route.errors);
+            builders[i] = allRoutes[i].routeBuilder;
+            errors.addAll(allRoutes[i].errors);
         }
         return new GrpcRoutes<GrpcService>(GrpcRouter.Builder.merge(builders), errors) {
             @Override
@@ -212,8 +208,8 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
             final Class<Req> requestClass, final Class<Resp> responseClass,
             final GrpcSerializationProvider serializationProvider) {
         final Method method = retrieveMethod(serviceClass, methodName, GrpcServiceContext.class, requestClass);
-        final GrpcExecutionStrategy executionStrategy = executionStrategy(path, method, serviceClass);
-        routeBuilder.addRoute(path, executionStrategy, route, requestClass, responseClass, serializationProvider);
+        routeBuilder.addRoute(path, executionStrategy(path, method, serviceClass), route, requestClass, responseClass,
+                serializationProvider);
     }
 
     /**
@@ -253,9 +249,8 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
             final StreamingRoute<Req, Resp> route, final Class<Req> requestClass, final Class<Resp> responseClass,
             final GrpcSerializationProvider serializationProvider) {
         final Method method = retrieveMethod(serviceClass, methodName, GrpcServiceContext.class, Publisher.class);
-        final GrpcExecutionStrategy executionStrategy = executionStrategy(path, method, serviceClass);
-        routeBuilder.addStreamingRoute(path, executionStrategy, route, requestClass, responseClass,
-                serializationProvider);
+        routeBuilder.addStreamingRoute(path, executionStrategy(path, method, serviceClass), route, requestClass,
+                responseClass, serializationProvider);
     }
 
     /**
@@ -296,9 +291,8 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
             final RequestStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
         final Method method = retrieveMethod(serviceClass, methodName, GrpcServiceContext.class, Publisher.class);
-        final GrpcExecutionStrategy executionStrategy = executionStrategy(path, method, serviceClass);
-        routeBuilder.addRequestStreamingRoute(path, executionStrategy, route, requestClass, responseClass,
-                serializationProvider);
+        routeBuilder.addRequestStreamingRoute(path, executionStrategy(path, method, serviceClass), route, requestClass,
+                responseClass, serializationProvider);
     }
 
     /**
@@ -339,9 +333,8 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
             final ResponseStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
         final Method method = retrieveMethod(serviceClass, methodName, GrpcServiceContext.class, requestClass);
-        final GrpcExecutionStrategy executionStrategy = executionStrategy(path, method, serviceClass);
-        routeBuilder.addResponseStreamingRoute(path, executionStrategy, route, requestClass, responseClass,
-                serializationProvider);
+        routeBuilder.addResponseStreamingRoute(path, executionStrategy(path, method, serviceClass), route, requestClass,
+                responseClass, serializationProvider);
     }
 
     /**
@@ -382,9 +375,8 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
             final BlockingRoute<Req, Resp> route, final Class<Req> requestClass, final Class<Resp> responseClass,
             final GrpcSerializationProvider serializationProvider) {
         final Method method = retrieveMethod(serviceClass, methodName, GrpcServiceContext.class, requestClass);
-        final GrpcExecutionStrategy executionStrategy = executionStrategy(path, method, serviceClass);
-        routeBuilder.addBlockingRoute(path, executionStrategy, route, requestClass, responseClass,
-                serializationProvider);
+        routeBuilder.addBlockingRoute(path, executionStrategy(path, method, serviceClass), route, requestClass,
+                responseClass, serializationProvider);
     }
 
     /**
@@ -426,9 +418,8 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
         final Method method = retrieveMethod(serviceClass, methodName, GrpcServiceContext.class, BlockingIterable.class,
                 GrpcPayloadWriter.class);
-        final GrpcExecutionStrategy executionStrategy = executionStrategy(path, method, serviceClass);
-        routeBuilder.addBlockingStreamingRoute(path, executionStrategy, route, requestClass, responseClass,
-                serializationProvider);
+        routeBuilder.addBlockingStreamingRoute(path, executionStrategy(path, method, serviceClass), route, requestClass,
+                responseClass, serializationProvider);
     }
 
     /**
@@ -470,9 +461,8 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
         final Method method = retrieveMethod(serviceClass, methodName, GrpcServiceContext.class,
                 BlockingIterable.class);
-        final GrpcExecutionStrategy executionStrategy = executionStrategy(path, method, serviceClass);
-        routeBuilder.addBlockingRequestStreamingRoute(path, executionStrategy, route, requestClass, responseClass,
-                serializationProvider);
+        routeBuilder.addBlockingRequestStreamingRoute(path, executionStrategy(path, method, serviceClass), route,
+                requestClass, responseClass, serializationProvider);
     }
 
     /**
@@ -514,9 +504,8 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
         final Method method = retrieveMethod(serviceClass, methodName, GrpcServiceContext.class, requestClass,
                 GrpcPayloadWriter.class);
-        final GrpcExecutionStrategy executionStrategy = executionStrategy(path, method, serviceClass);
-        routeBuilder.addBlockingResponseStreamingRoute(path, executionStrategy, route, requestClass, responseClass,
-                serializationProvider);
+        routeBuilder.addBlockingResponseStreamingRoute(path, executionStrategy(path, method, serviceClass), route,
+                requestClass, responseClass, serializationProvider);
     }
 
     /**

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
@@ -180,9 +180,10 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
     private GrpcExecutionStrategy executionStrategy(final String path, final Method method, final Class<?> clazz) {
         // Check if we already have a computed GrpcExecutionStrategy for this path. This happens when we re-register
         // filtered routes and have to use the original execution strategy for the route instead of analysing
-        // annotations on a service-filter class. Because previously registered strategy could be null, we use NULL
+        // annotations on a service-filter class. Because previously registered strategy could be null (if user did not
+        // configure it using ServiceFactory.Builder methods or via @RouteExecutionStrategy annotation), we use NULL
         // object as a marker to understand there was no strategy for this path.
-        final GrpcExecutionStrategy saved = routeBuilder.alreadyRegisteredExecutionStrategy(path, NULL);
+        final GrpcExecutionStrategy saved = routeBuilder.executionStrategyFor(path, NULL);
         if (saved != NULL) {
             return saved;
         }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
@@ -23,7 +23,6 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.grpc.api.GrpcRouter.RouteProviders;
 import io.servicetalk.grpc.api.GrpcServiceFactory.ServerBinder;
-import io.servicetalk.http.api.HttpExecutionStrategies;
 import io.servicetalk.router.api.RouteExecutionStrategy;
 import io.servicetalk.router.api.RouteExecutionStrategyFactory;
 import io.servicetalk.transport.api.ExecutionContext;
@@ -47,12 +46,10 @@ import static io.servicetalk.utils.internal.ReflectionUtils.retrieveMethod;
  */
 public abstract class GrpcRoutes<Service extends GrpcService> {
 
-    private static final GrpcExecutionStrategy NULL = new DefaultGrpcExecutionStrategy(
-            HttpExecutionStrategies.noOffloadsStrategy());
-
     private final GrpcRouter.Builder routeBuilder;
     private final Set<String> errors;
     private final RouteExecutionStrategyFactory<GrpcExecutionStrategy> strategyFactory;
+    private boolean registerFilters;
 
     /**
      * Create a new instance.
@@ -118,6 +115,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * @return {@link AllGrpcRoutes} representing this {@link GrpcRoutes}.
      */
     AllGrpcRoutes drainToStreamingRoutes() {
+        registerFilters = true;
         final RouteProviders routeProviders = routeBuilder.drainRoutes();
         return new AllGrpcRoutes() {
             @Override
@@ -178,14 +176,11 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
 
     @Nullable
     private GrpcExecutionStrategy executionStrategy(final String path, final Method method, final Class<?> clazz) {
-        // Check if we already have a computed GrpcExecutionStrategy for this path. This happens when we re-register
-        // filtered routes and have to use the original execution strategy for the route instead of analysing
-        // annotations on a service-filter class. Because previously registered strategy could be null (if user did not
-        // configure it using ServiceFactory.Builder methods or via @RouteExecutionStrategy annotation), we use NULL
-        // object as a marker to understand there was no strategy for this path.
-        final GrpcExecutionStrategy saved = routeBuilder.executionStrategyFor(path, NULL);
-        if (saved != NULL) {
-            return saved;
+        // If we are in the state of re-registering filtered service, we don't need to analyze annotations on the filter
+        // class. Instead, we should return the original execution strategy for this path that was computed/provided
+        // at the time of the first registration of this GrpcService.
+        if (registerFilters) {
+            return routeBuilder.executionStrategyFor(path);
         }
         return getAndValidateRouteExecutionStrategyAnnotationIfPresent(method, clazz, strategyFactory, errors,
                 noOffloadsStrategy());

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyTest.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.BlockingIterator;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ExecutorRule;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.grpc.api.GrpcExecutionStrategy;
 import io.servicetalk.grpc.api.GrpcServerBuilder;
 import io.servicetalk.grpc.netty.ExecutionStrategyTestServices.ThreadInfo;
 import io.servicetalk.grpc.netty.TesterProto.TestRequest;
@@ -27,6 +28,9 @@ import io.servicetalk.grpc.netty.TesterProto.TestResponse;
 import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTesterClient;
 import io.servicetalk.grpc.netty.TesterProto.Tester.ClientFactory;
 import io.servicetalk.grpc.netty.TesterProto.Tester.ServiceFactory;
+import io.servicetalk.grpc.netty.TesterProto.Tester.TesterService;
+import io.servicetalk.grpc.netty.TesterProto.Tester.TesterServiceFilter;
+import io.servicetalk.router.api.RouteExecutionStrategyFactory;
 import io.servicetalk.transport.api.ServerContext;
 
 import org.junit.After;
@@ -71,6 +75,7 @@ public class ExecutionStrategyTest {
 
     private static final String BUILDER_EXEC_NAME_PREFIX = "builder-executor";
     private static final String ROUTE_EXEC_NAME_PREFIX = "route-executor";
+    private static final String FILTER_EXEC_NAME_PREFIX = "filter-executor";
 
     @ClassRule
     public static final ExecutorRule<Executor> BUILDER_EXEC = ExecutorRule.withNamePrefix(BUILDER_EXEC_NAME_PREFIX);
@@ -78,7 +83,29 @@ public class ExecutionStrategyTest {
     @ClassRule
     public static final ExecutorRule<Executor> ROUTE_EXEC = ExecutorRule.withNamePrefix(ROUTE_EXEC_NAME_PREFIX);
 
+    @ClassRule
+    public static final ExecutorRule<Executor> FILTER_EXEC = ExecutorRule.withNamePrefix(FILTER_EXEC_NAME_PREFIX);
+
     private static final TestRequest REQUEST = TestRequest.newBuilder().setName("name").build();
+
+    private static final RouteExecutionStrategyFactory<GrpcExecutionStrategy> STRATEGY_FACTORY =
+            new TestExecutionStrategyFactory();
+
+    private static final class TestExecutionStrategyFactory
+            implements RouteExecutionStrategyFactory<GrpcExecutionStrategy> {
+
+        @Override
+        public GrpcExecutionStrategy get(final String id) {
+            switch (id) {
+                case "route":
+                    return defaultStrategy(ROUTE_EXEC.executor());
+                case "filter":
+                    return defaultStrategy(FILTER_EXEC.executor());
+                default:
+                    throw new IllegalArgumentException("Unknown id: " + id);
+            }
+        }
+    }
 
     private enum BuilderExecutionStrategy {
         DEFAULT {
@@ -107,32 +134,31 @@ public class ExecutionStrategyTest {
         ASYNC_DEFAULT {
             @Override
             ServiceFactory getServiceFactory() {
-                return new ServiceFactory(DEFAULT_STRATEGY_ASYNC_SERVICE);
+                return new ServiceFactory(DEFAULT_STRATEGY_ASYNC_SERVICE, STRATEGY_FACTORY);
             }
         },
         ASYNC_CLASS_EXEC_ID {
             @Override
             ServiceFactory getServiceFactory() {
-                return new ServiceFactory(CLASS_EXEC_ID_STRATEGY_ASYNC_SERVICE,
-                        __ -> defaultStrategy(ROUTE_EXEC.executor()));
+                return new ServiceFactory(CLASS_EXEC_ID_STRATEGY_ASYNC_SERVICE, STRATEGY_FACTORY);
             }
         },
         ASYNC_CLASS_NO_OFFLOADS {
             @Override
             ServiceFactory getServiceFactory() {
-                return new ServiceFactory(CLASS_NO_OFFLOADS_STRATEGY_ASYNC_SERVICE);
+                return new ServiceFactory(CLASS_NO_OFFLOADS_STRATEGY_ASYNC_SERVICE, STRATEGY_FACTORY);
             }
         },
         ASYNC_METHOD_NO_OFFLOADS {
             @Override
             ServiceFactory getServiceFactory() {
-                return new ServiceFactory(METHOD_NO_OFFLOADS_STRATEGY_ASYNC_SERVICE);
+                return new ServiceFactory(METHOD_NO_OFFLOADS_STRATEGY_ASYNC_SERVICE, STRATEGY_FACTORY);
             }
         },
         ASYNC_SERVICE_FACTORY_NO_OFFLOADS {
             @Override
             ServiceFactory getServiceFactory() {
-                return new ServiceFactory.Builder()
+                return new ServiceFactory.Builder(STRATEGY_FACTORY)
                         .test(noOffloadsStrategy(), DEFAULT_STRATEGY_ASYNC_SERVICE)
                         .testBiDiStream(noOffloadsStrategy(), DEFAULT_STRATEGY_ASYNC_SERVICE)
                         .testResponseStream(noOffloadsStrategy(), DEFAULT_STRATEGY_ASYNC_SERVICE)
@@ -143,32 +169,31 @@ public class ExecutionStrategyTest {
         BLOCKING_DEFAULT {
             @Override
             ServiceFactory getServiceFactory() {
-                return new ServiceFactory(DEFAULT_STRATEGY_BLOCKING_SERVICE);
+                return new ServiceFactory(DEFAULT_STRATEGY_BLOCKING_SERVICE, STRATEGY_FACTORY);
             }
         },
         BLOCKING_CLASS_EXEC_ID {
             @Override
             ServiceFactory getServiceFactory() {
-                return new ServiceFactory(CLASS_EXEC_ID_STRATEGY_BLOCKING_SERVICE,
-                        __ -> defaultStrategy(ROUTE_EXEC.executor()));
+                return new ServiceFactory(CLASS_EXEC_ID_STRATEGY_BLOCKING_SERVICE, STRATEGY_FACTORY);
             }
         },
         BLOCKING_CLASS_NO_OFFLOADS {
             @Override
             ServiceFactory getServiceFactory() {
-                return new ServiceFactory(CLASS_NO_OFFLOADS_STRATEGY_BLOCKING_SERVICE);
+                return new ServiceFactory(CLASS_NO_OFFLOADS_STRATEGY_BLOCKING_SERVICE, STRATEGY_FACTORY);
             }
         },
         BLOCKING_METHOD_NO_OFFLOADS {
             @Override
             ServiceFactory getServiceFactory() {
-                return new ServiceFactory(METHOD_NO_OFFLOADS_STRATEGY_BLOCKING_SERVICE);
+                return new ServiceFactory(METHOD_NO_OFFLOADS_STRATEGY_BLOCKING_SERVICE, STRATEGY_FACTORY);
             }
         },
         BLOCKING_SERVICE_FACTORY_NO_OFFLOADS {
             @Override
             ServiceFactory getServiceFactory() {
-                return new ServiceFactory.Builder()
+                return new ServiceFactory.Builder(STRATEGY_FACTORY)
                         .testBlocking(noOffloadsStrategy(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
                         .testBiDiStreamBlocking(noOffloadsStrategy(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
                         .testResponseStreamBlocking(noOffloadsStrategy(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
@@ -219,6 +244,41 @@ public class ExecutionStrategyTest {
         }
     }
 
+    private enum FilterConfiguration {
+        NO_FILTER {
+            @Override
+            void appendServiceFilter(final ServiceFactory serviceFactory) {
+                // noop
+            }
+        },
+        DEFAULT_FILTER {
+            @Override
+            void appendServiceFilter(final ServiceFactory serviceFactory) {
+                // This filter doesn't do anything, it just delegates, but we want to verify that presence of the filter
+                // does not break execution strategy configuration
+                serviceFactory.appendServiceFilter(TesterServiceFilter::new);
+            }
+        },
+        ANNOTATED_FILTER {
+            @Override
+            void appendServiceFilter(final ServiceFactory serviceFactory) {
+                // This filter wraps the service with annotated class as an attempt to modify route's execution strategy
+                // for the original service. We want to make sure that this annotation will be ignored
+                serviceFactory.appendServiceFilter(ServiceFilterWithExecutionStrategy::new);
+            }
+        };
+
+        abstract void appendServiceFilter(ServiceFactory serviceFactory);
+
+        @io.servicetalk.router.api.RouteExecutionStrategy(id = "filter")
+        private static final class ServiceFilterWithExecutionStrategy extends TesterServiceFilter {
+
+            ServiceFilterWithExecutionStrategy(final TesterService delegate) {
+                super(delegate);
+            }
+        }
+    }
+
     @Rule
     public final Timeout timeout = new ServiceTalkTestTimeout();
 
@@ -231,32 +291,28 @@ public class ExecutionStrategyTest {
     public ExecutionStrategyTest(BuilderExecutionStrategy builderStrategy,
                                  RouteExecutionStrategy routeStrategy,
                                  RouteApi routeApi,
-                                 boolean appendServiceFilter) throws Exception {
+                                 FilterConfiguration filterConfiguration) throws Exception {
         this.builderStrategy = builderStrategy;
         this.routeStrategy = routeStrategy;
         this.routeApi = routeApi;
         GrpcServerBuilder builder = GrpcServers.forAddress(localAddress(0));
         builderStrategy.configureBuilderExecutionStrategy(builder);
         ServiceFactory serviceFactory = routeStrategy.getServiceFactory();
-        if (appendServiceFilter) {
-            // This filter doesn't do anything, it just delegates, but we want to verify that presence of the filter
-            // does not break execution strategy configuration
-            serviceFactory.appendServiceFilter(TesterProto.Tester.TesterServiceFilter::new);
-        }
+        filterConfiguration.appendServiceFilter(serviceFactory);
         serverContext = builder.listenAndAwait(serviceFactory);
         client = GrpcClients.forAddress(serverHostAndPort(serverContext))
                 .executionStrategy(noOffloadsStrategy())
                 .buildBlocking(new ClientFactory());
     }
 
-    @Parameterized.Parameters(name = "builder={0} route={1}, api={2}, appendServiceFilter={3}")
+    @Parameterized.Parameters(name = "builder={0} route={1}, api={2}, filterConfiguration={3}")
     public static Collection<Object[]> data() {
         List<Object[]> parameters = new ArrayList<>();
         for (BuilderExecutionStrategy builderEs : BuilderExecutionStrategy.values()) {
             for (RouteExecutionStrategy routeEs : RouteExecutionStrategy.values()) {
                 for (RouteApi routeApi : RouteApi.values()) {
-                    for (boolean appendServiceFilter : new boolean[] {false, true}) {
-                        parameters.add(new Object[] {builderEs, routeEs, routeApi, appendServiceFilter});
+                    for (FilterConfiguration filterConfiguration : FilterConfiguration.values()) {
+                        parameters.add(new Object[] {builderEs, routeEs, routeApi, filterConfiguration});
                     }
                 }
             }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyTestServices.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyTestServices.java
@@ -205,14 +205,12 @@ public final class ExecutionStrategyTestServices {
                                    final GrpcPayloadWriter<TestResponse> responseWriter) throws Exception {
             request.forEach(__ -> { /* ignore */ });
             responseWriter.write(new ThreadInfo(ctx).encode());
-            responseWriter.close();
         }
 
         @Override
         public void testResponseStream(final GrpcServiceContext ctx, final TestRequest request,
                                        final GrpcPayloadWriter<TestResponse> responseWriter) throws Exception {
             responseWriter.write(new ThreadInfo(ctx).encode());
-            responseWriter.close();
         }
 
         @Override

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyTestServices.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyTestServices.java
@@ -153,7 +153,7 @@ public final class ExecutionStrategyTestServices {
         // Nothing to override
     }
 
-    @RouteExecutionStrategy(id = "test")
+    @RouteExecutionStrategy(id = "route")
     private static class ClassExecIdStrategyAsyncService extends EsAsyncService {
         // Nothing to override
     }
@@ -225,7 +225,7 @@ public final class ExecutionStrategyTestServices {
         // Nothing to override
     }
 
-    @RouteExecutionStrategy(id = "test")
+    @RouteExecutionStrategy(id = "route")
     private static class ClassExecIdStrategyBlockingService extends EsBlockingService {
         // Nothing to override
     }


### PR DESCRIPTION
Motivation:

When users append a service filter using `ServiceFactory`, it
reconstructs the `GrpcService` interface from registered routes,
wraps it with the filter, and re-registers the service again as
independent routes. This logic does not preserve the execution
strategy that was used to register the original route and it
uses the default strategy for a route.

Modifications:

- Save the route execution strategy if it was configured for the
original route;
- Use the saved execution strategy when we re-register filtered
routes;
- Add tests to verify the execution strategy configuration when
users apply a filter;
- Add tests to verify grpc router does not extract execution strategy
annotations from filters;
- Close `GrpcPayloadWriter` in the conversion layer from
`BlockingStreamingRoute` to `StreamingRoute`, because users of
`BlockingRequestStreamingRoute` does not have access to it;

Result:

gRPC filters do not override configured execution strategy for
the route.