### PR TITLE
publish-docs.sh overrides javadoc for older versions when it publishes SNAPSHOT update

### DIFF
--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -98,7 +98,11 @@ fi
 
 pushd gh-pages
 # Do not override older javadoc with Antora's placeholder:
-git diff --name-only | grep 'javadoc/index.html' | grep -v $version | grep -v SNAPSHOT | xargs git checkout --
+files_to_revert=$(git diff --name-only | grep 'javadoc/index.html' | grep -v SNAPSHOT)
+if [ ! -z "$version" ]; then
+    files_to_revert=$(echo $files_to_revert | grep -v $version)
+fi
+echo $files_to_revert | xargs git checkout --
 
 git add * .nojekyll
 if [ -z "$version" ]; then


### PR DESCRIPTION
Motivation:

If we publish docs update for SNAPSHOT version only, `publish-docs.sh`
mistakenly overrides javadoc `index.html` page for all older versions,
because `grep -v $version` filter produces empty output when the
`$version` is empty.

Modifications:

- Apply `grep -v $version` filter only when the `$version` is not empty;

Result:

SNAPSHOT docs publication does not break older versions of the docs.