### PR TITLE
Update list of excluded links for docs website validation

### DIFF
--- a/docs/generation/gradle/validateSite.gradle
+++ b/docs/generation/gradle/validateSite.gradle
@@ -22,17 +22,12 @@ if (!repositories) {
 
 // links that are allowed to be http rather than https
 def httpLinks = [
-    "http://www.slf4j.org/"
+    "http://www.slf4j.org"
 ]
 
-// links to exclude from validation (for example because they require authentication)
+// links to exclude from validation (for example because they require authentication or use untrusted cert)
 def excludedLinks = [
-    // Exclude the repo (and others) until they're public, otherwise the 404's fail the validation.
-    "https://github.com/apple/servicetalk",
-    "https://oss.sonatype.org/content/repositories/snapshots/io/servicetalk/",
-    "https://repo1.maven.org/maven2/io/servicetalk/",
-    "https://docs.servicetalk.io/",
-    "https://reactivex.io/", // untrusted cert
+    "https://reactivex.io", // untrusted cert
     "https://jemalloc.net" // untrusted cert
 ]
 


### PR DESCRIPTION
Motivation:

We had to exclude a few links from docs website validation
because these links required additional authentication.
Now they are public and can be removed from exclusion.

Modifications:

- Remove links from `excludedLinks` list that are public now;

Result:

Better links validation for docs website.