### PR TITLE
gRPC `BlockingResponseStreamingRoute` expects only one request item

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
@@ -158,7 +158,7 @@ final class DefaultGrpcClientCallFactory implements GrpcClientCallFactory {
                 final Resp firstItem = requireNonNull(iterator.next(), "Response item is null");
                 if (iterator.hasNext()) {
                     iterator.next(); // Consume the next item to make sure it's not a TerminalNotification with an error
-                    throw new IllegalStateException("More than one response message received");
+                    throw new IllegalArgumentException("More than one response message received");
                 }
                 return firstItem;
             }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
@@ -158,7 +158,7 @@ final class DefaultGrpcClientCallFactory implements GrpcClientCallFactory {
                 final Resp firstItem = requireNonNull(iterator.next(), "Response item is null");
                 if (iterator.hasNext()) {
                     iterator.next(); // Consume the next item to make sure it's not a TerminalNotification with an error
-                    throw new IllegalStateException("Only a single response item is expected, but saw the second one");
+                    throw new IllegalStateException("More than one response message received");
                 }
                 return firstItem;
             }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
@@ -155,7 +155,7 @@ final class DefaultGrpcClientCallFactory implements GrpcClientCallFactory {
                 newBlockingStreamingCall(serializationProvider, requestClass, responseClass);
         return (metadata, request) -> {
             try (BlockingIterator<Resp> iterator = streamingClientCall.request(metadata, request).iterator()) {
-                final Resp firstItem = requireNonNull(iterator.next(), "Response item is null");
+                final Resp firstItem = iterator.next();
                 if (iterator.hasNext()) {
                     iterator.next(); // Consume the next item to make sure it's not a TerminalNotification with an error
                     throw new IllegalArgumentException("More than one response message received");

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
@@ -157,6 +157,7 @@ final class DefaultGrpcClientCallFactory implements GrpcClientCallFactory {
             try (BlockingIterator<Resp> iterator = streamingClientCall.request(metadata, request).iterator()) {
                 final Resp firstItem = requireNonNull(iterator.next(), "Response item is null");
                 if (iterator.hasNext()) {
+                    iterator.next(); // Consume the next item to make sure it's not a TerminalNotification with an error
                     throw new IllegalStateException("Only a single response item is expected, but saw the second one");
                 }
                 return firstItem;

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -578,6 +578,8 @@ final class GrpcRouter {
                             try (BlockingIterator<Req> requestIterator = request.iterator()) {
                                 firstItem = requireNonNull(requestIterator.next(), "Request item is null");
                                 if (requestIterator.hasNext()) {
+                                    // Consume the next item to make sure it's not a TerminalNotification with an error
+                                    requestIterator.next();
                                     throw new GrpcStatus(INVALID_ARGUMENT, null,
                                             "Only a single request item is expected, but saw the second one")
                                             .asException();

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -581,8 +581,7 @@ final class GrpcRouter {
                                     // Consume the next item to make sure it's not a TerminalNotification with an error
                                     requestIterator.next();
                                     throw new GrpcStatus(INVALID_ARGUMENT, null,
-                                            "Only a single request item is expected, but saw the second one")
-                                            .asException();
+                                            "More than one request message received").asException();
                                 }
                             }
                             route.handle(ctx, firstItem, responseWriter);

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -82,7 +82,6 @@ import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
-import static java.util.Objects.requireNonNull;
 
 /**
  * A router that can route <a href="https://www.grpc.io">gRPC</a> requests to a user provided
@@ -598,7 +597,7 @@ final class GrpcRouter {
                                     throw new GrpcStatus(INVALID_ARGUMENT, null,
                                             SINGLE_MESSAGE_EXPECTED_NONE_RECEIVED_MSG).asException();
                                 }
-                                firstItem = requireNonNull(requestIterator.next(), "Request item is null");
+                                firstItem = requestIterator.next();
                                 if (requestIterator.hasNext()) {
                                     // Consume the next item to make sure it's not a TerminalNotification with an error
                                     requestIterator.next();

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/BlockingApiCorrectnessTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/BlockingApiCorrectnessTest.java
@@ -16,6 +16,7 @@
 package io.servicetalk.grpc.netty;
 
 import io.servicetalk.concurrent.BlockingIterable;
+import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.grpc.api.GrpcPayloadWriter;
@@ -23,12 +24,12 @@ import io.servicetalk.grpc.api.GrpcServiceContext;
 import io.servicetalk.grpc.api.GrpcStatusException;
 import io.servicetalk.grpc.netty.TesterProto.TestRequest;
 import io.servicetalk.grpc.netty.TesterProto.TestResponse;
-import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTestBiDiStreamRpc;
 import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTestResponseStreamRpc;
 import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTesterClient;
 import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTesterService;
 import io.servicetalk.grpc.netty.TesterProto.Tester.ClientFactory;
 import io.servicetalk.grpc.netty.TesterProto.Tester.ServiceFactory;
+import io.servicetalk.grpc.netty.TesterProto.Tester.TesterService;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -36,107 +37,172 @@ import io.servicetalk.http.api.StreamingHttpRequester;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.transport.api.ServerContext;
 
+import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
+import java.util.NoSuchElementException;
+import java.util.stream.IntStream;
+
+import static io.servicetalk.concurrent.api.Publisher.fromIterable;
 import static io.servicetalk.grpc.api.GrpcStatusCode.INVALID_ARGUMENT;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThrows;
 
+@RunWith(Parameterized.class)
 public class BlockingApiCorrectnessTest {
 
     @Rule
     public final Timeout timeout = new ServiceTalkTestTimeout();
 
     private final ServerContext serverContext;
+    private final BlockingTesterClient client;
 
-    public BlockingApiCorrectnessTest() throws Exception {
-        serverContext = GrpcServers.forAddress(localAddress(0))
-                .listenAndAwait(new ServiceFactory(new BlockingTesterService() {
-                    @Override
-                    public void testBiDiStream(GrpcServiceContext ctx, BlockingIterable<TestRequest> request,
-                                               GrpcPayloadWriter<TestResponse> responseWriter) throws Exception {
-                        responseWriter.write(newResponse());
-                        responseWriter.write(newResponse());
-                    }
+    public BlockingApiCorrectnessTest(boolean streaming) throws Exception {
+        serverContext = GrpcServers.forAddress(localAddress(0)).listenAndAwait(streaming ?
+                new ServiceFactory(new TesterServiceImpl()) :
+                new ServiceFactory(new BlockingTesterServiceImpl()));
 
+        client = GrpcClients.forAddress(serverHostAndPort(serverContext))
+                // HTTP filter that modifies path to workaround gRPC API constraints:
+                .appendHttpClientFilter(origin -> new StreamingHttpClientFilter(origin) {
                     @Override
-                    public TestResponse testRequestStream(GrpcServiceContext ctx,
-                                                          BlockingIterable<TestRequest> request) {
-                        throw new UnsupportedOperationException();
+                    protected Single<StreamingHttpResponse> request(StreamingHttpRequester delegate,
+                                                                    HttpExecutionStrategy strategy,
+                                                                    StreamingHttpRequest request) {
+                        // Change path to send the request to the route API that expects only a single request item
+                        // and generates requested number of response items:
+                        request.requestTarget(BlockingTestResponseStreamRpc.PATH);
+                        return super.request(delegate, strategy, request);
                     }
+                }).buildBlocking(new ClientFactory());
+    }
 
-                    @Override
-                    public void testResponseStream(GrpcServiceContext ctx, TestRequest request,
-                                                   GrpcPayloadWriter<TestResponse> responseWriter) throws Exception {
-                        responseWriter.write(newResponse());
-                    }
-
-                    @Override
-                    public TestResponse test(GrpcServiceContext ctx, TestRequest request) {
-                        throw new UnsupportedOperationException();
-                    }
-                }));
+    @Parameters(name = "streaming={0}")
+    public static Object[] params() {
+        return new Object[]{true, false};
     }
 
     @After
     public void tearDown() throws Exception {
-        serverContext.close();
-    }
-
-    @Test
-    public void serverBlockingResponseStreamingRouteFailsOnSecondResponseItem() throws Exception {
-        try (BlockingTesterClient client = GrpcClients.forAddress(serverHostAndPort(serverContext))
-                // HTTP filter that modifies path to workaround gRPC API constraints:
-                .appendHttpClientFilter(origin -> new StreamingHttpClientFilter(origin) {
-                    @Override
-                    protected Single<StreamingHttpResponse> request(StreamingHttpRequester delegate,
-                                                                    HttpExecutionStrategy strategy,
-                                                                    StreamingHttpRequest request) {
-                        // Change path to send multiple items to the route API that expects only a single request item:
-                        request.requestTarget(BlockingTestResponseStreamRpc.PATH);
-                        return super.request(delegate, strategy, request);
-                    }
-                }).buildBlocking(new ClientFactory())) {
-            GrpcStatusException e = assertThrows(GrpcStatusException.class, () ->
-                    client.testBiDiStream(asList(newRequest(), newRequest())).forEach(response -> { /* noop */ }));
-            assertThat(e.status().code(), is(INVALID_ARGUMENT));
-            assertThat(e.status().description(), equalTo("More than one request message received"));
+        try {
+            client.close();
+        } finally {
+            serverContext.close();
         }
     }
 
     @Test
-    public void clientBlockingRequestStreamingCallFailsOnSecondResponseItem() throws Exception {
-        try (BlockingTesterClient client = GrpcClients.forAddress(serverHostAndPort(serverContext))
-                // HTTP filter that modifies path to workaround gRPC API constraints:
-                .appendHttpClientFilter(origin -> new StreamingHttpClientFilter(origin) {
-                    @Override
-                    protected Single<StreamingHttpResponse> request(StreamingHttpRequester delegate,
-                                                                    HttpExecutionStrategy strategy,
-                                                                    StreamingHttpRequest request) {
-                        // Change path to send the request to the route API that generates multiple response items:
-                        request.requestTarget(BlockingTestBiDiStreamRpc.PATH);
-                        return super.request(delegate, strategy, request);
-                    }
-                }).buildBlocking(new ClientFactory())) {
-            IllegalStateException e = assertThrows(IllegalStateException.class,
-                    () -> client.testRequestStream(asList(newRequest(), newRequest())));
-            assertThat(e.getMessage(), equalTo("More than one response message received"));
-        }
+    public void serverBlockingResponseStreamingRouteFailsWithZeroRequestItems() {
+        serverBlockingResponseStreamingRouteFailsWithInvalidArgument(emptyList(),
+                "Single request message was expected, but none was received");
     }
 
-    private static TestRequest newRequest() {
-        return TestRequest.newBuilder().setName("request").build();
+    @Test
+    public void serverBlockingResponseStreamingRouteFailsOnSecondRequestItem() {
+        serverBlockingResponseStreamingRouteFailsWithInvalidArgument(asList(newRequest(0), newRequest(0)),
+                "More than one request message received");
+    }
+
+    private void serverBlockingResponseStreamingRouteFailsWithInvalidArgument(Iterable<TestRequest> requestItems,
+                                                                              String expectedMsg) {
+        GrpcStatusException e = assertThrows(GrpcStatusException.class,
+                () -> client.testBiDiStream(requestItems).forEach(response -> { /* noop */ }));
+        assertThat(e.status().code(), is(INVALID_ARGUMENT));
+        assertThat(e.status().description(), equalTo(expectedMsg));
+    }
+
+    @Test
+    public void clientBlockingRequestStreamingCallFailsWithZeroResponseItems() {
+        clientBlockingRequestStreamingCallFailsOnInvalidResponse(0, NoSuchElementException.class,
+                is(nullValue()));
+    }
+
+    @Test
+    public void clientBlockingRequestStreamingCallFailsOnSecondResponseItem() {
+        clientBlockingRequestStreamingCallFailsOnInvalidResponse(2, IllegalArgumentException.class,
+                equalTo("More than one response message received"));
+    }
+
+    private <T extends Throwable> void clientBlockingRequestStreamingCallFailsOnInvalidResponse(
+            int numberOfResponses, Class<T> exceptionClass, Matcher<Object> exceptionMsgMatcher) {
+        T e = assertThrows(exceptionClass,
+                () -> client.testRequestStream(singletonList(newRequest(numberOfResponses))));
+        assertThat(e.getMessage(), exceptionMsgMatcher);
+    }
+
+    private static TestRequest newRequest(int number) {
+        return TestRequest.newBuilder().setName(Integer.toString(number)).build();
     }
 
     private static TestResponse newResponse() {
         return TestResponse.newBuilder().setMessage("response").build();
+    }
+
+    private static class TesterServiceImpl implements TesterService {
+
+        @Override
+        public Single<TestResponse> test(GrpcServiceContext ctx, TestRequest request) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Publisher<TestResponse> testBiDiStream(GrpcServiceContext ctx, Publisher<TestRequest> request) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Publisher<TestResponse> testResponseStream(GrpcServiceContext ctx, TestRequest request) {
+            return fromIterable(IntStream.range(0, Integer.parseInt(request.getName()))
+                    .mapToObj(i -> newResponse())
+                    .collect(toList()));
+        }
+
+        @Override
+        public Single<TestResponse> testRequestStream(GrpcServiceContext ctx, Publisher<TestRequest> request) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class BlockingTesterServiceImpl implements BlockingTesterService {
+        @Override
+        public TestResponse test(GrpcServiceContext ctx, TestRequest request) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void testBiDiStream(GrpcServiceContext ctx, BlockingIterable<TestRequest> request,
+                                   GrpcPayloadWriter<TestResponse> responseWriter) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void testResponseStream(GrpcServiceContext ctx, TestRequest request,
+                                       GrpcPayloadWriter<TestResponse> responseWriter) throws Exception {
+            int numberOfResponses = Integer.parseInt(request.getName());
+            for (int i = 0; i < numberOfResponses; i++) {
+                responseWriter.write(newResponse());
+            }
+        }
+
+        @Override
+        public TestResponse testRequestStream(GrpcServiceContext ctx,
+                                              BlockingIterable<TestRequest> request) {
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/BlockingApiCorrectnessTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/BlockingApiCorrectnessTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.netty;
+
+import io.servicetalk.concurrent.BlockingIterable;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.grpc.api.GrpcPayloadWriter;
+import io.servicetalk.grpc.api.GrpcServiceContext;
+import io.servicetalk.grpc.api.GrpcStatusException;
+import io.servicetalk.grpc.netty.TesterProto.TestRequest;
+import io.servicetalk.grpc.netty.TesterProto.TestResponse;
+import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTestBiDiStreamRpc;
+import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTestRequestStreamRpc;
+import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTestResponseStreamRpc;
+import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTesterClient;
+import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTesterService;
+import io.servicetalk.grpc.netty.TesterProto.Tester.ClientFactory;
+import io.servicetalk.grpc.netty.TesterProto.Tester.ServiceFactory;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.transport.api.ServerContext;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import static io.servicetalk.grpc.api.GrpcStatusCode.INVALID_ARGUMENT;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThrows;
+
+public class BlockingApiCorrectnessTest {
+
+    @Rule
+    public Timeout timeout = new ServiceTalkTestTimeout();
+
+    private final ServerContext serverContext;
+
+    public BlockingApiCorrectnessTest() throws Exception {
+        serverContext = GrpcServers.forAddress(localAddress(0))
+                // HTTP filter to modify paths to workaround API restrictions:
+                .appendHttpServiceFilter(service -> new StreamingHttpServiceFilter(service) {
+
+                    @Override
+                    public Single<StreamingHttpResponse> handle(HttpServiceContext ctx, StreamingHttpRequest request,
+                                                                StreamingHttpResponseFactory responseFactory) {
+                        if (BlockingTestBiDiStreamRpc.PATH.equals(request.requestTarget())) {
+                            // Forward multiple items to the API that expects only a single request item:
+                            request.requestTarget(BlockingTestResponseStreamRpc.PATH);
+                        } else if (BlockingTestRequestStreamRpc.PATH.equals(request.requestTarget())) {
+                            // Forward request that expects a single response item to the API that generates multiple
+                            // response items:
+                            request.requestTarget(BlockingTestBiDiStreamRpc.PATH);
+                        }
+                        return delegate().handle(ctx, request, responseFactory);
+                    }
+                })
+                .listenAndAwait(new ServiceFactory(new BlockingTesterService() {
+                    @Override
+                    public void testBiDiStream(GrpcServiceContext ctx, BlockingIterable<TestRequest> request,
+                                               GrpcPayloadWriter<TestResponse> responseWriter) throws Exception {
+                        responseWriter.write(newResponse());
+                        responseWriter.write(newResponse());
+                    }
+
+                    @Override
+                    public TestResponse testRequestStream(GrpcServiceContext ctx,
+                                                          BlockingIterable<TestRequest> request) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public void testResponseStream(GrpcServiceContext ctx, TestRequest request,
+                                                   GrpcPayloadWriter<TestResponse> responseWriter) throws Exception {
+                        responseWriter.write(newResponse());
+                    }
+
+                    @Override
+                    public TestResponse test(GrpcServiceContext ctx, TestRequest request) {
+                        throw new UnsupportedOperationException();
+                    }
+                }));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        serverContext.close();
+    }
+
+    @Test
+    public void serverBlockingResponseStreamingRouteFailsOnSecondResponseItem() throws Exception {
+        try (BlockingTesterClient client = GrpcClients.forAddress(serverHostAndPort(serverContext))
+                .buildBlocking(new ClientFactory())) {
+            GrpcStatusException e = assertThrows(GrpcStatusException.class, () ->
+                    // Send multiple items that will be forwarded to BlockingTestResponseStreamRpc.PATH on the server:
+                    client.testBiDiStream(asList(newRequest(), newRequest())).forEach(response -> { /* noop */ }));
+            assertThat(e.status().code(), is(INVALID_ARGUMENT));
+            assertThat(e.status().description(), startsWith("Only a single request item is expected"));
+        }
+    }
+
+    @Test
+    public void clientBlockingRequestStreamingCallFailsOnSecondResponseItem() throws Exception {
+        try (BlockingTesterClient client = GrpcClients.forAddress(serverHostAndPort(serverContext))
+                .buildBlocking(new ClientFactory())) {
+            IllegalStateException e = assertThrows(IllegalStateException.class,
+                    // This request will be forwarded to BlockingTestBiDiStreamRpc.PATH on the server:
+                    () -> client.testRequestStream(asList(newRequest(), newRequest())));
+            assertThat(e.getMessage(), startsWith("Only a single response item is expected"));
+        }
+    }
+
+    private static TestRequest newRequest() {
+        return TestRequest.newBuilder().setName("request").build();
+    }
+
+    private static TestResponse newResponse() {
+        return TestResponse.newBuilder().setMessage("response").build();
+    }
+}

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/BlockingApiCorrectnessTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/BlockingApiCorrectnessTest.java
@@ -54,7 +54,7 @@ import static org.junit.Assert.assertThrows;
 public class BlockingApiCorrectnessTest {
 
     @Rule
-    public Timeout timeout = new ServiceTalkTestTimeout();
+    public final Timeout timeout = new ServiceTalkTestTimeout();
 
     private final ServerContext serverContext;
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/SingleRequestOrResponseApiTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/SingleRequestOrResponseApiTest.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.BlockingIterable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.grpc.api.GrpcClientBuilder;
 import io.servicetalk.grpc.api.GrpcPayloadWriter;
 import io.servicetalk.grpc.api.GrpcServiceContext;
 import io.servicetalk.grpc.api.GrpcStatusException;
@@ -29,15 +30,16 @@ import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTesterClient;
 import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTesterService;
 import io.servicetalk.grpc.netty.TesterProto.Tester.ClientFactory;
 import io.servicetalk.grpc.netty.TesterProto.Tester.ServiceFactory;
+import io.servicetalk.grpc.netty.TesterProto.Tester.TesterClient;
 import io.servicetalk.grpc.netty.TesterProto.Tester.TesterService;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequester;
 import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
 
-import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,9 +48,12 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import java.net.InetSocketAddress;
 import java.util.NoSuchElementException;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.IntStream;
 
+import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Publisher.fromIterable;
 import static io.servicetalk.grpc.api.GrpcStatusCode.INVALID_ARGUMENT;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
@@ -59,25 +64,31 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assume.assumeFalse;
 
 @RunWith(Parameterized.class)
-public class BlockingApiCorrectnessTest {
+public class SingleRequestOrResponseApiTest {
 
     @Rule
     public final Timeout timeout = new ServiceTalkTestTimeout();
 
+    private final boolean streamingServer;
+    private final boolean streamingClient;
     private final ServerContext serverContext;
-    private final BlockingTesterClient client;
+    private final GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder;
 
-    public BlockingApiCorrectnessTest(boolean streaming) throws Exception {
-        serverContext = GrpcServers.forAddress(localAddress(0)).listenAndAwait(streaming ?
+    public SingleRequestOrResponseApiTest(boolean streamingServer, boolean streamingClient) throws Exception {
+        this.streamingServer = streamingServer;
+        this.streamingClient = streamingClient;
+
+        serverContext = GrpcServers.forAddress(localAddress(0)).listenAndAwait(streamingServer ?
                 new ServiceFactory(new TesterServiceImpl()) :
                 new ServiceFactory(new BlockingTesterServiceImpl()));
 
-        client = GrpcClients.forAddress(serverHostAndPort(serverContext))
+        clientBuilder = GrpcClients.forAddress(serverHostAndPort(serverContext))
                 // HTTP filter that modifies path to workaround gRPC API constraints:
                 .appendHttpClientFilter(origin -> new StreamingHttpClientFilter(origin) {
                     @Override
@@ -89,60 +100,75 @@ public class BlockingApiCorrectnessTest {
                         request.requestTarget(BlockingTestResponseStreamRpc.PATH);
                         return super.request(delegate, strategy, request);
                     }
-                }).buildBlocking(new ClientFactory());
+                });
     }
 
-    @Parameters(name = "streaming={0}")
-    public static Object[] params() {
-        return new Object[]{true, false};
+    @Parameters(name = "streamingServer={0}, streamingServer={1}")
+    public static Object[][] params() {
+        return new Object[][]{{false, false}, {false, true}, {true, false}};
     }
 
     @After
     public void tearDown() throws Exception {
-        try {
-            client.close();
-        } finally {
-            serverContext.close();
-        }
+        serverContext.close();
     }
 
     @Test
-    public void serverBlockingResponseStreamingRouteFailsWithZeroRequestItems() {
-        serverBlockingResponseStreamingRouteFailsWithInvalidArgument(emptyList(),
+    public void serverResponseStreamingRouteFailsWithZeroRequestItems() throws Exception {
+        serverResponseStreamingRouteFailsWithInvalidArgument(emptyList(),
                 "Single request message was expected, but none was received");
     }
 
     @Test
-    public void serverBlockingResponseStreamingRouteFailsOnSecondRequestItem() {
-        serverBlockingResponseStreamingRouteFailsWithInvalidArgument(asList(newRequest(0), newRequest(0)),
+    public void serverResponseStreamingRouteFailsOnSecondRequestItem() throws Exception {
+        serverResponseStreamingRouteFailsWithInvalidArgument(asList(newRequest(0), newRequest(0)),
                 "More than one request message received");
     }
 
-    private void serverBlockingResponseStreamingRouteFailsWithInvalidArgument(Iterable<TestRequest> requestItems,
-                                                                              String expectedMsg) {
-        GrpcStatusException e = assertThrows(GrpcStatusException.class,
-                () -> client.testBiDiStream(requestItems).forEach(response -> { /* noop */ }));
-        assertThat(e.status().code(), is(INVALID_ARGUMENT));
-        assertThat(e.status().description(), equalTo(expectedMsg));
+    private void serverResponseStreamingRouteFailsWithInvalidArgument(Iterable<TestRequest> requestItems,
+                                                                      String expectedMsg) throws Exception {
+        assumeFalse(streamingClient);  // No need to run the test with different client-side, always use blocking client
+        try (BlockingTesterClient client = newBlockingClient()) {
+            GrpcStatusException e = assertThrows(GrpcStatusException.class,
+                    () -> client.testBiDiStream(requestItems).forEach(response -> { /* noop */ }));
+            assertThat(e.status().code(), is(INVALID_ARGUMENT));
+            assertThat(e.status().description(), equalTo(expectedMsg));
+        }
     }
 
     @Test
-    public void clientBlockingRequestStreamingCallFailsWithZeroResponseItems() {
-        clientBlockingRequestStreamingCallFailsOnInvalidResponse(0, NoSuchElementException.class,
-                is(nullValue()));
+    public void clientRequestStreamingCallFailsWithZeroResponseItems() throws Exception {
+        clientRequestStreamingCallFailsOnInvalidResponse(0, NoSuchElementException.class);
     }
 
     @Test
-    public void clientBlockingRequestStreamingCallFailsOnSecondResponseItem() {
-        clientBlockingRequestStreamingCallFailsOnInvalidResponse(2, IllegalArgumentException.class,
-                equalTo("More than one response message received"));
+    public void clientRequestStreamingCallFailsOnSecondResponseItem() throws Exception {
+        clientRequestStreamingCallFailsOnInvalidResponse(2, IllegalArgumentException.class);
     }
 
-    private <T extends Throwable> void clientBlockingRequestStreamingCallFailsOnInvalidResponse(
-            int numberOfResponses, Class<T> exceptionClass, Matcher<Object> exceptionMsgMatcher) {
-        T e = assertThrows(exceptionClass,
-                () -> client.testRequestStream(singletonList(newRequest(numberOfResponses))));
-        assertThat(e.getMessage(), exceptionMsgMatcher);
+    private <T extends Throwable> void clientRequestStreamingCallFailsOnInvalidResponse(
+            int numberOfResponses, Class<T> exceptionClass) throws Exception {
+        assumeFalse(streamingServer);  // No need to run the test with different server-side
+        if (streamingClient) {
+            try (TesterClient client = newClient()) {
+                ExecutionException e = assertThrows(ExecutionException.class,
+                        () -> client.testRequestStream(from(newRequest(numberOfResponses))).toFuture().get());
+                assertThat(e.getCause(), is(instanceOf(exceptionClass)));
+            }
+        } else {
+            try (BlockingTesterClient client = newBlockingClient()) {
+                assertThrows(exceptionClass,
+                        () -> client.testRequestStream(singletonList(newRequest(numberOfResponses))));
+            }
+        }
+    }
+
+    private BlockingTesterClient newBlockingClient() {
+        return clientBuilder.buildBlocking(new ClientFactory());
+    }
+
+    private TesterClient newClient() {
+        return clientBuilder.build(new ClientFactory());
     }
 
     private static TestRequest newRequest(int number) {


### PR DESCRIPTION
Motivation:

gRPC `BlockingResponseStreamingRoute` is implemented as a conversion
based on `BlockingStreamingRoute`, but must ensure that there is
only one proto item in the request and fail if there are more.
Otherwise, it does not drain request `BlockingIterable` and may lead
to the leaked resources.

Modifications:

- Throw if `BlockingResponseStreamingRoute` sees the second item
in the request `BlockingIterable`;
- Throw if `BlockingResponseStreamingRoute` sees no items in the
request `BlockingIterable`;
- Make exception messages of `ResponseStreamingRoute` consistent
with `BlockingResponseStreamingRoute`;
- Add tests to verify that these cases work as expected and
blocking/async API behavior is consistent;

Result:

`BlockingResponseStreamingRoute` fails if a client sends more than
one proto items in the request.