### PR TITLE
`when*` operators for async sources

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -910,13 +910,13 @@ public abstract class Completable {
     }
 
     /**
-     * Creates a new {@link Subscriber} (via the {@code subscriberSupplier} argument) on each call to
-     * subscribe and invokes all the {@link Subscriber} methods when the {@link Subscriber}s of the
-     * returned {@link Completable}.
+     * Creates a new {@link Subscriber} (via the {@code subscriberSupplier} argument) for each new subscribe and
+     * invokes methods on that {@link Subscriber} when the corresponding methods are called for {@link Subscriber}s of
+     * the returned {@link Publisher}.
      *
-     * @param subscriberSupplier Creates a new {@link Subscriber} on each call to subscribe and invokes all the
-     * {@link Subscriber} methods when the {@link Subscriber}s of the returned {@link Completable}.
-     * {@link Subscriber} methods <strong>MUST NOT</strong> throw.
+     * @param subscriberSupplier Creates a new {@link Subscriber} for each new subscribe and invokes methods on that
+     * {@link Subscriber} when the corresponding methods are called for {@link Subscriber}s of the returned
+     * {@link Publisher}. {@link Subscriber} methods <strong>MUST NOT</strong> throw.
      * @return The new {@link Completable}.
      */
     public final Completable whenSubscriber(Supplier<? extends Subscriber> subscriberSupplier) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -790,11 +790,11 @@ public abstract class Completable {
     }
 
     /**
-     * Invokes the {@code onSubscribe} {@link Consumer} argument <strong>when</strong>
+     * Invokes the {@code onSubscribe} {@link Consumer} argument when
      * {@link Subscriber#onSubscribe(Cancellable)} is called for {@link Subscriber}s of the returned
      * {@link Completable}.
      *
-     * @param onSubscribe Invoked <strong>when</strong> {@link Subscriber#onSubscribe(Cancellable)} is called for
+     * @param onSubscribe Invoked when {@link Subscriber#onSubscribe(Cancellable)} is called for
      * {@link Subscriber}s of the returned {@link Completable}. <strong>MUST NOT</strong> throw.
      * @return The new {@link Completable}.
      */
@@ -904,11 +904,11 @@ public abstract class Completable {
 
     /**
      * Creates a new {@link Subscriber} (via the {@code subscriberSupplier} argument) on each call to
-     * subscribe and invokes all the {@link Subscriber} methods <strong>when</strong> the {@link Subscriber}s of the
+     * subscribe and invokes all the {@link Subscriber} methods when the {@link Subscriber}s of the
      * returned {@link Completable}.
      *
      * @param subscriberSupplier Creates a new {@link Subscriber} on each call to subscribe and invokes all the
-     * {@link Subscriber} methods <strong>when</strong> the {@link Subscriber}s of the returned {@link Completable}.
+     * {@link Subscriber} methods when the {@link Subscriber}s of the returned {@link Completable}.
      * {@link Subscriber} methods <strong>MUST NOT</strong> throw.
      * @return The new {@link Completable}.
      */

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -802,8 +802,8 @@ public abstract class Completable {
      * {@link Subscriber}s of the returned {@link Completable}. <strong>MUST NOT</strong> throw.
      * @return The new {@link Completable}.
      *
-     * @see #beforeOnNext(Consumer)
-     * @see #afterOnNext(Consumer)
+     * @see #beforeOnSubscribe(Consumer)
+     * @see #afterOnSubscribe(Consumer)
      */
     public final Completable whenOnSubscribe(Consumer<Cancellable> onSubscribe) {
         return afterOnSubscribe(onSubscribe);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -789,7 +789,6 @@ public abstract class Completable {
         return afterSubscriber(doOnSubscribeSupplier(onSubscribe));
     }
 
-
     /**
      * Invokes the {@code onSubscribe} {@link Consumer} argument <strong>when</strong>
      * {@link Subscriber#onSubscribe(Cancellable)} is called for {@link Subscriber}s of the returned
@@ -802,7 +801,6 @@ public abstract class Completable {
     public final Completable whenOnSubscribe(Consumer<Cancellable> onSubscribe) {
         return afterOnSubscribe(onSubscribe);
     }
-
 
     /**
      * Invokes the {@code onComplete} {@link Runnable} argument <strong>after</strong> {@link Subscriber#onComplete()}
@@ -904,7 +902,6 @@ public abstract class Completable {
         return new AfterSubscriberCompletable(this, subscriberSupplier, executor);
     }
 
-
     /**
      * Creates a new {@link Subscriber} (via the {@code subscriberSupplier} argument) on each call to
      * subscribe and invokes all the {@link Subscriber} methods <strong>when</strong> the {@link Subscriber}s of the
@@ -918,7 +915,6 @@ public abstract class Completable {
     public final Completable whenSubscriber(Supplier<? extends Subscriber> subscriberSupplier) {
         return afterSubscriber(subscriberSupplier);
     }
-
 
     /**
      * <strong>This method requires advanced knowledge of building operators. Before using this method please attempt

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -793,10 +793,17 @@ public abstract class Completable {
      * Invokes the {@code onSubscribe} {@link Consumer} argument when
      * {@link Subscriber#onSubscribe(Cancellable)} is called for {@link Subscriber}s of the returned
      * {@link Completable}.
+     * <p>
+     * The order in which {@code onSubscribe} will be invoked relative to
+     * {@link Subscriber#onSubscribe(Cancellable)} is undefined. If you need strict ordering see
+     * {@link #beforeOnSubscribe(Consumer)} and {@link #afterOnSubscribe(Consumer)}.
      *
      * @param onSubscribe Invoked when {@link Subscriber#onSubscribe(Cancellable)} is called for
      * {@link Subscriber}s of the returned {@link Completable}. <strong>MUST NOT</strong> throw.
      * @return The new {@link Completable}.
+     *
+     * @see #beforeOnNext(Consumer)
+     * @see #afterOnNext(Consumer)
      */
     public final Completable whenOnSubscribe(Consumer<Cancellable> onSubscribe) {
         return afterOnSubscribe(onSubscribe);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -904,6 +904,22 @@ public abstract class Completable {
         return new AfterSubscriberCompletable(this, subscriberSupplier, executor);
     }
 
+
+    /**
+     * Creates a new {@link Subscriber} (via the {@code subscriberSupplier} argument) on each call to
+     * subscribe and invokes all the {@link Subscriber} methods <strong>when</strong> the {@link Subscriber}s of the
+     * returned {@link Completable}.
+     *
+     * @param subscriberSupplier Creates a new {@link Subscriber} on each call to subscribe and invokes all the
+     * {@link Subscriber} methods <strong>when</strong> the {@link Subscriber}s of the returned {@link Completable}.
+     * {@link Subscriber} methods <strong>MUST NOT</strong> throw.
+     * @return The new {@link Completable}.
+     */
+    public final Completable whenSubscriber(Supplier<? extends Subscriber> subscriberSupplier) {
+        return afterSubscriber(subscriberSupplier);
+    }
+
+
     /**
      * <strong>This method requires advanced knowledge of building operators. Before using this method please attempt
      * to compose existing operator(s) to satisfy your use case.</strong>

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -789,6 +789,21 @@ public abstract class Completable {
         return afterSubscriber(doOnSubscribeSupplier(onSubscribe));
     }
 
+
+    /**
+     * Invokes the {@code onSubscribe} {@link Consumer} argument <strong>when</strong>
+     * {@link Subscriber#onSubscribe(Cancellable)} is called for {@link Subscriber}s of the returned
+     * {@link Completable}.
+     *
+     * @param onSubscribe Invoked <strong>when</strong> {@link Subscriber#onSubscribe(Cancellable)} is called for
+     * {@link Subscriber}s of the returned {@link Completable}. <strong>MUST NOT</strong> throw.
+     * @return The new {@link Completable}.
+     */
+    public final Completable whenOnSubscribe(Consumer<Cancellable> onSubscribe) {
+        return afterOnSubscribe(onSubscribe);
+    }
+
+
     /**
      * Invokes the {@code onComplete} {@link Runnable} argument <strong>after</strong> {@link Subscriber#onComplete()}
      * is called for {@link Subscriber}s of the returned {@link Completable}.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -1697,6 +1697,23 @@ public abstract class Publisher<T> {
         return new AfterSubscriberPublisher<>(this, subscriberSupplier, executor);
     }
 
+
+    /**
+     * Creates a new {@link Subscriber} (via the {@code subscriberSupplier} argument) for each new subscribe and
+     * invokes all the {@link Subscriber} methods <strong>when</strong> the {@link Subscriber}s of the returned
+     * {@link Publisher}.
+     *
+     * @param subscriberSupplier Creates a new {@link Subscriber} for each new subscribe and invokes all the
+     * {@link Subscriber} methods <strong>when</strong> the {@link Subscriber}s of the returned {@link Publisher}.
+     * {@link Subscriber} methods <strong>MUST NOT</strong> throw.
+     * @return The new {@link Publisher}.
+     *
+     * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX do operator.</a>
+     */
+    public final Publisher<T> whenSubscriber(Supplier<? extends Subscriber<? super T>> subscriberSupplier) {
+        return afterSubscriber(subscriberSupplier);
+    }
+
     /**
      * Creates a new {@link Subscription} (via the {@code subscriptionSupplier} argument) for each new subscribe and
      * invokes all the {@link Subscription} methods <strong>after</strong> the {@link Subscription}s of the returned

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -1697,7 +1697,6 @@ public abstract class Publisher<T> {
         return new AfterSubscriberPublisher<>(this, subscriberSupplier, executor);
     }
 
-
     /**
      * Creates a new {@link Subscriber} (via the {@code subscriberSupplier} argument) for each new subscribe and
      * invokes all the {@link Subscriber} methods <strong>when</strong> the {@link Subscriber}s of the returned
@@ -1730,7 +1729,6 @@ public abstract class Publisher<T> {
         return new WhenSubscriptionPublisher<>(this, subscriptionSupplier, false, executor);
     }
 
-
     /**
      * Creates a new {@link Subscription} (via the {@code subscriptionSupplier} argument) for each new subscribe and
      * invokes all the {@link Subscription} methods <strong>when</strong> the {@link Subscription}s of the returned
@@ -1746,8 +1744,6 @@ public abstract class Publisher<T> {
     public final Publisher<T> whenSubscription(Supplier<? extends Subscription> subscriptionSupplier) {
         return afterSubscription(subscriptionSupplier);
     }
-
-
 
     /**
      * Subscribes to this {@link Publisher} and invokes {@code forEach} {@link Consumer} for each item emitted by this

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -1699,11 +1699,11 @@ public abstract class Publisher<T> {
 
     /**
      * Creates a new {@link Subscriber} (via the {@code subscriberSupplier} argument) for each new subscribe and
-     * invokes all the {@link Subscriber} methods <strong>when</strong> the {@link Subscriber}s of the returned
+     * invokes all the {@link Subscriber} methods when the {@link Subscriber}s of the returned
      * {@link Publisher}.
      *
      * @param subscriberSupplier Creates a new {@link Subscriber} for each new subscribe and invokes all the
-     * {@link Subscriber} methods <strong>when</strong> the {@link Subscriber}s of the returned {@link Publisher}.
+     * {@link Subscriber} methods when the {@link Subscriber}s of the returned {@link Publisher}.
      * {@link Subscriber} methods <strong>MUST NOT</strong> throw.
      * @return The new {@link Publisher}.
      *
@@ -1731,11 +1731,11 @@ public abstract class Publisher<T> {
 
     /**
      * Creates a new {@link Subscription} (via the {@code subscriptionSupplier} argument) for each new subscribe and
-     * invokes all the {@link Subscription} methods <strong>when</strong> the {@link Subscription}s of the returned
+     * invokes all the {@link Subscription} methods when the {@link Subscription}s of the returned
      * {@link Publisher}.
      *
      * @param subscriptionSupplier Creates a new {@link Subscription} for each new subscribe and invokes all the
-     * {@link Subscription} methods <strong>when</strong> the {@link Subscription}s of the returned {@link Publisher}.
+     * {@link Subscription} methods when the {@link Subscription}s of the returned {@link Publisher}.
      * {@link Subscription} methods <strong>MUST NOT</strong> throw.
      * @return The new {@link Publisher}.
      *

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -1729,7 +1729,7 @@ public abstract class Publisher<T> {
 
     /**
      * Creates a new {@link Subscription} (via the {@code subscriptionSupplier} argument) for each new subscribe and
-     * invokes all the {@link Subscription} methods when the {@link Subscription}s of the returned
+     * invokes all the {@link Subscription} methods when the corresponding methods are called for {@link Subscription}s of the returned
      * {@link Publisher}.
      *
      * @param subscriptionSupplier Creates a new {@link Subscription} for each new subscribe and invokes all the

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -1699,15 +1699,13 @@ public abstract class Publisher<T> {
 
     /**
      * Creates a new {@link Subscriber} (via the {@code subscriberSupplier} argument) for each new subscribe and
-     * invokes all the {@link Subscriber} methods when the {@link Subscriber}s of the returned
-     * {@link Publisher}.
+     * invokes methods on that {@link Subscriber} when the corresponding methods are called for {@link Subscriber}s of
+     * the returned {@link Publisher}.
      *
-     * @param subscriberSupplier Creates a new {@link Subscriber} for each new subscribe and invokes all the
-     * {@link Subscriber} methods when the {@link Subscriber}s of the returned {@link Publisher}.
-     * {@link Subscriber} methods <strong>MUST NOT</strong> throw.
-     * @return The new {@link Publisher}.
-     *
-     * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX do operator.</a>
+     * @param subscriberSupplier Creates a new {@link Subscriber} for each new subscribe and invokes methods on that
+     * {@link Subscriber} when the corresponding methods are called for {@link Subscriber}s of the returned
+     * {@link Publisher}. {@link Subscriber} methods <strong>MUST NOT</strong> throw.
+     *  @return The new {@link Publisher}.
      */
     public final Publisher<T> whenSubscriber(Supplier<? extends Subscriber<? super T>> subscriberSupplier) {
         return afterSubscriber(subscriberSupplier);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -1713,6 +1713,25 @@ public abstract class Publisher<T> {
         return new WhenSubscriptionPublisher<>(this, subscriptionSupplier, false, executor);
     }
 
+
+    /**
+     * Creates a new {@link Subscription} (via the {@code subscriptionSupplier} argument) for each new subscribe and
+     * invokes all the {@link Subscription} methods <strong>when</strong> the {@link Subscription}s of the returned
+     * {@link Publisher}.
+     *
+     * @param subscriptionSupplier Creates a new {@link Subscription} for each new subscribe and invokes all the
+     * {@link Subscription} methods <strong>when</strong> the {@link Subscription}s of the returned {@link Publisher}.
+     * {@link Subscription} methods <strong>MUST NOT</strong> throw.
+     * @return The new {@link Publisher}.
+     *
+     * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX do operator.</a>
+     */
+    public final Publisher<T> whenSubscription(Supplier<? extends Subscription> subscriptionSupplier) {
+        return afterSubscription(subscriptionSupplier);
+    }
+
+
+
     /**
      * Subscribes to this {@link Publisher} and invokes {@code forEach} {@link Consumer} for each item emitted by this
      * {@link Publisher}.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -1729,8 +1729,8 @@ public abstract class Publisher<T> {
 
     /**
      * Creates a new {@link Subscription} (via the {@code subscriptionSupplier} argument) for each new subscribe and
-     * invokes all the {@link Subscription} methods when the corresponding methods are called for {@link Subscription}s of the returned
-     * {@link Publisher}.
+     * invokes all the {@link Subscription} methods when the corresponding methods are called for {@link Subscription}s
+     * of the returned {@link Publisher}.
      *
      * @param subscriptionSupplier Creates a new {@link Subscription} for each new subscribe and invokes all the
      * {@link Subscription} methods when the {@link Subscription}s of the returned {@link Publisher}.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -700,10 +700,10 @@ public abstract class Single<T> {
     }
 
     /**
-     * Invokes the {@code onSubscribe} {@link Consumer} argument <strong>when</strong>
+     * Invokes the {@code onSubscribe} {@link Consumer} argument when
      * {@link Subscriber#onSubscribe(Cancellable)} is called for {@link Subscriber}s of the returned {@link Single}.
      *
-     * @param onSubscribe Invoked <strong>when</strong> {@link Subscriber#onSubscribe(Cancellable)} is called for
+     * @param onSubscribe Invoked when {@link Subscriber#onSubscribe(Cancellable)} is called for
      * {@link Subscriber}s of the returned {@link Single}. <strong>MUST NOT</strong> throw.
      * @return The new {@link Single}.
      */
@@ -810,11 +810,11 @@ public abstract class Single<T> {
 
     /**
      * Creates a new {@link Subscriber} (via the {@code subscriberSupplier} argument) on each call to subscribe and
-     * invokes all the {@link Subscriber} methods <strong>when</strong> the {@link Subscriber}s of the returned
+     * invokes all the {@link Subscriber} methods when the {@link Subscriber}s of the returned
      * {@link Single}.
      *
      * @param subscriberSupplier Creates a new {@link Subscriber} on each call to subscribe and invokes all the
-     * {@link Subscriber} methods <strong>when</strong> the {@link Subscriber}s of the returned {@link Single}.
+     * {@link Subscriber} methods when the {@link Subscriber}s of the returned {@link Single}.
      * {@link Subscriber} methods <strong>MUST NOT</strong> throw.
      * @return The new {@link Single}.
      */

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -817,13 +817,13 @@ public abstract class Single<T> {
     }
 
     /**
-     * Creates a new {@link Subscriber} (via the {@code subscriberSupplier} argument) on each call to subscribe and
-     * invokes all the {@link Subscriber} methods when the {@link Subscriber}s of the returned
-     * {@link Single}.
+     * Creates a new {@link Subscriber} (via the {@code subscriberSupplier} argument) for each new subscribe and
+     * invokes methods on that {@link Subscriber} when the corresponding methods are called for {@link Subscriber}s of
+     * the returned {@link Single}.
      *
-     * @param subscriberSupplier Creates a new {@link Subscriber} on each call to subscribe and invokes all the
-     * {@link Subscriber} methods when the {@link Subscriber}s of the returned {@link Single}.
-     * {@link Subscriber} methods <strong>MUST NOT</strong> throw.
+     * @param subscriberSupplier Creates a new {@link Subscriber} for each new subscribe and invokes methods on that
+     * {@link Subscriber} when the corresponding methods are called for {@link Subscriber}s of the returned
+     * {@link Single}. {@link Subscriber} methods <strong>MUST NOT</strong> throw.
      * @return The new {@link Single}.
      */
     public final Single<T> whenSubscriber(Supplier<? extends Subscriber<? super T>> subscriberSupplier) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -699,6 +699,20 @@ public abstract class Single<T> {
         return afterSubscriber(doOnSubscribeSupplier(onSubscribe));
     }
 
+
+    /**
+     * Invokes the {@code onSubscribe} {@link Consumer} argument <strong>when</strong>
+     * {@link Subscriber#onSubscribe(Cancellable)} is called for {@link Subscriber}s of the returned {@link Single}.
+     *
+     * @param onSubscribe Invoked <strong>when</strong> {@link Subscriber#onSubscribe(Cancellable)} is called for
+     * {@link Subscriber}s of the returned {@link Single}. <strong>MUST NOT</strong> throw.
+     * @return The new {@link Single}.
+     */
+    public final Single<T> whenOnSubscribe(Consumer<Cancellable> onSubscribe) {
+        return afterOnSubscribe(onSubscribe);
+    }
+
+
     /**
      * Invokes the {@code onSuccess} {@link Consumer} argument <strong>after</strong>
      * {@link Subscriber#onSuccess(Object)} is called for {@link Subscriber}s of the returned {@link Single}.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -712,8 +712,8 @@ public abstract class Single<T> {
      * {@link Subscriber}s of the returned {@link Single}. <strong>MUST NOT</strong> throw.
      * @return The new {@link Single}.
      *
-     * @see #beforeOnNext(Consumer)
-     * @see #afterOnNext(Consumer)
+     * @see #beforeOnSubscribe(Consumer)
+     * @see #afterOnSubscribe(Consumer)
      */
     public final Single<T> whenOnSubscribe(Consumer<Cancellable> onSubscribe) {
         return afterOnSubscribe(onSubscribe);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -703,9 +703,17 @@ public abstract class Single<T> {
      * Invokes the {@code onSubscribe} {@link Consumer} argument when
      * {@link Subscriber#onSubscribe(Cancellable)} is called for {@link Subscriber}s of the returned {@link Single}.
      *
+     * <p>
+     * The order in which {@code onSubscribe} will be invoked relative to
+     * {@link Subscriber#onSubscribe(Cancellable)} is undefined. If you need strict ordering see
+     * {@link #beforeOnSubscribe(Consumer)} and {@link #afterOnSubscribe(Consumer)}.
+     *
      * @param onSubscribe Invoked when {@link Subscriber#onSubscribe(Cancellable)} is called for
      * {@link Subscriber}s of the returned {@link Single}. <strong>MUST NOT</strong> throw.
      * @return The new {@link Single}.
+     *
+     * @see #beforeOnNext(Consumer)
+     * @see #afterOnNext(Consumer)
      */
     public final Single<T> whenOnSubscribe(Consumer<Cancellable> onSubscribe) {
         return afterOnSubscribe(onSubscribe);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -699,7 +699,6 @@ public abstract class Single<T> {
         return afterSubscriber(doOnSubscribeSupplier(onSubscribe));
     }
 
-
     /**
      * Invokes the {@code onSubscribe} {@link Consumer} argument <strong>when</strong>
      * {@link Subscriber#onSubscribe(Cancellable)} is called for {@link Subscriber}s of the returned {@link Single}.
@@ -711,7 +710,6 @@ public abstract class Single<T> {
     public final Single<T> whenOnSubscribe(Consumer<Cancellable> onSubscribe) {
         return afterOnSubscribe(onSubscribe);
     }
-
 
     /**
      * Invokes the {@code onSuccess} {@link Consumer} argument <strong>after</strong>
@@ -810,7 +808,6 @@ public abstract class Single<T> {
         return new AfterSubscriberSingle<>(this, subscriberSupplier, executor);
     }
 
-
     /**
      * Creates a new {@link Subscriber} (via the {@code subscriberSupplier} argument) on each call to subscribe and
      * invokes all the {@link Subscriber} methods <strong>when</strong> the {@link Subscriber}s of the returned
@@ -824,7 +821,6 @@ public abstract class Single<T> {
     public final Single<T> whenSubscriber(Supplier<? extends Subscriber<? super T>> subscriberSupplier) {
         return afterSubscriber(subscriberSupplier);
     }
-
 
     /**
      * Creates a new {@link Single} that will use the passed {@link Executor} to invoke all {@link Subscriber} methods.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -810,6 +810,22 @@ public abstract class Single<T> {
         return new AfterSubscriberSingle<>(this, subscriberSupplier, executor);
     }
 
+
+    /**
+     * Creates a new {@link Subscriber} (via the {@code subscriberSupplier} argument) on each call to subscribe and
+     * invokes all the {@link Subscriber} methods <strong>when</strong> the {@link Subscriber}s of the returned
+     * {@link Single}.
+     *
+     * @param subscriberSupplier Creates a new {@link Subscriber} on each call to subscribe and invokes all the
+     * {@link Subscriber} methods <strong>when</strong> the {@link Subscriber}s of the returned {@link Single}.
+     * {@link Subscriber} methods <strong>MUST NOT</strong> throw.
+     * @return The new {@link Single}.
+     */
+    public final Single<T> whenSubscriber(Supplier<? extends Subscriber<? super T>> subscriberSupplier) {
+        return afterSubscriber(subscriberSupplier);
+    }
+
+
     /**
      * Creates a new {@link Single} that will use the passed {@link Executor} to invoke all {@link Subscriber} methods.
      * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}


### PR DESCRIPTION
**Motivation**

Missing `when*` operators for async sources `Publisher`, `Single` and `Completable`



**Modifications**

Defining: 

- [x]  `Completable.whenOnSubscribe(Consumer<Cancellable>)`

- [x]  `Completable.whenSubscriber(Supplier<? extends Subscriber>)`

- [x] `Single.whenOnSubscribe(Consumer<Cancellable>)`
- [x] `Single.whenSubscriber(Supplier<? extends Subscriber<? super T>>)`
- [x] `Publisher.whenSubscription(Supplier<? extends Subscription>)`
- [x] `Publisher.whenSubscriber(Supplier<? extends Subscriber<? super T>>)`

**Result**

Above Operators will behave like `after*` .

Fixes: https://github.com/apple/servicetalk/issues/926
