### PR TITLE
Converting ZipkinPublisher to use a zipkin2.Reporter interface for reporting spans

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,6 +46,7 @@ jacksonVersion=2.10.3
 
 openTracingVersion=0.31.0
 zipkinVersion=2.20.1
+zipkinReporterVersion=2.12.2
 
 # Used for testing DNS ServiceDiscoverer
 apacheDirectoryServerVersion=1.5.7

--- a/servicetalk-opentracing-zipkin-publisher/build.gradle
+++ b/servicetalk-opentracing-zipkin-publisher/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-transport-netty-internal")
   implementation project(":servicetalk-concurrent-api-internal")
+  implementation project(":servicetalk-concurrent-internal")
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
   implementation "io.netty:netty-codec:$nettyVersion"
   implementation "io.netty:netty-transport:$nettyVersion"

--- a/servicetalk-opentracing-zipkin-publisher/build.gradle
+++ b/servicetalk-opentracing-zipkin-publisher/build.gradle
@@ -21,12 +21,14 @@ dependencies {
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-transport-netty-internal")
+  implementation project(":servicetalk-concurrent-api-internal")
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
   implementation "io.netty:netty-codec:$nettyVersion"
   implementation "io.netty:netty-transport:$nettyVersion"
   implementation "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
   implementation "io.netty:netty-transport-native-kqueue:$nettyVersion:osx-x86_64"
   implementation "io.zipkin.zipkin2:zipkin:$zipkinVersion"
+  implementation "io.zipkin.reporter2:zipkin-reporter:$zipkinReporterVersion"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/ZipkinPublisher.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/ZipkinPublisher.java
@@ -187,8 +187,8 @@ public final class ZipkinPublisher implements InMemorySpanEventListener, AsyncCl
      * Blocking close method delegates to {@link #closeAsync()}.
      */
     @Override
-    public void close() {
-        closeable.onClose();
+    public void close() throws Exception {
+        closeable.closeAsync().toFuture().get();
     }
 
     /**

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/ZipkinPublisher.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/ZipkinPublisher.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.AsyncCloseables.toAsyncCloseable;
+import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 import static io.servicetalk.transport.netty.internal.GlobalExecutionContext.globalExecutionContext;
 import static java.util.Objects.requireNonNull;
 
@@ -198,7 +199,7 @@ public final class ZipkinPublisher implements InMemorySpanEventListener, AsyncCl
      */
     @Override
     public Completable closeAsync() {
-        return closeable.closeAsync();
+        return awaitTermination(closeable.closeAsync().toFuture());
     }
 
     /**

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/ZipkinPublisher.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/ZipkinPublisher.java
@@ -15,146 +15,95 @@
  */
 package io.servicetalk.opentracing.zipkin.publisher;
 
+import io.servicetalk.concurrent.api.AsyncCloseable;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.opentracing.inmemory.api.InMemorySpan;
 import io.servicetalk.opentracing.inmemory.api.InMemorySpanEventListener;
 import io.servicetalk.opentracing.inmemory.api.InMemorySpanLog;
 
-import io.netty.bootstrap.Bootstrap;
-import io.netty.buffer.Unpooled;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelOutboundHandlerAdapter;
-import io.netty.channel.ChannelPromise;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.FixedRecvByteBufAllocator;
-import io.netty.channel.MaxMessagesRecvByteBufAllocator;
-import io.netty.channel.socket.DatagramPacket;
-import io.netty.util.concurrent.DefaultThreadFactory;
 import io.opentracing.tag.Tags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zipkin2.Endpoint;
 import zipkin2.Span;
-import zipkin2.codec.SpanBytesEncoder;
+import zipkin2.reporter.Reporter;
 
 import java.io.Closeable;
-import java.net.InetAddress;
+import java.io.Flushable;
+import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.util.Map;
 import javax.annotation.Nullable;
 
-import static io.netty.channel.ChannelOption.RCVBUF_ALLOCATOR;
-import static io.servicetalk.transport.netty.internal.BuilderUtils.datagramChannel;
-import static io.servicetalk.transport.netty.internal.NettyIoExecutors.createEventLoopGroup;
-import static java.lang.Thread.currentThread;
+import static io.servicetalk.concurrent.api.AsyncCloseables.toAsyncCloseable;
+import static io.servicetalk.transport.netty.internal.GlobalExecutionContext.globalExecutionContext;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * A publisher of {@link io.opentracing.Span}s to the zipkin transport.
  */
-public final class ZipkinPublisher implements InMemorySpanEventListener, Closeable {
+public final class ZipkinPublisher implements InMemorySpanEventListener, AsyncCloseable, Closeable {
+
     private static final Logger logger = LoggerFactory.getLogger(ZipkinPublisher.class);
 
-    /**
-     * The default maximum {@link DatagramPacket} size.
-     */
-    private static final int DEFAULT_MAX_DATAGRAM_PACKET_SIZE = 2048;
-    private static final MaxMessagesRecvByteBufAllocator DEFAULT_RECV_BUF_ALLOCATOR =
-            new FixedRecvByteBufAllocator(DEFAULT_MAX_DATAGRAM_PACKET_SIZE);
-
+    private final Reporter<Span> reporter;
     private final Endpoint endpoint;
-    private final EventLoopGroup group;
-    private final Channel channel;
+    private final ListenableAsyncCloseable closeable;
 
-    /**
-     * The serialization format for the zipkin write format data.
-     */
-    public enum Encoder {
-        JSON_V1(SpanBytesEncoder.JSON_V1), JSON_V2(SpanBytesEncoder.JSON_V2),
-        THRIFT(SpanBytesEncoder.THRIFT), PROTO3(SpanBytesEncoder.PROTO3);
-
-        final SpanBytesEncoder encoder;
-
-        Encoder(SpanBytesEncoder encoder) {
-            this.encoder = encoder;
-        }
-    }
-
-    /**
-     * The networking transport to use.
-     */
-    public enum Transport {
-        UDP {
-            Bootstrap buildBootstrap(EventLoopGroup group, Encoder encoder, SocketAddress collectorAddress) {
-                if (!(collectorAddress instanceof InetSocketAddress)) {
-                    throw new IllegalArgumentException("collectorAddress " + collectorAddress +
-                            " is invalid for transport " + this);
-                }
-                return new Bootstrap()
-                        .group(group)
-                        .channel(datagramChannel(group))
-                        .option(RCVBUF_ALLOCATOR, DEFAULT_RECV_BUF_ALLOCATOR)
-                        .handler(new ChannelOutboundHandlerAdapter() {
-                            @Override
-                            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-                                if (msg instanceof Span) {
-                                    byte[] bytes = encoder.encoder.encode((Span) msg);
-                                    ctx.write(new DatagramPacket(Unpooled.wrappedBuffer(bytes),
-                                            (InetSocketAddress) collectorAddress));
-                                } else {
-                                    ctx.write(msg, promise);
-                                }
-                            }
-                        });
+    private ZipkinPublisher(final String serviceName,
+                            final Reporter<Span> reporter,
+                            @Nullable final InetSocketAddress localSocketAddress) {
+        this.reporter = reporter;
+        this.endpoint = buildEndpoint(serviceName, localSocketAddress);
+        this.closeable = toAsyncCloseable(graceful -> {
+            // Some Reporter implementations may batch and need an explicit flush before closing (AsyncReporter)
+            Completable flush = Completable.completed();
+            if (graceful && reporter instanceof Flushable) {
+                flush = globalExecutionContext().executor().submit(() -> {
+                    try {
+                        ((Flushable) reporter).flush();
+                    } catch (IOException e) {
+                        logger.error("Exception while flushing reporter: {}", e.getMessage(), e);
+                    }
+                });
             }
-        };
-
-        abstract Bootstrap buildBootstrap(EventLoopGroup group, Encoder encoder, SocketAddress collectorAddress);
+            // ST Reporters can implement AsyncCloseable so we wouldn't have to call a blocking close in that case
+            Completable close = Completable.completed();
+            if (reporter instanceof AsyncCloseable) {
+                close = ((AsyncCloseable) reporter).closeAsyncGracefully();
+            } else if (reporter instanceof Closeable) {
+                close = globalExecutionContext().executor().submit(() -> {
+                    try {
+                        ((Closeable) reporter).close();
+                    } catch (IOException e) {
+                        logger.error("Exception while closing reporter: {}", e.getMessage(), e);
+                    }
+                });
+            }
+            return flush.concat(close);
+        });
     }
 
     /**
      * Builder for {@link ZipkinPublisher}.
      */
     public static final class Builder {
-        private String serviceName;
-        private SocketAddress collectorAddress;
+
+        private final String serviceName;
+        private final Reporter<Span> reporter;
         @Nullable
         private InetSocketAddress localAddress;
-        private Encoder encoder = Encoder.JSON_V2;
-        private Transport transport = Transport.UDP;
 
         /**
          * Create a new instance.
-         * @param serviceName the service name.
-         * @param collectorAddress the {@link SocketAddress} of the collector.
-         */
-        public Builder(String serviceName, SocketAddress collectorAddress) {
-            this.serviceName = requireNonNull(serviceName);
-            this.collectorAddress = requireNonNull(collectorAddress);
-        }
-
-        /**
-         * Configures the service name.
          *
          * @param serviceName the service name.
-         * @return this.
+         * @param reporter a {@link Reporter} implementation to send {@link Span}s to
          */
-        public Builder serviceName(String serviceName) {
+        public Builder(String serviceName, Reporter<Span> reporter) {
             this.serviceName = requireNonNull(serviceName);
-            return this;
-        }
-
-        /**
-         * Configures the collector address.
-         *
-         * @param collectorAddress the {@link SocketAddress} of the collector.
-         * @return this.
-         */
-        public Builder collectorAddress(SocketAddress collectorAddress) {
-            this.collectorAddress = requireNonNull(collectorAddress);
-            return this;
+            this.reporter = requireNonNull(reporter);
         }
 
         /**
@@ -164,108 +113,60 @@ public final class ZipkinPublisher implements InMemorySpanEventListener, Closeab
          * @return this.
          */
         public Builder localAddress(InetSocketAddress localAddress) {
-            this.localAddress = localAddress;
+            this.localAddress = requireNonNull(localAddress);
             return this;
         }
 
         /**
-         * Configures the format.
+         * Builds the ZipkinPublisher with supplied options.
          *
-         * @param encoder the {@link Encoder} to use.
-         * @return this.
-         */
-        public Builder encoder(Encoder encoder) {
-            this.encoder = requireNonNull(encoder);
-            return this;
-        }
-
-        /**
-         * Configures the transport.
-         *
-         * @param transport the {@link Transport} to use.
-         * @return this.
-         */
-        public Builder protocol(Transport transport) {
-            this.transport = requireNonNull(transport);
-            return this;
-        }
-
-        /**
-         * Note that this may block while the underlying channel is bound/connected.
-         * @return An interface which can publish tracing data using the zipkin API.
+         * @return A ZipkinPublisher which can publish tracing data using the zipkin Reporter API.
          */
         public ZipkinPublisher build() {
-            return new ZipkinPublisher(serviceName, collectorAddress, localAddress, encoder, transport);
+            return new ZipkinPublisher(serviceName, reporter, localAddress);
         }
     }
 
-    private ZipkinPublisher(String serviceName,
-                            SocketAddress collectorAddress,
-                            @Nullable InetSocketAddress localAddress,
-                            Encoder encoder,
-                            Transport transport) {
-        requireNonNull(serviceName);
-        requireNonNull(collectorAddress);
-        requireNonNull(encoder);
-        requireNonNull(transport);
-
-        endpoint = buildEndpoint(serviceName, localAddress);
-
-        group = createEventLoopGroup(1, new DefaultThreadFactory("zipkin-publisher", true));
-        try {
-            final Bootstrap bootstrap = transport.buildBootstrap(group, encoder, collectorAddress);
-            channel = bootstrap.bind(0).sync().channel();
-        } catch (InterruptedException e) {
-            currentThread().interrupt(); // Reset the interrupted flag.
-            throw new IllegalStateException("Failed to create " + transport + " client");
-        } catch (Exception e) {
-            logger.warn("Failed to create {} client", transport, e);
-            group.shutdownGracefully(0, 0, SECONDS);
-            throw e;
-        }
-    }
-
-    static Endpoint buildEndpoint(String serviceName, @Nullable InetSocketAddress localSocketAddress) {
+    private static Endpoint buildEndpoint(String serviceName, @Nullable InetSocketAddress localSocketAddress) {
         final Endpoint.Builder builder = Endpoint.newBuilder().serviceName(serviceName);
         if (localSocketAddress != null) {
-            final InetAddress localAddress = localSocketAddress.getAddress();
-            builder.ip(localAddress).port(localSocketAddress.getPort());
+            builder.ip(localSocketAddress.getAddress()).port(localSocketAddress.getPort());
         }
         return builder.build();
     }
 
     @Override
-    public void close() {
-        channel.close();
-        group.shutdownGracefully(0, 1, SECONDS);
-    }
-
-    @Override
     public void onSpanStarted(final InMemorySpan span) {
+        // nothing to do
     }
 
     @Override
     public void onEventLogged(final InMemorySpan span, final long epochMicros, final String eventName) {
+        // nothing to do
     }
 
     @Override
     public void onEventLogged(final InMemorySpan span, final long epochMicros, final Map<String, ?> fields) {
+        // nothing to do
     }
 
+    /**
+     * Converts a finished {@link InMemorySpan} to a {@link Span} and passes it to the {@link Reporter#report(Object)}.
+     */
     @Override
     public void onSpanFinished(final InMemorySpan span, long durationMicros) {
         final long begin = span.startEpochMicros();
         final long end = begin + durationMicros;
 
         Span.Builder builder = Span.newBuilder()
-            .name(span.operationName())
-            .traceId(span.traceIdHex())
-            .id(span.spanId())
-            .parentId(span.parentSpanIdHex())
-            .timestamp(begin)
-            .addAnnotation(end, "end")
-            .localEndpoint(endpoint)
-            .duration(durationMicros);
+                .name(span.operationName())
+                .traceId(span.traceIdHex())
+                .id(span.spanId())
+                .parentId(span.parentSpanIdHex())
+                .timestamp(begin)
+                .addAnnotation(end, "end")
+                .localEndpoint(endpoint)
+                .duration(durationMicros);
         span.tags().forEach((k, v) -> builder.putTag(k, v.toString()));
         Iterable<? extends InMemorySpanLog> logs = span.logs();
         if (logs != null) {
@@ -278,6 +179,35 @@ public final class ZipkinPublisher implements InMemorySpanEventListener, Closeab
             builder.kind(Span.Kind.CLIENT);
         }
 
-        channel.writeAndFlush(builder.build());
+        Span s = builder.build();
+        reporter.report(s);
+    }
+
+    /**
+     * Blocking close method delegates to {@link #closeAsync()}.
+     */
+    @Override
+    public void close() {
+        closeable.onClose();
+    }
+
+    /**
+     * Attempts to close the configured {@link Reporter}.
+     *
+     * @return a {@link Completable} that is completed when the close is done
+     */
+    @Override
+    public Completable closeAsync() {
+        return closeable.closeAsync();
+    }
+
+    /**
+     * Attempts to flush and close the configured {@link Reporter}.
+     *
+     * @return a {@link Completable} that is completed when the flush and close is done
+     */
+    @Override
+    public Completable closeAsyncGracefully() {
+        return closeable.closeAsyncGracefully();
     }
 }

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/LoggingReporter.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/LoggingReporter.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.opentracing.zipkin.publisher.reporter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import zipkin2.Span;
+import zipkin2.reporter.Reporter;
+
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A Simple {@link Reporter} that logs the span at INFO level.
+ */
+public final class LoggingReporter implements Reporter<Span> {
+    private final Logger logger;
+    private final LogLevel logLevel;
+
+    private LoggingReporter(Builder builder) {
+        this.logger = LoggerFactory.getLogger(builder.loggerName);
+        this.logLevel = builder.logLevel;
+    }
+
+    /**
+     * A builder to create a new {@link LoggingReporter}.
+     */
+    public static final class Builder {
+        private String loggerName;
+        private LogLevel logLevel = LogLevel.INFO;
+
+        public Builder(String loggerName) {
+            this.loggerName = requireNonNull(loggerName);
+        }
+
+        /**
+         * Sets the log level.
+         * <p>
+         * Logging will defaulit to {@link LogLevel#INFO} if not set.
+         *
+         * @param logLevel the {@link LogLevel} to use
+         * @return {@code this}
+         */
+        public Builder logLevel(LogLevel logLevel) {
+            this.logLevel = requireNonNull(logLevel);
+            return this;
+        }
+
+        /**
+         * Builds a new {@link LoggingReporter} instance with this builder's options.
+         *
+         * @return a new {@link LoggingReporter}
+         */
+        public LoggingReporter build() {
+            return new LoggingReporter(this);
+        }
+    }
+
+    /**
+     * Different log levels and how to log them.
+     */
+    public enum LogLevel {
+        TRACE(Logger::isTraceEnabled, Logger::trace),
+        DEBUG(Logger::isDebugEnabled, Logger::debug),
+        INFO(Logger::isInfoEnabled, Logger::info),
+        WARN(Logger::isWarnEnabled, Logger::warn),
+        ERROR(Logger::isErrorEnabled, Logger::error);
+
+        private final Predicate<Logger> isEnabled;
+        private final BiConsumer<Logger, String> log;
+
+        LogLevel(Predicate<Logger> isEnabled, BiConsumer<Logger, String> log) {
+            this.isEnabled = isEnabled;
+            this.log = log;
+        }
+    }
+
+    /**
+     * Logs a {@link Span} to the configured logger.
+     *
+     * @param span {@link Span} to log
+     */
+    @Override
+    public void report(Span span) {
+        if (logLevel.isEnabled.test(logger)) {
+            logLevel.log.accept(logger, requireNonNull(span).toString());
+        }
+    }
+}

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporter.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporter.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.opentracing.zipkin.publisher.reporter;
+
+import io.servicetalk.concurrent.api.AsyncCloseable;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
+import io.servicetalk.transport.api.IoExecutor;
+import io.servicetalk.transport.netty.internal.NettyFutureCompletable;
+import io.servicetalk.transport.netty.internal.StacklessClosedChannelException;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.MaxMessagesRecvByteBufAllocator;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+import zipkin2.Component;
+import zipkin2.Span;
+import zipkin2.codec.SpanBytesEncoder;
+import zipkin2.reporter.Reporter;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import javax.annotation.Nullable;
+
+import static io.netty.channel.ChannelOption.RCVBUF_ALLOCATOR;
+import static io.servicetalk.concurrent.api.AsyncCloseables.toAsyncCloseable;
+import static io.servicetalk.transport.netty.internal.BuilderUtils.datagramChannel;
+import static io.servicetalk.transport.netty.internal.EventLoopAwareNettyIoExecutors.toEventLoopAwareNettyIoExecutor;
+import static io.servicetalk.transport.netty.internal.GlobalExecutionContext.globalExecutionContext;
+import static java.lang.Thread.currentThread;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A {@link Span} {@link Reporter} that will publish to a UDP listener with a configurable encoding {@link Codec}.
+ */
+public final class UdpReporter extends Component implements Reporter<Span>, AsyncCloseable {
+
+    private static final Logger logger = LoggerFactory.getLogger(UdpReporter.class);
+
+    private static final int DEFAULT_MAX_DATAGRAM_PACKET_SIZE = 2048; // 2Kib
+    private static final MaxMessagesRecvByteBufAllocator DEFAULT_RECV_BUF_ALLOCATOR =
+            new FixedRecvByteBufAllocator(DEFAULT_MAX_DATAGRAM_PACKET_SIZE);
+
+    private final Channel channel;
+    private final ListenableAsyncCloseable closeable;
+
+    private UdpReporter(final Builder builder) {
+        EventLoopGroup group;
+        if (builder.ioExecutor != null) {
+            group = toEventLoopAwareNettyIoExecutor(builder.ioExecutor).eventLoopGroup();
+        } else {
+            group = toEventLoopAwareNettyIoExecutor(globalExecutionContext().ioExecutor()).eventLoopGroup();
+        }
+        try {
+            final Bootstrap bootstrap = buildBootstrap(group, builder.codec, builder.collectorAddress,
+                    builder.loggerName);
+            channel = bootstrap.bind(0).sync().channel();
+        } catch (InterruptedException e) {
+            currentThread().interrupt(); // Reset the interrupted flag.
+            throw new IllegalStateException("Failed to create UDP client");
+        } catch (Exception e) {
+            logger.warn("Failed to create UDP client", e);
+            throw e;
+        }
+        closeable = toAsyncCloseable(graceful -> new NettyFutureCompletable(channel::closeFuture));
+    }
+
+    /**
+     * The serialization format for the zipkin write format data.
+     */
+    public enum Codec {
+        JSON_V1(SpanBytesEncoder.JSON_V1), JSON_V2(SpanBytesEncoder.JSON_V2),
+        THRIFT(SpanBytesEncoder.THRIFT), PROTO3(SpanBytesEncoder.PROTO3);
+
+        final SpanBytesEncoder encoder;
+
+        Codec(SpanBytesEncoder encoder) {
+            this.encoder = encoder;
+        }
+    }
+
+    /**
+     * A builder to create a new {@link UdpReporter}.
+     */
+    public static final class Builder {
+        private final SocketAddress collectorAddress;
+        private Codec codec = Codec.JSON_V2;
+        @Nullable
+        private IoExecutor ioExecutor;
+        @Nullable
+        private String loggerName;
+
+        /**
+         * Create a new {@link UdpReporter.Builder} for a given collectorAddress.
+         *
+         * @param collectorAddress the collector SocketAddress
+         */
+        public Builder(SocketAddress collectorAddress) {
+            this.collectorAddress = collectorAddress;
+        }
+
+        /**
+         * Sets the {@link UdpReporter.Codec} to encode the Spans with.
+         *
+         * @param codec the codec to use for this span.
+         * @return {@code this}
+         */
+        public Builder codec(Codec codec) {
+            this.codec = requireNonNull(codec);
+            return this;
+        }
+
+        /**
+         * Sets an IoExecutor to use for writing to the datagram channel.
+         *
+         * @param ioExecutor IoExecutor to use to write with.
+         * @return {@code this}
+         */
+        public Builder ioExecutor(IoExecutor ioExecutor) {
+            this.ioExecutor = requireNonNull(ioExecutor);
+            return this;
+        }
+
+        /**
+         * Enables wire-logging for udp packets sent.
+         * <p>
+         * All wire events will be logged at {@link Level#TRACE TRACE} level.
+         *
+         * @param loggerName The name of the logger to log wire events.
+         * @return {@code this}
+         */
+        public Builder enableWireLogging(String loggerName) {
+            this.loggerName = loggerName;
+            return this;
+        }
+
+        /**
+         * Builds a new {@link UdpReporter} instance with this builder's options.
+         * <p>
+         * This method may block while the underlying UDP channel is being bound.
+         *
+         * @return a new {@link UdpReporter}
+         */
+        public UdpReporter build() {
+            return new UdpReporter(this);
+        }
+    }
+
+    private Bootstrap buildBootstrap(EventLoopGroup group, Codec codec, SocketAddress collectorAddress,
+                                     @Nullable String loggerName) {
+        if (!(collectorAddress instanceof InetSocketAddress)) {
+            throw new IllegalArgumentException("collectorAddress " + collectorAddress +
+                    " is invalid for UDP");
+        }
+        return new Bootstrap()
+                .group(group)
+                .channel(datagramChannel(group))
+                .option(RCVBUF_ALLOCATOR, DEFAULT_RECV_BUF_ALLOCATOR)
+                .handler(new ChannelInitializer<Channel>() {
+                    @Override
+                    protected void initChannel(final Channel ch) {
+                        if (loggerName != null) {
+                            ch.pipeline().addLast(new LoggingHandler(loggerName, LogLevel.TRACE));
+                        }
+                        ch.pipeline().addLast(new ChannelOutboundHandlerAdapter() {
+                            @Override
+                            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+                                if (msg instanceof Span) {
+                                    byte[] bytes = codec.encoder.encode((Span) msg);
+                                    ByteBuf buf = ctx.alloc().buffer(bytes.length).writeBytes(bytes);
+                                    ctx.write(new DatagramPacket(buf, (InetSocketAddress) collectorAddress), promise);
+                                } else {
+                                    ctx.write(msg, promise);
+                                }
+                            }
+                        });
+                    }
+                });
+    }
+
+    /**
+     * Non-blocking report method.
+     *
+     * @param span the span to report
+     */
+    @Override
+    public void report(final Span span) {
+        if (!channel.isActive()) {
+            throw new RuntimeException(StacklessClosedChannelException.newInstance(this.getClass(), "report"));
+        }
+        channel.writeAndFlush(span);
+    }
+
+    /**
+     * Blocking close method delegates to {@link #closeAsync()}).
+     */
+    @Override
+    public void close() {
+        closeable.onClose();
+    }
+
+    /**
+     * Marks the {@link UdpReporter} as closed to prevent accepting any more {@link Span}s.
+     *
+     * @return a {@link Completable} that is completed when close is done.
+     */
+    @Override
+    public Completable closeAsync() {
+        return closeable.closeAsync();
+    }
+}

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/package-info.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.opentracing.zipkin.publisher.reporter;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/ZipkinPublisherTest.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/ZipkinPublisherTest.java
@@ -19,180 +19,107 @@ import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.opentracing.inmemory.DefaultInMemoryTracer;
 import io.servicetalk.opentracing.inmemory.api.InMemorySpan;
 import io.servicetalk.opentracing.inmemory.api.InMemoryTracer;
-import io.servicetalk.opentracing.zipkin.publisher.ZipkinPublisher.Encoder;
 
-import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelOption;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.FixedRecvByteBufAllocator;
-import io.netty.channel.MaxMessagesRecvByteBufAllocator;
-import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.socket.DatagramPacket;
-import io.netty.channel.socket.nio.NioDatagramChannel;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import zipkin2.Span;
-import zipkin2.codec.SpanBytesDecoder;
+import zipkin2.reporter.Reporter;
 
+import java.io.Closeable;
+import java.io.Flushable;
 import java.net.InetSocketAddress;
 import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.ExecutionException;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.opentracing.asynccontext.AsyncContextInMemoryScopeManager.SCOPE_MANAGER;
-import static io.servicetalk.opentracing.zipkin.publisher.ZipkinPublisher.Encoder.JSON_V1;
-import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class ZipkinPublisherTest {
-    private static final int DEFAULT_MAX_DATAGRAM_PACKET_SIZE = 2048;
-    private static final MaxMessagesRecvByteBufAllocator DEFAULT_RECV_BUF_ALLOCATOR =
-            new FixedRecvByteBufAllocator(DEFAULT_MAX_DATAGRAM_PACKET_SIZE);
-    private static final int DUMMY_PORT = Optional.ofNullable(System.getenv("DUMMY_PORT"))
-            .map(Integer::parseInt).orElse(54321);
-
     @Rule
     public final Timeout timeout = new ServiceTalkTestTimeout();
 
-    private EventLoopGroup group;
     private InMemoryTracer tracer;
 
     @Before
     public void setUp() {
-        group = new NioEventLoopGroup(2);
         tracer = new DefaultInMemoryTracer.Builder(SCOPE_MANAGER).persistLogs(true).build();
     }
 
     @After
     public void tearDown() {
-        group.shutdownGracefully(0, 0, SECONDS);
     }
 
     @Test
-    public void testJsonV1RoundTrip() throws Exception {
-        testRoundTrip(JSON_V1, SpanBytesDecoder.JSON_V1);
-    }
-
-    @Test
-    public void testJsonV2RoundTrip() throws Exception {
-        testRoundTrip(Encoder.JSON_V2, SpanBytesDecoder.JSON_V2);
-    }
-
-    @Test
-    public void testThriftRoundTrip() throws Exception {
-        testRoundTrip(Encoder.THRIFT, SpanBytesDecoder.THRIFT);
-    }
-
-    @Test
-    public void testProto3RoundTrip() throws Exception {
-        testRoundTrip(Encoder.PROTO3, SpanBytesDecoder.PROTO3);
-    }
-
-    @Test
-    public void testNoReceiver() throws Exception {
-        try (ZipkinPublisher publisher = buildPublisher(localAddress(DUMMY_PORT), JSON_V1)) {
-            InMemorySpan span = tracer.buildSpan("test operation")
-                    .withTag("stringKey", "string")
-                    .withTag("boolKey", true)
-                    .withTag("shortKey", Short.MAX_VALUE)
-                    .withTag("intKey", Integer.MAX_VALUE)
-                    .withTag("longKey", Long.MAX_VALUE)
-                    .withTag("floatKey", Float.MAX_VALUE)
-                    .withTag("doubleKey", Double.MAX_VALUE)
-                    .start();
-            span.log("some event happened");
-            span.finish();
-
-            for (int i = 0; i < 10000; ++i) {
-                publisher.onSpanFinished(span, 1000 * 1000);
-            }
-
-            // Wait a little time, otherwise we may shutdown the channel too quickly
-            Thread.sleep(1000);
+    public void testReportSpan() throws ExecutionException, InterruptedException {
+        SpanHolder reporter = new SpanHolder();
+        try (ZipkinPublisher publisher = buildPublisher(reporter)) {
+            InMemorySpan span = buildSpan();
+            publisher.onSpanFinished(span, SECONDS.toMicros(1));
+            publisher.closeAsyncGracefully().toFuture().get();
         }
+        assertNotNull(reporter.span);
+        assertEquals("test operation", reporter.span.name());
+        assertEquals(1000 * 1000, (long) reporter.span.duration());
+        Map<String, String> tags = reporter.span.tags();
+        assertEquals("string", tags.get("stringKey"));
+        assertEquals(Boolean.TRUE.toString(), tags.get("boolKey"));
+        assertEquals(String.valueOf(Short.MAX_VALUE), tags.get("shortKey"));
+        assertEquals(String.valueOf(Integer.MAX_VALUE), tags.get("intKey"));
+        assertEquals(String.valueOf(Long.MAX_VALUE), tags.get("longKey"));
+        assertEquals(String.valueOf(Float.MAX_VALUE), tags.get("floatKey"));
+        assertEquals(String.valueOf(Double.MAX_VALUE), tags.get("doubleKey"));
+        assertTrue(reporter.span.annotations().stream().anyMatch(a -> a.value().equals("some event happened")));
+        assertTrue(reporter.flushed);
+        assertTrue(reporter.closed);
     }
 
-    private void testRoundTrip(Encoder encoder, SpanBytesDecoder decoder) throws Exception {
-        try (TestReceiver receiver = new TestReceiver(decoder)) {
-            try (ZipkinPublisher publisher = buildPublisher((InetSocketAddress) receiver.channel.localAddress(),
-                    encoder)) {
-                InMemorySpan span = tracer.buildSpan("test operation")
-                        .withTag("stringKey", "string")
-                        .withTag("boolKey", true)
-                        .withTag("shortKey", Short.MAX_VALUE)
-                        .withTag("intKey", Integer.MAX_VALUE)
-                        .withTag("longKey", Long.MAX_VALUE)
-                        .withTag("floatKey", Float.MAX_VALUE)
-                        .withTag("doubleKey", Double.MAX_VALUE)
-                        .start();
-                span.log("some event happened");
-                span.finish();
-                publisher.onSpanFinished(span, 1000 * 1000);
-            }
-            Span span = receiver.queue.take();
-
-            assertNotNull(span);
-            assertEquals("test operation", span.name());
-            assertEquals(1000 * 1000, (long) span.duration());
-            Map<String, String> tags = span.tags();
-            assertEquals("string", tags.get("stringKey"));
-            assertEquals(Boolean.TRUE.toString(), tags.get("boolKey"));
-            assertEquals(String.valueOf(Short.MAX_VALUE), tags.get("shortKey"));
-            assertEquals(String.valueOf(Integer.MAX_VALUE), tags.get("intKey"));
-            assertEquals(String.valueOf(Long.MAX_VALUE), tags.get("longKey"));
-            assertEquals(String.valueOf(Float.MAX_VALUE), tags.get("floatKey"));
-            assertEquals(String.valueOf(Double.MAX_VALUE), tags.get("doubleKey"));
-            assertTrue(span.annotations().stream().anyMatch(a -> a.value().equals("some event happened")));
-        }
-    }
-
-    private ZipkinPublisher buildPublisher(InetSocketAddress remoteAddress, Encoder encoder) {
-        return new ZipkinPublisher.Builder("test", remoteAddress)
-                .encoder(encoder)
-                .protocol(ZipkinPublisher.Transport.UDP)
+    private ZipkinPublisher buildPublisher(Reporter<Span> reporter) {
+        return new ZipkinPublisher.Builder("test", reporter)
+                .localAddress(new InetSocketAddress("localhost", 1))
                 .build();
     }
 
-    final class TestReceiver implements AutoCloseable {
-        final BlockingQueue<Span> queue = new LinkedBlockingDeque<>();
-        final Channel channel;
+    private InMemorySpan buildSpan() {
+        InMemorySpan span = tracer.buildSpan("test operation")
+                .withTag("stringKey", "string")
+                .withTag("boolKey", true)
+                .withTag("shortKey", Short.MAX_VALUE)
+                .withTag("intKey", Integer.MAX_VALUE)
+                .withTag("longKey", Long.MAX_VALUE)
+                .withTag("floatKey", Float.MAX_VALUE)
+                .withTag("doubleKey", Double.MAX_VALUE)
+                .start();
+        span.log("some event happened");
+        span.finish();
+        return span;
+    }
 
-        TestReceiver(SpanBytesDecoder decoder) throws Exception {
-            channel = new Bootstrap()
-                    .group(group)
-                    .channel(NioDatagramChannel.class)
-                    .option(ChannelOption.RCVBUF_ALLOCATOR, DEFAULT_RECV_BUF_ALLOCATOR)
-                    .handler(new ChannelInitializer<Channel>() {
-                        @Override
-                        protected void initChannel(Channel ch) {
-                            ch.pipeline().addLast(new SimpleChannelInboundHandler<DatagramPacket>() {
-                                @Override
-                                protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket msg) {
-                                    byte[] b = new byte[msg.content().readableBytes()];
-                                    msg.content().readBytes(b);
-                                    decoder.decode(b, queue);
-                                }
-                            });
-                        }
-                    })
-                    .localAddress(localAddress(0))
-                    .bind().sync().channel();
+    static final class SpanHolder implements Reporter<Span>, Flushable, Closeable {
+        @Nullable
+        Span span;
+        volatile boolean flushed;
+        volatile boolean closed;
+
+        @Override
+        public void report(final Span span) {
+            this.span = span;
+        }
+
+        @Override
+        public void flush() {
+            flushed = true;
         }
 
         @Override
         public void close() {
-            channel.close();
+            closed = true;
         }
     }
 }

--- a/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporterTest.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporterTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.opentracing.zipkin.publisher.reporter;
+
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.MaxMessagesRecvByteBufAllocator;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import zipkin2.Span;
+import zipkin2.codec.SpanBytesDecoder;
+
+import java.io.Closeable;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class UdpReporterTest {
+    private static final int DEFAULT_MAX_DATAGRAM_PACKET_SIZE = 2048;
+    private static final MaxMessagesRecvByteBufAllocator DEFAULT_RECV_BUF_ALLOCATOR =
+            new FixedRecvByteBufAllocator(DEFAULT_MAX_DATAGRAM_PACKET_SIZE);
+
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+
+    private EventLoopGroup group;
+
+    @Before
+    public void setUp() {
+        group = new NioEventLoopGroup(2);
+    }
+
+    @After
+    public void tearDown() {
+        group.shutdownGracefully(0, 0, SECONDS);
+    }
+
+    @Test
+    public void testJsonV1RoundTrip() throws Exception {
+        testRoundTrip(UdpReporter.Codec.JSON_V1, SpanBytesDecoder.JSON_V1);
+    }
+
+    @Test
+    public void testJsonV2RoundTrip() throws Exception {
+        testRoundTrip(UdpReporter.Codec.JSON_V2, SpanBytesDecoder.JSON_V2);
+    }
+
+    @Test
+    public void testThriftRoundTrip() throws Exception {
+        testRoundTrip(UdpReporter.Codec.THRIFT, SpanBytesDecoder.THRIFT);
+    }
+
+    @Test
+    public void testProto3RoundTrip() throws Exception {
+        testRoundTrip(UdpReporter.Codec.PROTO3, SpanBytesDecoder.PROTO3);
+    }
+
+    private void testRoundTrip(UdpReporter.Codec codec, SpanBytesDecoder decoder) throws Exception {
+        try (TestReceiver receiver = new TestReceiver(decoder)) {
+            try (UdpReporter reporter = buildReporter((InetSocketAddress) receiver.channel.localAddress(), codec)) {
+                Span span = Span.newBuilder()
+                        .name("test operation")
+                        .traceId("1234")
+                        .id(2)
+                        .timestamp(123456789L)
+                        .duration(SECONDS.toMicros(1))
+                        .putTag("stringKey", "string")
+                        .putTag("boolKey", String.valueOf(true))
+                        .putTag("shortKey", String.valueOf(Short.MAX_VALUE))
+                        .putTag("intKey", String.valueOf(Integer.MAX_VALUE))
+                        .putTag("longKey", String.valueOf(Long.MAX_VALUE))
+                        .putTag("floatKey", String.valueOf(Float.MAX_VALUE))
+                        .putTag("doubleKey", String.valueOf(Double.MAX_VALUE))
+                        .addAnnotation(System.currentTimeMillis() * 1000, "some event happened")
+                        .build();
+                reporter.report(span);
+            }
+
+            Span span = receiver.queue.take();
+
+            assertNotNull(span);
+            assertEquals("test operation", span.name());
+            assertEquals("0000000000001234", span.traceId());
+            assertEquals("0000000000000002", span.id());
+            assertEquals(123456789L, (long) span.timestamp());
+            assertEquals(1000 * 1000, (long) span.duration());
+            Map<String, String> tags = span.tags();
+            assertEquals("string", tags.get("stringKey"));
+            assertEquals(Boolean.TRUE.toString(), tags.get("boolKey"));
+            assertEquals(String.valueOf(Short.MAX_VALUE), tags.get("shortKey"));
+            assertEquals(String.valueOf(Integer.MAX_VALUE), tags.get("intKey"));
+            assertEquals(String.valueOf(Long.MAX_VALUE), tags.get("longKey"));
+            assertEquals(String.valueOf(Float.MAX_VALUE), tags.get("floatKey"));
+            assertEquals(String.valueOf(Double.MAX_VALUE), tags.get("doubleKey"));
+            assertTrue(span.annotations().stream().anyMatch(a -> a.value().equals("some event happened")));
+        }
+    }
+
+    private UdpReporter buildReporter(InetSocketAddress remoteAddress, UdpReporter.Codec codec) {
+        return new UdpReporter.Builder(remoteAddress)
+                .codec(codec)
+                .build();
+    }
+
+    final class TestReceiver implements Closeable {
+        final BlockingQueue<Span> queue = new LinkedBlockingDeque<>();
+        final Channel channel;
+
+        TestReceiver(SpanBytesDecoder decoder) throws Exception {
+            channel = new Bootstrap()
+                    .group(group)
+                    .channel(NioDatagramChannel.class)
+                    .option(ChannelOption.RCVBUF_ALLOCATOR, DEFAULT_RECV_BUF_ALLOCATOR)
+                    .handler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel ch) {
+                            ch.pipeline().addLast(new SimpleChannelInboundHandler<DatagramPacket>() {
+                                @Override
+                                protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket msg) {
+                                    byte[] b = new byte[msg.content().readableBytes()];
+                                    msg.content().readBytes(b);
+                                    decoder.decode(b, queue);
+                                }
+                            });
+                        }
+                    })
+                    .localAddress(localAddress(0))
+                    .bind().sync().channel();
+        }
+
+        @Override
+        public void close() {
+            channel.close();
+        }
+    }
+}

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelListenableAsyncCloseable.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelListenableAsyncCloseable.java
@@ -50,7 +50,7 @@ public class NettyChannelListenableAsyncCloseable implements ListenableAsyncClos
      * @param offloadingExecutor {@link Executor} used to offload any signals to any asynchronous created by this
      * {@link NettyChannelListenableAsyncCloseable} which could interact with the EventLoop.
      */
-    protected NettyChannelListenableAsyncCloseable(Channel channel, Executor offloadingExecutor) {
+    public NettyChannelListenableAsyncCloseable(Channel channel, Executor offloadingExecutor) {
         this.channel = requireNonNull(channel);
         onClose = new SubscribableCompletable() {
             @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyFutureCompletable.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyFutureCompletable.java
@@ -25,7 +25,7 @@ import java.util.function.Supplier;
 /**
  * A {@link Completable} that wraps a netty {@link Future}.
  */
-final class NettyFutureCompletable extends SubscribableCompletable {
+public final class NettyFutureCompletable extends SubscribableCompletable {
 
     private final Supplier<Future<?>> futureSupplier;
 
@@ -34,7 +34,7 @@ final class NettyFutureCompletable extends SubscribableCompletable {
      *
      * @param futureSupplier A {@link Supplier} that is invoked every time this {@link Completable} is subscribed.
      */
-    NettyFutureCompletable(Supplier<Future<?>> futureSupplier) {
+    public NettyFutureCompletable(Supplier<Future<?>> futureSupplier) {
         this.futureSupplier = futureSupplier;
     }
 


### PR DESCRIPTION
Converting ZipkinPublisher to use a zipkin2.Reporter interface for reporting spans.

Motivation:

The existing ZipkinPublisher isn’t readily extensible with different off the shelf reporters
and adopting that interface will allow users to drop in their own reporters.

Modifications:

- Modifying ZipkinPublisher to report spans to a Reporter<Span> interface.
- Moving the UDP implementation out to a UdpReporter

Result:

ZipkinPublisher can now accept other zipkin2 Reporters as publishing targets.