### PR TITLE
MultiAddressUrl client fails to send http request after https request

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -289,8 +289,7 @@ final class DefaultMultiAddressUrlHttpClientBuilder
             this.executionContext = requireNonNull(executionContext);
         }
 
-        private FilterableStreamingHttpClient selectClient(
-                HttpRequestMetaData metaData) {
+        private FilterableStreamingHttpClient selectClient(final HttpRequestMetaData metaData) {
             return group.get(keyFactory.apply(metaData));
         }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -289,7 +289,8 @@ final class DefaultMultiAddressUrlHttpClientBuilder
             this.executionContext = requireNonNull(executionContext);
         }
 
-        private FilterableStreamingHttpClient selectClient(final HttpRequestMetaData metaData) {
+        private FilterableStreamingHttpClient selectClient(
+                HttpRequestMetaData metaData) {
             return group.get(keyFactory.apply(metaData));
         }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientConfig.java
@@ -32,8 +32,8 @@ final class HttpClientConfig {
     }
 
     HttpClientConfig(final HttpClientConfig from) {
-        tcpConfig = from.tcpConfig();
-        protocolConfigs = from.protocolConfigs();
+        tcpConfig = new TcpClientConfig(from.tcpConfig());
+        protocolConfigs = new HttpConfig(from.protocolConfigs());
         connectAddress = from.connectAddress;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
@@ -29,10 +29,22 @@ import static java.util.Objects.requireNonNull;
 
 final class HttpConfig {
     @Nullable
-    private H1ProtocolConfig h1Config = h1Default();
+    private H1ProtocolConfig h1Config;
     @Nullable
     private H2ProtocolConfig h2Config;
-    private List<String> supportedAlpnProtocols = emptyList();
+    private List<String> supportedAlpnProtocols;
+
+    HttpConfig() {
+        h1Config = h1Default();
+        h2Config = null;
+        supportedAlpnProtocols = emptyList();
+    }
+
+    HttpConfig(final HttpConfig from) {
+        this.h1Config = from.h1Config;
+        this.h2Config = from.h2Config;
+        this.supportedAlpnProtocols = from.supportedAlpnProtocols;
+    }
 
     @Nullable
     H1ProtocolConfig h1Config() {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslAndNonSslConnectionsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslAndNonSslConnectionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslAndNonSslConnectionsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslAndNonSslConnectionsTest.java
@@ -202,6 +202,30 @@ public class SslAndNonSslConnectionsTest {
         }
     }
 
+    @Test
+    public void multiAddressClientToSecureServerThenToNonSecureServer() throws Exception {
+        try (BlockingHttpClient client = HttpClients.forMultiAddressUrl()
+                .secure((hap, config) -> config.disableHostnameVerification()
+                        .trustManager(DefaultTestCerts::loadMutualAuthCaPem))
+                .buildBlocking()) {
+            testRequestResponse(client, secureRequestTarget, true);
+            resetMocks();
+            testRequestResponse(client, requestTarget, false);
+        }
+    }
+
+    @Test
+    public void multiAddressClientToNonSecureServerThenToSecureServer() throws Exception {
+        try (BlockingHttpClient client = HttpClients.forMultiAddressUrl()
+                .secure((hap, config) -> config.disableHostnameVerification()
+                        .trustManager(DefaultTestCerts::loadMutualAuthCaPem))
+                .buildBlocking()) {
+            testRequestResponse(client, requestTarget, false);
+            resetMocks();
+            testRequestResponse(client, secureRequestTarget, true);
+        }
+    }
+
     private static void testRequestResponse(final BlockingHttpClient client, final String requestTarget,
                                             final boolean secure) throws Exception {
         final HttpResponse response = client.request(client.get(requestTarget));


### PR DESCRIPTION
Motivation:

If `MultiAddressUrl` was used to send an HTTPS request over secure
connection, all other requests to new non-secure servers will fail
with `DecoderException`. It happens because we incorrectly copy the
`HttpClientBuilder` template. We did not create a new instance of
`TcpClientConfig` and `HttpConfig`.

Modifications:

- Add copy ctor for `HttpConfig`;
- Use copy ctors for `TcpClientConfig` and `HttpConfig` in
`HttpClientConfig`;
- Add test to verify that `MultiAddressUrl` client can connect to
insecure server after connecting to a secure server and vice versa;

Result:

`HttpClientConfig` makes a full copy of `TcpClientConfig` and
`HttpConfig` that prevents the `HttpClientBuilder` template from
modifications. `MultiAddressUrl` client correctly copies the
builder template without internal state modifications.