### PR TITLE
Explicit set MacOSDnsServerAddressStreamProvider when it can be used …

### DIFF
--- a/servicetalk-dns-discovery-netty/build.gradle
+++ b/servicetalk-dns-discovery-netty/build.gradle
@@ -28,6 +28,8 @@ dependencies {
   implementation project(":servicetalk-transport-netty-internal")
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
   implementation "io.netty:netty-resolver-dns:$nettyVersion"
+  implementation "io.netty:netty-resolver-dns-native-macos:$nettyVersion:osx-x86_64"
+
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation testFixtures(project(":servicetalk-client-api-internal"))

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscoverer.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscoverer.java
@@ -37,6 +37,7 @@ import io.netty.resolver.ResolvedAddressTypes;
 import io.netty.resolver.dns.DefaultDnsCache;
 import io.netty.resolver.dns.DnsNameResolver;
 import io.netty.resolver.dns.DnsNameResolverBuilder;
+import io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import org.slf4j.Logger;
@@ -123,6 +124,9 @@ final class DefaultDnsServiceDiscoverer
         }
         if (dnsServerAddressStreamProvider != null) {
             builder.nameServerProvider(toNettyType(dnsServerAddressStreamProvider));
+        } else if (MacOSDnsServerAddressStreamProvider.isAvailable()) {
+            // We need to explicit enable the provider for MacOS to ensure we return the correct nameservers.
+            builder.nameServerProvider(new MacOSDnsServerAddressStreamProvider());
         }
         if (dnsResolverAddressTypes != null) {
             builder.resolvedAddressTypes(toNettyType(dnsResolverAddressTypes));


### PR DESCRIPTION
…to ensure we return the correct nameservers when on macOS

Motivation:

When on MacOS we need to use MacOSDnsServerAddressStreamProvider explicitly to ensure we return the correct nameservers when a VPN is used.

Modifications:

Check if MacOSDnsServerAddressStreamProvider can be used and if so explicit enable it

Result:

Resolution will use the correct nameservers on MacOS in all cases