### PR TITLE
Do not wrap unreleasable ByteBuf(s) with `Unpooled.unreleasableBuffer`

### DIFF
--- a/servicetalk-buffer-netty/build.gradle
+++ b/servicetalk-buffer-netty/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,5 +27,6 @@ dependencies {
 
   testImplementation project(":servicetalk-test-resources")
   testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 }

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableCompositeByteBuf.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableCompositeByteBuf.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.buffer.netty;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
 
@@ -29,26 +28,6 @@ final class UnreleasableCompositeByteBuf extends CompositeByteBuf {
         // visibility issues across threads and data corruption. We retain() here to imply the ByteBuf maybe shared and
         // these optimizations are not safe.
         super.retain();
-    }
-
-    @Override
-    public ByteBuf readRetainedSlice(int length) {
-        return readSlice(length);
-    }
-
-    @Override
-    public ByteBuf retainedSlice() {
-        return slice();
-    }
-
-    @Override
-    public ByteBuf retainedSlice(int index, int length) {
-        return slice(index, length);
-    }
-
-    @Override
-    public ByteBuf retainedDuplicate() {
-        return duplicate();
     }
 
     @Override

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableCompositeByteBuf.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableCompositeByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package io.servicetalk.buffer.netty;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
-import io.netty.buffer.Unpooled;
 
 final class UnreleasableCompositeByteBuf extends CompositeByteBuf {
 
@@ -33,28 +32,8 @@ final class UnreleasableCompositeByteBuf extends CompositeByteBuf {
     }
 
     @Override
-    public ByteBuf asReadOnly() {
-        return Unpooled.unreleasableBuffer(super.asReadOnly());
-    }
-
-    @Override
-    public ByteBuf readSlice(int length) {
-        return Unpooled.unreleasableBuffer(super.readSlice(length));
-    }
-
-    @Override
     public ByteBuf readRetainedSlice(int length) {
         return readSlice(length);
-    }
-
-    @Override
-    public ByteBuf slice() {
-        return Unpooled.unreleasableBuffer(super.slice());
-    }
-
-    @Override
-    public ByteBuf slice(int index, int length) {
-        return Unpooled.unreleasableBuffer(super.slice(index, length));
     }
 
     @Override
@@ -65,11 +44,6 @@ final class UnreleasableCompositeByteBuf extends CompositeByteBuf {
     @Override
     public ByteBuf retainedSlice(int index, int length) {
         return slice(index, length);
-    }
-
-    @Override
-    public ByteBuf duplicate() {
-        return Unpooled.unreleasableBuffer(super.duplicate());
     }
 
     @Override

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableDirectByteBuf.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableDirectByteBuf.java
@@ -44,26 +44,6 @@ final class UnreleasableDirectByteBuf extends UnpooledDirectByteBuf {
     }
 
     @Override
-    public ByteBuf readRetainedSlice(int length) {
-        return readSlice(length);
-    }
-
-    @Override
-    public ByteBuf retainedSlice() {
-        return slice();
-    }
-
-    @Override
-    public ByteBuf retainedSlice(int index, int length) {
-        return slice(index, length);
-    }
-
-    @Override
-    public ByteBuf retainedDuplicate() {
-        return duplicate();
-    }
-
-    @Override
     public ByteBuf retain(int increment) {
         return this;
     }

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableDirectByteBuf.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableDirectByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package io.servicetalk.buffer.netty;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledDirectByteBuf;
 
 import java.nio.ByteBuffer;
@@ -45,28 +44,8 @@ final class UnreleasableDirectByteBuf extends UnpooledDirectByteBuf {
     }
 
     @Override
-    public ByteBuf asReadOnly() {
-        return Unpooled.unreleasableBuffer(super.asReadOnly());
-    }
-
-    @Override
-    public ByteBuf readSlice(int length) {
-        return Unpooled.unreleasableBuffer(super.readSlice(length));
-    }
-
-    @Override
     public ByteBuf readRetainedSlice(int length) {
         return readSlice(length);
-    }
-
-    @Override
-    public ByteBuf slice() {
-        return Unpooled.unreleasableBuffer(super.slice());
-    }
-
-    @Override
-    public ByteBuf slice(int index, int length) {
-        return Unpooled.unreleasableBuffer(super.slice(index, length));
     }
 
     @Override
@@ -77,11 +56,6 @@ final class UnreleasableDirectByteBuf extends UnpooledDirectByteBuf {
     @Override
     public ByteBuf retainedSlice(int index, int length) {
         return slice(index, length);
-    }
-
-    @Override
-    public ByteBuf duplicate() {
-        return Unpooled.unreleasableBuffer(super.duplicate());
     }
 
     @Override

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableHeapByteBuf.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableHeapByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package io.servicetalk.buffer.netty;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledHeapByteBuf;
 
 class UnreleasableHeapByteBuf extends UnpooledHeapByteBuf {
@@ -43,28 +42,8 @@ class UnreleasableHeapByteBuf extends UnpooledHeapByteBuf {
     }
 
     @Override
-    public ByteBuf asReadOnly() {
-        return Unpooled.unreleasableBuffer(super.asReadOnly());
-    }
-
-    @Override
-    public ByteBuf readSlice(int length) {
-        return Unpooled.unreleasableBuffer(super.readSlice(length));
-    }
-
-    @Override
     public ByteBuf readRetainedSlice(int length) {
         return readSlice(length);
-    }
-
-    @Override
-    public ByteBuf slice() {
-        return Unpooled.unreleasableBuffer(super.slice());
-    }
-
-    @Override
-    public ByteBuf slice(int index, int length) {
-        return Unpooled.unreleasableBuffer(super.slice(index, length));
     }
 
     @Override
@@ -75,11 +54,6 @@ class UnreleasableHeapByteBuf extends UnpooledHeapByteBuf {
     @Override
     public ByteBuf retainedSlice(int index, int length) {
         return slice(index, length);
-    }
-
-    @Override
-    public ByteBuf duplicate() {
-        return Unpooled.unreleasableBuffer(super.duplicate());
     }
 
     @Override

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableHeapByteBuf.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableHeapByteBuf.java
@@ -42,52 +42,32 @@ class UnreleasableHeapByteBuf extends UnpooledHeapByteBuf {
     }
 
     @Override
-    public ByteBuf readRetainedSlice(int length) {
-        return readSlice(length);
-    }
-
-    @Override
-    public ByteBuf retainedSlice() {
-        return slice();
-    }
-
-    @Override
-    public ByteBuf retainedSlice(int index, int length) {
-        return slice(index, length);
-    }
-
-    @Override
-    public ByteBuf retainedDuplicate() {
-        return duplicate();
-    }
-
-    @Override
-    public ByteBuf retain(int increment) {
+    public final ByteBuf retain(int increment) {
         return this;
     }
 
     @Override
-    public ByteBuf retain() {
+    public final ByteBuf retain() {
         return this;
     }
 
     @Override
-    public ByteBuf touch() {
+    public final ByteBuf touch() {
         return this;
     }
 
     @Override
-    public ByteBuf touch(Object hint) {
+    public final ByteBuf touch(Object hint) {
         return this;
     }
 
     @Override
-    public boolean release() {
+    public final boolean release() {
         return false;
     }
 
     @Override
-    public boolean release(int decrement) {
+    public final boolean release(int decrement) {
         return false;
     }
 }

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableUnsafeDirectByteBuf.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableUnsafeDirectByteBuf.java
@@ -43,26 +43,6 @@ class UnreleasableUnsafeDirectByteBuf extends UnpooledUnsafeDirectByteBuf {
     }
 
     @Override
-    public final ByteBuf readRetainedSlice(int length) {
-        return readSlice(length);
-    }
-
-    @Override
-    public final ByteBuf retainedSlice() {
-        return slice();
-    }
-
-    @Override
-    public final ByteBuf retainedSlice(int index, int length) {
-        return slice(index, length);
-    }
-
-    @Override
-    public final ByteBuf retainedDuplicate() {
-        return duplicate();
-    }
-
-    @Override
     public final ByteBuf retain(int increment) {
         return this;
     }

--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableUnsafeDirectByteBuf.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableUnsafeDirectByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package io.servicetalk.buffer.netty;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledUnsafeDirectByteBuf;
 
 import java.nio.ByteBuffer;
@@ -44,28 +43,8 @@ class UnreleasableUnsafeDirectByteBuf extends UnpooledUnsafeDirectByteBuf {
     }
 
     @Override
-    public final ByteBuf asReadOnly() {
-        return Unpooled.unreleasableBuffer(super.asReadOnly());
-    }
-
-    @Override
-    public final ByteBuf readSlice(int length) {
-        return Unpooled.unreleasableBuffer(super.readSlice(length));
-    }
-
-    @Override
     public final ByteBuf readRetainedSlice(int length) {
         return readSlice(length);
-    }
-
-    @Override
-    public final ByteBuf slice() {
-        return Unpooled.unreleasableBuffer(super.slice());
-    }
-
-    @Override
-    public final ByteBuf slice(int index, int length) {
-        return Unpooled.unreleasableBuffer(super.slice(index, length));
     }
 
     @Override
@@ -76,11 +55,6 @@ class UnreleasableUnsafeDirectByteBuf extends UnpooledUnsafeDirectByteBuf {
     @Override
     public final ByteBuf retainedSlice(int index, int length) {
         return slice(index, length);
-    }
-
-    @Override
-    public final ByteBuf duplicate() {
-        return Unpooled.unreleasableBuffer(super.duplicate());
     }
 
     @Override


### PR DESCRIPTION
Motivation:

For cases when `AbstractByteBuf` wraps `ByteBuf`(s) allocated by ST
with another interface (slice/duplicate/readOnly) we wrap them one
more time with `UnreleasableByteBuf`. However, this is not necessary
as our `ByteBuf`(s) are always unreleasable and final. There is no
way it can be unwrapped and released. Therefore, `UnreleasableByteBuf`
is useless and just creates more garbage for GC.

Modifications:

- Remove all methods that apply `Unpooled.unreleasableBuffer` for
returned results;
- Remove unnecessary overrides for methods that return retained
slice or duplicate;
- Add missed `final` modifiers for methods of
`UnreleasableHeapByteBuf`;
- Enhance tests to cover all API that may return a new `ByteBuf`
or a new wrapped `ByteBuf`;
- Assert that all `Buffer`s allocated by ST have `refCnt() > 1`;

Result:

Less memory allocation for slice/duplicate/readOnly methods of
already unreleasable `ByteBuf`(s).