### PR TITLE
Enforce JDK8 when running `publish-docs.sh`

### DIFF
--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -49,7 +49,7 @@ function clean_up_gh_pages() {
 }
 
 # Enforce JDK8 to keep javadoc format consistent for all versions:
-java_version=$(java -version 2>&1 | grep 'version' 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]"."a[2]}')
+java_version=$(./gradlew --no-daemon -version | grep ^JVM: | awk -F\. '{gsub(/^JVM:[ \t]*/,"",$1); print $1"."$2}')
 if [ "$java_version" != "1.8" ]; then
   echo "Docs can be published only using Java 1.8, current version: $java_version"
   exit 1

--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -48,6 +48,13 @@ function clean_up_gh_pages() {
   rm -rf gh-pages
 }
 
+# Enforce JDK8 to keep javadoc format consistent for all versions:
+java_version=$(java -version 2>&1 | grep 'version' 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]"."a[2]}')
+if [ "$java_version" != "1.8" ]; then
+  echo "Docs can be published only using Java 1.8, current version: $java_version"
+  exit 1
+fi
+
 if [ "$#" -eq "0" ]; then
     echo "Publishing docs website for the SNAPSHOT version only"
 elif [ "$#" -eq "1" ]; then


### PR DESCRIPTION
Motivation:

Different JDK versions produce different website style for
javadoc.

Modifications:

- Make sure the current Java version is 1.8 before running
`publish-docs.sh`;

Result:

Javadoc website always published with the consistent format
and style.