### PR TITLE
Work around SpotBugs JDK11 bug, make code more robust

### DIFF
--- a/servicetalk-grpc-api/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-grpc-api/gradle/spotbugs/main-exclusions.xml
@@ -15,4 +15,12 @@
   ~ limitations under the License.
   -->
 <FindBugsFilter>
+  <!-- false positive in Java 11, see https://github.com/spotbugs/spotbugs/issues/756 -->
+  <Match>
+    <Or>
+      <Class name="io.servicetalk.grpc.api.DefaultGrpcClientCallFactory"/>
+      <Class name="io.servicetalk.grpc.api.GrpcRouter$Builder$9"/>
+    </Or>
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -593,11 +593,10 @@ final class GrpcRouter {
                                            final GrpcPayloadWriter<Resp> responseWriter) throws Exception {
                             final Req firstItem;
                             try (BlockingIterator<Req> requestIterator = request.iterator()) {
-                                if (!requestIterator.hasNext()) {
+                                if (!requestIterator.hasNext() || (firstItem = requestIterator.next()) == null) {
                                     throw new GrpcStatus(INVALID_ARGUMENT, null,
                                             SINGLE_MESSAGE_EXPECTED_NONE_RECEIVED_MSG).asException();
                                 }
-                                firstItem = requestIterator.next();
                                 if (requestIterator.hasNext()) {
                                     // Consume the next item to make sure it's not a TerminalNotification with an error
                                     requestIterator.next();

--- a/servicetalk-grpc-netty/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-grpc-netty/gradle/spotbugs/test-exclusions.xml
@@ -31,4 +31,13 @@
     <Method name="extractResponse"/>
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
   </Match>
+  <!-- false positive in Java 11, see https://github.com/spotbugs/spotbugs/issues/756 -->
+  <Match>
+    <Class name="io.servicetalk.grpc.netty.GrpcServiceContextProtocolTest"/>
+    <Or>
+      <Method name="testBiDiStream"/>
+      <Method name="testResponseStream"/>
+    </Or>
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Motivation:
SpotBugs has a bug impacting builds on JDK11 https://github.com/spotbugs/spotbugs/issues/756. This also hinted at an area that could be made more robust.

Modifications:
- Ignore SpotBugs warning due to bug
- Improve robustness of handling null element from iterator

Result:
SpotBugs no longer fails on JDK11 builds.