### PR TITLE
Add `ambWith` and `amb` methods for `Single` and `Completable`

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AmbSingles.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AmbSingles.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.SingleSource.Subscriber;
+import io.servicetalk.concurrent.internal.DelayedCancellable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import javax.annotation.Nullable;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
+
+final class AmbSingles<T> extends Single<T> {
+    private final Single<? extends T>[] singles;
+
+    @SafeVarargs
+    AmbSingles(final Single<? extends T>... singles) {
+        for (Single<? extends T> single : singles) {
+            requireNonNull(single);
+        }
+        this.singles = singles;
+    }
+
+    AmbSingles(final Iterable<Single<? extends T>> singles) {
+        List<Single<? extends T>> allSingles = new ArrayList<>();
+        for (Single<? extends T> single : singles) {
+            allSingles.add(requireNonNull(single));
+        }
+        @SuppressWarnings({"unchecked", "SuspiciousToArrayCall"})
+        Single<? extends T>[] singlesArr = (Single<? extends T>[]) allSingles.toArray(new Single[0]);
+        this.singles = singlesArr;
+    }
+
+    @Override
+    protected void handleSubscribe(final Subscriber<? super T> subscriber) {
+        final Cancellable[] cancellables = new Cancellable[singles.length];
+        final State<T> state = new State<>(subscriber);
+        subscriber.onSubscribe(state);
+        try {
+            for (int i = 0; i < singles.length; i++) {
+                AmbSubscriber<T> sub = new AmbSubscriber<>(state);
+                cancellables[i] = sub;
+                singles[i].subscribeInternal(sub);
+            }
+        } catch (Throwable t) {
+            state.delayedCancellable(CompositeCancellable.create(cancellables));
+            state.tryError(t);
+            return;
+        }
+        state.delayedCancellable(CompositeCancellable.create(cancellables));
+    }
+
+    static final class AmbSubscriber<T> extends DelayedCancellable implements Subscriber<T> {
+        private final State<T> state;
+
+        AmbSubscriber(final State<T> state) {
+            this.state = state;
+        }
+
+        @Override
+        public void onSubscribe(final Cancellable cancellable) {
+            delayedCancellable(cancellable);
+        }
+
+        @Override
+        public void onSuccess(@Nullable final T result) {
+            state.trySuccess(result);
+        }
+
+        @Override
+        public void onError(final Throwable t) {
+            state.tryError(t);
+        }
+    }
+
+    static final class State<T> extends DelayedCancellable {
+        @SuppressWarnings("rawtypes")
+        private static final AtomicIntegerFieldUpdater<State> doneUpdater =
+                newUpdater(State.class, "done");
+        private final Subscriber<? super T> target;
+
+        private volatile int done;
+
+        State(final Subscriber<? super T> target) {
+            this.target = target;
+        }
+
+        void trySuccess(@Nullable final T result) {
+            if (doneUpdater.compareAndSet(this, 0, 1)) {
+                // Cancel other as we got a result.
+                try {
+                    cancel();
+                } catch (Throwable t) {
+                    target.onError(t);
+                    return;
+                }
+                target.onSuccess(result);
+            }
+        }
+
+        void tryError(final Throwable t) {
+            if (doneUpdater.compareAndSet(this, 0, 1)) {
+                // Cancel other as we got a result.
+                try {
+                    cancel();
+                } catch (Throwable tt) {
+                    target.onError(tt);
+                    return;
+                }
+                target.onError(t);
+            }
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -1217,9 +1217,8 @@ public abstract class Completable {
     }
 
     /**
-     * Creates a new {@link Completable} that ambiguates the result of this {@link Completable} with the passed
-     * {@code other} {@link Completable} such that whichever of them terminates first (successfully or with an error),
-     * the returned {@link Completable} will return that result.
+     * Creates a new {@link Completable} that terminates with the result (either success or error) of either this
+     * {@link Completable} or the passed {@code other} {@link Completable}, whichever terminates first.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -1230,9 +1229,8 @@ public abstract class Completable {
      * }</pre>
      *
      * @param other {@link Completable} with which the result of this {@link Completable} is to be ambiguated.
-     * @return A new {@link Completable} that ambiguates the result of this {@link Completable} with the passed
-     * {@code other} @link Completable} such that whichever of them terminates first (successfully or with an error),
-     * the returned {@link Completable} will return that result.
+     * @return A new {@link Completable} that terminates with the result (either success or error) of either this
+     * {@link Completable} or the passed {@code other} {@link Completable}, whichever terminates first.
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
      */
     public final Completable ambWith(final Completable other) {
@@ -1670,9 +1668,8 @@ public abstract class Completable {
     }
 
     /**
-     * Creates a new {@link Completable} that ambiguates the result of all the passed {@code completables} such that
-     * whichever of them terminates first (successfully or with an error), the returned {@link Completable} will return
-     * that result.
+     * Creates a new {@link Completable} that terminates with the result (either success or error) of whichever amongst
+     * the passed {@code completables} that terminates first.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -1683,9 +1680,8 @@ public abstract class Completable {
      * }</pre>
      *
      * @param completables {@link Completable}s the result of which are to be ambiguated.
-     * @return A new {@link Completable} that ambiguates the result of all the passed {@code completables} such that
-     * whichever of them terminates first (successfully or with an error), the returned {@link Completable} will return
-     * that result.
+     * @return A new {@link Completable} that terminates with the result (either success or error) of whichever amongst
+     * the passed {@code completables} that terminates first.
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
      */
     public static Completable amb(final Completable... completables) {
@@ -1694,9 +1690,8 @@ public abstract class Completable {
     }
 
     /**
-     * Creates a new {@link Completable} that ambiguates the result of all the passed {@code completables} such that
-     * whichever of them terminates first (successfully or with an error), the returned {@link Completable} will return
-     * that result.
+     * Creates a new {@link Completable} that terminates with the result (either success or error) of whichever amongst
+     * the passed {@code completables} that terminates first.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -1707,14 +1702,57 @@ public abstract class Completable {
      * }</pre>
      *
      * @param completables {@link Completable}s the result of which are to be ambiguated.
-     * @return A new {@link Completable} that ambiguates the result of all the passed {@code completables} such that
-     * whichever of them terminates first (successfully or with an error), the returned {@link Completable} will return
+     * @return A new {@link Completable} that terminates with the result (either success or error) of whichever amongst
+     * the passed {@code completables} that terminates first.
      * that result.
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
      */
     public static Completable amb(final Iterable<Completable> completables) {
         return Single.amb(stream(completables.spliterator(), false)
                 .map(Completable::toSingle).collect(toList())).ignoreElement();
+    }
+
+    /**
+     * Creates a new {@link Completable} that terminates with the result (either success or error) of whichever amongst
+     * the passed {@code completables} that terminates first.
+     * <p>
+     * From a sequential programming point of view this method is roughly equivalent to the following:
+     * <pre>{@code
+     *      for (Future<T> ft: futures) { // Provided Futures (analogous to the Completables here)
+     *          // This is an approximation, this operator will pick the first result from any of the futures.
+     *          return ft.get();
+     *      }
+     * }</pre>
+     *
+     * @param completables {@link Completable}s the result of which are to be ambiguated.
+     * @return A new {@link Completable} that terminates with the result (either success or error) of whichever amongst
+     * the passed {@code completables} that terminates first.
+     * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
+     */
+    public static Completable anyOf(final Completable... completables) {
+        return amb(completables);
+    }
+
+    /**
+     * Creates a new {@link Completable} that terminates with the result (either success or error) of whichever amongst
+     * the passed {@code completables} that terminates first.
+     * <p>
+     * From a sequential programming point of view this method is roughly equivalent to the following:
+     * <pre>{@code
+     *      for (Future<T> ft: futures) { // Provided Futures (analogous to the Completables here)
+     *          // This is an approximation, this operator will pick the first result from any of the futures.
+     *          return ft.get();
+     *      }
+     * }</pre>
+     *
+     * @param completables {@link Completable}s the result of which are to be ambiguated.
+     * @return A new {@link Completable} that terminates with the result (either success or error) of whichever amongst
+     * the passed {@code completables} that terminates first.
+     * that result.
+     * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
+     */
+    public static Completable anyOf(final Iterable<Completable> completables) {
+        return amb(completables);
     }
 
     //

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1127,6 +1127,29 @@ public abstract class Single<T> {
         return new LiftAsynchronousSingleOperator<>(this, operator, executor);
     }
 
+    /**
+     * Creates a new {@link Single} that ambiguates the result of this {@link Single} with the passed {@code other}
+     * {@link Single} such that whichever of them terminates first (successfully or with an error), the returned
+     * {@link Single} will return that result.
+     * <p>
+     * From a sequential programming point of view this method is roughly equivalent to the following:
+     * <pre>{@code
+     *      for (Future<T> ft: futures) { // Provided Futures (analogous to the Singles here)
+     *          // This is an approximation, this operator will pick the first result from either of the futures.
+     *          return ft.get();
+     *      }
+     * }</pre>
+     *
+     * @param other {@link Single} with which the result of this {@link Single} is to be ambiguated.
+     * @return A new {@link Single} that ambiguates the result of this {@link Single} with the passed {@code other}
+     * {@link Single} such that whichever of them terminates first (successfully or with an error), the returned
+     * {@link Single} will return that result.
+     * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
+     */
+    public final Single<T> ambWith(final Single<T> other) {
+        return new SingleAmbWith<>(executor, this, other);
+    }
+
     //
     // Operators End
     //
@@ -1631,6 +1654,51 @@ public abstract class Single<T> {
      */
     public static <T> Single<T> fromStage(CompletionStage<? extends T> stage) {
         return new CompletionStageToSingle<>(stage);
+    }
+
+    /**
+     * Creates a new {@link Single} that ambiguates the result of all the passed {@code singles} such that whichever
+     * of them terminates first (successfully or with an error), the returned {@link Single} will return that result.
+     * <p>
+     * From a sequential programming point of view this method is roughly equivalent to the following:
+     * <pre>{@code
+     *      for (Future<T> ft: futures) { // Provided Futures (analogous to the Singles here)
+     *          // This is an approximation, this operator will pick the first result from any of the futures.
+     *          return ft.get();
+     *      }
+     * }</pre>
+     *
+     * @param singles {@link Single}s the result of which are to be ambiguated.
+     * @param <T> Type of the result of the individual {@link Single}s
+     * @return A new {@link Single} that ambiguates the result of all the passed {@code singles} such that whichever
+     * of them terminates first (successfully or with an error), the returned {@link Single} will return that result.
+     * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
+     */
+    @SafeVarargs
+    public static <T> Single<T> amb(final Single<? extends T>... singles) {
+        return new AmbSingles<>(singles);
+    }
+
+    /**
+     * Creates a new {@link Single} that ambiguates the result of all the passed {@code singles} such that whichever
+     * of them terminates first (successfully or with an error), the returned {@link Single} will return that result.
+     * <p>
+     * From a sequential programming point of view this method is roughly equivalent to the following:
+     * <pre>{@code
+     *      for (Future<T> ft: futures) { // Provided Futures (analogous to the Singles here)
+     *          // This is an approximation, this operator will pick the first result from any of the futures.
+     *          return ft.get();
+     *      }
+     * }</pre>
+     *
+     * @param singles {@link Single}s the result of which are to be ambiguated.
+     * @param <T> Type of the result of the individual {@link Single}s
+     * @return A new {@link Single} that ambiguates the result of all the passed {@code singles} such that whichever
+     * of them terminates first (successfully or with an error), the returned {@link Single} will return that result.
+     * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
+     */
+    public static <T> Single<T> amb(final Iterable<Single<? extends T>> singles) {
+        return new AmbSingles<>(singles);
     }
 
     //

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1128,9 +1128,8 @@ public abstract class Single<T> {
     }
 
     /**
-     * Creates a new {@link Single} that ambiguates the result of this {@link Single} with the passed {@code other}
-     * {@link Single} such that whichever of them terminates first (successfully or with an error), the returned
-     * {@link Single} will return that result.
+     * Creates a new {@link Single} that terminates with the result (either success or error) of either this
+     * {@link Single} or the passed {@code other} {@link Single}, whichever terminates first.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -1141,9 +1140,8 @@ public abstract class Single<T> {
      * }</pre>
      *
      * @param other {@link Single} with which the result of this {@link Single} is to be ambiguated.
-     * @return A new {@link Single} that ambiguates the result of this {@link Single} with the passed {@code other}
-     * {@link Single} such that whichever of them terminates first (successfully or with an error), the returned
-     * {@link Single} will return that result.
+     * @return A new {@link Single} that terminates with the result (either success or error) of either this
+     * {@link Single} or the passed {@code other} {@link Single}, whichever terminates first.
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
      */
     public final Single<T> ambWith(final Single<T> other) {
@@ -1657,8 +1655,8 @@ public abstract class Single<T> {
     }
 
     /**
-     * Creates a new {@link Single} that ambiguates the result of all the passed {@code singles} such that whichever
-     * of them terminates first (successfully or with an error), the returned {@link Single} will return that result.
+     * Creates a new {@link Single} that terminates with the result (either success or error) of whichever amongst the
+     * passed {@code singles} that terminates first.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -1670,8 +1668,8 @@ public abstract class Single<T> {
      *
      * @param singles {@link Single}s the result of which are to be ambiguated.
      * @param <T> Type of the result of the individual {@link Single}s
-     * @return A new {@link Single} that ambiguates the result of all the passed {@code singles} such that whichever
-     * of them terminates first (successfully or with an error), the returned {@link Single} will return that result.
+     * @return A new {@link Single} that terminates with the result (either success or error) of whichever amongst the
+     * passed {@code singles} that terminates first.
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
      */
     @SafeVarargs
@@ -1680,8 +1678,8 @@ public abstract class Single<T> {
     }
 
     /**
-     * Creates a new {@link Single} that ambiguates the result of all the passed {@code singles} such that whichever
-     * of them terminates first (successfully or with an error), the returned {@link Single} will return that result.
+     * Creates a new {@link Single} that terminates with the result (either success or error) of whichever amongst the
+     * passed {@code singles} that terminates first.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -1693,12 +1691,57 @@ public abstract class Single<T> {
      *
      * @param singles {@link Single}s the result of which are to be ambiguated.
      * @param <T> Type of the result of the individual {@link Single}s
-     * @return A new {@link Single} that ambiguates the result of all the passed {@code singles} such that whichever
-     * of them terminates first (successfully or with an error), the returned {@link Single} will return that result.
+     * @return A new {@link Single} that terminates with the result (either success or error) of whichever amongst the
+     * passed {@code singles} that terminates first.
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
      */
     public static <T> Single<T> amb(final Iterable<Single<? extends T>> singles) {
         return new AmbSingles<>(singles);
+    }
+
+    /**
+     * Creates a new {@link Single} that terminates with the result (either success or error) of whichever amongst the
+     * passed {@code singles} that terminates first.
+     * <p>
+     * From a sequential programming point of view this method is roughly equivalent to the following:
+     * <pre>{@code
+     *      for (Future<T> ft: futures) { // Provided Futures (analogous to the Singles here)
+     *          // This is an approximation, this operator will pick the first result from any of the futures.
+     *          return ft.get();
+     *      }
+     * }</pre>
+     *
+     * @param singles {@link Single}s the result of which are to be ambiguated.
+     * @param <T> Type of the result of the individual {@link Single}s
+     * @return A new {@link Single} that terminates with the result (either success or error) of whichever amongst the
+     * passed {@code singles} that terminates first.
+     * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
+     */
+    @SafeVarargs
+    public static <T> Single<T> anyOf(final Single<? extends T>... singles) {
+        return amb(singles);
+    }
+
+    /**
+     * Creates a new {@link Single} that terminates with the result (either success or error) of whichever amongst the
+     * passed {@code singles} that terminates first.
+     * <p>
+     * From a sequential programming point of view this method is roughly equivalent to the following:
+     * <pre>{@code
+     *      for (Future<T> ft: futures) { // Provided Futures (analogous to the Singles here)
+     *          // This is an approximation, this operator will pick the first result from any of the futures.
+     *          return ft.get();
+     *      }
+     * }</pre>
+     *
+     * @param singles {@link Single}s the result of which are to be ambiguated.
+     * @param <T> Type of the result of the individual {@link Single}s
+     * @return A new {@link Single} that terminates with the result (either success or error) of whichever amongst the
+     * passed {@code singles} that terminates first.
+     * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
+     */
+    public static <T> Single<T> anyOf(final Iterable<Single<? extends T>> singles) {
+        return amb(singles);
     }
 
     //

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleAmbWith.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleAmbWith.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.api.AmbSingles.AmbSubscriber;
+import io.servicetalk.concurrent.api.AmbSingles.State;
+import io.servicetalk.concurrent.internal.SignalOffloader;
+
+import static java.util.Objects.requireNonNull;
+
+final class SingleAmbWith<T> extends AbstractNoHandleSubscribeSingle<T> {
+    private final Single<T> original;
+    private final Single<T> ambWith;
+
+    SingleAmbWith(final Executor executor, final Single<T> original, final Single<T> ambWith) {
+        super(executor);
+        this.original = requireNonNull(original);
+        this.ambWith = requireNonNull(ambWith);
+    }
+
+    @Override
+    void handleSubscribe(final Subscriber<? super T> subscriber, final SignalOffloader signalOffloader,
+                         final AsyncContextMap contextMap, final AsyncContextProvider contextProvider) {
+        State<T> state = new State<>(subscriber);
+        subscriber.onSubscribe(state);
+        AmbSubscriber<T> originalSubscriber = new AmbSubscriber<>(state);
+        AmbSubscriber<T> ambWithSubscriber = new AmbSubscriber<>(state);
+        state.delayedCancellable(CompositeCancellable.create(originalSubscriber, ambWithSubscriber));
+        try {
+            original.delegateSubscribe(originalSubscriber, signalOffloader, contextMap, contextProvider);
+            // If the other Single's result is propagated then we should offload it to the original Single's Executor
+            ambWith.subscribeInternal(signalOffloader.offloadSubscriber(
+                    // If the other Single delivers the result, we should restore the context.
+                    contextProvider.wrapSingleSubscriber(ambWithSubscriber, contextMap)));
+        } catch (Throwable t) {
+            state.tryError(t);
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableAmbTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableAmbTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.internal.TerminalNotification;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.function.BiFunction;
+
+import static io.servicetalk.concurrent.api.Completable.amb;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+@RunWith(Parameterized.class)
+public class CompletableAmbTest {
+
+    private final TestCompletable first = new TestCompletable();
+    private final TestCompletable second = new TestCompletable();
+    private final TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
+    private final TestCancellable cancellable = new TestCancellable();
+
+    public CompletableAmbTest(final BiFunction<Completable, Completable, Completable> ambSupplier) {
+        toSource(ambSupplier.apply(first, second)).subscribe(subscriber);
+        assertThat("Cancellable not received.", subscriber.cancellableReceived(), is(true));
+        assertThat("First source not subscribed.", first.isSubscribed(), is(true));
+        assertThat("Second source not subscribed.", second.isSubscribed(), is(true));
+    }
+
+    @Parameterized.Parameters
+    public static Collection<BiFunction<Completable, Completable, Completable>> data() {
+        return asList(Completable::ambWith,
+                (first, second) -> amb(first, second),
+                (first, second) -> amb(asList(first, second)));
+    }
+
+    @Test
+    public void successFirst() {
+        sendSuccessToAndVerify(first);
+        verifyCancelled(second);
+    }
+
+    @Test
+    public void successSecond() {
+        sendSuccessToAndVerify(second);
+        verifyCancelled(first);
+    }
+
+    @Test
+    public void failFirst() {
+        sendErrorToAndVerify(first);
+        verifyCancelled(second);
+    }
+
+    @Test
+    public void failSecond() {
+        sendErrorToAndVerify(second);
+        verifyCancelled(first);
+    }
+
+    @Test
+    public void successFirstThenSecond() {
+        sendSuccessToAndVerify(first);
+        verifyCancelled(second);
+        second.onComplete();
+        verifyNoMoreResult();
+    }
+
+    @Test
+    public void successSecondThenFirst() {
+        sendSuccessToAndVerify(second);
+        verifyCancelled(first);
+        first.onComplete();
+        verifyNoMoreResult();
+    }
+
+    @Test
+    public void failFirstThenSecond() {
+        sendErrorToAndVerify(first);
+        verifyCancelled(second);
+        second.onError(DELIBERATE_EXCEPTION);
+        verifyNoMoreResult();
+    }
+
+    @Test
+    public void failSecondThenFirst() {
+        sendErrorToAndVerify(second);
+        verifyCancelled(first);
+        first.onError(DELIBERATE_EXCEPTION);
+        verifyNoMoreResult();
+    }
+
+    @Test
+    public void successFirstThenSecondFail() {
+        sendSuccessToAndVerify(first);
+        verifyCancelled(second);
+        second.onError(DELIBERATE_EXCEPTION);
+        verifyNoMoreResult();
+    }
+
+    @Test
+    public void successSecondThenFirstFail() {
+        sendSuccessToAndVerify(second);
+        verifyCancelled(first);
+        first.onError(DELIBERATE_EXCEPTION);
+        verifyNoMoreResult();
+    }
+
+    @Test
+    public void failFirstThenSecondSuccess() {
+        sendErrorToAndVerify(first);
+        verifyCancelled(second);
+        second.onComplete();
+        verifyNoMoreResult();
+    }
+
+    @Test
+    public void failSecondThenFirstSuccess() {
+        sendErrorToAndVerify(second);
+        verifyCancelled(first);
+        first.onComplete();
+        verifyNoMoreResult();
+    }
+
+    private void sendSuccessToAndVerify(final TestCompletable source) {
+        source.onComplete();
+        TerminalNotification term = subscriber.takeTerminal();
+        assertThat("Unexpected termination.", term, is(notNullValue()));
+        assertThat("Unexpected error termination.", term.cause(), is(nullValue()));
+    }
+
+    private void sendErrorToAndVerify(final TestCompletable source) {
+        source.onError(DELIBERATE_EXCEPTION);
+        TerminalNotification term = subscriber.takeTerminal();
+        assertThat("Unexpected termination.", term, is(notNullValue()));
+        assertThat("Unexpected error termination.", term.cause(), is(sameInstance(DELIBERATE_EXCEPTION)));
+    }
+
+    private void verifyCancelled(final TestCompletable other) {
+        other.onSubscribe(cancellable);
+        assertThat("Other source not cancelled.", cancellable.isCancelled(), is(true));
+    }
+
+    private void verifyNoMoreResult() {
+        TerminalNotification term = subscriber.takeTerminal();
+        assertThat("Unexpected termination.", term, is(nullValue()));
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbSubscribeThrowsTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbSubscribeThrowsTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.function.BiFunction;
+
+import static io.servicetalk.concurrent.api.Single.amb;
+import static io.servicetalk.concurrent.api.Single.defer;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+@RunWith(Parameterized.class)
+public class SingleAmbSubscribeThrowsTest {
+
+    private volatile boolean throwFromFirst;
+    private volatile boolean throwFromSecond;
+    private final TestSingle<Integer> first = new TestSingle<>();
+    private final TestSingle<Integer> second = new TestSingle<>();
+    private final TestCancellable cancellable = new TestCancellable();
+    private final TestSingleSubscriber<Integer> subscriber = new TestSingleSubscriber<>();
+    private final Single<Integer> amb;
+
+    public SingleAmbSubscribeThrowsTest(
+            final BiFunction<Single<Integer>, Single<Integer>, Single<Integer>> ambSupplier) {
+        amb = ambSupplier.apply(defer(() -> {
+            if (throwFromFirst) {
+                throw DELIBERATE_EXCEPTION;
+            }
+            return first;
+        }), defer(() -> {
+            if (throwFromSecond) {
+                throw DELIBERATE_EXCEPTION;
+            }
+            return second;
+        }));
+    }
+
+    @Parameterized.Parameters
+    public static Collection<BiFunction<Single<Integer>, Single<Integer>, Single<Integer>>> data() {
+        return asList(Single::ambWith,
+                (first, second) -> amb(first, second),
+                (first, second) -> amb(asList(first, second)));
+    }
+
+    @Test
+    public void firstSubscribeThrows() {
+        throwFromFirst = true;
+        subscribeToAmbAndVerifyFail();
+        second.onSubscribe(cancellable);
+        assertThat("Other source not cancelled.", cancellable.isCancelled(), is(true));
+
+        second.onSuccess(2);
+        verifyNoMoreResult();
+    }
+
+    @Test
+    public void secondSubscribeThrows() {
+        throwFromSecond = true;
+        subscribeToAmbAndVerifyFail();
+        first.onSubscribe(cancellable);
+        assertThat("Other source not cancelled.", cancellable.isCancelled(), is(true));
+
+        first.onSuccess(1);
+        verifyNoMoreResult();
+    }
+
+    private void subscribeToAmbAndVerifyFail() {
+        toSource(amb).subscribe(subscriber);
+        assertThat("Cancellable not received.", subscriber.cancellableReceived(), is(true));
+        assertThat("Unexpected error result.", subscriber.takeError(), is(sameInstance(DELIBERATE_EXCEPTION)));
+        assertThat("Unexpected result.", subscriber.takeResult(), is(nullValue()));
+    }
+
+    private void verifyNoMoreResult() {
+        assertThat("Unexpected error result.", subscriber.takeError(), is(nullValue()));
+        assertThat("Unexpected result.", subscriber.takeResult(), is(nullValue()));
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.function.BiFunction;
+
+import static io.servicetalk.concurrent.api.Single.amb;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+@RunWith(Parameterized.class)
+public class SingleAmbTest {
+
+    private final TestSingle<Integer> first = new TestSingle<>();
+    private final TestSingle<Integer> second = new TestSingle<>();
+    private final TestSingleSubscriber<Integer> subscriber = new TestSingleSubscriber<>();
+    private final TestCancellable cancellable = new TestCancellable();
+
+    public SingleAmbTest(final BiFunction<Single<Integer>, Single<Integer>, Single<Integer>> ambSupplier) {
+        toSource(ambSupplier.apply(first, second)).subscribe(subscriber);
+        assertThat("Cancellable not received.", subscriber.cancellableReceived(), is(true));
+        assertThat("First source not subscribed.", first.isSubscribed(), is(true));
+        assertThat("Second source not subscribed.", second.isSubscribed(), is(true));
+    }
+
+    @Parameterized.Parameters
+    public static Collection<BiFunction<Single<Integer>, Single<Integer>, Single<Integer>>> data() {
+        return asList(Single::ambWith,
+                (first, second) -> amb(first, second),
+                (first, second) -> amb(asList(first, second)));
+    }
+
+    @Test
+    public void successFirst() {
+        sendSuccessToAndVerify(first);
+        verifyCancelled(second);
+    }
+
+    @Test
+    public void successSecond() {
+        sendSuccessToAndVerify(second);
+        verifyCancelled(first);
+    }
+
+    @Test
+    public void failFirst() {
+        sendErrorToAndVerify(first);
+        verifyCancelled(second);
+    }
+
+    @Test
+    public void failSecond() {
+        sendErrorToAndVerify(second);
+        verifyCancelled(first);
+    }
+
+    @Test
+    public void successFirstThenSecond() {
+        sendSuccessToAndVerify(first);
+        verifyCancelled(second);
+        second.onSuccess(2);
+        verifyNoMoreResult();
+    }
+
+    @Test
+    public void successSecondThenFirst() {
+        sendSuccessToAndVerify(second);
+        verifyCancelled(first);
+        first.onSuccess(2);
+        verifyNoMoreResult();
+    }
+
+    @Test
+    public void failFirstThenSecond() {
+        sendErrorToAndVerify(first);
+        verifyCancelled(second);
+        second.onError(DELIBERATE_EXCEPTION);
+        verifyNoMoreResult();
+    }
+
+    @Test
+    public void failSecondThenFirst() {
+        sendErrorToAndVerify(second);
+        verifyCancelled(first);
+        first.onError(DELIBERATE_EXCEPTION);
+        verifyNoMoreResult();
+    }
+
+    @Test
+    public void successFirstThenSecondFail() {
+        sendSuccessToAndVerify(first);
+        verifyCancelled(second);
+        second.onError(DELIBERATE_EXCEPTION);
+        verifyNoMoreResult();
+    }
+
+    @Test
+    public void successSecondThenFirstFail() {
+        sendSuccessToAndVerify(second);
+        verifyCancelled(first);
+        first.onError(DELIBERATE_EXCEPTION);
+        verifyNoMoreResult();
+    }
+
+    @Test
+    public void failFirstThenSecondSuccess() {
+        sendErrorToAndVerify(first);
+        verifyCancelled(second);
+        second.onSuccess(2);
+        verifyNoMoreResult();
+    }
+
+    @Test
+    public void failSecondThenFirstSuccess() {
+        sendErrorToAndVerify(second);
+        verifyCancelled(first);
+        first.onSuccess(2);
+        verifyNoMoreResult();
+    }
+
+    private void sendSuccessToAndVerify(final TestSingle<Integer> source) {
+        source.onSuccess(1);
+        assertThat("Unexpected error result.", subscriber.takeError(), is(nullValue()));
+        assertThat("Unexpected result.", subscriber.takeResult(), is(1));
+    }
+
+    private void sendErrorToAndVerify(final TestSingle<Integer> source) {
+        source.onError(DELIBERATE_EXCEPTION);
+        assertThat("Unexpected error result.", subscriber.takeError(), is(sameInstance(DELIBERATE_EXCEPTION)));
+        assertThat("Unexpected result.", subscriber.takeResult(), is(nullValue()));
+    }
+
+    private void verifyCancelled(final TestSingle<Integer> other) {
+        other.onSubscribe(cancellable);
+        assertThat("Other source not cancelled.", cancellable.isCancelled(), is(true));
+    }
+
+    private void verifyNoMoreResult() {
+        assertThat("Unexpected error result.", subscriber.takeError(), is(nullValue()));
+        assertThat("Unexpected result.", subscriber.takeResult(), is(nullValue()));
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleAmbTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleAmbTckTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+import org.testng.annotations.Test;
+
+import static io.servicetalk.concurrent.api.Single.amb;
+import static io.servicetalk.concurrent.api.Single.never;
+import static io.servicetalk.concurrent.api.Single.succeeded;
+
+@Test
+public class SingleAmbTckTest extends AbstractSingleTckTest<Integer> {
+
+    @Override
+    public Publisher<Integer> createServiceTalkPublisher(long elements) {
+        return amb(succeeded(1), never()).toPublisher();
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleAmbWithTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleAmbWithTckTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Single;
+
+import org.testng.annotations.Test;
+
+import static io.servicetalk.concurrent.api.Single.never;
+
+@Test
+public class SingleAmbWithTckTest extends AbstractSingleOperatorTckTest<Integer> {
+
+    @Override
+    protected Single<Integer> composeSingle(Single<Integer> single) {
+        return single.ambWith(never());
+    }
+}


### PR DESCRIPTION
__Motivation__

[`amb`](http://reactivex.io/documentation/operators/amb.html) is a useful operator for trying multiple sources and using the first result. Few cases that are common;
- Use as a windowing scheme (number of items or time as window boundarirs)
- Backup/hedge requests for clients.

__Modification__

Use two flavors of these operators:

- Static factory where an arbitrary number of sources can be ambiguated.
- Operator to ambiguate a source with other.

__Result__

More operators, more fun!