### PR TITLE
`ProxyConnectConnectionFactoryFilter` leaks connection in case of errors

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -244,7 +244,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
             if (roConfig.hasProxy() && sslContext != null) {
                 assert roConfig.connectAddress() != null;
                 connectionFactoryFilter = new ProxyConnectConnectionFactoryFilter<R, FilterableStreamingHttpConnection>(
-                        roConfig.connectAddress(), reqRespFactory).append(connectionFactoryFilter);
+                        roConfig.connectAddress()).append(connectionFactoryFilter);
             }
 
             final HttpExecutionStrategy executionStrategy = ctx.executionContext.executionStrategy();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,11 @@ import io.servicetalk.client.api.ConnectionFactory;
 import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.DelegatingConnectionFactory;
 import io.servicetalk.concurrent.SingleSource;
-import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.api.Single.TerminalSignalConsumer;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpExecutionStrategyInfluencer;
-import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.transport.netty.internal.DeferSslHandler;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;
 
@@ -32,6 +31,8 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+
+import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Processors.newSingleProcessor;
 import static io.servicetalk.concurrent.api.Single.failed;
@@ -47,17 +48,12 @@ import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_
  * @param <ResolvedAddress> The type of a resolved address that can be used for connecting.
  * @param <C> The type of connections created by this factory.
  */
-final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C
-        extends ListenableAsyncCloseable & FilterableStreamingHttpConnection>
-        implements ConnectionFactoryFilter<ResolvedAddress, C>,
-                   HttpExecutionStrategyInfluencer {
+final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends FilterableStreamingHttpConnection>
+        implements ConnectionFactoryFilter<ResolvedAddress, C>, HttpExecutionStrategyInfluencer {
 
-    private final StreamingHttpRequestResponseFactory reqRespFactory;
     private final String connectAddress;
 
-    ProxyConnectConnectionFactoryFilter(final CharSequence connectAddress,
-                                        final StreamingHttpRequestResponseFactory reqRespFactory) {
-        this.reqRespFactory = reqRespFactory;
+    ProxyConnectConnectionFactoryFilter(final CharSequence connectAddress) {
         this.connectAddress = connectAddress.toString();
     }
 
@@ -74,14 +70,21 @@ final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C
 
         @Override
         public Single<C> newConnection(final ResolvedAddress resolvedAddress) {
-            return delegate().newConnection(resolvedAddress).flatMap(c ->
+            return delegate().newConnection(resolvedAddress).flatMap(c -> {
+            try {
                 // We currently only have access to a StreamingHttpRequester, which means we are forced to provide an
                 // HttpExecutionStrategy. Because we can't be sure if there is any blocking code in the connection
                 // filters we use the default strategy which should offload everything to be safe.
-                c.request(defaultStrategy(),
-                            reqRespFactory.connect(connectAddress).addHeader(CONTENT_LENGTH, ZERO))
+                return c.request(defaultStrategy(), c.connect(connectAddress).addHeader(CONTENT_LENGTH, ZERO))
                  .flatMap(response -> {
-                if (SUCCESSFUL_2XX.contains(response.status())) {
+                    // Drain response payload body asynchronously as we are not interested in it:
+                    response.payloadBodyAndTrailers().ignoreElements().subscribe();
+
+                    if (response.status().statusClass() != SUCCESSFUL_2XX) {
+                        return failed(new ProxyResponseException("Non-successful response from proxy CONNECT " +
+                                connectAddress, response.status()));
+                    }
+
                     final Channel channel = ((NettyConnectionContext) c.connectionContext()).nettyChannel();
                     final SingleSource.Processor<C, C> processor = newSingleProcessor();
 
@@ -100,26 +103,41 @@ final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C
                         }
                     });
 
-                    DeferSslHandler deferSslHandler = channel.pipeline().get(DeferSslHandler.class);
+                    final DeferSslHandler deferSslHandler = channel.pipeline().get(DeferSslHandler.class);
                     if (deferSslHandler == null) {
-                        return response.payloadBodyAndTrailers().ignoreElements().concat(failed(
-                                new IllegalStateException("Failed to find a handler of type " +
-                                        DeferSslHandler.class + " in channel pipeline.")));
+                        return failed(new IllegalStateException("Failed to find a handler of type " +
+                                DeferSslHandler.class + " in channel pipeline."));
                     }
-
                     deferSslHandler.ready();
 
-                    // There is no need to apply offloading explicitly (despite completing `processor` on the
-                    // EventLoop) because `payloadBody()` will be offloaded according to the strategy for the
-                    // request.
-                    return response.payloadBodyAndTrailers().ignoreElements().concat(fromSource(processor));
-                } else {
-                    return response.payloadBodyAndTrailers().ignoreElements().concat(
-                            failed(new ProxyResponseException("Bad response from proxy CONNECT " + connectAddress,
-                                    response.status())));
-                }
-            }));
+                    return fromSource(processor);
+                    // Close recently created connection in case of any error or cancellation while it connects to proxy
+                 }).whenFinally(new TerminalSignalConsumer<C>() {
+                    @Override
+                    public void onSuccess(@Nullable final C result) {
+                        // noop
+                    }
+
+                    @Override
+                    public void onError(final Throwable ignore) {
+                        closeConnection(c);
+                    }
+
+                    @Override
+                    public void cancel() {
+                        closeConnection(c);
+                    }
+                 });
+            } catch (Exception e) {
+                closeConnection(c);
+                return failed(e);
+            }
+            });
         }
+    }
+
+    private static <C extends FilterableStreamingHttpConnection> void closeConnection(C connection) {
+        connection.closeAsync().subscribe();
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
@@ -81,8 +81,8 @@ final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends Filte
                             // Close recently created connection in case of any error while it connects to the proxy
                             // or cancellation:
                             .recoverWith(t -> c.closeAsync().concat(failed(t)))
-                            // Use whenFinally to prevent handling cancel event after termination:
-                            .whenFinally(new SingleTerminalSignalConsumer<C>() {
+                            // Use afterFinally to prevent handling cancel event after termination:
+                            .afterFinally(new SingleTerminalSignalConsumer<C>() {
                                 @Override
                                 public void cancel() {
                                     c.closeAsync().subscribe();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
@@ -85,43 +85,38 @@ final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends Filte
     }
 
     private Single<C> handleConnectResponse(final C connection, final StreamingHttpResponse response) {
-        try {
-            if (response.status().statusClass() != SUCCESSFUL_2XX) {
-                return failed(new ProxyResponseException("Non-successful response from proxy CONNECT " +
-                        connectAddress, response.status()));
-            }
-
-            final Channel channel = ((NettyConnectionContext) connection.connectionContext()).nettyChannel();
-            final SingleSource.Processor<C, C> processor = newSingleProcessor();
-            channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
-                @Override
-                public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) {
-                    if (evt instanceof SslHandshakeCompletionEvent) {
-                        SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
-                        if (event.isSuccess()) {
-                            processor.onSuccess(connection);
-                        } else {
-                            processor.onError(event.cause());
-                        }
-                    }
-                    ctx.fireUserEventTriggered(evt);
-                }
-            });
-
-            final DeferSslHandler deferSslHandler = channel.pipeline().get(DeferSslHandler.class);
-            if (deferSslHandler == null) {
-                return failed(new IllegalStateException("Failed to find a handler of type " +
-                        DeferSslHandler.class + " in channel pipeline."));
-            }
-            deferSslHandler.ready();
-
-            // There is no need to apply offloading explicitly (despite completing `processor` on the
-            // EventLoop) because `payloadBody()` will be offloaded according to the strategy for the
-            // request.
-            return response.payloadBodyAndTrailers().ignoreElements().concat(fromSource(processor));
-        } catch (Throwable t) {
-            return failed(t);
+        if (response.status().statusClass() != SUCCESSFUL_2XX) {
+            return failed(new ProxyResponseException("Non-successful response from proxy CONNECT " +
+                    connectAddress, response.status()));
         }
+
+        final Channel channel = ((NettyConnectionContext) connection.connectionContext()).nettyChannel();
+        final SingleSource.Processor<C, C> processor = newSingleProcessor();
+        channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+            @Override
+            public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) {
+                if (evt instanceof SslHandshakeCompletionEvent) {
+                    SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
+                    if (event.isSuccess()) {
+                        processor.onSuccess(connection);
+                    } else {
+                        processor.onError(event.cause());
+                    }
+                }
+                ctx.fireUserEventTriggered(evt);
+            }
+        });
+
+        final DeferSslHandler deferSslHandler = channel.pipeline().get(DeferSslHandler.class);
+        if (deferSslHandler == null) {
+            return failed(new IllegalStateException("Failed to find a handler of type " +
+                    DeferSslHandler.class + " in channel pipeline."));
+        }
+        deferSslHandler.ready();
+
+        // There is no need to apply offloading explicitly (despite completing `processor` on the EventLoop)
+        // because `payloadBody()` will be offloaded according to the strategy for the request.
+        return response.payloadBodyAndTrailers().ignoreElements().concat(fromSource(processor));
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
@@ -108,9 +108,8 @@ final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends Filte
     private Single<C> handleConnectResponse(final C connection, final StreamingHttpResponse response) {
         try {
             if (response.status().statusClass() != SUCCESSFUL_2XX) {
-                return response.payloadBodyAndTrailers().ignoreElements().concat(failed(
-                        new ProxyResponseException("Non-successful response from proxy CONNECT " +
-                                connectAddress, response.status())));
+                return failed(new ProxyResponseException("Non-successful response from proxy CONNECT " +
+                        connectAddress, response.status()));
             }
 
             final Channel channel = ((NettyConnectionContext) connection.connectionContext()).nettyChannel();
@@ -132,9 +131,8 @@ final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends Filte
 
             final DeferSslHandler deferSslHandler = channel.pipeline().get(DeferSslHandler.class);
             if (deferSslHandler == null) {
-                return response.payloadBodyAndTrailers().ignoreElements().concat(failed(
-                        new IllegalStateException("Failed to find a handler of type " +
-                                DeferSslHandler.class + " in channel pipeline.")));
+                return failed(new IllegalStateException("Failed to find a handler of type " +
+                        DeferSslHandler.class + " in channel pipeline."));
             }
             deferSslHandler.ready();
 
@@ -143,7 +141,7 @@ final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends Filte
             // request.
             return response.payloadBodyAndTrailers().ignoreElements().concat(fromSource(processor));
         } catch (Throwable t) {
-            return response.payloadBodyAndTrailers().ignoreElements().concat(failed(t));
+            return failed(t);
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilterTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.client.api.ConnectionFactory;
+import io.servicetalk.concurrent.api.TestCompletable;
+import io.servicetalk.concurrent.api.TestPublisher;
+import io.servicetalk.concurrent.api.TestSingleSubscriber;
+import io.servicetalk.http.api.DefaultHttpHeadersFactory;
+import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
+import io.servicetalk.http.api.FilterableStreamingHttpConnection;
+import io.servicetalk.http.api.HttpConnectionContext;
+import io.servicetalk.http.api.StreamingHttpRequestFactory;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.netty.internal.DeferSslHandler;
+import io.servicetalk.transport.netty.internal.NettyConnectionContext;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+
+import javax.annotation.Nullable;
+
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.concurrent.api.Single.failed;
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ProxyConnectConnectionFactoryFilterTest {
+
+    private static final StreamingHttpRequestFactory REQ_FACTORY = new DefaultStreamingHttpRequestResponseFactory(
+            DEFAULT_ALLOCATOR, DefaultHttpHeadersFactory.INSTANCE, HTTP_1_1);
+    private static final String CONNECT_ADDRESS = "foo.bar";
+    private static final String RESOLVED_ADDRESS = "bar.foo";
+
+    private final TestCompletable connectionClose = new TestCompletable();
+    private final FilterableStreamingHttpConnection connection = mock(FilterableStreamingHttpConnection.class);
+    private final TestSingleSubscriber<FilterableStreamingHttpConnection> subscriber = new TestSingleSubscriber<>();
+    private final TestPublisher<Object> payloadBodyAndTrailers = new TestPublisher<>();
+
+    public ProxyConnectConnectionFactoryFilterTest() {
+        when(connection.closeAsync()).thenReturn(connectionClose);
+        payloadBodyAndTrailers.whenRequest(__ -> payloadBodyAndTrailers.onComplete());
+    }
+
+    private ChannelPipeline configurePipeline(@Nullable SslHandshakeCompletionEvent event) {
+        ChannelPipeline pipeline = mock(ChannelPipeline.class);
+        when(pipeline.addLast(any())).then((Answer<ChannelPipeline>) invocation -> {
+            ChannelInboundHandler handshakeAwait = invocation.getArgument(0);
+            if (event != null) {
+                handshakeAwait.userEventTriggered(mock(ChannelHandlerContext.class), event);
+            }
+            return pipeline;
+        });
+        return pipeline;
+    }
+
+    private void configureDeferSslHandler(ChannelPipeline pipeline) {
+        when(pipeline.get(DeferSslHandler.class)).thenReturn(mock(DeferSslHandler.class));
+    }
+
+    private void configureConnectionContext(ChannelPipeline pipeline) {
+        Channel channel = mock(Channel.class);
+        when(channel.pipeline()).thenReturn(pipeline);
+
+        NettyHttpConnectionContext nettyContext = mock(NettyHttpConnectionContext.class);
+        when(nettyContext.nettyChannel()).thenReturn(channel);
+        when(connection.connectionContext()).thenReturn(nettyContext);
+    }
+
+    private void configureRequestSend() {
+        StreamingHttpResponse response = mock(StreamingHttpResponse.class);
+        when(response.status()).thenReturn(OK);
+        when(response.payloadBodyAndTrailers()).thenReturn(payloadBodyAndTrailers);
+        when(connection.request(any(), any())).thenReturn(succeeded(response));
+    }
+
+    private void configureConnectRequest() {
+        when(connection.connect(any())).thenReturn(REQ_FACTORY.connect(CONNECT_ADDRESS));
+    }
+
+    private void subscribeToProxyConnectionFactory() {
+        @SuppressWarnings("unchecked")
+        ConnectionFactory<String, FilterableStreamingHttpConnection> original = mock(ConnectionFactory.class);
+        when(original.newConnection(any())).thenReturn(succeeded(connection));
+        toSource(new ProxyConnectConnectionFactoryFilter<String, FilterableStreamingHttpConnection>(CONNECT_ADDRESS)
+                .create(original).newConnection(RESOLVED_ADDRESS)).subscribe(subscriber);
+    }
+
+    @Test
+    public void newConnectRequestThrows() {
+        when(connection.connect(any())).thenThrow(DELIBERATE_EXCEPTION);
+        subscribeToProxyConnectionFactory();
+
+        assertThat(subscriber.isErrored(), is(true));
+        assertThat(subscriber.error(), is(DELIBERATE_EXCEPTION));
+        verify(connection).connect(any());
+        verify(connection, never()).request(any(), any());
+        assertConnectionClosed();
+    }
+
+    @Test
+    public void connectRequestFails() {
+        when(connection.request(any(), any())).thenReturn(failed(DELIBERATE_EXCEPTION));
+
+        configureConnectRequest();
+        subscribeToProxyConnectionFactory();
+
+        assertThat(subscriber.isErrored(), is(true));
+        assertThat(subscriber.error(), is(DELIBERATE_EXCEPTION));
+        verify(connection).connect(any());
+        verify(connection).request(any(), any());
+        assertConnectionClosed();
+    }
+
+    @Test
+    public void nonSuccessfulResponseCode() {
+        StreamingHttpResponse response = mock(StreamingHttpResponse.class);
+        when(response.status()).thenReturn(INTERNAL_SERVER_ERROR);
+        when(response.payloadBodyAndTrailers()).thenReturn(payloadBodyAndTrailers);
+        when(connection.request(any(), any())).thenReturn(succeeded(response));
+
+        configureConnectRequest();
+        subscribeToProxyConnectionFactory();
+
+        assertThat(subscriber.isErrored(), is(true));
+        Throwable error = subscriber.error();
+        assertThat(error, is(notNullValue()));
+        assertThat(error, instanceOf(ProxyResponseException.class));
+        assertThat(((ProxyResponseException) error).status(), is(INTERNAL_SERVER_ERROR));
+        assertConnectPayloadConsumed();
+        assertConnectionClosed();
+    }
+
+    @Test
+    public void cannotAccessNettyChannel() {
+        // Does not implement NettyConnectionContext:
+        when(connection.connectionContext()).thenReturn(mock(HttpConnectionContext.class));
+
+        configureRequestSend();
+        configureConnectRequest();
+        subscribeToProxyConnectionFactory();
+
+        assertThat(subscriber.isErrored(), is(true));
+        Throwable error = subscriber.error();
+        assertThat(error, is(notNullValue()));
+        assertThat(error, instanceOf(ClassCastException.class));
+        assertConnectPayloadConsumed();
+        assertConnectionClosed();
+    }
+
+    @Test
+    public void noDeferSslHandler() {
+        ChannelPipeline pipeline = configurePipeline(SslHandshakeCompletionEvent.SUCCESS);
+        // Do not configureDeferSslHandler(pipeline);
+        configureConnectionContext(pipeline);
+        configureRequestSend();
+        configureConnectRequest();
+        subscribeToProxyConnectionFactory();
+
+        assertThat(subscriber.isErrored(), is(true));
+        Throwable error = subscriber.error();
+        assertThat(error, is(notNullValue()));
+        assertThat(error, instanceOf(IllegalStateException.class));
+        assertThat(error.getMessage(), containsString(DeferSslHandler.class.getSimpleName()));
+        assertConnectPayloadConsumed();
+        assertConnectionClosed();
+    }
+
+    @Test
+    public void deferSslHandlerReadyThrows() {
+        ChannelPipeline pipeline = configurePipeline(SslHandshakeCompletionEvent.SUCCESS);
+        when(pipeline.get(DeferSslHandler.class)).thenThrow(DELIBERATE_EXCEPTION);
+
+        configureConnectionContext(pipeline);
+        configureRequestSend();
+        configureConnectRequest();
+        subscribeToProxyConnectionFactory();
+
+        assertThat(subscriber.isErrored(), is(true));
+        assertThat(subscriber.error(), is(DELIBERATE_EXCEPTION));
+        assertConnectPayloadConsumed();
+        assertConnectionClosed();
+    }
+
+    @Test
+    public void sslHandshakeFailure() {
+        ChannelPipeline pipeline = configurePipeline(new SslHandshakeCompletionEvent(DELIBERATE_EXCEPTION));
+
+        configureDeferSslHandler(pipeline);
+        configureConnectionContext(pipeline);
+        configureRequestSend();
+        configureConnectRequest();
+        subscribeToProxyConnectionFactory();
+
+        assertThat(subscriber.isErrored(), is(true));
+        assertThat(subscriber.error(), is(DELIBERATE_EXCEPTION));
+        assertConnectPayloadConsumed();
+        assertConnectionClosed();
+    }
+
+    @Test
+    public void cancelledBeforeSslHandshakeCompletionEvent() {
+        ChannelPipeline pipeline = configurePipeline(null); // Do not generate any SslHandshakeCompletionEvent
+
+        configureDeferSslHandler(pipeline);
+        configureConnectionContext(pipeline);
+        configureRequestSend();
+        configureConnectRequest();
+        subscribeToProxyConnectionFactory();
+
+        assertThat(subscriber.cancellableReceived(), is(true));
+        assertThat(subscriber.isErrored(), is(false));
+        assertThat(subscriber.isSuccess(), is(false));
+        assertThat(connectionClose.isSubscribed(), is(false));
+        subscriber.cancel();
+        assertConnectPayloadConsumed();
+        assertConnectionClosed();
+    }
+
+    @Test
+    public void successfulConnect() {
+        ChannelPipeline pipeline = configurePipeline(SslHandshakeCompletionEvent.SUCCESS);
+        configureDeferSslHandler(pipeline);
+        configureConnectionContext(pipeline);
+        configureRequestSend();
+        configureConnectRequest();
+        subscribeToProxyConnectionFactory();
+
+        assertThat(subscriber.isSuccess(), is(true));
+        assertThat(subscriber.result(), is(sameInstance(this.connection)));
+        assertConnectPayloadConsumed();
+        assertThat("Connection closed", connectionClose.isSubscribed(), is(false));
+    }
+
+    private void assertConnectPayloadConsumed() {
+        verify(connection).connect(any());
+        verify(connection).request(any(), any());
+        assertThat("CONNECT response payload body was not consumed", payloadBodyAndTrailers.isSubscribed(), is(true));
+    }
+
+    private void assertConnectionClosed() {
+        assertThat("Closure of the connection was not triggered", connectionClose.isSubscribed(), is(true));
+    }
+
+    private interface NettyHttpConnectionContext extends HttpConnectionContext, NettyConnectionContext {
+        // no methods
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilterTest.java
@@ -164,8 +164,7 @@ public class ProxyConnectConnectionFactoryFilterTest {
 
         assertThat(subscriber.isErrored(), is(true));
         assertThat(subscriber.error(), is(DELIBERATE_EXCEPTION));
-        verify(connection).connect(any());
-        verify(connection).request(any(), any());
+        assertConnectPayloadConsumed(false);
         assertConnectionClosed();
     }
 
@@ -184,7 +183,7 @@ public class ProxyConnectConnectionFactoryFilterTest {
         assertThat(error, is(notNullValue()));
         assertThat(error, instanceOf(ProxyResponseException.class));
         assertThat(((ProxyResponseException) error).status(), is(INTERNAL_SERVER_ERROR));
-        assertConnectPayloadConsumed();
+        assertConnectPayloadConsumed(false);
         assertConnectionClosed();
     }
 
@@ -201,7 +200,7 @@ public class ProxyConnectConnectionFactoryFilterTest {
         Throwable error = subscriber.error();
         assertThat(error, is(notNullValue()));
         assertThat(error, instanceOf(ClassCastException.class));
-        assertConnectPayloadConsumed();
+        assertConnectPayloadConsumed(false);
         assertConnectionClosed();
     }
 
@@ -219,7 +218,7 @@ public class ProxyConnectConnectionFactoryFilterTest {
         assertThat(error, is(notNullValue()));
         assertThat(error, instanceOf(IllegalStateException.class));
         assertThat(error.getMessage(), containsString(DeferSslHandler.class.getSimpleName()));
-        assertConnectPayloadConsumed();
+        assertConnectPayloadConsumed(false);
         assertConnectionClosed();
     }
 
@@ -235,7 +234,7 @@ public class ProxyConnectConnectionFactoryFilterTest {
 
         assertThat(subscriber.isErrored(), is(true));
         assertThat(subscriber.error(), is(DELIBERATE_EXCEPTION));
-        assertConnectPayloadConsumed();
+        assertConnectPayloadConsumed(false);
         assertConnectionClosed();
     }
 
@@ -251,7 +250,7 @@ public class ProxyConnectConnectionFactoryFilterTest {
 
         assertThat(subscriber.isErrored(), is(true));
         assertThat(subscriber.error(), is(DELIBERATE_EXCEPTION));
-        assertConnectPayloadConsumed();
+        assertConnectPayloadConsumed(true);
         assertConnectionClosed();
     }
 
@@ -270,7 +269,7 @@ public class ProxyConnectConnectionFactoryFilterTest {
         assertThat(subscriber.isSuccess(), is(false));
         assertThat(connectionClose.isSubscribed(), is(false));
         subscriber.cancel();
-        assertConnectPayloadConsumed();
+        assertConnectPayloadConsumed(true);
         assertConnectionClosed();
     }
 
@@ -285,14 +284,15 @@ public class ProxyConnectConnectionFactoryFilterTest {
 
         assertThat(subscriber.isSuccess(), is(true));
         assertThat(subscriber.result(), is(sameInstance(this.connection)));
-        assertConnectPayloadConsumed();
+        assertConnectPayloadConsumed(true);
         assertThat("Connection closed", connectionClose.isSubscribed(), is(false));
     }
 
-    private void assertConnectPayloadConsumed() {
+    private void assertConnectPayloadConsumed(boolean expected) {
         verify(connection).connect(any());
         verify(connection).request(any(), any());
-        assertThat("CONNECT response payload body was not consumed", payloadBodyAndTrailers.isSubscribed(), is(true));
+        assertThat("CONNECT response payload body was " + (expected ? "was" : "unnecessarily") + " consumed",
+                payloadBodyAndTrailers.isSubscribed(), is(expected));
     }
 
     private void assertConnectionClosed() {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilterTest.java
@@ -34,6 +34,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.stubbing.Answer;
 
@@ -255,6 +256,7 @@ public class ProxyConnectConnectionFactoryFilterTest {
     }
 
     @Test
+    @Ignore("https://github.com/apple/servicetalk/issues/1010")
     public void cancelledBeforeSslHandshakeCompletionEvent() {
         ChannelPipeline pipeline = configurePipeline(null); // Do not generate any SslHandshakeCompletionEvent
 


### PR DESCRIPTION
Motivation:

In case of any error or cancellation, `ProxyConnectConnectionFactoryFilter`
does not close the connection to the proxy.

Modifications:

- Add tests to verify different failure scenarios for
`ProxyConnectConnectionFactoryFilter`;
- Close connection when `CONNECT` request or SSL handshake failures;
- Do not drain the response payload body in case of error, because the
connection will be closed anyway;

Result:

`ProxyConnectConnectionFactoryFilter` does not leak connections.