### PR TITLE
Allocate smaller `ArrayDeque` for `NettyChannelPublisher.addPending`

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
@@ -257,7 +257,7 @@ final class NettyChannelPublisher<T> extends SubscribablePublisher<T> {
 
     private void addPending(Object p) {
         if (pending == null) {
-            pending = new ArrayDeque<>();
+            pending = new ArrayDeque<>(4);  // queue should be able to fit: headers + payloadBody + trailers
         }
         pending.add(p);
     }


### PR DESCRIPTION
Motivation:

We use `ArrayDeque` to temporary part `channelRead` events until
we receive a `Subscription` for `NettyChannelPublisher`. By default
it allocates a queue for 16 elements, but in most cases, we have only
a few elements: headers only or headers + payloadBody + trailers.

Modifications:

- Allocate a smaller `ArrayDeque` that may fit one full request or
response object with headers + payloadBody + trailers;

Result:

Less memory allocation.