### PR TITLE
Adding RFC links for standardised HttpHeaderNames constants in javadoc

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
@@ -123,6 +123,8 @@ public final class HttpHeaderNames {
     public static final CharSequence CONTENT_LANGUAGE = newAsciiString("content-language");
     /**
      * {@code "content-length"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7230#section-3.3.2">RFC7230, section 3.3.2</a>
      */
     public static final CharSequence CONTENT_LENGTH = newAsciiString("content-length");
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
@@ -460,7 +460,7 @@ public final class HttpHeaderNames {
     /**
      * {@code "www-authenticate"}
      *
-     * @see <a href="https://tools.ietf.org/html/rfc#section-">RFC, section </a>
+     * @see <a href="https://tools.ietf.org/html/rfc7235#section-4.1">RFC7235, section 4.1</a>
      */
     public static final CharSequence WWW_AUTHENTICATE = newAsciiString("www-authenticate");
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
@@ -113,6 +113,8 @@ public final class HttpHeaderNames {
     public static final CharSequence CONTENT_BASE = newAsciiString("content-base");
     /**
      * {@code "content-encoding"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-3.1.2.2">RFC7231, section 3.1.2.2</a>
      */
     public static final CharSequence CONTENT_ENCODING = newAsciiString("content-encoding");
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
@@ -103,6 +103,8 @@ public final class HttpHeaderNames {
     public static final CharSequence CACHE_CONTROL = newAsciiString("cache-control");
     /**
      * {@code "connection"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7230#section-6.1">RFC7230, section 6.1</a>
      */
     public static final CharSequence CONNECTION = newAsciiString("connection");
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
@@ -184,6 +184,8 @@ public final class HttpHeaderNames {
     public static final CharSequence CONTENT_RANGE = newAsciiString("content-range");
     /**
      * {@code "content-security-policy"}
+     *
+     * @see <a href="https://www.w3.org/TR/CSP3/#csp-header">csp-header</a>
      */
     public static final CharSequence CONTENT_SECURITY_POLICY = newAsciiString("content-security-policy");
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
@@ -24,30 +24,43 @@ import static io.servicetalk.http.api.CharSequences.newAsciiString;
 public final class HttpHeaderNames {
     /**
      * {@code "accept"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.3.2">RFC7231, section 5.3.2</a>
      */
     public static final CharSequence ACCEPT = newAsciiString("accept");
     /**
      * {@code "accept-charset"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.3.3">RFC7231, section 5.3.3</a>
      */
     public static final CharSequence ACCEPT_CHARSET = newAsciiString("accept-charset");
     /**
      * {@code "accept-encoding"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.3.4">RFC7231, section 5.3.4</a>
      */
     public static final CharSequence ACCEPT_ENCODING = newAsciiString("accept-encoding");
     /**
      * {@code "accept-language"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.3.5">RFC7231, section 5.3.5</a>
      */
     public static final CharSequence ACCEPT_LANGUAGE = newAsciiString("accept-language");
     /**
      * {@code "accept-ranges"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7233#section-2.3">RFC7233, section 2.3</a>
      */
     public static final CharSequence ACCEPT_RANGES = newAsciiString("accept-ranges");
     /**
      * {@code "accept-patch"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc5789#section-3.1">RFC5789, section 3.1</a>
      */
     public static final CharSequence ACCEPT_PATCH = newAsciiString("accept-patch");
     /**
      * {@code "access-control-allow-credentials"}
+     *
      */
     public static final CharSequence ACCESS_CONTROL_ALLOW_CREDENTIALS =
             newAsciiString("access-control-allow-credentials");
@@ -87,18 +100,26 @@ public final class HttpHeaderNames {
             newAsciiString("access-control-request-method");
     /**
      * {@code "age"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.1">RFC7234, section 5.1</a>
      */
     public static final CharSequence AGE = newAsciiString("age");
     /**
      * {@code "allow"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.4.1">RFC7231, section 7.4.1</a>
      */
     public static final CharSequence ALLOW = newAsciiString("allow");
     /**
      * {@code "authorization"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7235#section-4.2">RFC7235, section 4.2</a>
      */
     public static final CharSequence AUTHORIZATION = newAsciiString("authorization");
     /**
      * {@code "cache-control"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.2">RFC7234, section 5.2</a>
      */
     public static final CharSequence CACHE_CONTROL = newAsciiString("cache-control");
     /**
@@ -109,6 +130,8 @@ public final class HttpHeaderNames {
     public static final CharSequence CONNECTION = newAsciiString("connection");
     /**
      * {@code "content-base"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc2110#section-4.2">RFC2110, section 4.2</a>
      */
     public static final CharSequence CONTENT_BASE = newAsciiString("content-base");
     /**
@@ -119,6 +142,8 @@ public final class HttpHeaderNames {
     public static final CharSequence CONTENT_ENCODING = newAsciiString("content-encoding");
     /**
      * {@code "content-language"}
+     *
+     *  @see <a href="https://tools.ietf.org/html/rfc7231#section-3.1.3.2">RFC7231, section 3.1.3.2</a>
      */
     public static final CharSequence CONTENT_LANGUAGE = newAsciiString("content-language");
     /**
@@ -129,22 +154,32 @@ public final class HttpHeaderNames {
     public static final CharSequence CONTENT_LENGTH = newAsciiString("content-length");
     /**
      * {@code "content-location"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-3.1.4.2">RFC7231, section 3.1.4.2</a>
      */
     public static final CharSequence CONTENT_LOCATION = newAsciiString("content-location");
     /**
      * {@code "content-transfer-encoding"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc2045#section-6">RFC2045, section 6</a>
      */
     public static final CharSequence CONTENT_TRANSFER_ENCODING = newAsciiString("content-transfer-encoding");
     /**
      * {@code "content-disposition"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6266">RFC6266 </a>
      */
     public static final CharSequence CONTENT_DISPOSITION = newAsciiString("content-disposition");
     /**
      * {@code "content-md5"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc2616#section-14.15">RFC2616, section 14.15</a>
      */
     public static final CharSequence CONTENT_MD5 = newAsciiString("content-md5");
     /**
      * {@code "content-range"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7233#section-4.2">RFC7233, section 4.2</a>
      */
     public static final CharSequence CONTENT_RANGE = newAsciiString("content-range");
     /**
@@ -153,26 +188,38 @@ public final class HttpHeaderNames {
     public static final CharSequence CONTENT_SECURITY_POLICY = newAsciiString("content-security-policy");
     /**
      * {@code "content-type"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.5">RFC7231, section 3.1.1.5</a>
      */
     public static final CharSequence CONTENT_TYPE = newAsciiString("content-type");
     /**
      * {@code "cookie"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6265#section-4.2">RFC6265, section 4.2</a>
      */
     public static final CharSequence COOKIE = newAsciiString("cookie");
     /**
      * {@code "date"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.2">RFC7231, section 7.1.1.2</a>
      */
     public static final CharSequence DATE = newAsciiString("date");
     /**
      * {@code "etag"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7232#section-2.3">RFC7232, section 2.3</a>
      */
     public static final CharSequence ETAG = newAsciiString("etag");
     /**
      * {@code "expect"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.1.1">RFC7231, section 5.1.1</a>
      */
     public static final CharSequence EXPECT = newAsciiString("expect");
     /**
      * {@code "expires"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.3">RFC7234, section 5.3</a>
      */
     public static final CharSequence EXPIRES = newAsciiString("expires");
     /**
@@ -186,70 +233,104 @@ public final class HttpHeaderNames {
     public static final CharSequence FORWARDED = newAsciiString("forwarded");
     /**
      * {@code "from"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.5.1">RFC7231, section 5.5.1</a>
      */
     public static final CharSequence FROM = newAsciiString("from");
     /**
      * {@code "host"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7230#section-5.4">RFC7230, section 5.4</a>
      */
     public static final CharSequence HOST = newAsciiString("host");
     /**
      * {@code "if-match"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7232#section-3.1">RFC7232, section 3.1</a>
      */
     public static final CharSequence IF_MATCH = newAsciiString("if-match");
     /**
      * {@code "if-modified-since"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7232#section-3.3">RFC7232, section 3.3</a>
      */
     public static final CharSequence IF_MODIFIED_SINCE = newAsciiString("if-modified-since");
     /**
      * {@code "if-none-match"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7232#section-3.2">RFC7232, section 3.2</a>
      */
     public static final CharSequence IF_NONE_MATCH = newAsciiString("if-none-match");
     /**
      * {@code "if-range"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7233#section-3.2">RFC7233, section 3.2</a>
      */
     public static final CharSequence IF_RANGE = newAsciiString("if-range");
     /**
      * {@code "if-unmodified-since"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7232#section-3.4">RFC7232, section 3.4</a>
      */
     public static final CharSequence IF_UNMODIFIED_SINCE = newAsciiString("if-unmodified-since");
     /**
      * {@code "last-modified"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7232#section-2.2">RFC7232, section 2.2</a>
      */
     public static final CharSequence LAST_MODIFIED = newAsciiString("last-modified");
     /**
      * {@code "location"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.1.2">RFC7231, section 7.1.2</a>
      */
     public static final CharSequence LOCATION = newAsciiString("location");
     /**
      * {@code "max-forwards"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.1.2">RFC7231, section 5.1.2</a>
      */
     public static final CharSequence MAX_FORWARDS = newAsciiString("max-forwards");
     /**
      * {@code "origin"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6454#section-3.2">RFC6454, section 3.2</a>
      */
     public static final CharSequence ORIGIN = newAsciiString("origin");
     /**
      * {@code "pragma"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.4">RFC7234, section 5.4</a>
      */
     public static final CharSequence PRAGMA = newAsciiString("pragma");
     /**
      * {@code "proxy-authenticate"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7235#section-4.3">RFC7235, section 4.3</a>
      */
     public static final CharSequence PROXY_AUTHENTICATE = newAsciiString("proxy-authenticate");
     /**
      * {@code "proxy-authorization"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7235#section-4.4">RFC7235, section 4.4</a>
      */
     public static final CharSequence PROXY_AUTHORIZATION = newAsciiString("proxy-authorization");
     /**
      * {@code "range"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7233#section-3.1">RFC7233, section 3.1</a>
      */
     public static final CharSequence RANGE = newAsciiString("range");
     /**
      * {@code "referer"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.5.2">RFC7231, section 5.5.2</a>
      */
     public static final CharSequence REFERER = newAsciiString("referer");
     /**
      * {@code "retry-after"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.1.3">RFC7231, section 7.1.3</a>
      */
     public static final CharSequence RETRY_AFTER = newAsciiString("retry-after");
     /**
@@ -270,66 +351,98 @@ public final class HttpHeaderNames {
     public static final CharSequence SEC_WEBSOCKET_ORIGIN = newAsciiString("sec-websocket-origin");
     /**
      * {@code "sec-websocket-protocol"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6455#section-11.3.4">RFC6455, section 11.3.4</a>
      */
     public static final CharSequence SEC_WEBSOCKET_PROTOCOL = newAsciiString("sec-websocket-protocol");
     /**
      * {@code "sec-websocket-version"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6455#section-11.3.5">RFC6455, section 11.3.5</a>
      */
     public static final CharSequence SEC_WEBSOCKET_VERSION = newAsciiString("sec-websocket-version");
     /**
      * {@code "sec-websocket-key"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6455#section-11.3.1">RFC6455, section 11.3.1</a>
      */
     public static final CharSequence SEC_WEBSOCKET_KEY = newAsciiString("sec-websocket-key");
     /**
      * {@code "sec-websocket-accept"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6455#section-11.3.3">RFC6455, section 11.3.3</a>
      */
     public static final CharSequence SEC_WEBSOCKET_ACCEPT = newAsciiString("sec-websocket-accept");
     /**
      * {@code "sec-websocket-protocol"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6455#section-11.3.2">RFC455, section 11.3.2</a>
      */
     public static final CharSequence SEC_WEBSOCKET_EXTENSIONS = newAsciiString("sec-websocket-extensions");
     /**
      * {@code "server"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.4.2">RFC7231, section 7.4.2</a>
      */
     public static final CharSequence SERVER = newAsciiString("server");
     /**
      * {@code "set-cookie"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6265#section-4.1">RFC6265, section 4.1</a>
      */
     public static final CharSequence SET_COOKIE = newAsciiString("set-cookie");
     /**
      * {@code "set-cookie2"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6265#section-9.4">RFC6265, section 9.4</a>
      */
     public static final CharSequence SET_COOKIE2 = newAsciiString("set-cookie2");
     /**
      * {@code "te"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7230#section-4.3">RFC7230, section 4.3</a>
      */
     public static final CharSequence TE = newAsciiString("te");
     /**
      * {@code "trailer"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7230#section-4.4">RFC7230, section 4.4</a>
      */
     public static final CharSequence TRAILER = newAsciiString("trailer");
     /**
      * {@code "transfer-encoding"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7230#section-3.3.1">RFC7230, section 3.3.1</a>
      */
     public static final CharSequence TRANSFER_ENCODING = newAsciiString("transfer-encoding");
     /**
      * {@code "upgrade"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7230#section-6.7">RFC7230, section 6.7</a>
      */
     public static final CharSequence UPGRADE = newAsciiString("upgrade");
     /**
      * {@code "user-agent"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.5.3">RFC7231, section 5.5.3</a>
      */
     public static final CharSequence USER_AGENT = newAsciiString("user-agent");
     /**
      * {@code "vary"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.1.4">RFC7231, section 7.1.4</a>
      */
     public static final CharSequence VARY = newAsciiString("vary");
     /**
      * {@code "via"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7230#section-5.7.1">RFC7230, section 5.7.1</a>
      */
     public static final CharSequence VIA = newAsciiString("via");
     /**
      * {@code "warning"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.5">RFC7234, section 5.5 </a>
      */
     public static final CharSequence WARNING = newAsciiString("warning");
     /**
@@ -346,6 +459,8 @@ public final class HttpHeaderNames {
     public static final CharSequence WEBSOCKET_PROTOCOL = newAsciiString("websocket-protocol");
     /**
      * {@code "www-authenticate"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc#section-">RFC, section </a>
      */
     public static final CharSequence WWW_AUTHENTICATE = newAsciiString("www-authenticate");
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
@@ -61,6 +61,8 @@ public final class HttpHeaderNames {
     /**
      * {@code "access-control-allow-credentials"}
      *
+     * @see <a href="https://www.w3.org/TR/cors/#access-control-allow-credentials-response-header">
+     *     W3C Cross-Origin Resource Sharing, section 5.2</a>
      */
     public static final CharSequence ACCESS_CONTROL_ALLOW_CREDENTIALS =
             newAsciiString("access-control-allow-credentials");
@@ -167,7 +169,7 @@ public final class HttpHeaderNames {
     /**
      * {@code "content-disposition"}
      *
-     * @see <a href="https://tools.ietf.org/html/rfc6266">RFC6266 </a>
+     * @see <a href="https://tools.ietf.org/html/rfc6266">RFC6266</a>
      */
     public static final CharSequence CONTENT_DISPOSITION = newAsciiString("content-disposition");
     /**
@@ -185,7 +187,7 @@ public final class HttpHeaderNames {
     /**
      * {@code "content-security-policy"}
      *
-     * @see <a href="https://www.w3.org/TR/CSP3/#csp-header">csp-header</a>
+     * @see <a href="https://www.w3.org/TR/CSP3/#csp-header"> W3C Cross-Origin Resource Sharing, section 3.1</a>
      */
     public static final CharSequence CONTENT_SECURITY_POLICY = newAsciiString("content-security-policy");
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
@@ -223,12 +223,14 @@ public final class HttpHeaderNames {
      */
     public static final CharSequence EXPIRES = newAsciiString("expires");
     /**
-     * <a href="https://tools.ietf.org/html/rfc7239#section-4">forwarded</a> is a header field that contains a list of
+     * {@code "forwarded"} is a header field that contains a list of
      * parameter-identifier pairs that disclose information that is altered or lost when a proxy is involved in the path
      * of the request.
      * <p>
      * The alternative and de-facto standard versions of this header are the {@link #X_FORWARDED_FOR "x-forwarded-for"},
      * {@link #X_FORWARDED_HOST "x-forwarded-host"} and {@link #X_FORWARDED_PROTO "x-forwarded-proto"} headers.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7239#section-4">RFC7231, section 4</a>
      */
     public static final CharSequence FORWARDED = newAsciiString("forwarded");
     /**
@@ -442,7 +444,7 @@ public final class HttpHeaderNames {
     /**
      * {@code "warning"}
      *
-     * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.5">RFC7234, section 5.5 </a>
+     * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.5">RFC7234, section 5.5</a>
      */
     public static final CharSequence WARNING = newAsciiString("warning");
     /**
@@ -464,27 +466,34 @@ public final class HttpHeaderNames {
      */
     public static final CharSequence WWW_AUTHENTICATE = newAsciiString("www-authenticate");
     /**
-     * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For">x-forwarded-for</a> (XFF)
+     * {@code "x-forwarded-for"} (XFF)
      * header is a de-facto standard header for identifying the originating IP address of a client connecting to a web
      * server through an HTTP proxy or a load balancer.
      * <p>
      * A standardized version of this header is the HTTP {@link #FORWARDED "forwarded"} header.
+     *
+     * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For">X-Forwarded-For</a>
+     *
      */
     public static final CharSequence X_FORWARDED_FOR = newAsciiString("x-forwarded-for");
     /**
-     * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host">x-forwarded-host</a> (XFH)
+     *  {@code "x-forwarded-host"} (XFH)
      * header is a de-facto standard header for identifying the original host requested by the client in the
      * {@link #HOST host} HTTP request header.
      * <p>
      * A standardized version of this header is the HTTP {@link #FORWARDED "forwarded"} header.
+     *
+     * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host">x-forwarded-host</a>
      */
     public static final CharSequence X_FORWARDED_HOST = newAsciiString("x-forwarded-host");
     /**
-     * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto">x-forwarded-proto</a> (XFP)
+     * {@code "x-forwarded-proto"} (XFP)
      * header is a de-facto standard header for identifying the protocol (HTTP or HTTPS) that a client used to connect
      * to your proxy or load balancer.
      * <p>
      * A standardized version of this header is the HTTP {@link #FORWARDED "forwarded"} header.
+     *
+     * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto">x-forwarded-proto</a>
      */
     public static final CharSequence X_FORWARDED_PROTO = newAsciiString("x-forwarded-proto");
     /**


### PR DESCRIPTION
**Motivation**

Enhance javadoc for HTTP header name constants in HttpHeaderNames class with links to the related RFC sections.



**Modifications**


Adding `@see` like:


```
 @see <a href="https://tools.ietf.org/html/rfc7230#section-6.1">RFC7230, section 6.1</a>
```

in `HttpHeaderNames.java` file for constants.

**Result**


 javadoc for HTTP header name constants will be updated with related RFC sections.

Fixes: https://github.com/apple/servicetalk/issues/885
