### PR TITLE
H2 client ignores query parameters

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -80,10 +80,10 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
             method = metaData.method();
             h2Headers.method(method.name());
             if (!CONNECT.equals(method)) {
-                // The ":scheme" and ":path" pseudo-header fields MUST be omitted.
+                // The ":scheme" and ":path" pseudo-header fields MUST be omitted for CONNECT.
                 // https://tools.ietf.org/html/rfc7540#section-8.3
                 h2Headers.scheme(scheme.name());
-                h2Headers.path(metaData.path());
+                h2Headers.path(metaData.requestTarget());
             }
             ctx.write(new DefaultHttp2HeadersFrame(h2Headers, false), promise);
         } else if (msg instanceof Buffer) {


### PR DESCRIPTION
__Motivation__

When using H2 as the transport with HTTP clients, if query parameters are present in the request, they get ignored while writing the request on the network.

__Modification__

`H2ToStH1ClientDuplexHandler` is using `request.path()` as the value for the `:path` pseudo-header in H2. `path()` omits query parameters. Now using `requestTarget()`.

__Results__

Query parameters are preserved when using H2 transport.