### PR TITLE
Don't re-use *Exceptions when stored in static fields if enableSuppre…

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/NoAvailableHostException.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/NoAvailableHostException.java
@@ -20,7 +20,7 @@ import io.servicetalk.transport.api.RetryableException;
 /**
  * Thrown when no host is available but at least one is required.
  */
-public final class NoAvailableHostException extends RuntimeException implements RetryableException {
+public class NoAvailableHostException extends RuntimeException implements RetryableException {
     private static final long serialVersionUID = 5340791072245425967L;
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
@@ -35,8 +35,7 @@ public final class RepeatStrategies {
     public static final class TerminateRepeatException extends Exception {
         private static final long serialVersionUID = -1725458427890873886L;
 
-        // It is fine to reuse this instance and let it escape to the user as we enableSuppression is set to false
-        // while constructing it.
+        // It is fine to reuse this instance and let it escape to the user as enableSuppression is set to false.
         static final TerminateRepeatException INSTANCE = new TerminateRepeatException();
 
         // Package-private as the user should never instance it.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
@@ -35,6 +35,8 @@ public final class RepeatStrategies {
     public static final class TerminateRepeatException extends Exception {
         private static final long serialVersionUID = -1725458427890873886L;
 
+        // It is fine to reuse this instance and let it escape to the user as we enableSuppression is set to false
+        // while constructing it.
         static final TerminateRepeatException INSTANCE = new TerminateRepeatException();
 
         // Package-private as the user should never instance it.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -161,6 +161,11 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
         }
 
         @Override
+        boolean hasSubscriber() {
+            return subscriber != null;
+        }
+
+        @Override
         void tryCompleteSubscriber() {
             if (subscriber != null) {
                 Subscriber<? super H2ClientParentConnection> subscriberCopy = subscriber;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -31,6 +31,7 @@ import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.FlushStrategyHolder;
 import io.servicetalk.transport.netty.internal.NettyChannelListenableAsyncCloseable;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;
+import io.servicetalk.transport.netty.internal.StacklessClosedChannelException;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -49,7 +50,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.SocketAddress;
 import java.net.SocketOption;
-import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
@@ -63,7 +63,6 @@ import static io.netty.util.ReferenceCountUtil.release;
 import static io.servicetalk.concurrent.api.Processors.newCompletableProcessor;
 import static io.servicetalk.concurrent.api.Processors.newSingleProcessor;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
-import static io.servicetalk.concurrent.internal.ThrowableUtils.unknownStackTrace;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.H2ToStH1Utils.DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_MILLIS;
 import static io.servicetalk.transport.netty.internal.NettyIoExecutors.fromNettyEventLoop;
@@ -73,11 +72,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable implements NettyConnectionContext,
                                                                                         HttpConnectionContext {
-    private static final ClosedChannelException CLOSED_CHANNEL_INACTIVE = unknownStackTrace(
-            new ClosedChannelException(), H2ClientParentConnectionContext.class, "channelInactive(..)");
-    private static final ClosedChannelException CLOSED_HANDLER_REMOVED =
-            unknownStackTrace(new ClosedChannelException(), H2ClientParentConnectionContext.class,
-                    "handlerRemoved(..)");
+
     private static final AtomicIntegerFieldUpdater<H2ParentConnectionContext> activeChildChannelsUpdater =
             AtomicIntegerFieldUpdater.newUpdater(H2ParentConnectionContext.class, "activeChildChannels");
     private static final Logger LOGGER = LoggerFactory.getLogger(H2ParentConnectionContext.class);
@@ -264,6 +259,8 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
             this.waitForSslHandshake = waitForSslHandshake;
         }
 
+        abstract boolean hasSubscriber();
+
         abstract void tryCompleteSubscriber();
 
         abstract void tryFailSubscriber(Throwable cause);
@@ -291,13 +288,17 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
 
         @Override
         public final void channelInactive(ChannelHandlerContext ctx) {
-            tryFailSubscriber(CLOSED_CHANNEL_INACTIVE);
+            if (hasSubscriber()) {
+                tryFailSubscriber(new StacklessClosedChannelException());
+            }
             doConnectionCleanup();
         }
 
         @Override
         public final void handlerRemoved(ChannelHandlerContext ctx) {
-            tryFailSubscriber(CLOSED_HANDLER_REMOVED);
+            if (hasSubscriber()) {
+                tryFailSubscriber(new StacklessClosedChannelException());
+            }
             doConnectionCleanup();
         }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -289,7 +289,8 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
         @Override
         public final void channelInactive(ChannelHandlerContext ctx) {
             if (hasSubscriber()) {
-                tryFailSubscriber(new StacklessClosedChannelException());
+                tryFailSubscriber(StacklessClosedChannelException.newInstance(
+                        H2ParentConnectionContext.class, "channelInactive(...)"));
             }
             doConnectionCleanup();
         }
@@ -297,7 +298,8 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
         @Override
         public final void handlerRemoved(ChannelHandlerContext ctx) {
             if (hasSubscriber()) {
-                tryFailSubscriber(new StacklessClosedChannelException());
+                tryFailSubscriber(StacklessClosedChannelException.newInstance(
+                        H2ParentConnectionContext.class, "handlerRemoved(...)"));
             }
             doConnectionCleanup();
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -192,6 +192,11 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
         }
 
         @Override
+        boolean hasSubscriber() {
+            return subscriber != null;
+        }
+
+        @Override
         void tryCompleteSubscriber() {
             if (subscriber != null) {
                 Subscriber<? super H2ServerParentConnectionContext> subscriberCopy = subscriber;

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -57,7 +57,6 @@ import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
-import static io.servicetalk.concurrent.internal.ThrowableUtils.unknownStackTrace;
 import static java.util.Collections.binarySearch;
 import static java.util.Collections.emptyList;
 import static java.util.Comparator.comparing;
@@ -87,12 +86,6 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
         implements LoadBalancer<C> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RoundRobinLoadBalancer.class);
-    private static final IllegalStateException LB_CLOSED_SELECT_CNX_EXCEPTION =
-            unknownStackTrace(new IllegalStateException("LoadBalancer has closed"), RoundRobinLoadBalancer.class,
-                    "selectConnection0(...)");
-    private static final NoAvailableHostException NO_ACTIVE_HOSTS_SELECT_CNX_EXCEPTION =
-            unknownStackTrace(new NoAvailableHostException("No hosts are available to connect."),
-                    RoundRobinLoadBalancer.class, "selectConnection0(...)");
 
     private static final AtomicReferenceFieldUpdater<RoundRobinLoadBalancer, List> activeHostsUpdater =
             newUpdater(RoundRobinLoadBalancer.class, List.class, "activeHosts");
@@ -250,13 +243,13 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
 
     private Single<C> selectConnection0(Predicate<C> selector) {
         if (closed) {
-            return failed(LB_CLOSED_SELECT_CNX_EXCEPTION);
+            return failed(new IllegalStateException("LoadBalancer has closed"));
         }
 
         final List<Host<ResolvedAddress, C>> activeHosts = this.activeHosts;
         if (activeHosts.isEmpty()) {
             // This is the case when SD has emitted some items but none of the hosts are active.
-            return failed(NO_ACTIVE_HOSTS_SELECT_CNX_EXCEPTION);
+            return failed(new StacklessNoAvailableHostException("No hosts are available to connect."));
         }
 
         final int cursor = (indexUpdater.getAndIncrement(this) & Integer.MAX_VALUE) % activeHosts.size();
@@ -312,7 +305,7 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
                                 existing = connections;
                             }
 
-                            return failed(LB_CLOSED_SELECT_CNX_EXCEPTION);
+                            return failed(new IllegalStateException("LoadBalancer has closed"));
                         }
                         return succeeded(newCnx);
                     }
@@ -432,5 +425,16 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
     private static final class MutableAddressHost<Addr, C extends ListenableAsyncCloseable> extends Host<Addr, C> {
         @Nullable
         Addr mutableAddress;
+    }
+
+    private static final class StacklessNoAvailableHostException extends NoAvailableHostException {
+        StacklessNoAvailableHostException(final String message) {
+            super(message);
+        }
+
+        @Override
+        public Throwable fillInStackTrace() {
+            return this;
+        }
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -33,6 +33,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.SpScPublisherProcessor;
 import io.servicetalk.concurrent.internal.SequentialCancellable;
 
+import io.servicetalk.concurrent.internal.ThrowableUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -249,7 +250,8 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
         final List<Host<ResolvedAddress, C>> activeHosts = this.activeHosts;
         if (activeHosts.isEmpty()) {
             // This is the case when SD has emitted some items but none of the hosts are active.
-            return failed(new StacklessNoAvailableHostException("No hosts are available to connect."));
+            return failed(StacklessNoAvailableHostException.newInstance(
+                    "No hosts are available to connect.",  RoundRobinLoadBalancer.class, "selectConnection0(...)"));
         }
 
         final int cursor = (indexUpdater.getAndIncrement(this) & Integer.MAX_VALUE) % activeHosts.size();
@@ -428,13 +430,17 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
     }
 
     private static final class StacklessNoAvailableHostException extends NoAvailableHostException {
-        StacklessNoAvailableHostException(final String message) {
+        private StacklessNoAvailableHostException(final String message) {
             super(message);
         }
 
         @Override
         public Throwable fillInStackTrace() {
             return this;
+        }
+
+        public static StacklessNoAvailableHostException newInstance(String message, Class<?> clazz, String method) {
+            return ThrowableUtils.unknownStackTrace(new StacklessNoAvailableHostException(message), clazz, method);
         }
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -32,8 +32,8 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.SpScPublisherProcessor;
 import io.servicetalk.concurrent.internal.SequentialCancellable;
-
 import io.servicetalk.concurrent.internal.ThrowableUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -251,7 +251,7 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
         if (activeHosts.isEmpty()) {
             // This is the case when SD has emitted some items but none of the hosts are active.
             return failed(StacklessNoAvailableHostException.newInstance(
-                    "No hosts are available to connect.",  RoundRobinLoadBalancer.class, "selectConnection0(...)"));
+                    "No hosts are available to connect.", RoundRobinLoadBalancer.class, "selectConnection0(...)"));
         }
 
         final int cursor = (indexUpdater.getAndIncrement(this) & Integer.MAX_VALUE) % activeHosts.size();

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -442,8 +442,8 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
             // never notify the write writeSubscriber of the inactive event. So if the channel is inactive we notify
             // the writeSubscriber.
             if (!channel().isActive()) {
-                newChannelOutboundListener.channelClosed(
-                        StacklessClosedChannelException.newInstance(DefaultNettyConnection.class, "failIfWriteActive(...)"));
+                newChannelOutboundListener.channelClosed(StacklessClosedChannelException.newInstance(
+                        DefaultNettyConnection.class, "failIfWriteActive(...)"));
                 return false;
             }
             return true;

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -49,7 +49,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.SocketAddress;
 import java.net.SocketOption;
-import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -62,7 +61,6 @@ import static io.servicetalk.concurrent.api.Processors.newSingleProcessor;
 import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
-import static io.servicetalk.concurrent.internal.ThrowableUtils.unknownStackTrace;
 import static io.servicetalk.transport.netty.internal.ChannelSet.CHANNEL_CLOSEABLE_KEY;
 import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
 import static io.servicetalk.transport.netty.internal.Flush.composeFlushes;
@@ -86,12 +84,6 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     private static final ChannelOutboundListener PLACE_HOLDER_OUTBOUND_LISTENER = new NoopChannelOutboundListener();
     private static final ChannelOutboundListener SINGLE_ITEM_OUTBOUND_LISTENER = new NoopChannelOutboundListener();
 
-    private static final ClosedChannelException CLOSED_CHANNEL_INACTIVE = unknownStackTrace(
-            new ClosedChannelException(), NettyToStChannelInboundHandler.class, "channelInactive(..)");
-    private static final ClosedChannelException CLOSED_FAIL_ACTIVE =
-            unknownStackTrace(new ClosedChannelException(), DefaultNettyConnection.class, "failIfWriteActive(..)");
-    private static final ClosedChannelException CLOSED_HANDLER_REMOVED =
-            unknownStackTrace(new ClosedChannelException(), NettyToStChannelInboundHandler.class, "handlerRemoved(..)");
     private static final AtomicReferenceFieldUpdater<DefaultNettyConnection, ChannelOutboundListener>
             writableListenerUpdater = newUpdater(DefaultNettyConnection.class, ChannelOutboundListener.class,
                                                  "channelOutboundListener");
@@ -450,7 +442,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
             // never notify the write writeSubscriber of the inactive event. So if the channel is inactive we notify
             // the writeSubscriber.
             if (!channel().isActive()) {
-                newChannelOutboundListener.channelClosed(CLOSED_FAIL_ACTIVE);
+                newChannelOutboundListener.channelClosed(new StacklessClosedChannelException());
                 return false;
             }
             return true;
@@ -561,7 +553,9 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
 
         @Override
         public void handlerRemoved(ChannelHandlerContext ctx) {
-            tryFailSubscriber(CLOSED_HANDLER_REMOVED);
+            if (subscriber != null) {
+                tryFailSubscriber(new StacklessClosedChannelException());
+            }
         }
 
         @Override
@@ -587,7 +581,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
                 connection.channelOutboundListener.channelOutboundClosed();
             } else if (evt == ChannelOutputShutdownEvent.INSTANCE) {
                 connection.closeHandler.channelClosedOutbound(ctx);
-                connection.channelOutboundListener.channelClosed(CLOSED_CHANNEL_INACTIVE);
+                connection.channelOutboundListener.channelClosed(new StacklessClosedChannelException());
             } else if (evt == ChannelInputShutdownReadComplete.INSTANCE) {
                 // Notify close handler first to enhance error reporting
                 connection.closeHandler.channelClosedInbound(ctx);
@@ -621,8 +615,9 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
 
         @Override
         public void channelInactive(ChannelHandlerContext ctx) {
-            tryFailSubscriber(CLOSED_CHANNEL_INACTIVE);
-            connection.channelOutboundListener.channelClosed(CLOSED_CHANNEL_INACTIVE);
+            Throwable closedChannelException = new StacklessClosedChannelException();
+            tryFailSubscriber(closedChannelException);
+            connection.channelOutboundListener.channelClosed(closedChannelException);
             connection.nettyChannelPublisher.channelInboundClosed();
         }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -442,7 +442,8 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
             // never notify the write writeSubscriber of the inactive event. So if the channel is inactive we notify
             // the writeSubscriber.
             if (!channel().isActive()) {
-                newChannelOutboundListener.channelClosed(new StacklessClosedChannelException());
+                newChannelOutboundListener.channelClosed(
+                        StacklessClosedChannelException.newInstance(DefaultNettyConnection.class, "failIfWriteActive(...)"));
                 return false;
             }
             return true;
@@ -554,7 +555,8 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
         @Override
         public void handlerRemoved(ChannelHandlerContext ctx) {
             if (subscriber != null) {
-                tryFailSubscriber(new StacklessClosedChannelException());
+                tryFailSubscriber(StacklessClosedChannelException.newInstance(
+                        DefaultNettyConnection.class, "handlerRemoved(...)"));
             }
         }
 
@@ -581,7 +583,8 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
                 connection.channelOutboundListener.channelOutboundClosed();
             } else if (evt == ChannelOutputShutdownEvent.INSTANCE) {
                 connection.closeHandler.channelClosedOutbound(ctx);
-                connection.channelOutboundListener.channelClosed(new StacklessClosedChannelException());
+                connection.channelOutboundListener.channelClosed(StacklessClosedChannelException.newInstance(
+                        DefaultNettyConnection.class, "userEventTriggered(...)"));
             } else if (evt == ChannelInputShutdownReadComplete.INSTANCE) {
                 // Notify close handler first to enhance error reporting
                 connection.closeHandler.channelClosedInbound(ctx);
@@ -615,7 +618,8 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
 
         @Override
         public void channelInactive(ChannelHandlerContext ctx) {
-            Throwable closedChannelException = new StacklessClosedChannelException();
+            Throwable closedChannelException = StacklessClosedChannelException.newInstance(
+                    DefaultNettyConnection.class, "channelInactive(...)");
             tryFailSubscriber(closedChannelException);
             connection.channelOutboundListener.channelClosed(closedChannelException);
             connection.nettyChannelPublisher.channelInboundClosed();

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
@@ -116,7 +116,8 @@ final class NettyChannelPublisher<T> extends SubscribablePublisher<T> {
 
     void channelInboundClosed() {
         assertInEventloop();
-        Throwable error = StacklessClosedChannelException.newInstance(NettyChannelPublisher.class, "channelInboundClosed");
+        Throwable error = StacklessClosedChannelException.newInstance(
+                NettyChannelPublisher.class, "channelInboundClosed");
         fatalError = error;
         exceptionCaught(error);
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
@@ -116,7 +116,7 @@ final class NettyChannelPublisher<T> extends SubscribablePublisher<T> {
 
     void channelInboundClosed() {
         assertInEventloop();
-        Throwable error = new StacklessClosedChannelException();
+        Throwable error = StacklessClosedChannelException.newInstance(NettyChannelPublisher.class, "channelInboundClosed");
         fatalError = error;
         exceptionCaught(error);
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
@@ -24,7 +24,6 @@ import io.netty.channel.EventLoop;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
 
-import java.nio.channels.ClosedChannelException;
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.function.Predicate;
@@ -34,12 +33,9 @@ import static io.servicetalk.concurrent.internal.EmptySubscription.EMPTY_SUBSCRI
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
-import static io.servicetalk.concurrent.internal.ThrowableUtils.unknownStackTrace;
 import static java.util.Objects.requireNonNull;
 
 final class NettyChannelPublisher<T> extends SubscribablePublisher<T> {
-    private static final ClosedChannelException CLOSED_CHANNEL_EXCEPTION =
-            unknownStackTrace(new ClosedChannelException(), NettyChannelPublisher.class, "channelInboundClosed");
 
     // All state is only touched from eventloop.
     private long requestCount;
@@ -120,8 +116,9 @@ final class NettyChannelPublisher<T> extends SubscribablePublisher<T> {
 
     void channelInboundClosed() {
         assertInEventloop();
-        fatalError = CLOSED_CHANNEL_EXCEPTION;
-        exceptionCaught(CLOSED_CHANNEL_EXCEPTION);
+        Throwable error = new StacklessClosedChannelException();
+        fatalError = error;
+        exceptionCaught(error);
     }
 
     // All private methods MUST be invoked from the eventloop.

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/StacklessClosedChannelException.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/StacklessClosedChannelException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import java.nio.channels.ClosedChannelException;
+
+public final class StacklessClosedChannelException extends ClosedChannelException {
+
+    @Override
+    public Throwable fillInStackTrace() {
+        // Don't fill in the stacktrace to reduce performance overhead
+        return this;
+    }
+}

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/StacklessClosedChannelException.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/StacklessClosedChannelException.java
@@ -19,6 +19,10 @@ import io.servicetalk.concurrent.internal.ThrowableUtils;
 
 import java.nio.channels.ClosedChannelException;
 
+/**
+ * {@link ClosedChannelException} that will not not fill in the stacktrace but use a cheaper way of producing
+ * limited stacktrace details for the user.
+ */
 public final class StacklessClosedChannelException extends ClosedChannelException {
 
     private StacklessClosedChannelException() { }
@@ -29,6 +33,13 @@ public final class StacklessClosedChannelException extends ClosedChannelExceptio
         return this;
     }
 
+    /**
+     * Creates a new {@link StacklessClosedChannelException} instance.
+     *
+     * @param clazz The class in which this {@link StacklessClosedChannelException} will be used.
+     * @param method The method from which it will be thrown.
+     * @return a new instance.
+     */
     public static StacklessClosedChannelException newInstance(Class<?> clazz, String method) {
         return ThrowableUtils.unknownStackTrace(new StacklessClosedChannelException(), clazz, method);
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/StacklessClosedChannelException.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/StacklessClosedChannelException.java
@@ -15,13 +15,21 @@
  */
 package io.servicetalk.transport.netty.internal;
 
+import io.servicetalk.concurrent.internal.ThrowableUtils;
+
 import java.nio.channels.ClosedChannelException;
 
 public final class StacklessClosedChannelException extends ClosedChannelException {
+
+    private StacklessClosedChannelException() { }
 
     @Override
     public Throwable fillInStackTrace() {
         // Don't fill in the stacktrace to reduce performance overhead
         return this;
+    }
+
+    public static StacklessClosedChannelException newInstance(Class<?> clazz, String method) {
+        return ThrowableUtils.unknownStackTrace(new StacklessClosedChannelException(), clazz, method);
     }
 }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
@@ -490,7 +490,7 @@ public class DefaultNettyConnectionTest {
         writeListener.verifyFailure(exCaptor);
 
         // Exception should NOT be of type CloseEventObservedException
-        assertThat(exCaptor.getValue(), instanceOf(ClosedChannelException.class));
+        assertThat(exCaptor.getValue(), instanceOf(StacklessClosedChannelException.class));
         assertThat(exCaptor.getValue().getCause(), nullValue());
         assertThat(exCaptor.getValue().getStackTrace()[0].getClassName(),
                 equalTo(DefaultNettyConnection.class.getName()));


### PR DESCRIPTION
…ssion can not be set to false

Motivation:

Have a static instance of an Exception which does not set enableSuppression to false when constructed is considered to be dangerous as it may escape to the user where an user may add more exceptions to it. The problem with this is that the internal storage will grow and grow over time and never be GC'ed. This can lead to OOME situations.

Modifications:

Create new *Exceptions when needed and remove usage of static stored *Exceptions if needed.

Result:

No more risk of OOME due user calling `addSuppressed` on exceptions that are propagated through the code