### PR TITLE
Add a classifier for `netty-resolver-dns-native-macos` in docs

### DIFF
--- a/servicetalk-client-api/docs/modules/ROOT/pages/service-discovery.adoc
+++ b/servicetalk-client-api/docs/modules/ROOT/pages/service-discovery.adoc
@@ -69,4 +69,4 @@ This implementation is backed by `io.netty:netty-resolver-dns` and provides non-
 
 IMPORTANT: _macOS_ users may experience problems with resolving host addresses in certain environments. In this case,
 users need to add the additional dependency on the classpath which will ensure the right nameservers are selected when
-running on macOS: `io.netty:netty-resolver-dns-native-macos`.
+running on macOS: `io.netty:netty-resolver-dns-native-macos:$nettyVersion:osx-x86_64`.


### PR DESCRIPTION
Motivation:

`netty-resolver-dns-native-macos` dependency requires the `osx-x86_64`
classifier to be set.

Modifications:

- Add `osx-x86_64` classifier for `netty-resolver-dns-native-macos`
dependency in `Service Discovery` docs;

Result:

Correct dependency declaration for `netty-resolver-dns-native-macos`.