### PR TITLE
NettyChannelPublisher cancel active subscriber should terminate

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
@@ -74,6 +74,9 @@ final class NettyChannelPublisher<T> extends SubscribablePublisher<T> {
             channelReadReferenceCounted((ReferenceCounted) data);
             return;
         }
+        if (fatalError != null) {
+            return;
+        }
 
         if (subscription == null || shouldBuffer()) {
             addPending(data);
@@ -92,9 +95,11 @@ final class NettyChannelPublisher<T> extends SubscribablePublisher<T> {
             // We do not expect ref-counted objects here as ST does not support them and do not take care to clean them
             // in error conditions. Hence we fail-fast when we see such objects.
             pending = null;
-            fatalError = new IllegalArgumentException("Reference counted leaked netty's pipeline. Object: " +
-                    data.getClass().getSimpleName());
-            exceptionCaught(fatalError);
+            if (fatalError == null) {
+                fatalError = new IllegalArgumentException("Reference counted leaked netty's pipeline. Object: " +
+                        data.getClass().getSimpleName());
+                exceptionCaught0(fatalError);
+            }
             channel.close();
         }
     }
@@ -109,6 +114,14 @@ final class NettyChannelPublisher<T> extends SubscribablePublisher<T> {
 
     void exceptionCaught(Throwable throwable) {
         assertInEventloop();
+        if (fatalError != null) {
+            return;
+        }
+        exceptionCaught0(throwable);
+    }
+
+
+    private void exceptionCaught0(Throwable throwable) {
         if (subscription == null || shouldBuffer()) {
             addPending(TerminalNotification.error(throwable));
             if (subscription != null) {
@@ -121,9 +134,11 @@ final class NettyChannelPublisher<T> extends SubscribablePublisher<T> {
 
     void channelInboundClosed() {
         assertInEventloop();
-        fatalError = StacklessClosedChannelException.newInstance(
-                NettyChannelPublisher.class, "channelInboundClosed");
-        exceptionCaught(fatalError);
+        if (fatalError == null) {
+            fatalError = StacklessClosedChannelException.newInstance(
+                    NettyChannelPublisher.class, "channelInboundClosed");
+            exceptionCaught0(fatalError);
+        }
     }
 
     // All private methods MUST be invoked from the eventloop.
@@ -242,7 +257,9 @@ final class NettyChannelPublisher<T> extends SubscribablePublisher<T> {
         // If a cancel occurs with a valid subscription we need to clear any pending data and set a fatalError so that
         // any future Subscribers don't get partial data delivered from the queue.
         pending = null;
-        fatalError = StacklessClosedChannelException.newInstance(NettyChannelPublisher.class, "cancel");
+        if (fatalError == null) {
+            fatalError = StacklessClosedChannelException.newInstance(NettyChannelPublisher.class, "cancel");
+        }
 
         // If an incomplete subscriber is cancelled then close channel. A subscriber can cancel after getting complete,
         // which should not close the channel.
@@ -286,7 +303,7 @@ final class NettyChannelPublisher<T> extends SubscribablePublisher<T> {
             subscriber.onSubscribe(subscription);
             // Fatal error is removed from the queue once it is drained for a Subscriber.
             // In absence of the below, any subsequent Subscriber will not get any fatal error.
-            if (!processPending(subscription) && fatalError != null && pending != null && pending.isEmpty()) {
+            if (!processPending(subscription) && (fatalError != null && (pending == null || pending.isEmpty()))) {
                 // We are already on the eventloop, so we are sure that nobody else is emitting to the Subscriber.
                 sendErrorToTarget(subscription, fatalError);
             }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
@@ -120,7 +120,6 @@ final class NettyChannelPublisher<T> extends SubscribablePublisher<T> {
         exceptionCaught0(throwable);
     }
 
-
     private void exceptionCaught0(Throwable throwable) {
         if (subscription == null || shouldBuffer()) {
             addPending(TerminalNotification.error(throwable));


### PR DESCRIPTION
Motivation:
NettyChannelPublisher allows for resubscribes, and delivers queued data to the new Subscriber. If the previous Subscriber consumed some data and cancelled this may lead to the new Subscriber receiveing partial data from the last request.

Modifications:
- NettyChannelPublisher should discard any pending data, and deliver an error to new Subscribers if a previously active Subscriber cancels.

Result:
Resubscribes to NettyChannelPublisher won't get partial data for previous requests, like in the case of client pipelinining.