### PR TITLE
Use `int`s as scores for `ScoreSupplier`

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ScoreSupplier.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ScoreSupplier.java
@@ -21,9 +21,9 @@ package io.servicetalk.client.api;
 public interface ScoreSupplier {
 
     /**
-     * Returns the current score of a resource, where 0.0 is the lowest score and 1.0 is the highest. {@link
-     * LoadBalancer}s prefer resources with a higher score.
+     * Returns the current score of a resource. {@link LoadBalancer}s prefer resources with a higher score.
+     *
      * @return the score
      */
-    float score();
+    int score();
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -66,6 +66,7 @@ import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.globalDnsServiceDiscoverer;
 import static io.servicetalk.loadbalancer.RoundRobinLoadBalancer.newRoundRobinFactory;
+import static java.lang.Integer.MAX_VALUE;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -117,7 +118,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
         executionContextBuilder = new HttpExecutionContextBuilder();
         influencerChainBuilder = new ClientStrategyInfluencerChainBuilder();
         this.loadBalancerFactory = new StrategyInfluencingLoadBalancerFactory<>(newRoundRobinFactory());
-        this.protocolBinder = StaticScoreHttpProtocolBinder.provideStaticScoreIfNeeded(1);
+        this.protocolBinder = StaticScoreHttpProtocolBinder.provideStaticScoreIfNeeded(MAX_VALUE);
         this.serviceDiscoverer = requireNonNull(serviceDiscoverer);
     }
 
@@ -128,7 +129,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
         executionContextBuilder = new HttpExecutionContextBuilder();
         influencerChainBuilder = new ClientStrategyInfluencerChainBuilder();
         this.loadBalancerFactory = new StrategyInfluencingLoadBalancerFactory<>(newRoundRobinFactory());
-        this.protocolBinder = StaticScoreHttpProtocolBinder.provideStaticScoreIfNeeded(1);
+        this.protocolBinder = StaticScoreHttpProtocolBinder.provideStaticScoreIfNeeded(MAX_VALUE);
         this.serviceDiscoverer = requireNonNull(serviceDiscoverer);
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpConnection.java
@@ -158,7 +158,7 @@ final class LoadBalancedStreamingHttpConnection implements FilterableStreamingHt
     }
 
     @Override
-    public float score() {
+    public int score() {
         return filteredConnection.score();
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StaticScoreHttpProtocolBinder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StaticScoreHttpProtocolBinder.java
@@ -29,15 +29,15 @@ import java.util.function.Function;
 final class StaticScoreHttpProtocolBinder extends StreamingHttpConnectionFilter
         implements FilterableStreamingHttpLoadBalancedConnection {
 
-    private final float score;
+    private final int score;
 
-    private StaticScoreHttpProtocolBinder(final FilterableStreamingHttpConnection delegate, float score) {
+    private StaticScoreHttpProtocolBinder(final FilterableStreamingHttpConnection delegate, int score) {
         super(delegate);
         this.score = score;
     }
 
     @Override
-    public float score() {
+    public int score() {
         return score;
     }
 
@@ -50,7 +50,7 @@ final class StaticScoreHttpProtocolBinder extends StreamingHttpConnectionFilter
      * @return the wrapped connection
      */
     static Function<FilterableStreamingHttpConnection, FilterableStreamingHttpLoadBalancedConnection>
-    provideStaticScoreIfNeeded(float score) {
+    provideStaticScoreIfNeeded(int score) {
         return conn -> conn instanceof FilterableStreamingHttpLoadBalancedConnection ?
                 (FilterableStreamingHttpLoadBalancedConnection) conn : new StaticScoreHttpProtocolBinder(conn, score);
     }


### PR DESCRIPTION
__Motivation__

`ScoreSupplier#score()` returns a `float` today with an intent to have precisions for slightly varying scores. However floating point arithmentic adds more complexity in score computations. Instead we can use `int`s and use bigger scores for precision (eg: multiply by `1000`)

__Modification__

Make `ScoreSupplier#score()` return an `int`.

__Result__

Simpler score calculations.