### PR TITLE
Promote Single.TerminalSignalConsumer to top level interface

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AfterFinallySingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AfterFinallySingle.java
@@ -23,9 +23,9 @@ import static java.util.Objects.requireNonNull;
 
 final class AfterFinallySingle<T> extends AbstractSynchronousSingleOperator<T, T> {
 
-    private final TerminalSignalConsumer<T> doFinally;
+    private final SingleTerminalSignalConsumer<T> doFinally;
 
-    AfterFinallySingle(Single<T> original, TerminalSignalConsumer<T> doFinally, Executor executor) {
+    AfterFinallySingle(Single<T> original, SingleTerminalSignalConsumer<T> doFinally, Executor executor) {
         super(original, executor);
         this.doFinally = requireNonNull(doFinally);
     }
@@ -37,14 +37,14 @@ final class AfterFinallySingle<T> extends AbstractSynchronousSingleOperator<T, T
 
     private static final class AfterFinallySingleSubscriber<T> implements Subscriber<T> {
         private final Subscriber<? super T> original;
-        private final TerminalSignalConsumer<T> doFinally;
+        private final SingleTerminalSignalConsumer<T> doFinally;
 
         private static final AtomicIntegerFieldUpdater<AfterFinallySingleSubscriber> doneUpdater =
                 AtomicIntegerFieldUpdater.newUpdater(AfterFinallySingleSubscriber.class, "done");
         @SuppressWarnings("unused")
         private volatile int done;
 
-        AfterFinallySingleSubscriber(Subscriber<? super T> original, TerminalSignalConsumer<T> doFinally) {
+        AfterFinallySingleSubscriber(Subscriber<? super T> original, SingleTerminalSignalConsumer<T> doFinally) {
             this.original = original;
             this.doFinally = doFinally;
         }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BeforeFinallySingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BeforeFinallySingle.java
@@ -23,9 +23,9 @@ import static java.util.Objects.requireNonNull;
 
 final class BeforeFinallySingle<T> extends AbstractSynchronousSingleOperator<T, T> {
 
-    private final TerminalSignalConsumer<T> doFinally;
+    private final SingleTerminalSignalConsumer<T> doFinally;
 
-    BeforeFinallySingle(Single<T> original, TerminalSignalConsumer<T> doFinally, Executor executor) {
+    BeforeFinallySingle(Single<T> original, SingleTerminalSignalConsumer<T> doFinally, Executor executor) {
         super(original, executor);
         this.doFinally = requireNonNull(doFinally);
     }
@@ -37,14 +37,14 @@ final class BeforeFinallySingle<T> extends AbstractSynchronousSingleOperator<T, 
 
     private static final class BeforeFinallySingleSubscriber<T> implements Subscriber<T> {
         private final Subscriber<? super T> original;
-        private final TerminalSignalConsumer<T> doFinally;
+        private final SingleTerminalSignalConsumer<T> doFinally;
 
         private static final AtomicIntegerFieldUpdater<BeforeFinallySingleSubscriber> doneUpdater =
                 AtomicIntegerFieldUpdater.newUpdater(BeforeFinallySingleSubscriber.class, "done");
         @SuppressWarnings("unused")
         private volatile int done;
 
-        BeforeFinallySingleSubscriber(Subscriber<? super T> original, TerminalSignalConsumer<T> doFinally) {
+        BeforeFinallySingleSubscriber(Subscriber<? super T> original, SingleTerminalSignalConsumer<T> doFinally) {
             this.original = original;
             this.doFinally = doFinally;
         }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RunnableSingleTerminalSignalConsumer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RunnableSingleTerminalSignalConsumer.java
@@ -19,10 +19,6 @@ import javax.annotation.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
-/**
- * A {@link SingleTerminalSignalConsumer} where each method executes a {@link Runnable#run()}.
- * @param <T> Type of the result of the {@link Single}.
- */
 final class RunnableSingleTerminalSignalConsumer<T> implements SingleTerminalSignalConsumer<T> {
     private final Runnable onFinally;
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RunnableSingleTerminalSignalConsumer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RunnableSingleTerminalSignalConsumer.java
@@ -15,24 +15,23 @@
  */
 package io.servicetalk.concurrent.api;
 
+import javax.annotation.Nullable;
+
 import static java.util.Objects.requireNonNull;
 
 /**
- * A {@link TerminalSignalConsumer} where each method executes a {@link Runnable#run()}.
+ * A {@link SingleTerminalSignalConsumer} where each method executes a {@link Runnable#run()}.
+ * @param <T> Type of the result of the {@link Single}.
  */
-public final class RunnableTerminalSignalConsumer implements TerminalSignalConsumer {
+final class RunnableSingleTerminalSignalConsumer<T> implements SingleTerminalSignalConsumer<T> {
     private final Runnable onFinally;
 
-    /**
-     * Create a new instance.
-     * @param onFinally The {@link Runnable} to run for each method.
-     */
-    public RunnableTerminalSignalConsumer(final Runnable onFinally) {
+    RunnableSingleTerminalSignalConsumer(final Runnable onFinally) {
         this.onFinally = requireNonNull(onFinally);
     }
 
     @Override
-    public void onComplete() {
+    public void onSuccess(@Nullable final T result) {
         onFinally.run();
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RunnableTerminalSignalConsumer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RunnableTerminalSignalConsumer.java
@@ -17,17 +17,10 @@ package io.servicetalk.concurrent.api;
 
 import static java.util.Objects.requireNonNull;
 
-/**
- * A {@link TerminalSignalConsumer} where each method executes a {@link Runnable#run()}.
- */
-public final class RunnableTerminalSignalConsumer implements TerminalSignalConsumer {
+final class RunnableTerminalSignalConsumer implements TerminalSignalConsumer {
     private final Runnable onFinally;
 
-    /**
-     * Create a new instance.
-     * @param onFinally The {@link Runnable} to run for each method.
-     */
-    public RunnableTerminalSignalConsumer(final Runnable onFinally) {
+    RunnableTerminalSignalConsumer(final Runnable onFinally) {
         this.onFinally = requireNonNull(onFinally);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -297,18 +297,20 @@ public abstract class Single<T> {
     }
 
     /**
-     * Invokes the corresponding method on {@code whenFinally} {@link TerminalSignalConsumer} argument when any of the
-     * following terminal methods are called:
+     * Invokes the corresponding method on {@code whenFinally} {@link SingleTerminalSignalConsumer} argument when any
+     * of the following terminal methods are called:
      * <ul>
-     *     <li>{@link Subscriber#onSuccess(Object)} - invokes {@link TerminalSignalConsumer#onSuccess(Object)}</li>
-     *     <li>{@link Subscriber#onError(Throwable)} - invokes {@link TerminalSignalConsumer#onError(Throwable)}</li>
-     *     <li>{@link Cancellable#cancel()} - invokes {@link TerminalSignalConsumer#cancel()}</li>
+     *     <li>{@link Subscriber#onSuccess(Object)} - invokes
+     *     {@link SingleTerminalSignalConsumer#onSuccess(Object)}</li>
+     *     <li>{@link Subscriber#onError(Throwable)} - invokes
+     *     {@link SingleTerminalSignalConsumer#onError(Throwable)}</li>
+     *     <li>{@link Cancellable#cancel()} - invokes {@link SingleTerminalSignalConsumer#cancel()}</li>
      * </ul>
      * for Subscriptions/{@link Subscriber}s of the returned {@link Single}.
      * <p>
      * The order in which {@code whenFinally} will be invoked relative to the above methods is undefined. If you need
-     * strict ordering see {@link #beforeFinally(TerminalSignalConsumer)} and
-     * {@link #afterFinally(TerminalSignalConsumer)}.
+     * strict ordering see {@link #beforeFinally(SingleTerminalSignalConsumer)} and
+     * {@link #afterFinally(SingleTerminalSignalConsumer)}.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -327,12 +329,12 @@ public abstract class Single<T> {
      * }</pre>
      *
      * @param doFinally For each subscribe of the returned {@link Single}, at most one method of this
-     * {@link TerminalSignalConsumer} will be invoked.
+     * {@link SingleTerminalSignalConsumer} will be invoked.
      * @return The new {@link Single}.
-     * @see #beforeFinally(TerminalSignalConsumer)
-     * @see #afterFinally(TerminalSignalConsumer)
+     * @see #beforeFinally(SingleTerminalSignalConsumer)
+     * @see #afterFinally(SingleTerminalSignalConsumer)
      */
-    public final Single<T> whenFinally(TerminalSignalConsumer<T> doFinally) {
+    public final Single<T> whenFinally(SingleTerminalSignalConsumer<T> doFinally) {
         return beforeFinally(doFinally);
     }
 
@@ -714,16 +716,18 @@ public abstract class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX do operator.</a>
      */
     public final Single<T> beforeFinally(Runnable doFinally) {
-        return beforeFinally(new RunnableTerminalSignalConsumer<>(doFinally));
+        return beforeFinally(new RunnableSingleTerminalSignalConsumer<>(doFinally));
     }
 
     /**
-     * Invokes the corresponding method on {@code beforeFinally} {@link TerminalSignalConsumer} argument
+     * Invokes the corresponding method on {@code beforeFinally} {@link SingleTerminalSignalConsumer} argument
      * <strong>before</strong> any of the following terminal methods are called:
      * <ul>
-     *     <li>{@link Subscriber#onSuccess(Object)} - invokes {@link TerminalSignalConsumer#onSuccess(Object)}</li>
-     *     <li>{@link Subscriber#onError(Throwable)} - invokes {@link TerminalSignalConsumer#onError(Throwable)}</li>
-     *     <li>{@link Cancellable#cancel()} - invokes {@link TerminalSignalConsumer#cancel()}</li>
+     *     <li>{@link Subscriber#onSuccess(Object)} - invokes
+     *     {@link SingleTerminalSignalConsumer#onSuccess(Object)}</li>
+     *     <li>{@link Subscriber#onError(Throwable)} - invokes
+     *     {@link SingleTerminalSignalConsumer#onError(Throwable)}</li>
+     *     <li>{@link Cancellable#cancel()} - invokes {@link SingleTerminalSignalConsumer#cancel()}</li>
      * </ul>
      * for Subscriptions/{@link Subscriber}s of the returned {@link Single}.
      * <p>
@@ -742,11 +746,11 @@ public abstract class Single<T> {
      * }</pre>
      *
      * @param doFinally For each subscribe of the returned {@link Single}, at most one method of this
-     * {@link TerminalSignalConsumer} will be invoked.
+     * {@link SingleTerminalSignalConsumer} will be invoked.
      * @return The new {@link Single}.
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX do operator.</a>
      */
-    public final Single<T> beforeFinally(TerminalSignalConsumer<T> doFinally) {
+    public final Single<T> beforeFinally(SingleTerminalSignalConsumer<T> doFinally) {
         return new BeforeFinallySingle<>(this, doFinally, executor);
     }
 
@@ -878,16 +882,18 @@ public abstract class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX do operator.</a>
      */
     public final Single<T> afterFinally(Runnable doFinally) {
-        return afterFinally(new RunnableTerminalSignalConsumer<>(doFinally));
+        return afterFinally(new RunnableSingleTerminalSignalConsumer<>(doFinally));
     }
 
     /**
-     * Invokes the corresponding method on {@code afterFinally} {@link TerminalSignalConsumer} argument
+     * Invokes the corresponding method on {@code afterFinally} {@link SingleTerminalSignalConsumer} argument
      * <strong>after</strong> any of the following terminal methods are called:
      * <ul>
-     *     <li>{@link Subscriber#onSuccess(Object)} - invokes {@link TerminalSignalConsumer#onSuccess(Object)}</li>
-     *     <li>{@link Subscriber#onError(Throwable)} - invokes {@link TerminalSignalConsumer#onError(Throwable)}</li>
-     *     <li>{@link Cancellable#cancel()} - invokes {@link TerminalSignalConsumer#cancel()}</li>
+     *     <li>{@link Subscriber#onSuccess(Object)} - invokes
+     *     {@link SingleTerminalSignalConsumer#onSuccess(Object)}</li>
+     *     <li>{@link Subscriber#onError(Throwable)} - invokes
+     *     {@link SingleTerminalSignalConsumer#onError(Throwable)}</li>
+     *     <li>{@link Cancellable#cancel()} - invokes {@link SingleTerminalSignalConsumer#cancel()}</li>
      * </ul>
      * for Subscriptions/{@link Subscriber}s of the returned {@link Single}.
      * <p>
@@ -906,11 +912,11 @@ public abstract class Single<T> {
      * }</pre>
      *
      * @param doFinally For each subscribe of the returned {@link Single}, at most one method of this
-     * {@link TerminalSignalConsumer} will be invoked.
+     * {@link SingleTerminalSignalConsumer} will be invoked.
      * @return The new {@link Single}.
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX do operator.</a>
      */
-    public final Single<T> afterFinally(TerminalSignalConsumer<T> doFinally) {
+    public final Single<T> afterFinally(SingleTerminalSignalConsumer<T> doFinally) {
         return new AfterFinallySingle<>(this, doFinally, executor);
     }
 
@@ -1753,55 +1759,4 @@ public abstract class Single<T> {
     //
     // Internal Methods End
     //
-
-    /**
-     * A contract that provides discrete callbacks for various ways in which a {@link SingleSource.Subscriber} can
-     * terminate.
-     *
-     * @param <T> Type of the result of the {@link Single}.
-     */
-    public interface TerminalSignalConsumer<T> {
-
-        /**
-         * Callback to indicate termination via {@link Subscriber#onSuccess(Object)}.
-         *
-         * @param result the observed result of type {@link T}.
-         */
-        void onSuccess(@Nullable T result);
-
-        /**
-         * Callback to indicate termination via {@link Subscriber#onError(Throwable)}.
-         *
-         * @param throwable the observed {@link Throwable}.
-         */
-        void onError(Throwable throwable);
-
-        /**
-         * Callback to indicate termination via {@link Cancellable#cancel()}.
-         */
-        void cancel();
-    }
-
-    private static final class RunnableTerminalSignalConsumer<T> implements TerminalSignalConsumer<T> {
-        private final Runnable onFinally;
-
-        RunnableTerminalSignalConsumer(final Runnable onFinally) {
-            this.onFinally = requireNonNull(onFinally);
-        }
-
-        @Override
-        public void onSuccess(@Nullable final T result) {
-            onFinally.run();
-        }
-
-        @Override
-        public void onError(final Throwable throwable) {
-            onFinally.run();
-        }
-
-        @Override
-        public void cancel() {
-            onFinally.run();
-        }
-    }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleTerminalSignalConsumer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleTerminalSignalConsumer.java
@@ -45,4 +45,14 @@ public interface SingleTerminalSignalConsumer<T> {
      * Callback to indicate termination via {@link Cancellable#cancel()}.
      */
     void cancel();
+
+    /**
+     * Create a {@link SingleTerminalSignalConsumer} where each method executes a {@link Runnable#run()}.
+     * @param runnable The {@link Runnable} which is invoked in each method of the returned
+     * {@link SingleTerminalSignalConsumer}.
+     * @return a {@link SingleTerminalSignalConsumer} where each method executes a {@link Runnable#run()}.
+     */
+    static <X> SingleTerminalSignalConsumer<X> from(Runnable runnable) {
+        return new RunnableSingleTerminalSignalConsumer<>(runnable);
+    }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleTerminalSignalConsumer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleTerminalSignalConsumer.java
@@ -50,6 +50,7 @@ public interface SingleTerminalSignalConsumer<T> {
      * Create a {@link SingleTerminalSignalConsumer} where each method executes a {@link Runnable#run()}.
      * @param runnable The {@link Runnable} which is invoked in each method of the returned
      * {@link SingleTerminalSignalConsumer}.
+     * @param <X> The type of {@link SingleTerminalSignalConsumer}.
      * @return a {@link SingleTerminalSignalConsumer} where each method executes a {@link Runnable#run()}.
      */
     static <X> SingleTerminalSignalConsumer<X> from(Runnable runnable) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleTerminalSignalConsumer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleTerminalSignalConsumer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.SingleSource;
+
+import javax.annotation.Nullable;
+
+/**
+ * A contract that provides discrete callbacks for various ways in which a {@link SingleSource.Subscriber} can
+ * terminate.
+ *
+ * @param <T> Type of the result of the {@link Single}.
+ */
+public interface SingleTerminalSignalConsumer<T> {
+    /**
+     * Callback to indicate termination via {@link SingleSource.Subscriber#onSuccess(Object)}.
+     *
+     * @param result the observed result of type {@link T}.
+     */
+    void onSuccess(@Nullable T result);
+
+    /**
+     * Callback to indicate termination via {@link SingleSource.Subscriber#onError(Throwable)}.
+     *
+     * @param throwable the observed {@link Throwable}.
+     */
+    void onError(Throwable throwable);
+
+    /**
+     * Callback to indicate termination via {@link Cancellable#cancel()}.
+     */
+    void cancel();
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TerminalSignalConsumer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TerminalSignalConsumer.java
@@ -24,7 +24,6 @@ import io.servicetalk.concurrent.PublisherSource;
  * {@link CompletableSource.Subscriber} can terminate.
  */
 public interface TerminalSignalConsumer {
-
     /**
      * Callback to indicate termination via {@link PublisherSource.Subscriber#onComplete()} or
      * {@link CompletableSource.Subscriber#onComplete()}.
@@ -43,4 +42,14 @@ public interface TerminalSignalConsumer {
      * Callback to indicate termination via {@link Cancellable#cancel()}.
      */
     void cancel();
+
+    /**
+     * Create a {@link TerminalSignalConsumer} where each method executes a {@link Runnable#run()}.
+     * @param runnable The {@link Runnable} which is invoked in each method of the returned
+     * {@link TerminalSignalConsumer}.
+     * @return a {@link TerminalSignalConsumer} where each method executes a {@link Runnable#run()}.
+     */
+    static TerminalSignalConsumer from(Runnable runnable) {
+        return new RunnableTerminalSignalConsumer(runnable);
+    }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenFinallyTest.java
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api.single;
 import io.servicetalk.concurrent.api.LegacyMockedSingleListenerRule;
 import io.servicetalk.concurrent.api.LegacyTestSingle;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.concurrent.api.Single.TerminalSignalConsumer;
+import io.servicetalk.concurrent.api.SingleTerminalSignalConsumer;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,7 +44,7 @@ abstract class AbstractWhenFinallyTest {
     public final ExpectedException thrown = ExpectedException.none();
 
     @SuppressWarnings("unchecked")
-    private final TerminalSignalConsumer<String> doFinally = mock(TerminalSignalConsumer.class);
+    private final SingleTerminalSignalConsumer<String> doFinally = mock(SingleTerminalSignalConsumer.class);
 
     @Test
     public void testForCancel() {
@@ -90,7 +90,7 @@ abstract class AbstractWhenFinallyTest {
 
     @Test
     public void testCallbackThrowsErrorOnCancel() {
-        TerminalSignalConsumer<String> mock = throwableMock(DELIBERATE_EXCEPTION);
+        SingleTerminalSignalConsumer<String> mock = throwableMock(DELIBERATE_EXCEPTION);
         LegacyTestSingle<String> single = new LegacyTestSingle<>();
         try {
             listener.listen(doFinally(single, mock));
@@ -110,11 +110,11 @@ abstract class AbstractWhenFinallyTest {
     @Test
     public abstract void testCallbackThrowsErrorOnError();
 
-    protected abstract <T> Single<T> doFinally(Single<T> single, TerminalSignalConsumer<T> signalConsumer);
+    protected abstract <T> Single<T> doFinally(Single<T> single, SingleTerminalSignalConsumer<T> signalConsumer);
 
     @SuppressWarnings("unchecked")
-    protected TerminalSignalConsumer<String> throwableMock(RuntimeException exception) {
-        return mock(TerminalSignalConsumer.class, delegatesTo(new TerminalSignalConsumer<String>() {
+    protected SingleTerminalSignalConsumer<String> throwableMock(RuntimeException exception) {
+        return mock(SingleTerminalSignalConsumer.class, delegatesTo(new SingleTerminalSignalConsumer<String>() {
             @Override
             public void onSuccess(@Nullable final String result) {
                 throw exception;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterFinallyTest.java
@@ -16,7 +16,7 @@
 package io.servicetalk.concurrent.api.single;
 
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.concurrent.api.Single.TerminalSignalConsumer;
+import io.servicetalk.concurrent.api.SingleTerminalSignalConsumer;
 import io.servicetalk.concurrent.internal.DeliberateException;
 
 import org.junit.Test;
@@ -27,14 +27,14 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class AfterFinallyTest extends AbstractWhenFinallyTest {
     @Override
-    protected <T> Single<T> doFinally(Single<T> single, TerminalSignalConsumer<T> doFinally) {
+    protected <T> Single<T> doFinally(Single<T> single, SingleTerminalSignalConsumer<T> doFinally) {
         return single.afterFinally(doFinally);
     }
 
     @Test
     @Override
     public void testCallbackThrowsErrorOnSuccess() {
-        TerminalSignalConsumer<String> mock = throwableMock(DELIBERATE_EXCEPTION);
+        SingleTerminalSignalConsumer<String> mock = throwableMock(DELIBERATE_EXCEPTION);
         String result = "Hello";
         listener.listen(doFinally(Single.succeeded(result), mock))
                 .verifySuccess(result);
@@ -45,7 +45,7 @@ public class AfterFinallyTest extends AbstractWhenFinallyTest {
     @Test
     @Override
     public void testCallbackThrowsErrorOnError() {
-        TerminalSignalConsumer<String> mock = throwableMock(new DeliberateException());
+        SingleTerminalSignalConsumer<String> mock = throwableMock(new DeliberateException());
         listener.listen(doFinally(Single.failed(DELIBERATE_EXCEPTION), mock))
                 .verifyFailure(DELIBERATE_EXCEPTION);
         verify(mock).onError(DELIBERATE_EXCEPTION);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeFinallyTest.java
@@ -16,7 +16,7 @@
 package io.servicetalk.concurrent.api.single;
 
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.concurrent.api.Single.TerminalSignalConsumer;
+import io.servicetalk.concurrent.api.SingleTerminalSignalConsumer;
 import io.servicetalk.concurrent.internal.DeliberateException;
 
 import org.junit.Test;
@@ -27,14 +27,14 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class BeforeFinallyTest extends AbstractWhenFinallyTest {
     @Override
-    protected <T> Single<T> doFinally(Single<T> single, TerminalSignalConsumer<T> doFinally) {
+    protected <T> Single<T> doFinally(Single<T> single, SingleTerminalSignalConsumer<T> doFinally) {
         return single.beforeFinally(doFinally);
     }
 
     @Test
     @Override
     public void testCallbackThrowsErrorOnSuccess() {
-        TerminalSignalConsumer<String> mock = throwableMock(DELIBERATE_EXCEPTION);
+        SingleTerminalSignalConsumer<String> mock = throwableMock(DELIBERATE_EXCEPTION);
         String result = "Hello";
         listener.listen(doFinally(Single.succeeded(result), mock))
                 .verifyFailure(DELIBERATE_EXCEPTION);
@@ -46,7 +46,7 @@ public class BeforeFinallyTest extends AbstractWhenFinallyTest {
     @Override
     public void testCallbackThrowsErrorOnError() {
         DeliberateException exception = new DeliberateException();
-        TerminalSignalConsumer<String> mock = throwableMock(exception);
+        SingleTerminalSignalConsumer<String> mock = throwableMock(exception);
         listener.listen(doFinally(Single.failed(DELIBERATE_EXCEPTION), mock))
                 .verifyFailure(exception)
                 .verifySuppressedFailure(DELIBERATE_EXCEPTION);

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
@@ -20,7 +20,6 @@ import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.api.RunnableTerminalSignalConsumer;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.SingleOperator;
 import io.servicetalk.concurrent.api.TerminalSignalConsumer;
@@ -83,7 +82,7 @@ public final class BeforeFinallyHttpOperator implements SingleOperator<Streaming
      * across both sources.
      */
     public BeforeFinallyHttpOperator(final Runnable beforeFinally) {
-        this(new RunnableTerminalSignalConsumer(beforeFinally));
+        this(TerminalSignalConsumer.from(beforeFinally));
     }
 
     @Override

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.RunnableTerminalSignalConsumer;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.SingleOperator;
 import io.servicetalk.concurrent.api.TerminalSignalConsumer;
@@ -251,30 +252,6 @@ public final class BeforeFinallyHttpOperator implements SingleOperator<Streaming
         @Override
         public void onComplete() {
             // Ignore.
-        }
-    }
-
-    private static final class RunnableTerminalSignalConsumer implements TerminalSignalConsumer {
-
-        private final Runnable onFinally;
-
-        private RunnableTerminalSignalConsumer(Runnable onFinally) {
-            this.onFinally = requireNonNull(onFinally);
-        }
-
-        @Override
-        public void onComplete() {
-            onFinally.run();
-        }
-
-        @Override
-        public void onError(final Throwable throwable) {
-            onFinally.run();
-        }
-
-        @Override
-        public void cancel() {
-            onFinally.run();
         }
     }
 }


### PR DESCRIPTION
Motivation:
TerminalSignalConsumer for Completable and Publisher is a top level
type, but Single has an internal type for the same purpose. This makes
it more challenging to expose utilities classes in a consistent manner
and also may lead to naming collisions.

Modifications:
- Move Single.TerminalSignalConsumer to a top level interface and rename
to SingleTerminalSignalConsumer to avoid naming collisions.
- Expose RunnableTerminalSignalConsumer and re-use it in
BeforeFinallyOnHttpResponseOperator.

Result:
More consistent type definition scheme for TerminalSignalConsumer and
SingleTerminalSignalConsumer and ability to expose conversion/utility
methods outside the scope of the Source.