### PR TITLE
`RoundRobinLoadBalancer` should compose connection closure with error response

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -277,18 +277,17 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
                     // Invoke the selector before adding the connection to the pool, otherwise, connection can be used
                     // concurrently and hence a new connection can be rejected by the selector.
                     if (!selector.test(newCnx)) {
-                        newCnx.closeAsync().subscribe();
                         // Failure in selection could be temporary, hence add it to the queue and be consistent with the
                         // fact that select failure does not close a connection.
-                        return failed(new ConnectionRejectedException("Newly created connection " + newCnx +
-                                " rejected by the selection filter."));
+                        return newCnx.closeAsync().concat(failed(new ConnectionRejectedException(
+                                "Newly created connection " + newCnx + " rejected by the selection filter.")));
                     }
                     if (host.addConnection(newCnx)) {
                         // If the LB has closed, we attempt to remove the connection, if the removal succeeds, close it.
                         // If we can't remove it, it means it's been removed concurrently and we assume that whoever
                         // removed it also closed it or that it has been removed as a consequence of closing.
+                        boolean needClose = false;
                         if (closed) {
-
                             List<C> existing = connections;
                             for (;;) {
                                 if (existing == Host.INACTIVE) {
@@ -299,18 +298,20 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
                                     break;
                                 }
                                 if (Host.connectionsUpdater.compareAndSet(host, existing, connectionRemoved)) {
-                                    newCnx.closeAsync().subscribe();
+                                    needClose = true;
                                     break;
                                 }
                                 existing = connections;
                             }
 
-                            return failed(new IllegalStateException("LoadBalancer has closed"));
+                            final Single<C> lbClosed = failed(new IllegalStateException("LoadBalancer has closed"));
+                            return needClose ? newCnx.closeAsync().concat(lbClosed) : lbClosed;
                         }
                         return succeeded(newCnx);
                     }
-                    return failed(new ConnectionRejectedException("Failed to add newly created connection for host: " +
-                            host.address + ", host inactive? " + (host.connections == Host.INACTIVE)));
+                    return newCnx.closeAsync().concat(failed(new ConnectionRejectedException(
+                            "Failed to add newly created connection for host: " + host.address + ", host inactive? " +
+                                    (host.connections == Host.INACTIVE))));
                 });
     }
 
@@ -386,7 +387,6 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
             for (;;) {
                 List<C> existing = this.connections;
                 if (existing == INACTIVE) {
-                    connection.closeAsync().subscribe();
                     return false;
                 }
                 ArrayList<C> connectionAdded = new ArrayList<>(existing);

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -1,4 +1,4 @@
-    /*
+/*
  * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+    /*
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.servicetalk.loadbalancer;
 
 import io.servicetalk.client.api.ConnectionFactory;
+import io.servicetalk.client.api.ConnectionRejectedException;
 import io.servicetalk.client.api.DefaultServiceDiscovererEvent;
 import io.servicetalk.client.api.LoadBalancedConnection;
 import io.servicetalk.client.api.LoadBalancerReadyEvent;
@@ -72,18 +73,21 @@ import static io.servicetalk.concurrent.internal.ServiceTalkTestTimeout.DEFAULT_
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toSet;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -98,10 +102,10 @@ public class RoundRobinLoadBalancerTest {
     public final LegacyMockedSingleListenerRule<TestLoadBalancedConnection> selectConnectionListener =
             new LegacyMockedSingleListenerRule<>();
 
-    private final TestPublisher<ServiceDiscovererEvent<String>> serviceDiscoveryPublisher = new TestPublisher<>();
     private final List<TestLoadBalancedConnection> connectionsCreated = new CopyOnWriteArrayList<>();
     private final Queue<Runnable> connectionRealizers = new ConcurrentLinkedQueue<>();
 
+    private TestPublisher<ServiceDiscovererEvent<String>> serviceDiscoveryPublisher = new TestPublisher<>();
     private RoundRobinLoadBalancer<String, TestLoadBalancedConnection> lb;
     private DelegatingConnectionFactory connectionFactory;
 
@@ -384,6 +388,22 @@ public class RoundRobinLoadBalancerTest {
     public void closeClosesConnectionFactory() throws Exception {
         awaitIndefinitely(lb.closeAsync());
         assertTrue("ConnectionFactory not closed.", connectionFactory.isClosed());
+    }
+
+    @Test
+    public void newConnectionIsClosedWhenSelectorRejects() throws Exception {
+        sendServiceDiscoveryEvents(upEvent("address-1"));
+        try {
+            awaitIndefinitely(lb.selectConnection(__ -> false));
+            fail();
+        } catch (ExecutionException e) {
+            assertThat(e.getCause(), is(instanceOf(ConnectionRejectedException.class)));
+        }
+        assertThat(connectionsCreated, hasSize(1));
+        TestLoadBalancedConnection connection = connectionsCreated.get(0);
+        assertThat(connection, is(notNullValue()));
+        assertThat(connection.address(), is(equalTo("address-1")));
+        awaitIndefinitely(connection.onClose());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Motivation:

Dangling subscribes is usually a bad idea. As RRLB is not composing the
subscribe, it will still keep closing the connection after it returns a failure.
Worse if the closure does not complete, it will keep this subscribe around
forever (and so the resources associated with the subscribe).

Modification:

- Compose new connection closure with the `Single.failed` returned from
`flatMap`;
- Add a test to verify that new connection is closed if it's rejected by
selector;

Result:

A new connection is closed before RRLB fails the returned `Single` from
`selectConnection`.