### PR TITLE
Publisher#range operator

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2382,6 +2382,33 @@ public abstract class Publisher<T> {
     }
 
     /**
+     * Create a new {@link Publisher} that when subscribed will emit all {@link Integer}s within the range of
+     * [{@code begin}, {@code end}).
+     * @param begin The beginning of the range (inclusive).
+     * @param end The end of the range (exclusive).
+     * @return a new {@link Publisher} that when subscribed will emit all {@link Integer}s within the range of
+     * [{@code begin}, {@code end}).
+     * @see <a href="http://reactivex.io/documentation/operators/range.html">Range.</a>
+     */
+    public static Publisher<Integer> range(int begin, int end) {
+        return new RangeIntPublisher(begin, end);
+    }
+
+    /**
+     * Create a new {@link Publisher} that when subscribed will emit all {@link Integer}s within the range of
+     * [{@code begin}, {@code end}) with an increment of {@code stride} between each signal.
+     * @param begin The beginning of the range (inclusive).
+     * @param end The end of the range (exclusive).
+     * @param stride The amount to increment in between each signal.
+     * @return a new {@link Publisher} that when subscribed will emit all {@link Integer}s within the range of
+     * [{@code begin}, {@code end}) with an increment of {@code stride} between each signal.
+     * @see <a href="http://reactivex.io/documentation/operators/range.html">Range.</a>
+     */
+    public static Publisher<Integer> range(int begin, int end, int stride) {
+        return new RangeIntPublisher(begin, end, stride);
+    }
+
+    /**
      * Creates a new {@link Publisher} that completes when subscribed without emitting any item to its
      * {@link Subscriber}.
      *

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RangeIntPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RangeIntPublisher.java
@@ -41,7 +41,7 @@ final class RangeIntPublisher extends AbstractSynchronousPublisher<Integer> {
             throw new IllegalArgumentException("begin(" + begin + ") > end(" + end + ")");
         }
         if (stride <= 0) {
-            throw new IllegalArgumentException("stride: " + stride);
+            throw new IllegalArgumentException("stride: " + stride + " (expected >0)");
         }
         this.begin = begin;
         this.end = end;
@@ -85,7 +85,7 @@ final class RangeIntPublisher extends AbstractSynchronousPublisher<Integer> {
                     return;
                 }
             }
-            if (index >= end) {
+            if (index == end) {
                 sendComplete();
             }
         }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RangeIntPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RangeIntPublisher.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.PublisherSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
+import static java.lang.Math.min;
+import static java.util.Objects.requireNonNull;
+
+final class RangeIntPublisher extends AbstractSynchronousPublisher<Integer> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RangeIntPublisher.class);
+    private final int begin;
+    private final int end;
+    private final int stride;
+
+    RangeIntPublisher(int begin, int end) {
+        this(begin, end, 1);
+    }
+
+    RangeIntPublisher(int begin, int end, int stride) {
+        if (begin > end) {
+            throw new IllegalArgumentException("begin(" + begin + ") > end(" + end + ")");
+        }
+        if (stride <= 0) {
+            throw new IllegalArgumentException("stride: " + stride);
+        }
+        this.begin = begin;
+        this.end = end;
+        this.stride = stride;
+    }
+
+    @Override
+    void doSubscribe(final Subscriber<? super Integer> subscriber) {
+        subscriber.onSubscribe(new RangeIntSubscription(subscriber));
+    }
+
+    private final class RangeIntSubscription implements PublisherSource.Subscription {
+        private final PublisherSource.Subscriber<? super Integer> subscriber;
+        private long pendingN;
+        private int index = RangeIntPublisher.this.begin;
+
+        private RangeIntSubscription(PublisherSource.Subscriber<? super Integer> subscriber) {
+            this.subscriber = requireNonNull(subscriber);
+        }
+
+        @Override
+        public void request(long n) {
+            if (pendingN < 0) {
+                return;
+            }
+            if (!isRequestNValid(n)) {
+                sendOnError(newExceptionForInvalidRequestN(n));
+                return;
+            }
+            if (pendingN != 0) {
+                // this call is re-entrant. just add to pending and deliver onNext when the stack unwinds.
+                pendingN = addWithOverflowProtection(pendingN, n);
+                return;
+            }
+            pendingN = addWithOverflowProtection(pendingN, n);
+            for (; pendingN > 0 && index < end; --pendingN, index += min(stride, (long) end - index)) {
+                try {
+                    subscriber.onNext(index);
+                } catch (Throwable cause) {
+                    sendOnError(cause);
+                    return;
+                }
+            }
+            if (index >= end) {
+                sendComplete();
+            }
+        }
+
+        @Override
+        public void cancel() {
+            pendingN = -1; // must be negative value to prevent signal after terminal event.
+        }
+
+        private void sendOnError(Throwable cause) {
+            cancel();
+            try {
+                subscriber.onError(cause);
+            } catch (Throwable t) {
+                LOGGER.info("Ignoring exception from onError of Subscriber {}.", subscriber, t);
+            }
+        }
+
+        private void sendComplete() {
+            cancel();
+            try {
+                subscriber.onComplete();
+            } catch (Throwable t) {
+                LOGGER.info("Ignoring exception from onComplete of Subscriber {}.", subscriber, t);
+            }
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromIntRangePublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromIntRangePublisherTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api.publisher;
+
+import io.servicetalk.concurrent.api.TestPublisherSubscriber;
+
+import org.junit.Test;
+
+import static io.servicetalk.concurrent.api.Publisher.range;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FromIntRangePublisherTest {
+    final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
+
+    @Test
+    public void zeroElements() {
+        toSource(range(Integer.MAX_VALUE, Integer.MAX_VALUE)).subscribe(subscriber);
+        subscriber.request(1);
+        assertThat(subscriber.takeItems(), is(empty()));
+        assertTrue(subscriber.isCompleted());
+    }
+
+    @Test
+    public void zeroElementsStride() {
+        toSource(range(-1, -1, 2)).subscribe(subscriber);
+        subscriber.request(1);
+        assertThat(subscriber.takeItems(), is(empty()));
+        assertTrue(subscriber.isCompleted());
+    }
+
+    @Test
+    public void singleElement() {
+        toSource(range(-1, 0)).subscribe(subscriber);
+        subscriber.request(1);
+        assertThat(subscriber.takeItems(), contains(-1));
+        assertTrue(subscriber.isCompleted());
+    }
+
+    @Test
+    public void singleElementStride() {
+        toSource(range(0, 1, 2)).subscribe(subscriber);
+        subscriber.request(1);
+        assertThat(subscriber.takeItems(), contains(0));
+        assertTrue(subscriber.isCompleted());
+    }
+
+    @Test
+    public void multipleElements() {
+        toSource(range(0, 5)).subscribe(subscriber);
+        subscriber.request(5);
+        assertThat(subscriber.takeItems(), contains(0, 1, 2, 3, 4));
+        assertTrue(subscriber.isCompleted());
+    }
+
+    @Test
+    public void multipleElementsStride() {
+        toSource(range(0, 10, 3)).subscribe(subscriber);
+        subscriber.request(4);
+        assertThat(subscriber.takeItems(), contains(0, 3, 6, 9));
+        assertTrue(subscriber.isCompleted());
+    }
+
+    @Test
+    public void overflowStride() {
+        int begin = Integer.MAX_VALUE - 1;
+        toSource(range(begin, Integer.MAX_VALUE, 10)).subscribe(subscriber);
+        subscriber.request(1);
+        assertThat(subscriber.takeItems(), contains(begin));
+        assertTrue(subscriber.isCompleted());
+    }
+
+    @Test
+    public void negativeToPositive() {
+        toSource(range(-2, 3)).subscribe(subscriber);
+        subscriber.request(5);
+        assertThat(subscriber.takeItems(), contains(-2, -1, 0, 1, 2));
+        assertTrue(subscriber.isCompleted());
+    }
+
+    @Test
+    public void negativeToPositiveStride() {
+        toSource(range(-1, Integer.MAX_VALUE, Integer.MAX_VALUE)).subscribe(subscriber);
+        subscriber.request(2);
+        assertThat(subscriber.takeItems(), contains(-1, Integer.MAX_VALUE - 1));
+        assertTrue(subscriber.isCompleted());
+    }
+
+    @Test
+    public void allNegative() {
+        toSource(range(-10, -5)).subscribe(subscriber);
+        subscriber.request(5);
+        assertThat(subscriber.takeItems(), contains(-10, -9, -8, -7, -6));
+        assertTrue(subscriber.isCompleted());
+    }
+
+    @Test
+    public void allNegativeStride() {
+        toSource(range(-20, -10, 2)).subscribe(subscriber);
+        subscriber.request(5);
+        assertThat(subscriber.takeItems(), contains(-20, -18, -16, -14, -12));
+        assertTrue(subscriber.isCompleted());
+    }
+
+    @Test
+    public void thrownExceptionTerminatesOnError() {
+        thrownExceptionTerminatesOnError(false);
+    }
+
+    @Test
+    public void thrownExceptionTerminatesOnErrorStride() {
+        thrownExceptionTerminatesOnError(true);
+    }
+
+    private void thrownExceptionTerminatesOnError(boolean stride) {
+        toSource((stride ? range(0, 5, 2) : range(0, 5)).whenOnNext(n -> {
+            throw DELIBERATE_EXCEPTION;
+        })).subscribe(subscriber);
+        subscriber.request(1);
+        assertThat(subscriber.takeError(), sameInstance(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    public void reentrantDeliversInOrder() {
+        toSource(range(0, 5).whenOnNext(n -> subscriber.request(1))).subscribe(subscriber);
+        subscriber.request(1);
+        assertThat(subscriber.takeItems(), contains(0, 1, 2, 3, 4));
+        assertTrue(subscriber.isCompleted());
+    }
+
+    @Test
+    public void reentrantDeliversInOrderStride() {
+        toSource(range(5, 15, 4).whenOnNext(n -> subscriber.request(1))).subscribe(subscriber);
+        subscriber.request(1);
+        assertThat(subscriber.takeItems(), contains(5, 9, 13));
+        assertTrue(subscriber.isCompleted());
+    }
+
+    @Test
+    public void reentrantCancelStopsDelivery() {
+        reentrantCancelStopsDelivery(true);
+    }
+
+    @Test
+    public void reentrantCancelStopsDeliveryStride() {
+        reentrantCancelStopsDelivery(false);
+    }
+
+    private void reentrantCancelStopsDelivery(boolean stride) {
+        toSource((stride ? range(0, 5, 2) : range(0, 5)).whenOnNext(n -> {
+            if (n != null && n == 0) {
+                subscriber.cancel();
+            }
+        })).subscribe(subscriber);
+        subscriber.request(5);
+        assertThat(subscriber.takeItems(), contains(0));
+        assertFalse(subscriber.isTerminated());
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RangeIntPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RangeIntPublisherTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class FromIntRangePublisherTest {
+public class RangeIntPublisherTest {
     final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
 
     @Test
@@ -174,6 +174,29 @@ public class FromIntRangePublisherTest {
         })).subscribe(subscriber);
         subscriber.request(5);
         assertThat(subscriber.takeItems(), contains(0));
+        assertFalse(subscriber.isTerminated());
+    }
+
+    @Test
+    public void requestNAfterCancelIsNoop() {
+        requestNAfterCancelIsNoop(false);
+    }
+
+    @Test
+    public void requestNAfterCancelIsNoopStride() {
+        requestNAfterCancelIsNoop(true);
+    }
+
+    private void requestNAfterCancelIsNoop(boolean stride) {
+        toSource((stride ? range(0, 5, 2) : range(0, 5)).whenOnNext(n -> {
+            if (n != null && n == 0) {
+                subscriber.cancel();
+            }
+        })).subscribe(subscriber);
+        subscriber.request(1);
+        assertThat(subscriber.takeItems(), contains(0));
+        subscriber.request(Long.MAX_VALUE);
+        assertThat(subscriber.takeItems(), is(empty()));
         assertFalse(subscriber.isTerminated());
     }
 }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherRangeStrideTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherRangeStrideTckTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+import org.testng.annotations.Test;
+
+import static io.servicetalk.concurrent.api.Publisher.range;
+import static io.servicetalk.concurrent.reactivestreams.tck.TckUtils.requestNToInt;
+
+@Test
+public class PublisherRangeStrideTckTest extends AbstractPublisherTckTest<Integer> {
+    @Override
+    public Publisher<Integer> createServiceTalkPublisher(final long elements) {
+        return range(0, requestNToInt(elements) * 2, 2);
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        // divide by 2 to avoid overflow above when we expand the boundary in order to deliver the same number
+        // of elements with a stride of 2.
+        return TckUtils.maxElementsFromPublisher() / 2;
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherRangeTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherRangeTckTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+import org.testng.annotations.Test;
+
+import static io.servicetalk.concurrent.api.Publisher.range;
+import static io.servicetalk.concurrent.reactivestreams.tck.TckUtils.requestNToInt;
+
+@Test
+public class PublisherRangeTckTest extends AbstractPublisherTckTest<Integer> {
+    @Override
+    public Publisher<Integer> createServiceTalkPublisher(final long elements) {
+        return range(0, requestNToInt(elements));
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return TckUtils.maxElementsFromPublisher();
+    }
+}


### PR DESCRIPTION
Motivation:
The canonocal way to do an asynchornous for lop with integer indexes in reactive streams is to use a range() operator. We currently don't have a range operator.

Modifications:
- Add Publisher#range(int begin, int end)
- Add Publisher#range(int begin, int end, int stride)

Result:
For loops with integer indexes can be done directly with Publisher#range(..)