### PR TITLE
H2 client should send `ENABLE_PUSH=false` setting for new connections

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
@@ -26,8 +26,6 @@ import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
 import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.codec.http2.Http2MultiplexHandler;
 import io.netty.handler.codec.http2.Http2Settings;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.function.BiPredicate;
 
@@ -72,8 +70,6 @@ final class H2ClientParentChannelInitializer implements ChannelInitializer {
 
     @ChannelHandler.Sharable
     private static final class H2PushStreamHandler extends ChannelInboundHandlerAdapter {
-
-        private static final Logger LOGGER = LoggerFactory.getLogger(H2PushStreamHandler.class);
 
         static final ChannelInboundHandlerAdapter INSTANCE = new H2PushStreamHandler();
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
@@ -25,7 +25,6 @@ import io.netty.handler.codec.http2.DefaultHttp2GoAwayFrame;
 import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
 import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.codec.http2.Http2MultiplexHandler;
-import io.netty.handler.codec.http2.Http2Settings;
 
 import java.util.function.BiPredicate;
 
@@ -47,11 +46,12 @@ final class H2ClientParentChannelInitializer implements ChannelInitializer {
                 // The max concurrent streams is made available via a publisher and may be consumed asynchronously
                 // (e.g. when offloading is enabled), so we manually control the SETTINGS ACK frames.
                 .autoAckSettingsFrame(false)
-                // Notify server that this client does not support server push and request it to be disabled.
-                .initialSettings(Http2Settings.defaultSettings().pushEnabled(false).maxConcurrentStreams(0L))
                 // We don't want to rely upon Netty to manage the graceful close timeout, because we expect
                 // the user to apply their own timeout at the call site.
                 .gracefulShutdownTimeoutMillis(-1);
+
+        // Notify server that this client does not support server push and request it to be disabled.
+        multiplexCodecBuilder.initialSettings().pushEnabled(false).maxConcurrentStreams(0L);
 
         final BiPredicate<CharSequence, CharSequence> headersSensitivityDetector =
                 config.headersSensitivityDetector();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
@@ -51,7 +51,7 @@ final class H2ClientParentChannelInitializer implements ChannelInitializer {
                 // (e.g. when offloading is enabled), so we manually control the SETTINGS ACK frames.
                 .autoAckSettingsFrame(false)
                 // Notify server that this client does not support server push and request it to be disabled.
-                .initialSettings(Http2Settings.defaultSettings().pushEnabled(false))
+                .initialSettings(Http2Settings.defaultSettings().pushEnabled(false).maxConcurrentStreams(0L))
                 // We don't want to rely upon Netty to manage the graceful close timeout, because we expect
                 // the user to apply their own timeout at the call site.
                 .gracefulShutdownTimeoutMillis(-1);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
@@ -38,8 +38,6 @@ import static io.netty.handler.logging.LogLevel.TRACE;
 
 final class H2ClientParentChannelInitializer implements ChannelInitializer {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(H2ClientParentChannelInitializer.class);
-
     private final H2ProtocolConfig config;
 
     H2ClientParentChannelInitializer(final H2ProtocolConfig config) {
@@ -75,6 +73,9 @@ final class H2ClientParentChannelInitializer implements ChannelInitializer {
 
     @ChannelHandler.Sharable
     private static final class H2PushStreamHandler extends ChannelInboundHandlerAdapter {
+
+        private static final Logger LOGGER = LoggerFactory.getLogger(H2PushStreamHandler.class);
+
         static final ChannelInboundHandlerAdapter INSTANCE = new H2PushStreamHandler();
 
         private H2PushStreamHandler() {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
@@ -18,7 +18,6 @@ package io.servicetalk.http.netty;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -85,13 +84,8 @@ final class H2ClientParentChannelInitializer implements ChannelInitializer {
         @Override
         public void channelRegistered(final ChannelHandlerContext ctx) {
             // See SETTINGS_ENABLE_PUSH in https://tools.ietf.org/html/rfc7540#section-6.5.2
-            ctx.writeAndFlush(new DefaultHttp2GoAwayFrame(PROTOCOL_ERROR))
-                    .addListener((ChannelFutureListener) future -> {
-                if (!future.isSuccess()) {
-                    LOGGER.debug("Failed to send a GO_AWAY frame for received PUSH_PROMISE frame", future.cause());
-                }
-                ctx.close(); // push streams are not supported
-            });
+            ctx.writeAndFlush(new DefaultHttp2GoAwayFrame(PROTOCOL_ERROR));
+            // Http2ConnectionHandler.processGoAwayWriteResult will close the connection after GO_AWAY is flushed
         }
     }
 }


### PR DESCRIPTION
Motivation:

To notify server-side that ST client currently does not support
server push, client should send `ENABLE_PUSH=false` setting when it
connects to the server.
If server sends a `PUSH_PROMISE` frame, client should send `GO_AWAY`
before closing the connection.

Modifications:

- Add `ENABLE_PUSH=false` and `MAX_CONCURRENT_STREAMS=0` to
the set of initial h2 settings;
- Send `GO_AWAY` frame with `PROTOCOL_ERROR` if client receives a
`PUSH_PROMISE` frame from server;

Result:

H2 client notifies server that it does not support server push and
sends `GO_AWAY` frame before closing the connection, if server sends
a push.