### PR TITLE
Follow-up enhancements for `servicetalk-grpc-gradle-plugin`

### DIFF
--- a/servicetalk-examples/grpc/helloworld/build.gradle
+++ b/servicetalk-examples/grpc/helloworld/build.gradle
@@ -37,3 +37,9 @@ serviceTalkGrpc {
       "${project.rootProject.rootDir}/servicetalk-grpc-protoc/build/buildExecutable/servicetalk-grpc-protoc-" +
           project.version + "-all.jar"
 }
+
+// The following setting must be omitted in users projects and is necessary here
+// only because we want to use the locally built version of the plugin
+afterEvaluate {
+  generateProto.dependsOn(":servicetalk-grpc-protoc:buildExecutable")
+}

--- a/servicetalk-examples/grpc/routeguide/build.gradle
+++ b/servicetalk-examples/grpc/routeguide/build.gradle
@@ -39,3 +39,9 @@ serviceTalkGrpc {
       "${project.rootProject.rootDir}/servicetalk-grpc-protoc/build/buildExecutable/servicetalk-grpc-protoc-" +
           project.version + "-all.jar"
 }
+
+// The following setting must be omitted in users projects and is necessary here
+// only because we want to use the locally built version of the plugin
+afterEvaluate {
+  generateProto.dependsOn(":servicetalk-grpc-protoc:buildExecutable")
+}

--- a/servicetalk-grpc-gradle-plugin/src/main/groovy/io/servicetalk/grpc/gradle/plugin/ServiceTalkGrpcPlugin.groovy
+++ b/servicetalk-grpc-gradle-plugin/src/main/groovy/io/servicetalk/grpc/gradle/plugin/ServiceTalkGrpcPlugin.groovy
@@ -79,14 +79,9 @@ class ServiceTalkGrpcPlugin implements Plugin<Project> {
           // uber jar which contains the protoc logic, as otherwise the grpc-gradle-plugin will only add a dependency
           // on the executable script
           File uberJarFile
-          String scriptNamePrefix
           if (serviceTalkProtocPluginPath) {
-            scriptNamePrefix = serviceTalkGrpcProtoc + "-" +
-                // fallback to the current project.version if there is no version in plugin meta
-                (isVersion(serviceTalkVersion) ? serviceTalkVersion : project.version)
             uberJarFile = new File(serviceTalkProtocPluginPath.toString())
           } else {
-            scriptNamePrefix = serviceTalkGrpcProtoc + "-" + serviceTalkVersion
             def stGrpcProtocDep =
                 project.getDependencies().create("io.servicetalk:$serviceTalkGrpcProtoc:$serviceTalkVersion:all")
             compileOnlyDeps.add(stGrpcProtocDep)
@@ -100,7 +95,7 @@ class ServiceTalkGrpcPlugin implements Plugin<Project> {
           }
 
           final boolean isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
-          File scriptExecutableFile = new File("${project.buildDir}/scripts/${scriptNamePrefix}." +
+          File scriptExecutableFile = new File("${project.buildDir}/scripts/${serviceTalkGrpcProtoc}." +
               (isWindows ? "bat" : "sh"))
 
           doFirst {

--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -59,6 +59,8 @@ serviceTalkGrpc {
           project.version + "-all.jar"
 }
 
+// The following setting must be omitted in users projects and is necessary here
+// only because we want to use the locally built version of the plugin
 afterEvaluate {
   generateTestProto.dependsOn(":servicetalk-grpc-protoc:buildExecutable")
 }


### PR DESCRIPTION
Motivation:

There are a few issues with `servicetalk-grpc-gradle-plugin`.

Modifications:

- Fix incorrect plugin name in exception message;
- Correctly verify that `serviceTalkVersion` has correct value as
it's always not empty, but may have unprocessed value;
- Do not add `serviceTalkVersion` to the `scriptExecutableFile`
name as it's not necessary;
- Generate script only for projects that use
`servicetalk-grpc-gradle-plugin` instead of the root project;
- Do not looks for `serviceTalkGrpcProtocGenerateScript` task
before creating it;
- Delete generated script file when users run `clean` task;
- Recreate executable script file on every run to avoid having
an outdated file (for example if gradle changes the hash for
cached artifacts or if users run another project with and
without `--include-build`);

Result:

`servicetalk-grpc-gradle-plugin` behaves correctly.