### PR TITLE
gRPC protoc script pushd not found

### DIFF
--- a/buildSrc/src/main/java/io/servicetalk/internal/build/ExecutableBuilder.java
+++ b/buildSrc/src/main/java/io/servicetalk/internal/build/ExecutableBuilder.java
@@ -31,9 +31,10 @@ public final class ExecutableBuilder {
         prepareOutputFile(outputFile);
         try(FileOutputStream execOutputStream = new FileOutputStream(outputFile)) {
             execOutputStream.write(("#!/bin/sh\n" +
-                    "pushd $(dirname \"$0\") > /dev/null\n" +
+                    "PWD_BEFORE=$PWD\n"+
+                    "cd $(dirname \"$0\")\n" +
                     "exec java -jar " + uberJarName + " \"$@\"\n" +
-                    "popd > /dev/null\n").getBytes(StandardCharsets.US_ASCII));
+                    "cd $PWD_BEFORE\n").getBytes(StandardCharsets.US_ASCII));
         }
         finalizeOutputFile(outputFile);
     }


### PR DESCRIPTION
Motivation:
The gRPC protoc unix script is expected to execute in a /bin/sh environment, but it depends upon pushd/popd which may not be available in /bin/sh. This may lead to a 'pushd: not found' error.

Modifications:
- Avoid using pushd in the unix script and manually save/restore the directory

Result:
gRPC protoc script can execute in limited /bin/sh environments without
failure.