### PR TITLE
AsyncContextInMemoryScopeManager to restore previous Scope on close()

### DIFF
--- a/servicetalk-opentracing-asynccontext/src/main/java/io/servicetalk/opentracing/asynccontext/AsyncContextInMemoryScopeManager.java
+++ b/servicetalk-opentracing-asynccontext/src/main/java/io/servicetalk/opentracing/asynccontext/AsyncContextInMemoryScopeManager.java
@@ -30,7 +30,7 @@ import static java.util.Objects.requireNonNull;
  * A {@link InMemoryScopeManager} that uses {@link AsyncContext} as the backing storage.
  */
 public final class AsyncContextInMemoryScopeManager implements InMemoryScopeManager {
-    private static final AsyncContextMap.Key<AsyncContextInMemoryScope> SCOPE_KEY = newKey("opentracing");
+    private static final AsyncContextMap.Key<InMemoryScope> SCOPE_KEY = newKey("opentracing");
     public static final InMemoryScopeManager SCOPE_MANAGER = new AsyncContextInMemoryScopeManager();
 
     private AsyncContextInMemoryScopeManager() {
@@ -54,11 +54,11 @@ public final class AsyncContextInMemoryScopeManager implements InMemoryScopeMana
 
     private static final class AsyncContextInMemoryScope implements InMemoryScope {
         @Nullable
-        private final AsyncContextInMemoryScope previousScope;
+        private final InMemoryScope previousScope;
         private final InMemorySpan span;
         private final boolean finishSpanOnClose;
 
-        AsyncContextInMemoryScope(@Nullable AsyncContextInMemoryScope previousScope,
+        AsyncContextInMemoryScope(@Nullable InMemoryScope previousScope,
                                   InMemorySpan span, boolean finishSpanOnClose) {
             this.previousScope = previousScope;
             this.span = requireNonNull(span);

--- a/servicetalk-opentracing-asynccontext/src/test/java/io/servicetalk/opentracing/asynccontext/AsyncContextInMemoryScopeManagerTest.java
+++ b/servicetalk-opentracing-asynccontext/src/test/java/io/servicetalk/opentracing/asynccontext/AsyncContextInMemoryScopeManagerTest.java
@@ -30,10 +30,16 @@ import static org.mockito.MockitoAnnotations.initMocks;
 public class AsyncContextInMemoryScopeManagerTest {
     @Mock
     private InMemorySpan mockSpan;
+    @Mock
+    private InMemorySpan mockSpan2;
 
     @Before
     public void setup() {
         initMocks(this);
+        InMemoryScope previousScope = SCOPE_MANAGER.active();
+        if (previousScope != null) {
+            previousScope.close();
+        }
     }
 
     @Test
@@ -46,11 +52,12 @@ public class AsyncContextInMemoryScopeManagerTest {
     }
 
     @Test
-    public void closedScopeReturnedByActiveOrClosed() {
+    public void previousScopeRestoredAfterCurrentScopeClosed() {
+        InMemoryScope previousScope = SCOPE_MANAGER.activate(mockSpan2, true);
         InMemoryScope scope = SCOPE_MANAGER.activate(mockSpan, true);
         assertSame(scope, SCOPE_MANAGER.active());
         assertSame(mockSpan, scope.span());
         scope.close();
-        assertSame(scope, SCOPE_MANAGER.currentScope());
+        assertSame(previousScope, SCOPE_MANAGER.active());
     }
 }

--- a/servicetalk-opentracing-http/build.gradle
+++ b/servicetalk-opentracing-http/build.gradle
@@ -31,11 +31,15 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
+  testImplementation testFixtures(project(":servicetalk-log4j2-mdc-utils"))
   testImplementation project(":servicetalk-buffer-netty")
   testImplementation project(":servicetalk-data-jackson")
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-opentracing-asynccontext")
   testImplementation project(":servicetalk-test-resources")
+  testImplementation project(":servicetalk-opentracing-log4j2")
+  testImplementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+  testImplementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
   testImplementation "junit:junit:$junitVersion"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/AbstractTracingHttpFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/AbstractTracingHttpFilter.java
@@ -55,7 +55,7 @@ abstract class AbstractTracingHttpFilter {
         this.formatter = traceStateFormatter(validateTraceKeyFormat);
     }
 
-    class ScopeTracker implements TerminalSignalConsumer {
+    static class ScopeTracker implements TerminalSignalConsumer {
 
         protected final Scope currentScope;
         @Nullable

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilter.java
@@ -46,10 +46,11 @@ import static io.opentracing.tag.Tags.SPAN_KIND_CLIENT;
  * An HTTP filter that supports open tracing.
  * <p>
  * Append this filter before others that are expected to to see {@link Scope} for this request/response. Filters
- * appended after this filter that use operators with the <strong>after*</strong> prefix on the
- * {@link StreamingHttpResponse#transformRawPayloadBody(UnaryOperator) response payload body} (e.g.
- * {@link Publisher#afterFinally(Runnable)}) will execute after this filter invokes {@link Scope#close()} and therefore
- * will not see the {@link Span} for the current request/response.
+ * appended after this filter that use operators with the <strong>after*</strong> prefix on
+ * {@link io.servicetalk.http.api.StreamingHttpClient#request(StreamingHttpRequest) response meta data} or the
+ * {@link StreamingHttpResponse#transformRawPayloadBody(UnaryOperator) response payload body}
+ * (e.g. {@link Publisher#afterFinally(Runnable)}) will execute after this filter invokes {@link Scope#close()} and
+ * therefore will not see the {@link Span} for the current request/response.
  */
 public class TracingHttpRequesterFilter extends AbstractTracingHttpFilter
         implements StreamingHttpClientFilterFactory, StreamingHttpConnectionFilterFactory,

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilter.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.opentracing.http;
 
+import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
@@ -34,6 +35,8 @@ import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.Tracer.SpanBuilder;
 
+import java.util.function.UnaryOperator;
+
 import static io.opentracing.tag.Tags.HTTP_METHOD;
 import static io.opentracing.tag.Tags.HTTP_URL;
 import static io.opentracing.tag.Tags.SPAN_KIND;
@@ -41,6 +44,12 @@ import static io.opentracing.tag.Tags.SPAN_KIND_CLIENT;
 
 /**
  * An HTTP filter that supports open tracing.
+ * <p>
+ * Append this filter before others that are expected to to see {@link Scope} for this request/response. Filters
+ * appended after this filter that use operators with the <strong>after*</strong> prefix on the
+ * {@link StreamingHttpResponse#transformRawPayloadBody(UnaryOperator) response payload body} (e.g.
+ * {@link Publisher#afterFinally(Runnable)}) will execute after this filter invokes {@link Scope#close()} and therefore
+ * will not see the {@link Span} for the current request/response.
  */
 public class TracingHttpRequesterFilter extends AbstractTracingHttpFilter
         implements StreamingHttpClientFilterFactory, StreamingHttpConnectionFilterFactory,

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpServiceFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpServiceFilter.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.opentracing.http;
 
+import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpResponseMetaData;
@@ -27,9 +28,11 @@ import io.servicetalk.http.api.StreamingHttpServiceFilter;
 import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
 
 import io.opentracing.Scope;
+import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 
+import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
 
 import static io.opentracing.Tracer.SpanBuilder;
@@ -40,6 +43,12 @@ import static io.opentracing.tag.Tags.SPAN_KIND_SERVER;
 
 /**
  * A {@link StreamingHttpService} that supports open tracing.
+ * <p>
+ * Append this filter before others that are expected to see {@link Scope} for this request/response. Filters appended
+ * after this filter that use operators with the <strong>after*</strong> prefix on the
+ * {@link StreamingHttpResponse#transformRawPayloadBody(UnaryOperator) response payload body} (e.g.
+ * {@link Publisher#afterFinally(Runnable)}) will execute after this filter invokes {@link Scope#close()} and therefore
+ * will not see the {@link Span} for the current request/response.
  */
 public class TracingHttpServiceFilter extends AbstractTracingHttpFilter implements StreamingHttpServiceFilterFactory {
 

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpServiceFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpServiceFilter.java
@@ -44,11 +44,12 @@ import static io.opentracing.tag.Tags.SPAN_KIND_SERVER;
 /**
  * A {@link StreamingHttpService} that supports open tracing.
  * <p>
- * Append this filter before others that are expected to see {@link Scope} for this request/response. Filters appended
- * after this filter that use operators with the <strong>after*</strong> prefix on the
- * {@link StreamingHttpResponse#transformRawPayloadBody(UnaryOperator) response payload body} (e.g.
- * {@link Publisher#afterFinally(Runnable)}) will execute after this filter invokes {@link Scope#close()} and therefore
- * will not see the {@link Span} for the current request/response.
+ * Append this filter before others that are expected to to see {@link Scope} for this request/response. Filters
+ * appended after this filter that use operators with the <strong>after*</strong> prefix on
+ * {@link StreamingHttpService#handle(HttpServiceContext, StreamingHttpRequest, StreamingHttpResponseFactory)
+ * response meta data} or the {@link StreamingHttpResponse#transformRawPayloadBody(UnaryOperator) response payload body}
+ * (e.g. {@link Publisher#afterFinally(Runnable)}) will execute after this filter invokes {@link Scope#close()} and
+ * therefore will not see the {@link Span} for the current request/response.
  */
 public class TracingHttpServiceFilter extends AbstractTracingHttpFilter implements StreamingHttpServiceFilterFactory {
 

--- a/servicetalk-opentracing-http/src/test/resources/log4j2-test.xml
+++ b/servicetalk-opentracing-http/src/test/resources/log4j2-test.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="info">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d %30t traceId=%X{traceId} spanId=%X{spanId} parentSpanId=%X{parentSpanId} [%-5level] %-30logger{1} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger name="io.netty" level="info"/>
+    <Root level="debug">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/servicetalk-opentracing-log4j2/src/main/java/io/servicetalk/opentracing/log4j2/ServiceTalkTracingThreadContextMap.java
+++ b/servicetalk-opentracing-log4j2/src/main/java/io/servicetalk/opentracing/log4j2/ServiceTalkTracingThreadContextMap.java
@@ -58,21 +58,21 @@ public final class ServiceTalkTracingThreadContextMap extends ServiceTalkThreadC
         // isEmpty() may return true, but then get(..) may return elements from the trace.
         switch (key) {
             case TRACE_ID_KEY: {
-                InMemoryScope scope = SCOPE_MANAGER.currentScope();
+                InMemoryScope scope = SCOPE_MANAGER.active();
                 if (scope != null) {
                     return scope.span().traceIdHex();
                 }
                 break;
             }
             case SPAN_ID_KEY: {
-                InMemoryScope scope = SCOPE_MANAGER.currentScope();
+                InMemoryScope scope = SCOPE_MANAGER.active();
                 if (scope != null) {
                     return scope.span().spanIdHex();
                 }
                 break;
             }
             case PARENT_SPAN_ID_KEY: {
-                InMemoryScope scope = SCOPE_MANAGER.currentScope();
+                InMemoryScope scope = SCOPE_MANAGER.active();
                 if (scope != null) {
                     return scope.span().nonnullParentSpanIdHex();
                 }
@@ -91,7 +91,7 @@ public final class ServiceTalkTracingThreadContextMap extends ServiceTalkThreadC
 
     private static boolean containsTracingKey(String key) {
         if (TRACE_ID_KEY.equals(key) || SPAN_ID_KEY.equals(key) || PARENT_SPAN_ID_KEY.equals(key)) {
-            InMemoryScope scope = SCOPE_MANAGER.currentScope();
+            InMemoryScope scope = SCOPE_MANAGER.active();
             return scope != null;
         }
         return false;
@@ -99,7 +99,7 @@ public final class ServiceTalkTracingThreadContextMap extends ServiceTalkThreadC
 
     @Override
     protected Map<String, String> getCopy(Map<String, String> storage) {
-        return getCopy(storage, SCOPE_MANAGER.currentScope());
+        return getCopy(storage, SCOPE_MANAGER.active());
     }
 
     private Map<String, String> getCopy(Map<String, String> storage, @Nullable InMemoryScope scope) {
@@ -115,7 +115,7 @@ public final class ServiceTalkTracingThreadContextMap extends ServiceTalkThreadC
     @Nullable
     @Override
     protected Map<String, String> getImmutableMapOrNull(Map<String, String> storage) {
-        InMemoryScope scope = SCOPE_MANAGER.currentScope();
+        InMemoryScope scope = SCOPE_MANAGER.active();
         if (storage.isEmpty() && scope == null) {
             return null;
         }
@@ -128,7 +128,7 @@ public final class ServiceTalkTracingThreadContextMap extends ServiceTalkThreadC
 
     @Override
     public boolean isEmpty() {
-        return super.isEmpty() && SCOPE_MANAGER.currentScope() == null;
+        return super.isEmpty() && SCOPE_MANAGER.active() == null;
     }
 
     @Override
@@ -167,7 +167,7 @@ public final class ServiceTalkTracingThreadContextMap extends ServiceTalkThreadC
 
             @Override
             public Map<String, String> toMap() {
-                return getCopy(storage, SCOPE_MANAGER.currentScope());
+                return getCopy(storage, SCOPE_MANAGER.active());
             }
 
             @Override
@@ -178,7 +178,7 @@ public final class ServiceTalkTracingThreadContextMap extends ServiceTalkThreadC
             @SuppressWarnings("unchecked")
             @Override
             public <V> void forEach(BiConsumer<String, ? super V> action) {
-                InMemoryScope scope = SCOPE_MANAGER.currentScope();
+                InMemoryScope scope = SCOPE_MANAGER.active();
                 if (scope != null) {
                     InMemorySpan span = scope.span();
                     action.accept(TRACE_ID_KEY, (V) span.traceIdHex());
@@ -191,7 +191,7 @@ public final class ServiceTalkTracingThreadContextMap extends ServiceTalkThreadC
             @SuppressWarnings("unchecked")
             @Override
             public <V, S> void forEach(TriConsumer<String, ? super V, S> action, S state) {
-                InMemoryScope scope = SCOPE_MANAGER.currentScope();
+                InMemoryScope scope = SCOPE_MANAGER.active();
                 if (scope != null) {
                     InMemorySpan span = scope.span();
                     action.accept(TRACE_ID_KEY, (V) span.traceIdHex(), state);
@@ -206,21 +206,21 @@ public final class ServiceTalkTracingThreadContextMap extends ServiceTalkThreadC
             public <V> V getValue(String key) {
                 switch (key) {
                     case TRACE_ID_KEY: {
-                        InMemoryScope scope = SCOPE_MANAGER.currentScope();
+                        InMemoryScope scope = SCOPE_MANAGER.active();
                         if (scope != null) {
                             return (V) scope.span().traceIdHex();
                         }
                         break;
                     }
                     case SPAN_ID_KEY: {
-                        InMemoryScope scope = SCOPE_MANAGER.currentScope();
+                        InMemoryScope scope = SCOPE_MANAGER.active();
                         if (scope != null) {
                             return (V) scope.span().spanIdHex();
                         }
                         break;
                     }
                     case PARENT_SPAN_ID_KEY: {
-                        InMemoryScope scope = SCOPE_MANAGER.currentScope();
+                        InMemoryScope scope = SCOPE_MANAGER.active();
                         if (scope != null) {
                             return (V) scope.span().nonnullParentSpanIdHex();
                         }
@@ -234,12 +234,12 @@ public final class ServiceTalkTracingThreadContextMap extends ServiceTalkThreadC
 
             @Override
             public boolean isEmpty() {
-                return storage.isEmpty() && SCOPE_MANAGER.currentScope() == null;
+                return storage.isEmpty() && SCOPE_MANAGER.active() == null;
             }
 
             @Override
             public int size() {
-                InMemoryScope scope = SCOPE_MANAGER.currentScope();
+                InMemoryScope scope = SCOPE_MANAGER.active();
                 return scope != null ? storage.size() + 3 : storage.size();
             }
         };

--- a/servicetalk-opentracing-log4j2/src/test/java/io/servicetalk/opentracing/log4j2/ServiceTalkTracingThreadContextMapTest.java
+++ b/servicetalk-opentracing-log4j2/src/test/java/io/servicetalk/opentracing/log4j2/ServiceTalkTracingThreadContextMapTest.java
@@ -20,6 +20,7 @@ import io.servicetalk.opentracing.inmemory.DefaultInMemoryTracer;
 import io.servicetalk.opentracing.inmemory.api.InMemoryScope;
 import io.servicetalk.opentracing.inmemory.api.InMemorySpan;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -36,6 +37,11 @@ public class ServiceTalkTracingThreadContextMapTest {
     @Before
     public void setup() {
         LoggerStringWriter.reset();
+    }
+
+    @After
+    public void tearDown() {
+        LoggerStringWriter.remove();
     }
 
     @Test


### PR DESCRIPTION
Motivation:
AsyncContextInMemoryScopeManager currently doesn't restore the previous
Scope when the current Scope is closed. This behavior is provided for
ThreadLocalScope and allows users to use try-with-resources type
constructs to create sub-spans more easily.

Modifications:
- AsyncContextInMemoryScopeManager to save/restore the previous Scope
when a new Scope is activated
- AsyncContextInMemoryScopeManager to remove the currentScope() hack so
lifetime of Scopes is more narrowly/correctly constrainted. This means
that filter ordering is important and use of after* operators should be
done with care!

Result:
AsyncContextInMemoryScopeManager has more consistent behavior with
ThreadLocalScope, and lifetimes of Scopes are more narrowly/correctly
constrainted.