### PR TITLE
Rename BeforeFinallyOnHttpResponseOperator to BeforeFinallyHttpOperator

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
@@ -29,7 +29,7 @@ import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
-import io.servicetalk.http.utils.BeforeFinallyOnHttpResponseOperator;
+import io.servicetalk.http.utils.BeforeFinallyHttpOperator;
 
 import java.util.function.Predicate;
 
@@ -66,7 +66,7 @@ final class LoadBalancedStreamingHttpClient implements FilterableStreamingHttpCl
         // correct.
         return loadBalancer.selectConnection(SELECTOR_FOR_REQUEST)
                 .flatMap(c -> c.request(strategy, request)
-                        .liftSync(new BeforeFinallyOnHttpResponseOperator(new TerminalSignalConsumer() {
+                        .liftSync(new BeforeFinallyHttpOperator(new TerminalSignalConsumer() {
                             @Override
                             public void onComplete() {
                                 c.requestFinished();

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
@@ -53,16 +53,15 @@ import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
  *     // coarse grained, any terminal signal calls the provided `Runnable`
  *     return requester.request(strategy, request)
  *                     .beforeOnSubscribe(__ -> tracker.requestStarted())
- *                     .liftSync(new BeforeFinallyOnHttpResponseOperator(tracker::requestFinished));
+ *                     .liftSync(new BeforeFinallyHttpOperator(tracker::requestFinished));
  *
  *     // fine grained, `tracker` implements `TerminalSignalConsumer`, terminal signal indicated by the callback method
  *     return requester.request(strategy, request)
  *                     .beforeOnSubscribe(__ -> tracker.requestStarted())
- *                     .liftSync(new BeforeFinallyOnHttpResponseOperator(tracker));
+ *                     .liftSync(new BeforeFinallyHttpOperator(tracker));
  * }</pre>
  */
-public final class BeforeFinallyOnHttpResponseOperator
-        implements SingleOperator<StreamingHttpResponse, StreamingHttpResponse> {
+public final class BeforeFinallyHttpOperator implements SingleOperator<StreamingHttpResponse, StreamingHttpResponse> {
 
     private final TerminalSignalConsumer beforeFinally;
 
@@ -72,7 +71,7 @@ public final class BeforeFinallyOnHttpResponseOperator
      * @param beforeFinally the callback which is executed just once whenever the sources reach a terminal state
      * across both sources.
      */
-    public BeforeFinallyOnHttpResponseOperator(final TerminalSignalConsumer beforeFinally) {
+    public BeforeFinallyHttpOperator(final TerminalSignalConsumer beforeFinally) {
         this.beforeFinally = requireNonNull(beforeFinally);
     }
 
@@ -82,7 +81,7 @@ public final class BeforeFinallyOnHttpResponseOperator
      * @param beforeFinally the callback which is executed just once whenever the sources reach a terminal state
      * across both sources.
      */
-    public BeforeFinallyOnHttpResponseOperator(final Runnable beforeFinally) {
+    public BeforeFinallyHttpOperator(final Runnable beforeFinally) {
         this(new RunnableTerminalSignalConsumer(beforeFinally));
     }
 

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/BeforeFinallyHttpOperatorTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/BeforeFinallyHttpOperatorTest.java
@@ -61,7 +61,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(MockitoJUnitRunner.class)
-public class BeforeFinallyOnHttpResponseOperatorTest {
+public class BeforeFinallyHttpOperatorTest {
     private static final BufferAllocator allocator = DEFAULT_ALLOCATOR;
     private static final StreamingHttpRequestResponseFactory reqRespFactory =
             new DefaultStreamingHttpRequestResponseFactory(allocator, DefaultHttpHeadersFactory.INSTANCE, HTTP_1_1);
@@ -77,7 +77,7 @@ public class BeforeFinallyOnHttpResponseOperatorTest {
 
     @Before
     public void setUp() {
-        operator = new BeforeFinallyOnHttpResponseOperator(beforeFinally);
+        operator = new BeforeFinallyHttpOperator(beforeFinally);
     }
 
     @Test

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/AbstractTracingHttpFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/AbstractTracingHttpFilter.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.api.TerminalSignalConsumer;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.StreamingHttpResponse;
-import io.servicetalk.http.utils.BeforeFinallyOnHttpResponseOperator;
+import io.servicetalk.http.utils.BeforeFinallyHttpOperator;
 import io.servicetalk.opentracing.inmemory.api.InMemoryTraceStateFormat;
 
 import io.opentracing.Scope;
@@ -106,8 +106,8 @@ abstract class AbstractTracingHttpFilter {
         }
 
         Single<StreamingHttpResponse> track(Single<StreamingHttpResponse> responseSingle) {
-            return responseSingle.liftSync(new BeforeFinallyOnHttpResponseOperator(this))
-                    // BeforeFinallyOnHttpResponseOperator conditionally outputs a Single<Meta> with a failed
+            return responseSingle.liftSync(new BeforeFinallyHttpOperator(this))
+                    // BeforeFinallyHttpOperator conditionally outputs a Single<Meta> with a failed
                     // Publisher<Data> instead of the real Publisher<Data> in case a cancel signal is observed before
                     // completion of Meta. So in order for downstream operators to get a consistent view of the data
                     // path beforeOnSuccess() needs to be applied last.


### PR DESCRIPTION
Motivation:
BeforeFinallyOnHttpResponseOperator include the 'On' terminology which
doesn't make sense in this context as the event name doesn't include
'On' (e.g. onSubscribe). The 'Response' component can also be dropped to
simplify the naming.

Modifications:
- Rename BeforeFinallyOnHttpResponseOperator to
BeforeFinallyHttpOperator

Result:
More concise naming of BeforeFinallyHttpOperator.