### PR TITLE
Replace ConcurrentSubscription with DelayedCancellable when synchronous request(Long.MAX_VALUE)

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PubToCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PubToCompletable.java
@@ -52,7 +52,8 @@ final class PubToCompletable<T> extends AbstractNoHandleSubscribeCompletable {
         source.delegateSubscribe(offloadedSubscription, signalOffloader, contextMap, contextProvider);
     }
 
-    private static final class PubToCompletableSubscriber<T> implements PublisherSource.Subscriber<T> {
+    private static final class PubToCompletableSubscriber<T> extends DelayedCancellable
+            implements PublisherSource.Subscriber<T> {
 
         private final Subscriber subscriber;
 
@@ -62,10 +63,9 @@ final class PubToCompletable<T> extends AbstractNoHandleSubscribeCompletable {
 
         @Override
         public void onSubscribe(final Subscription s) {
-            DelayedCancellable delayedCancellable = new DelayedCancellable();
-            subscriber.onSubscribe(delayedCancellable);
+            subscriber.onSubscribe(this);
             s.request(Long.MAX_VALUE);
-            delayedCancellable.delayedCancellable(s);
+            delayedCancellable(s);
         }
 
         @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PubToCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PubToCompletable.java
@@ -17,10 +17,8 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
-import io.servicetalk.concurrent.internal.ConcurrentSubscription;
+import io.servicetalk.concurrent.internal.DelayedCancellable;
 import io.servicetalk.concurrent.internal.SignalOffloader;
-
-import static io.servicetalk.concurrent.internal.ConcurrentSubscription.wrap;
 
 /**
  * A {@link Completable} created from a {@link Publisher}.
@@ -64,9 +62,10 @@ final class PubToCompletable<T> extends AbstractNoHandleSubscribeCompletable {
 
         @Override
         public void onSubscribe(final Subscription s) {
-            final ConcurrentSubscription cs = wrap(s);
-            subscriber.onSubscribe(cs);
-            cs.request(Long.MAX_VALUE);
+            DelayedCancellable delayedCancellable = new DelayedCancellable();
+            subscriber.onSubscribe(delayedCancellable);
+            s.request(Long.MAX_VALUE);
+            delayedCancellable.delayedCancellable(s);
         }
 
         @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ReduceSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ReduceSingle.java
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
-import io.servicetalk.concurrent.internal.ConcurrentSubscription;
+import io.servicetalk.concurrent.internal.DelayedCancellable;
 import io.servicetalk.concurrent.internal.SignalOffloader;
 
 import java.util.function.BiFunction;
@@ -25,7 +25,6 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.PublishAndSubscribeOnSingles.deliverOnSubscribeAndOnError;
-import static io.servicetalk.concurrent.internal.ConcurrentSubscription.wrap;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -92,9 +91,10 @@ final class ReduceSingle<R, T> extends AbstractNoHandleSubscribeSingle<R> {
 
         @Override
         public void onSubscribe(final Subscription s) {
-            final ConcurrentSubscription cs = wrap(s);
-            subscriber.onSubscribe(cs);
-            cs.request(Long.MAX_VALUE);
+            DelayedCancellable delayedCancellable = new DelayedCancellable();
+            subscriber.onSubscribe(delayedCancellable);
+            s.request(Long.MAX_VALUE);
+            delayedCancellable.delayedCancellable(s);
         }
 
         @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ReduceSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ReduceSingle.java
@@ -75,7 +75,8 @@ final class ReduceSingle<R, T> extends AbstractNoHandleSubscribeSingle<R> {
         source.delegateSubscribe(offloadedSubscription, signalOffloader, contextMap, contextProvider);
     }
 
-    private static final class ReduceSubscriber<R, T> implements PublisherSource.Subscriber<T> {
+    private static final class ReduceSubscriber<R, T> extends DelayedCancellable
+            implements PublisherSource.Subscriber<T> {
 
         private final BiFunction<? super R, ? super T, R> reducer;
         private final Subscriber<? super R> subscriber;
@@ -91,10 +92,9 @@ final class ReduceSingle<R, T> extends AbstractNoHandleSubscribeSingle<R> {
 
         @Override
         public void onSubscribe(final Subscription s) {
-            DelayedCancellable delayedCancellable = new DelayedCancellable();
-            subscriber.onSubscribe(delayedCancellable);
+            subscriber.onSubscribe(this);
             s.request(Long.MAX_VALUE);
-            delayedCancellable.delayedCancellable(s);
+            delayedCancellable(s);
         }
 
         @Override


### PR DESCRIPTION
Motivation:
There are some operators which convert from Publisher to Completable or
Single. Since the demand for Completable and Single is implicit on
subscribe(..) these operators need to simulate the demand in
onSubscribe. In order to prevent concurrent access on the Subscription
with the downstream Subscriber and the synchornous requestN call it is
wrapped in a ConcurrentSubscription. However ConcurrentSubscription has
to coordinate between two methods and is inheritly more complicated than
DelayedCancellable. We can use DelayedCancellable which is a simpler
operation at the cost of requesting demand before propagating
synchronous cancel operation. This isn't perceived as a deal breaker
because demand is implicit anyways, and cancel is best effort.

Modifications:
- When converting from Publisher to Completable or Single use
DelayedCancellable instead of ConcurrentSubscription

Result:
Less complicated and less expensive conversion from Subscription to
Cancellable when converting from Publisher to Single or Completable.