### PR TITLE
Change when* operators to before* instead of after*

### DIFF
--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/SpScPublisherProcessorTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/SpScPublisherProcessorTest.java
@@ -119,7 +119,7 @@ public class SpScPublisherProcessorTest {
 
     @Test
     public void onNextThrows() {
-        toSource(publisher.whenOnNext(i -> {
+        toSource(publisher.afterOnNext(i -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(subscriber);
         subscriber.request(1);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -144,7 +144,7 @@ public abstract class Completable {
      * @see #afterOnComplete(Runnable)
      */
     public final Completable whenOnComplete(Runnable onComplete) {
-        return afterOnComplete(onComplete);
+        return beforeOnComplete(onComplete);
     }
 
     /**
@@ -173,7 +173,7 @@ public abstract class Completable {
      * @see #afterOnError(Consumer)
      */
     public final Completable whenOnError(Consumer<Throwable> onError) {
-        return afterOnError(onError);
+        return beforeOnError(onError);
     }
 
     /**
@@ -212,7 +212,7 @@ public abstract class Completable {
      * @see #afterFinally(Runnable)
      */
     public final Completable whenFinally(Runnable doFinally) {
-        return afterFinally(doFinally);
+        return beforeFinally(doFinally);
     }
 
     /**
@@ -251,7 +251,7 @@ public abstract class Completable {
      * @see #afterFinally(TerminalSignalConsumer)
      */
     public final Completable whenFinally(TerminalSignalConsumer doFinally) {
-        return afterFinally(doFinally);
+        return beforeFinally(doFinally);
     }
 
     /**
@@ -268,7 +268,7 @@ public abstract class Completable {
      * @see #afterCancel(Runnable)
      */
     public final Completable whenCancel(Runnable onCancel) {
-        return afterCancel(onCancel);
+        return beforeCancel(onCancel);
     }
 
     /**
@@ -878,7 +878,7 @@ public abstract class Completable {
      * @see #afterOnSubscribe(Consumer)
      */
     public final Completable whenOnSubscribe(Consumer<Cancellable> onSubscribe) {
-        return afterOnSubscribe(onSubscribe);
+        return beforeOnSubscribe(onSubscribe);
     }
 
     /**
@@ -1025,7 +1025,7 @@ public abstract class Completable {
      * @return The new {@link Completable}.
      */
     public final Completable whenSubscriber(Supplier<? extends Subscriber> subscriberSupplier) {
-        return afterSubscriber(subscriberSupplier);
+        return beforeSubscriber(subscriberSupplier);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -575,7 +575,7 @@ public abstract class Publisher<T> {
      * @see #afterOnNext(Consumer)
      */
     public final Publisher<T> whenOnSubscribe(Consumer<? super Subscription> onSubscribe) {
-        return afterOnSubscribe(onSubscribe);
+        return beforeOnSubscribe(onSubscribe);
     }
 
     /**
@@ -601,7 +601,7 @@ public abstract class Publisher<T> {
      * @see #afterOnNext(Consumer)
      */
     public final Publisher<T> whenOnNext(Consumer<? super T> onNext) {
-        return afterOnNext(onNext);
+        return beforeOnNext(onNext);
     }
 
     /**
@@ -626,7 +626,7 @@ public abstract class Publisher<T> {
      * @see #afterOnComplete(Runnable)
      */
     public final Publisher<T> whenOnComplete(Runnable onComplete) {
-        return afterOnComplete(onComplete);
+        return beforeOnComplete(onComplete);
     }
 
     /**
@@ -655,7 +655,7 @@ public abstract class Publisher<T> {
      * @see #afterOnError(Consumer)
      */
     public final Publisher<T> whenOnError(Consumer<Throwable> onError) {
-        return afterOnError(onError);
+        return beforeOnError(onError);
     }
 
     /**
@@ -694,7 +694,7 @@ public abstract class Publisher<T> {
      * @see #afterFinally(Runnable)
      */
     public final Publisher<T> whenFinally(Runnable doFinally) {
-        return afterFinally(doFinally);
+        return beforeFinally(doFinally);
     }
 
     /**
@@ -733,7 +733,7 @@ public abstract class Publisher<T> {
      * @see #afterFinally(TerminalSignalConsumer)
      */
     public final Publisher<T> whenFinally(TerminalSignalConsumer doFinally) {
-        return afterFinally(doFinally);
+        return beforeFinally(doFinally);
     }
 
     /**
@@ -746,7 +746,7 @@ public abstract class Publisher<T> {
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX do operator.</a>
      */
     public final Publisher<T> whenRequest(LongConsumer onRequest) {
-        return afterRequest(onRequest);
+        return beforeRequest(onRequest);
     }
 
     /**
@@ -762,7 +762,7 @@ public abstract class Publisher<T> {
      * @see #afterCancel(Runnable)
      */
     public final Publisher<T> whenCancel(Runnable onCancel) {
-        return afterCancel(onCancel);
+        return beforeCancel(onCancel);
     }
 
     /**
@@ -1809,7 +1809,7 @@ public abstract class Publisher<T> {
      *  @return The new {@link Publisher}.
      */
     public final Publisher<T> whenSubscriber(Supplier<? extends Subscriber<? super T>> subscriberSupplier) {
-        return afterSubscriber(subscriberSupplier);
+        return beforeSubscriber(subscriberSupplier);
     }
 
     /**
@@ -1841,7 +1841,7 @@ public abstract class Publisher<T> {
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX do operator.</a>
      */
     public final Publisher<T> whenSubscription(Supplier<? extends Subscription> subscriptionSupplier) {
-        return afterSubscription(subscriptionSupplier);
+        return beforeSubscription(subscriptionSupplier);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -226,7 +226,7 @@ public abstract class Single<T> {
      * @see #afterOnSuccess(Consumer)
      */
     public final Single<T> whenOnSuccess(Consumer<? super T> onSuccess) {
-        return afterOnSuccess(onSuccess);
+        return beforeOnSuccess(onSuccess);
     }
 
     /**
@@ -254,7 +254,7 @@ public abstract class Single<T> {
      * @see #afterOnError(Consumer)
      */
     public final Single<T> whenOnError(Consumer<Throwable> onError) {
-        return afterOnError(onError);
+        return beforeOnError(onError);
     }
 
     /**
@@ -293,7 +293,7 @@ public abstract class Single<T> {
      * @see #afterFinally(Runnable)
      */
     public final Single<T> whenFinally(Runnable doFinally) {
-        return afterFinally(doFinally);
+        return beforeFinally(doFinally);
     }
 
     /**
@@ -333,7 +333,7 @@ public abstract class Single<T> {
      * @see #afterFinally(TerminalSignalConsumer)
      */
     public final Single<T> whenFinally(TerminalSignalConsumer<T> doFinally) {
-        return afterFinally(doFinally);
+        return beforeFinally(doFinally);
     }
 
     /**
@@ -350,7 +350,7 @@ public abstract class Single<T> {
      * @see #afterCancel(Runnable)
      */
     public final Single<T> whenCancel(Runnable onCancel) {
-        return afterCancel(onCancel);
+        return beforeCancel(onCancel);
     }
 
     /**
@@ -793,7 +793,7 @@ public abstract class Single<T> {
      * @see #afterOnSubscribe(Consumer)
      */
     public final Single<T> whenOnSubscribe(Consumer<Cancellable> onSubscribe) {
-        return afterOnSubscribe(onSubscribe);
+        return beforeOnSubscribe(onSubscribe);
     }
 
     /**
@@ -939,7 +939,7 @@ public abstract class Single<T> {
      * @return The new {@link Single}.
      */
     public final Single<T> whenSubscriber(Supplier<? extends Subscriber<? super T>> subscriberSupplier) {
-        return afterSubscriber(subscriberSupplier);
+        return beforeSubscriber(subscriberSupplier);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherConcatMapIterableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherConcatMapIterableTest.java
@@ -244,7 +244,7 @@ public class PublisherConcatMapIterableTest {
     @Test
     public void exceptionFromOnErrorIsPropagated() {
         toSource(publisher.flatMapConcatIterable(identity())
-                .whenOnError(t -> {
+                .afterOnError(t -> {
                     throw DELIBERATE_EXCEPTION;
                 })).subscribe(subscriber);
         assertTrue(subscriber.subscriptionReceived());
@@ -285,7 +285,7 @@ public class PublisherConcatMapIterableTest {
     @Test
     public void exceptionFromOnCompleteIsPropagated() {
         toSource(publisher.flatMapConcatIterable(identity())
-                .whenOnComplete(() -> {
+                .afterOnComplete(() -> {
                     throw DELIBERATE_EXCEPTION;
                 })).subscribe(subscriber);
         assertTrue(subscriber.subscriptionReceived());

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromInMemoryPublisherAbstractTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromInMemoryPublisherAbstractTest.java
@@ -98,7 +98,7 @@ public abstract class FromInMemoryPublisherAbstractTest {
     public void testRequestPostError() {
         String[] values = {"Hello", null};
         InMemorySource source = newPublisher(immediate(), values);
-        toSource(source.publisher().whenOnNext(n -> {
+        toSource(source.publisher().afterOnNext(n -> {
             if (n == null) {
                 throw DELIBERATE_EXCEPTION;
             }
@@ -155,7 +155,7 @@ public abstract class FromInMemoryPublisherAbstractTest {
     @Test
     public void testCancelFromInOnNext() {
         InMemorySource source = newSource(2);
-        toSource(source.publisher().whenOnNext(n -> {
+        toSource(source.publisher().afterOnNext(n -> {
             subscriber.cancel();
         })).subscribe(subscriber);
         subscriber.request(1);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromSingleItemPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromSingleItemPublisherTest.java
@@ -35,7 +35,7 @@ public class FromSingleItemPublisherTest {
 
     @Test
     public void exceptionInTerminalCallsOnError() {
-        toSource(from("foo").whenOnNext(n -> {
+        toSource(from("foo").afterOnNext(n -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(subscriber);
         subscriber.request(1);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToPublisherTest.java
@@ -122,7 +122,7 @@ public class SingleToPublisherTest {
 
     @Test
     public void exceptionInTerminalCallsOnError() {
-        toSource(Single.succeeded("Hello").toPublisher().whenOnNext(n -> {
+        toSource(Single.succeeded("Hello").toPublisher().afterOnNext(n -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(verifier);
         // The mock behavior must be applied after subscribe, because a new mock is created as part of this process.

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerBinder.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerBinder.java
@@ -122,7 +122,7 @@ public final class TcpServerBinder {
                                     // subscribeOn is required to offload calls to connectionAcceptor#accept
                                     .subscribeOn(executionContext.executor()));
                 }
-                connectionSingle.afterOnError(cause -> {
+                connectionSingle.beforeOnError(cause -> {
                     // Getting the remote-address may involve volatile reads and potentially a syscall, so guard it.
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug("Failed to create a connection for remote address {}", channel.remoteAddress(),

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerBinder.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerBinder.java
@@ -122,7 +122,7 @@ public final class TcpServerBinder {
                                     // subscribeOn is required to offload calls to connectionAcceptor#accept
                                     .subscribeOn(executionContext.executor()));
                 }
-                connectionSingle.whenOnError(cause -> {
+                connectionSingle.afterOnError(cause -> {
                     // Getting the remote-address may involve volatile reads and potentially a syscall, so guard it.
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug("Failed to create a connection for remote address {}", channel.remoteAddress(),


### PR DESCRIPTION
Motivation:
The when* operators provide call backs to take action when that action
isn't sensitive to execution order. The current implementation of the
when* operators uses after* semantics, despite the order being explicitly
undefiend by the API. The after* semantics may result in user code
executing in unexpected times, espeically when local state is involved.
For example tracing filters utilize AsyncContext and trigger the state
cleanup on the response payload Publisher termination. This filter must
be appended first in order for the trace information to be initialized
correctly and if any subsequent filters apply a payload Publisher
transformation with after* semantics the terminal methods will be
invoked after the tracing Scope has been closed. If subsequent operators
use before* semantics they will not be subject to this ordering issue.

Modifications:
- Change Publisher, Single, Completable when* operators to use before*
semantics instead of after* semantics.

Result:
when* operators use before* semantics to reduce the risk that local
state managed outside the scope of the operator flow is cleaned up when
user code executes.