### PR TITLE
Add Publisher#flatMapMerge operator

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -189,8 +189,15 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Each element of this {@link Publisher} is mapped into a {@link Publisher} (potentially of a different type) and
-     * flatten all signals emitted from each mapped {@link Publisher} into the returned {@link Publisher}.
+     * Map each element of this {@link Publisher} into a {@link Publisher}&lt;{@link R}&gt; and flatten all signals
+     * emitted from each mapped {@link Publisher}&lt;{@link R}&gt; into the returned
+     * {@link Publisher}&lt;{@link R}&gt;.
+     * <p>
+     * To control the amount of concurrent processing done by this operator see
+     * {@link #flatMapMerge(Function, int, int)}.
+     * <p>
+     * This method is similar to {@link #map(Function)} but the result is an asynchronous stream, and provides a data
+     * transformation in sequential programming similar to:
      * <pre>{@code
      *     ExecutorService e = ...;
      *     List<Future<List<R>>> futures = ...; // assume this is thread safe
@@ -219,8 +226,12 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Each element of this {@link Publisher} is mapped into a {@link Publisher} (potentially of a different type) and
-     * flatten all signals emitted from each mapped {@link Publisher} into the returned {@link Publisher}.
+     * Map each element of this {@link Publisher} into a {@link Publisher}&lt;{@link R}&gt; and flatten all signals
+     * emitted from each mapped {@link Publisher}&lt;{@link R}&gt; into the returned
+     * {@link Publisher}&lt;{@link R}&gt;.
+     * <p>
+     * This method is similar to {@link #map(Function)} but the result is an asynchronous stream, and provides a data
+     * transformation in sequential programming similar to:
      * <pre>{@code
      *     ExecutorService e = ...;
      *     List<Future<List<R>>> futures = ...; // assume this is thread safe
@@ -252,12 +263,20 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Each element of this {@link Publisher} is mapped into a {@link Publisher} (potentially of a different type) and
-     * flatten all signals emitted from each mapped {@link Publisher} into the returned {@link Publisher}.
+     * Map each element of this {@link Publisher} into a {@link Publisher}&lt;{@link R}&gt; and flatten all signals
+     * emitted from each mapped {@link Publisher}&lt;{@link R}&gt; into the returned
+     * {@link Publisher}&lt;{@link R}&gt;.
+     * <p>
      * This is the same as {@link #flatMapMerge(Function)} just that if any mapped {@link Publisher} returned by
      * {@code mapper}, terminates with an error, the returned {@link Publisher} will not immediately terminate. Instead,
      * it will wait for this {@link Publisher} and all mapped {@link Publisher}s to terminate and then terminate the
      * returned {@link Publisher} with all errors emitted by the mapped {@link Publisher}s.
+     * <p>
+     * To control the amount of concurrent processing done by this operator see
+     * {@link #flatMapMergeDelayError(Function, int, int)}.
+     * <p>
+     * This method is similar to {@link #map(Function)} but the result is an asynchronous stream, and provides a data
+     * transformation in sequential programming similar to:
      * <pre>{@code
      *     Executor e = ...;
      *     List<T> tResults = resultOfThisPublisher();
@@ -294,12 +313,17 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Each element of this {@link Publisher} is mapped into a {@link Publisher} (potentially of a different type) and
-     * flatten all signals emitted from each mapped {@link Publisher} into the returned {@link Publisher}.
-     * This is the same as {@link #flatMapMerge(Function, int, int)} just that if any mapped {@link Publisher}
-     * returned by {@code mapper}, terminates with an error, the returned {@link Publisher} will not immediately
-     * terminate. Instead, it will wait for this {@link Publisher} and all mapped {@link Publisher}s to terminate and
-     * then terminate the returned {@link Publisher} with all errors emitted by the mapped {@link Publisher}s.
+     * Map each element of this {@link Publisher} into a {@link Publisher}&lt;{@link R}&gt; and flatten all signals
+     * emitted from each mapped {@link Publisher}&lt;{@link R}&gt; into the returned
+     * {@link Publisher}&lt;{@link R}&gt;.
+     * <p>
+     * This is the same as {@link #flatMapMerge(Function)} just that if any mapped {@link Publisher} returned by
+     * {@code mapper}, terminates with an error, the returned {@link Publisher} will not immediately terminate. Instead,
+     * it will wait for this {@link Publisher} and all mapped {@link Publisher}s to terminate and then terminate the
+     * returned {@link Publisher} with all errors emitted by the mapped {@link Publisher}s.
+     * <p>
+     * This method is similar to {@link #map(Function)} but the result is an asynchronous stream, and provides a data
+     * transformation in sequential programming similar to:
      * <pre>{@code
      *     Executor e = ...;
      *     List<T> tResults = resultOfThisPublisher();
@@ -339,8 +363,9 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Turns every item emitted by this {@link Publisher} into a {@link Single} and emits the items emitted by each of
-     * those {@link Single}s.
+     * Map each element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all signals
+     * emitted from each mapped {@link Single}&lt;{@link R}&gt; into the returned
+     * {@link Publisher}&lt;{@link R}&gt;.
      * <p>
      * To control the amount of concurrent processing done by this operator see
      * {@link #flatMapMergeSingle(Function, int)}.
@@ -377,8 +402,9 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Turns every item emitted by this {@link Publisher} into a {@link Single} and emits the items emitted by each of
-     * those {@link Single}s.
+     * Map each element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all signals
+     * emitted from each mapped {@link Single}&lt;{@link R}&gt; into the returned
+     * {@link Publisher}&lt;{@link R}&gt;.
      * <p>
      * This method is similar to {@link #map(Function)} but the result is asynchronous, and provides a data
      * transformation in sequential programming similar to:
@@ -415,8 +441,11 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Turns every item emitted by this {@link Publisher} into a {@link Single} and emits the items emitted by each of
-     * those {@link Single}s. This is the same as {@link #flatMapMergeSingle(Function, int)} just that if any
+     * Map each element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all signals
+     * emitted from each mapped {@link Single}&lt;{@link R}&gt; into the returned
+     * {@link Publisher}&lt;{@link R}&gt;.
+     * <p>
+     * The behavior is the same as {@link #flatMapMergeSingle(Function, int)} with the exception that if any
      * {@link Single} returned by {@code mapper}, terminates with an error, the returned {@link Publisher} will not
      * immediately terminate. Instead, it will wait for this {@link Publisher} and all {@link Single}s to terminate and
      * then terminate the returned {@link Publisher} with all errors emitted by the {@link Single}s produced by the
@@ -451,7 +480,7 @@ public abstract class Publisher<T> {
      *         return rResults;
      *     }
      *     createAndThrowACompositeException(errors);
-    * }</pre>
+     * }</pre>
      *
      * @param mapper {@link Function} to convert each item emitted by this {@link Publisher} into a {@link Single}.
      * @param <R> Type of items emitted by the returned {@link Publisher}.
@@ -466,8 +495,11 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Turns every item emitted by this {@link Publisher} into a {@link Single} and emits the items emitted by each of
-     * those {@link Single}s. This is the same as {@link #flatMapMergeSingle(Function, int)} just that if any
+     * Map each element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all signals
+     * emitted from each mapped {@link Single}&lt;{@link R}&gt; into the returned
+     * {@link Publisher}&lt;{@link R}&gt;.
+     * <p>
+     * The behavior is the same as {@link #flatMapMergeSingle(Function, int)} with the exception that if any
      * {@link Single} returned by {@code mapper}, terminates with an error, the returned {@link Publisher} will not
      * immediately terminate. Instead, it will wait for this {@link Publisher} and all {@link Single}s to terminate and
      * then terminate the returned {@link Publisher} with all errors emitted by the {@link Single}s produced by the
@@ -516,10 +548,11 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Turns every item emitted by this {@link Publisher} into a {@link Completable} and terminate the returned
-     * {@link Completable} when all the intermediate {@link Completable}s have terminated successfully or any one of
-     * them has terminated with a failure.
-     * If the returned {@link Completable} should wait for the termination of all remaining {@link Completable}s when
+     * Map each element of this {@link Publisher} into a {@link Completable} and flatten all signals
+     * such that the returned {@link Completable} terminates when all mapped {@link Completable}s have terminated
+     * successfully or any one of them has terminated with a failure.
+     * <p>
+     * If the returned {@link Completable} should wait for the termination of all mapped {@link Completable}s when
      * any one of them terminates with a failure, {@link #flatMapCompletableDelayError(Function)} should be used.
      * <p>
      * To control the amount of concurrent processing done by this operator see
@@ -555,10 +588,11 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Turns every item emitted by this {@link Publisher} into a {@link Completable} and terminate the returned
-     * {@link Completable} when all the intermediate {@link Completable}s have terminated successfully or any one of
-     * them has terminated with a failure.
-     * If the returned {@link Completable} should wait for the termination of all remaining {@link Completable}s when
+     * Map each element of this {@link Publisher} into a {@link Completable} and flatten all signals
+     * such that the returned {@link Completable} terminates when all mapped {@link Completable}s have terminated
+     * successfully or any one of them has terminated with a failure.
+     * <p>
+     * If the returned {@link Completable} should wait for the termination of all mapped {@link Completable}s when
      * any one of them terminates with a failure, {@link #flatMapCompletableDelayError(Function)} should be used.
      * <p>
      * This method is similar to {@link #map(Function)} but the result is asynchronous, and provides a data
@@ -592,12 +626,12 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Turns every item emitted by this {@link Publisher} into a {@link Completable} and terminate the returned
-     * {@link Completable} when all the intermediate {@link Completable}s have terminated. If any {@link Completable}
-     * returned by {@code mapper}, terminates with an error, the returned {@link Completable} will not immediately
-     * terminate. Instead, it will wait for this {@link Publisher} and all {@link Completable}s to terminate and then
-     * terminate the returned {@link Completable} with all errors emitted by the {@link Completable}s produced by the
-     * {@code mapper}.
+     * Map each element of this {@link Publisher} into a {@link Completable} and flatten all signals
+     * such that the returned {@link Completable} terminates when all mapped {@link Completable}s have terminated
+     * successfully or any one of them has terminated with a failure.
+     * <p>
+     * If any mapped {@link Completable} terminates with an error the returned {@link Completable} will not immediately
+     * terminate. Instead, it will wait for this {@link Publisher} and all mapped {@link Completable}s to terminate.
      * <p>
      * To control the amount of concurrent processing done by this operator see
      * {@link #flatMapCompletableDelayError(Function, int)}.
@@ -638,12 +672,12 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Turns every item emitted by this {@link Publisher} into a {@link Completable} and terminate the returned
-     * {@link Completable} when all the intermediate {@link Completable}s have terminated.If any {@link Completable}
-     * returned by {@code mapper}, terminates with an error, the returned {@link Completable} will not immediately
-     * terminate. Instead, it will wait for this {@link Publisher} and all {@link Completable}s to terminate and then
-     * terminate the returned {@link Completable} with all errors emitted by the {@link Completable}s produced by the
-     * {@code mapper}.
+     * Map each element of this {@link Publisher} into a {@link Completable} and flatten all signals
+     * such that the returned {@link Completable} terminates when all mapped {@link Completable}s have terminated
+     * successfully or any one of them has terminated with a failure.
+     * <p>
+     * If any mapped {@link Completable} terminates with an error the returned {@link Completable} will not immediately
+     * terminate. Instead, it will wait for this {@link Publisher} and all mapped {@link Completable}s to terminate.
      * <p>
      * This method is similar to {@link #map(Function)} but the result is asynchronous, and provides a data
      * transformation in sequential programming similar to:

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -251,15 +251,15 @@ public abstract class Publisher<T> {
      * }</pre>
      * @param mapper Convert each item emitted by this {@link Publisher} into another {@link Publisher}.
      * @param maxConcurrency Maximum amount of outstanding upstream {@link Subscription#request(long) demand}.
-     * @param maxMappedDemandHint Hint for the maximum amount of {@link Subscription#request(long) demand} for
+     * @param minMappedDemandHint Hint for the minimum amount of {@link Subscription#request(long) demand} for
      * each mapped {@link Publisher}.
      * @param <R> The type of mapped {@link Publisher}.
      * @return A new {@link Publisher} which flattens the emissions from all mapped {@link Publisher}s.
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX flatMap operator.</a>
      */
     public final <R> Publisher<R> flatMapMerge(Function<? super T, ? extends Publisher<? extends R>> mapper,
-                                               int maxConcurrency, int maxMappedDemandHint) {
-        return new PublisherFlatMapMerge<>(this, mapper, false, maxConcurrency, maxMappedDemandHint, executor);
+                                               int maxConcurrency, int minMappedDemandHint) {
+        return new PublisherFlatMapMerge<>(this, mapper, false, maxConcurrency, minMappedDemandHint, executor);
     }
 
     /**
@@ -351,15 +351,15 @@ public abstract class Publisher<T> {
      * }</pre>
      * @param mapper Convert each item emitted by this {@link Publisher} into another {@link Publisher}.
      * @param maxConcurrency Maximum amount of outstanding upstream {@link Subscription#request(long) demand}.
-     * @param maxMappedDemandHint Hint for the maximum amount of {@link Subscription#request(long) demand} for
+     * @param minMappedDemandHint Hint for the minimum amount of {@link Subscription#request(long) demand} for
      * each mapped {@link Publisher}.
      * @param <R> The type of mapped {@link Publisher}.
      * @return A new {@link Publisher} which flattens the emissions from all mapped {@link Publisher}s.
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX flatMap operator.</a>
      */
     public final <R> Publisher<R> flatMapMergeDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper,
-                                                         int maxConcurrency, int maxMappedDemandHint) {
-        return new PublisherFlatMapMerge<>(this, mapper, true, maxConcurrency, maxMappedDemandHint, executor);
+                                                         int maxConcurrency, int minMappedDemandHint) {
+        return new PublisherFlatMapMerge<>(this, mapper, true, maxConcurrency, minMappedDemandHint, executor);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -193,8 +193,7 @@ public abstract class Publisher<T> {
      * emitted from each mapped {@link Publisher}&lt;{@link R}&gt; into the returned
      * {@link Publisher}&lt;{@link R}&gt;.
      * <p>
-     * To control the amount of concurrent processing done by this operator see
-     * {@link #flatMapMerge(Function, int, int)}.
+     * To control the amount of concurrent processing done by this operator see {@link #flatMapMerge(Function, int)}.
      * <p>
      * This method is similar to {@link #map(Function)} but the result is an asynchronous stream, and provides a data
      * transformation in sequential programming similar to:
@@ -251,15 +250,13 @@ public abstract class Publisher<T> {
      * }</pre>
      * @param mapper Convert each item emitted by this {@link Publisher} into another {@link Publisher}.
      * @param maxConcurrency Maximum amount of outstanding upstream {@link Subscription#request(long) demand}.
-     * @param minMappedDemandHint Hint for the minimum amount of {@link Subscription#request(long) demand} for
-     * each mapped {@link Publisher}.
      * @param <R> The type of mapped {@link Publisher}.
      * @return A new {@link Publisher} which flattens the emissions from all mapped {@link Publisher}s.
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX flatMap operator.</a>
      */
     public final <R> Publisher<R> flatMapMerge(Function<? super T, ? extends Publisher<? extends R>> mapper,
-                                               int maxConcurrency, int minMappedDemandHint) {
-        return new PublisherFlatMapMerge<>(this, mapper, false, maxConcurrency, minMappedDemandHint, executor);
+                                               int maxConcurrency) {
+        return new PublisherFlatMapMerge<>(this, mapper, false, maxConcurrency, executor);
     }
 
     /**
@@ -273,7 +270,7 @@ public abstract class Publisher<T> {
      * returned {@link Publisher} with all errors emitted by the mapped {@link Publisher}s.
      * <p>
      * To control the amount of concurrent processing done by this operator see
-     * {@link #flatMapMergeDelayError(Function, int, int)}.
+     * {@link #flatMapMergeDelayError(Function, int)}.
      * <p>
      * This method is similar to {@link #map(Function)} but the result is an asynchronous stream, and provides a data
      * transformation in sequential programming similar to:
@@ -351,15 +348,13 @@ public abstract class Publisher<T> {
      * }</pre>
      * @param mapper Convert each item emitted by this {@link Publisher} into another {@link Publisher}.
      * @param maxConcurrency Maximum amount of outstanding upstream {@link Subscription#request(long) demand}.
-     * @param minMappedDemandHint Hint for the minimum amount of {@link Subscription#request(long) demand} for
-     * each mapped {@link Publisher}.
      * @param <R> The type of mapped {@link Publisher}.
      * @return A new {@link Publisher} which flattens the emissions from all mapped {@link Publisher}s.
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX flatMap operator.</a>
      */
     public final <R> Publisher<R> flatMapMergeDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper,
-                                                         int maxConcurrency, int minMappedDemandHint) {
-        return new PublisherFlatMapMerge<>(this, mapper, true, maxConcurrency, minMappedDemandHint, executor);
+                                                         int maxConcurrency) {
+        return new PublisherFlatMapMerge<>(this, mapper, true, maxConcurrency, executor);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
@@ -110,7 +110,7 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
         private volatile int activeMappedSources;
         private volatile long pendingDemand;
 
-        // protected by emitting lock, or only accessed in side the Subscriber thread
+        // protected by emitting lock, or only accessed inside the Subscriber thread
         private boolean targetTerminated;
         private int upstreamDemand;
         @Nullable
@@ -126,7 +126,7 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
             this.target = target;
             // Start with a small capacity as maxConcurrency can be large.
             signals = newUnboundedMpscQueue(min(2, source.maxConcurrency * source.maxMappedDemand));
-            subscribers = newSetFromMap(new ConcurrentHashMap<>());
+            subscribers = newSetFromMap(new ConcurrentHashMap<>(min(16, source.maxConcurrency)));
         }
 
         @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
@@ -544,13 +544,9 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
                 if (!pendingDemandUpdater.compareAndSet(this, 0, n)) {
                     return 0;
                 }
-                clearSignalsQueued();
+                signalsQueued = false;
                 subscription.request(n);
                 return n;
-            }
-
-            void clearSignalsQueued() {
-                signalsQueued = false;
             }
 
             void markSignalsQueued() {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
@@ -398,7 +398,7 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
             targetTerminated = true;
             CompositeException de = this.delayedError;
             if (de != null) {
-                de.finishAndThrow();
+                de.transferPendingToSuppressed();
                 if (terminalNotification.cause() == de) {
                     terminalNotification.terminate(target);
                 } else {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
@@ -1,0 +1,687 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.internal.ConcurrentSubscription;
+import io.servicetalk.concurrent.internal.EmptySubscription;
+import io.servicetalk.concurrent.internal.FlowControlUtils;
+import io.servicetalk.concurrent.internal.QueueFullException;
+import io.servicetalk.concurrent.internal.TerminalNotification;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.NULL_TOKEN;
+import static io.servicetalk.concurrent.internal.ConcurrentUtils.releaseLock;
+import static io.servicetalk.concurrent.internal.ConcurrentUtils.tryAcquireLock;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateSubscription;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.trySetTerminal;
+import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
+import static io.servicetalk.concurrent.internal.ThrowableUtils.catchUnexpected;
+import static io.servicetalk.utils.internal.PlatformDependent.newUnboundedMpscQueue;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static java.lang.Math.min;
+import static java.util.Collections.newSetFromMap;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
+
+/**
+ * This flatMap implementation doesn't rely upon queuing to manage demand. Instead it leases out demand quota
+ * (capped by {@link #maxMappedDemand}) mapped {@link Publisher}s and reclaims any unused quota when each mapped
+ * {@link Publisher} is terminated or cancelled. {@link FlatMapSubscriber.FlatMapPublisherSubscriber} carefully manages
+ * outstanding demand to ensure when quota is reclaimed there are no subsequent
+ * {@link Subscriber#onNext(Object) signals} to avoid returning inaccurate amounts which would otherwise result in
+ * deadlock (under delivering {@link Subscriber#onNext(Object) signals}) or violation of
+ * <a href="https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#1.1">Reactive Streams
+ * Specification</a> (over delivering {@link Subscriber#onNext(Object) signals}) to the downstream {@link Subscriber}.
+ *
+ * @param <T> Type of original {@link Publisher}.
+ * @param <R> Type of {@link Publisher} returned by the operator.
+ */
+final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOperator<T, R> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PublisherFlatMapMerge.class);
+    private final Function<? super T, ? extends Publisher<? extends R>> mapper;
+    private final int maxConcurrency;
+    private final int maxMappedDemand;
+    private final boolean delayError;
+
+    PublisherFlatMapMerge(Publisher<T> original, Function<? super T, ? extends Publisher<? extends R>> mapper,
+                          boolean delayError, Executor executor) {
+        this(original, mapper, delayError, 16, 64, executor);
+    }
+
+    PublisherFlatMapMerge(Publisher<T> original, Function<? super T, ? extends Publisher<? extends R>> mapper,
+                          boolean delayError, int maxConcurrency, int maxMappedDemand, Executor executor) {
+        super(original, executor);
+        this.mapper = requireNonNull(mapper);
+        if (maxConcurrency <= 0) {
+            throw new IllegalArgumentException("maxConcurrency: " + maxConcurrency + " (expected >0)");
+        }
+        if (maxMappedDemand <= 0) {
+            throw new IllegalArgumentException("maxMappedDemand: " + maxMappedDemand + " (expected >0)");
+        }
+        this.maxMappedDemand = maxMappedDemand;
+        this.maxConcurrency = maxConcurrency;
+        this.delayError = delayError;
+    }
+
+    @Override
+    public Subscriber<? super T> apply(final Subscriber<? super R> subscriber) {
+        return new FlatMapSubscriber<>(this, subscriber);
+    }
+
+    private static final class FlatMapSubscriber<T, R> implements Subscriber<T>, Subscription {
+        @SuppressWarnings("rawtypes")
+        private static final AtomicReferenceFieldUpdater<FlatMapSubscriber, CompositeException> delayedErrorUpdater =
+                newUpdater(FlatMapSubscriber.class, CompositeException.class, "delayedError");
+        @SuppressWarnings("rawtypes")
+        private static final AtomicIntegerFieldUpdater<FlatMapSubscriber> emittingLockUpdater =
+                AtomicIntegerFieldUpdater.newUpdater(FlatMapSubscriber.class, "emittingLock");
+        @SuppressWarnings("rawtypes")
+        private static final AtomicIntegerFieldUpdater<FlatMapSubscriber> tryRequestMoreLockUpdater =
+                AtomicIntegerFieldUpdater.newUpdater(FlatMapSubscriber.class, "tryRequestMoreLock");
+        @SuppressWarnings("rawtypes")
+        private static final AtomicLongFieldUpdater<FlatMapSubscriber> pendingDemandUpdater =
+                AtomicLongFieldUpdater.newUpdater(FlatMapSubscriber.class, "pendingDemand");
+        @SuppressWarnings("rawtypes")
+        private static final AtomicIntegerFieldUpdater<FlatMapSubscriber> activeMappedSourcesUpdater =
+                AtomicIntegerFieldUpdater.newUpdater(FlatMapSubscriber.class, "activeMappedSources");
+        @SuppressWarnings("rawtypes")
+        private static final AtomicReferenceFieldUpdater<FlatMapSubscriber, TerminalNotification>
+                terminalNotificationUpdater = newUpdater(FlatMapSubscriber.class, TerminalNotification.class,
+                "terminalNotification");
+
+        @Nullable
+        private volatile CompositeException delayedError;
+        @SuppressWarnings("unused")
+        private volatile int tryRequestMoreLock;
+        @SuppressWarnings("unused")
+        private volatile int emittingLock;
+        private volatile long pendingDemand;
+        private volatile int activeMappedSources;
+        @SuppressWarnings("unused")
+        @Nullable
+        private volatile TerminalNotification terminalNotification;
+
+        /**
+         * This variable is only accessed within the "emitting lock" so we rely upon this to provide visibility to
+         * other threads.
+         */
+        private boolean targetTerminated;
+        @Nullable
+        private Subscription subscription;
+
+        private final Subscriber<? super R> target;
+        private final Queue<Object> pending;
+        private final PublisherFlatMapMerge<T, R> source;
+        private final Set<FlatMapPublisherSubscriber<T, R>> subscribers;
+
+        FlatMapSubscriber(PublisherFlatMapMerge<T, R> source, Subscriber<? super R> target) {
+            this.source = source;
+            this.target = target;
+            // Start with a small capacity as maxConcurrency can be large.
+            pending = newUnboundedMpscQueue(min(2, source.maxConcurrency));
+            subscribers = newSetFromMap(new ConcurrentHashMap<>());
+        }
+
+        @Override
+        public void cancel() {
+            doCancel(true);
+        }
+
+        @Override
+        public void request(final long n) {
+            assert subscription != null;
+            if (!isRequestNValid(n)) {
+                subscription.request(n);
+            } else {
+                pendingDemandUpdater.accumulateAndGet(this, n, FlowControlUtils::addWithOverflowProtection);
+                tryRequestMore();
+            }
+        }
+
+        @Override
+        public void onSubscribe(final Subscription s) {
+            if (!checkDuplicateSubscription(subscription, s)) {
+                return;
+            }
+
+            // We assume that FlatMapSubscriber#cancel() will never be called before this method, and therefore we
+            // don't have to worry about being cancelled before the onSubscribe method is called.
+            subscription = ConcurrentSubscription.wrap(s);
+            target.onSubscribe(this);
+
+            // Currently we always request maxConcurrency elements from upstream.
+            subscription.request(source.maxConcurrency);
+        }
+
+        @Override
+        public void onNext(@Nullable final T t) {
+            final Publisher<? extends R> publisher = requireNonNull(source.mapper.apply(t));
+            FlatMapPublisherSubscriber<T, R> subscriber = new FlatMapPublisherSubscriber<>(this);
+            final boolean added = subscribers.add(subscriber);
+            assert added; // FlatMapPublisherSubscriber relies upon object equality and should never fail.
+            for (;;) {
+                final int prevActiveSources = activeMappedSources;
+                if (prevActiveSources < 0) {
+                    // We have been cancelled, or already completed and the active count flipped to negative, either way
+                    // we don't want to Subscribe or retain a reference to this Publisher.
+                    subscribers.remove(subscriber);
+                    break;
+                } else if (activeMappedSourcesUpdater.compareAndSet(this, prevActiveSources, prevActiveSources + 1)) {
+                    publisher.subscribeInternal(subscriber);
+                    tryRequestMore(subscriber);
+                    break;
+                }
+            }
+        }
+
+        @Override
+        public void onError(final Throwable t) {
+            if (!onError0(t, false, false)) {
+                LOGGER.debug("Already terminated/cancelled, ignoring error notification.", t);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            // Setting terminal must be done before terminateActiveMappedSources to ensure visibility of the terminal.
+            final boolean setTerminal = trySetTerminal(complete(), false, terminalNotificationUpdater, this);
+            final boolean allSourcesTerminated = terminateActiveMappedSources();
+            if (setTerminal && allSourcesTerminated) {
+                enqueueAndDrain(complete());
+            }
+        }
+
+        private boolean onError0(Throwable throwable, boolean overrideComplete,
+                                 boolean cancelSubscriberIfNecessary) {
+            final TerminalNotification notification = TerminalNotification.error(throwable);
+            if (trySetTerminal(notification, overrideComplete, terminalNotificationUpdater, this)) {
+                try {
+                    doCancel(cancelSubscriberIfNecessary);
+                } finally {
+                    enqueueAndDrain(notification);
+                }
+                return true;
+            }
+            return false;
+        }
+
+        private void doCancel(boolean cancelSubscription) {
+            Throwable delayedCause = null;
+            // Prevent future onNext operations from adding to subscribers which otherwise may result in
+            // not cancelling mapped Subscriptions. This should be Integer.MIN_VALUE to prevent subsequent mapped
+            // source completion from incrementing the count to 0 or positive as terminateActiveMappedSources flips
+            // the count to negative to signal to mapped sources we have completed.
+            activeMappedSources = Integer.MIN_VALUE;
+            try {
+                if (cancelSubscription) {
+                    assert subscription != null;
+                    subscription.cancel();
+                }
+            } finally {
+                for (FlatMapPublisherSubscriber<T, R> subscriber : subscribers) {
+                    try {
+                        subscriber.cancelFromUpstream();
+                    } catch (Throwable c) {
+                        if (delayedCause == null) {
+                            delayedCause = c;
+                        }
+                    }
+                }
+                subscribers.clear();
+            }
+            if (delayedCause != null) {
+                throwException(delayedCause);
+            }
+        }
+
+        private void enqueueAndDrain(Object item) {
+            if (!pending.offer(item)) {
+                enqueueAndDrainFailed(item);
+            }
+            drainPending();
+        }
+
+        private void enqueueAndDrainFailed(Object item) {
+            QueueFullException exception = new QueueFullException("pending");
+            if (item instanceof TerminalNotification) {
+                LOGGER.error("Queue should be unbounded, but an offer failed!", exception);
+                throw exception;
+            } else {
+                onError0(exception, true, true);
+            }
+        }
+
+        private void drainPending() {
+            long emittedCount = 0;
+            Throwable delayedCause = null;
+            boolean tryAcquire = true;
+            while (tryAcquire && tryAcquireLock(emittingLockUpdater, this)) {
+                try {
+                    Object t;
+                    while ((t = pending.poll()) != null) {
+                        try {
+                            if (sendToTarget(t)) {
+                                ++emittedCount;
+                            }
+                        } catch (Throwable cause) {
+                            delayedCause = catchUnexpected(delayedCause, cause);
+                        }
+                    }
+                } finally {
+                    tryAcquire = !releaseLock(emittingLockUpdater, this);
+                }
+            }
+
+            if (emittedCount != 0) {
+                tryRequestMore();
+            }
+
+            if (delayedCause != null) {
+                throwException(delayedCause);
+            }
+        }
+
+        private boolean sendToTarget(Object item) {
+            if (targetTerminated) {
+                // No notifications past terminal/cancelled
+                return false;
+            }
+            if (item instanceof TerminalNotification) {
+                targetTerminated = true;
+                // Load the terminal notification in case an error happened after an onComplete and we override the
+                // terminal value.
+                TerminalNotification terminalNotification = this.terminalNotification;
+                assert terminalNotification != null;
+                CompositeException de = this.delayedError;
+                if (de != null) {
+                    de.finishAndThrow();
+                    if (terminalNotification.cause() == de) {
+                        terminalNotification.terminate(target);
+                    } else {
+                        terminalNotification.terminate(target, de);
+                    }
+                } else {
+                    terminalNotification.terminate(target);
+                }
+                return false;
+            }
+            @SuppressWarnings("unchecked")
+            final R rItem = item == NULL_TOKEN ? null : (R) item;
+            target.onNext(rItem);
+            return true;
+        }
+
+        private void tryRequestMore(FlatMapPublisherSubscriber<T, R> subscriber) {
+            if (tryAcquireLock(tryRequestMoreLockUpdater, this)) {
+                try {
+                    final long availableRequestN = pendingDemandUpdater.getAndSet(this, 0);
+                    if (availableRequestN != 0) {
+                        final int consumedRequestN = subscriber.requestFromUpstream(
+                                (int) min(source.maxMappedDemand, availableRequestN));
+                        assert availableRequestN >= consumedRequestN;
+                        if (consumedRequestN != availableRequestN) {
+                            giveBackRequestN(availableRequestN - consumedRequestN);
+                        }
+                    }
+                } finally {
+                    if (!releaseLock(tryRequestMoreLockUpdater, this)) {
+                        tryRequestMore();
+                    }
+                }
+            }
+        }
+
+        private void tryRequestMore() {
+            Throwable delayedCause = null;
+            boolean tryAcquire = true;
+            while (tryAcquire && tryAcquireLock(tryRequestMoreLockUpdater, this)) {
+                try {
+                    final long availableRequestN = pendingDemandUpdater.getAndSet(this, 0);
+                    if (availableRequestN != 0) {
+                        long remainingRequestN = availableRequestN;
+                        Iterator<FlatMapPublisherSubscriber<T, R>> itr = subscribers.iterator();
+                        while (itr.hasNext() && remainingRequestN > 0) {
+                            remainingRequestN -= itr.next().requestFromUpstream(
+                                    (int) Math.min(source.maxMappedDemand, remainingRequestN));
+                        }
+
+                        assert availableRequestN >= remainingRequestN && remainingRequestN >= 0;
+                        if (remainingRequestN > 0) {
+                            giveBackRequestN(remainingRequestN);
+                        }
+                    }
+                } catch (Throwable cause) {
+                    delayedCause = catchUnexpected(delayedCause, cause);
+                } finally {
+                    tryAcquire = !releaseLock(tryRequestMoreLockUpdater, this);
+                }
+            }
+            if (delayedCause != null) {
+                throwException(delayedCause);
+            }
+        }
+
+        private void giveBackRequestN(final long delta) {
+            pendingDemandUpdater.addAndGet(this, delta);
+        }
+
+        private boolean terminateActiveMappedSources() {
+            for (;;) {
+                final int prevActiveSources = activeMappedSources;
+                assert prevActiveSources >= 0; // otherwise we have seen multiple onComplete signals
+                if (activeMappedSourcesUpdater.compareAndSet(this, prevActiveSources, -prevActiveSources)) {
+                    return prevActiveSources == 0;
+                }
+            }
+        }
+
+        private boolean decrementActiveMappedSources() {
+            for (;;) {
+                final int prevActiveSources = activeMappedSources;
+                assert prevActiveSources != 0;
+                if (prevActiveSources > 0) {
+                    if (activeMappedSourcesUpdater.compareAndSet(this, prevActiveSources, prevActiveSources - 1)) {
+                        return false;
+                    }
+                } else if (activeMappedSourcesUpdater.compareAndSet(this, prevActiveSources, prevActiveSources + 1)) {
+                    return prevActiveSources == -1;
+                }
+            }
+        }
+
+        private boolean removeSubscriber(final FlatMapPublisherSubscriber<T, R> subscriber,
+                                         final long requestNGiveBack) {
+            if (subscribers.remove(subscriber)) {
+                if (decrementActiveMappedSources()) {
+                    return true;
+                }
+
+                assert subscription != null;
+                subscription.request(1);
+
+                if (requestNGiveBack > 0) {
+                    giveBackRequestN(requestNGiveBack);
+                    tryRequestMore();
+                }
+            }
+            return false;
+        }
+
+        private static final class FlatMapPublisherSubscriber<T, R> implements Subscriber<R> {
+            private static final long OUTSTANDING_DEMAND_TERMINATED = -1;
+            private static final Subscription CANCELLED = new EmptySubscription();
+            private static final Subscription CANCEL_PENDING = new EmptySubscription();
+            private static final Subscription REQUEST_PENDING = new EmptySubscription();
+            private static final Subscription PROCESSING_REQUEST = new EmptySubscription();
+            private static final Subscription PROCESSING_ONNEXT = new EmptySubscription();
+            @SuppressWarnings("rawtypes")
+            private static final AtomicReferenceFieldUpdater<FlatMapPublisherSubscriber, Subscription>
+                    subscriptionUpdater = newUpdater(FlatMapPublisherSubscriber.class, Subscription.class,
+                    "subscription");
+            @SuppressWarnings("rawtypes")
+            private static final AtomicLongFieldUpdater<FlatMapPublisherSubscriber> outstandingDemandUpdater =
+                    AtomicLongFieldUpdater.newUpdater(FlatMapPublisherSubscriber.class, "outstandingDemand");
+            @SuppressWarnings("rawtypes")
+            private static final AtomicLongFieldUpdater<FlatMapPublisherSubscriber> pendingDemandUpdater =
+                    AtomicLongFieldUpdater.newUpdater(FlatMapPublisherSubscriber.class, "pendingDemand");
+
+            private final FlatMapSubscriber<T, R> parent;
+
+            @SuppressWarnings("unused")
+            @Nullable
+            private volatile Subscription subscription;
+            private volatile long pendingDemand;
+            private volatile long outstandingDemand;
+
+            FlatMapPublisherSubscriber(FlatMapSubscriber<T, R> parent) {
+                this.parent = parent;
+            }
+
+            void cancelFromUpstream() {
+                for (;;) {
+                    final Subscription prevSubscription = subscription;
+                    if (prevSubscription == null) {
+                        if (subscriptionUpdater.compareAndSet(this, null, CANCELLED)) {
+                            break;
+                        }
+                    } else if (prevSubscription == CANCELLED || prevSubscription == CANCEL_PENDING) {
+                        break;
+                    } else if (prevSubscription == PROCESSING_ONNEXT || prevSubscription == PROCESSING_REQUEST) {
+                        if (subscriptionUpdater.compareAndSet(this, prevSubscription, CANCEL_PENDING)) {
+                            break;
+                        }
+                    } else if (subscriptionUpdater.compareAndSet(this, prevSubscription, CANCELLED)) {
+                        cancelAndGiveBack(prevSubscription);
+                        break;
+                    }
+                }
+            }
+
+            int requestFromUpstream(final int n) {
+                for (;;) {
+                    final long prevOutstandingDemand = outstandingDemand;
+                    if (prevOutstandingDemand == OUTSTANDING_DEMAND_TERMINATED) {
+                        return 0; // we have already been cancelled, or terminated
+                    }
+                    final int quotaToUse = (int) min(Long.MAX_VALUE - prevOutstandingDemand,
+                            min(parent.source.maxMappedDemand - prevOutstandingDemand, n));
+                    if (quotaToUse == 0) {
+                        if (outstandingDemandUpdater.compareAndSet(this, prevOutstandingDemand,
+                                prevOutstandingDemand)) {
+                            return 0;
+                        }
+                    } else if (outstandingDemandUpdater.compareAndSet(this, prevOutstandingDemand,
+                            prevOutstandingDemand + quotaToUse)) {
+                        pendingDemandUpdater.addAndGet(this, quotaToUse);
+                        for (;;) {
+                            final Subscription prevSubscription = subscription;
+                            if (prevSubscription == null) {
+                                if (subscriptionUpdater.compareAndSet(this, null, REQUEST_PENDING)) {
+                                    break;
+                                }
+                            } else if (prevSubscription == CANCELLED || prevSubscription == CANCEL_PENDING) {
+                                break;
+                            } else if (prevSubscription == REQUEST_PENDING || prevSubscription == PROCESSING_ONNEXT ||
+                                       prevSubscription == PROCESSING_REQUEST) {
+                                if (subscriptionUpdater.compareAndSet(this, prevSubscription, REQUEST_PENDING)) {
+                                    break;
+                                }
+                            } else if (subscriptionUpdater.compareAndSet(this, prevSubscription, PROCESSING_REQUEST)) {
+                                doRequestMore(prevSubscription);
+                                break;
+                            }
+                        }
+                        return quotaToUse;
+                    }
+                }
+            }
+
+            private void doRequestMore(Subscription prevSubscription) {
+                long availableRequestN = pendingDemandUpdater.getAndSet(this, 0);
+                for (;;) {
+                    if (availableRequestN > 0) {
+                        try {
+                            prevSubscription.request(availableRequestN);
+                        } catch (Throwable cause) {
+                            subscription = CANCELLED;
+                            cancelAndGiveBack(prevSubscription);
+                            throw cause;
+                        }
+                    }
+
+                    final Subscription afterLockSubscription = subscription;
+                    if (afterLockSubscription == PROCESSING_ONNEXT || afterLockSubscription == CANCELLED) {
+                        // onNext is allowed to interrupt, and will handle any pending cancel/request events
+                        // after it completes (otherwise we may drop signals).
+                        break;
+                    } else if (afterLockSubscription == CANCEL_PENDING) {
+                        subscription = CANCELLED;
+                        cancelAndGiveBack(prevSubscription);
+                        break;
+                    } else if (afterLockSubscription == REQUEST_PENDING) {
+                        if (subscriptionUpdater.compareAndSet(this, REQUEST_PENDING, PROCESSING_REQUEST)) {
+                            availableRequestN = pendingDemandUpdater.getAndSet(this, 0);
+                            // continue through next iteration to try to unlock
+                        }
+                    } else if (subscriptionUpdater.compareAndSet(this, PROCESSING_REQUEST, prevSubscription)) {
+                        break;
+                    }
+                }
+            }
+
+            private void cancelAndGiveBack(Subscription subscription) {
+                try {
+                    subscription.cancel();
+                } finally {
+                    giveBackUnusedRequestN();
+                }
+            }
+
+            private boolean giveBackUnusedRequestN() {
+                // assert subscription == CANCELLED; entry condition to ensure we do not deliver any more data in onNext
+                // We need to give back the outstanding amount that has been requested, but not emitted. Setting the
+                // demand to a negative value will prevent any future use of the Subscription.request() or accepting
+                // more demand from downstream.
+                final long prevOutstandingDemand = outstandingDemandUpdater.getAndSet(this,
+                        OUTSTANDING_DEMAND_TERMINATED);
+                return prevOutstandingDemand != OUTSTANDING_DEMAND_TERMINATED &&
+                        parent.removeSubscriber(this, prevOutstandingDemand);
+            }
+
+            @Override
+            public void onSubscribe(final Subscription s) {
+                for (;;) {
+                    final Subscription prevSubscription = subscription;
+                    assert prevSubscription != CANCEL_PENDING && prevSubscription != PROCESSING_ONNEXT &&
+                            prevSubscription != PROCESSING_REQUEST;
+                    if (prevSubscription == null) {
+                        if (subscriptionUpdater.compareAndSet(this, null, s)) {
+                            break;
+                        }
+                    } else if (prevSubscription == REQUEST_PENDING) {
+                        if (subscriptionUpdater.compareAndSet(this, REQUEST_PENDING, PROCESSING_REQUEST)) {
+                            doRequestMore(s);
+                            break;
+                        }
+                    } else {
+                        s.cancel(); // already cancelled or duplicate onSubscribe
+                        break;
+                    }
+                }
+            }
+
+            @Override
+            public void onNext(@Nullable final R r) {
+                boolean acquiredLock = false;
+                for (;;) {
+                    final Subscription prevSubscription = subscription;
+                    assert prevSubscription != null;
+                    if (prevSubscription == CANCELLED || prevSubscription == CANCEL_PENDING) {
+                        // we have already given our undelivered requestN quota up, or will after we unroll process
+                        // onNext. we are not allowed to deliver more data or else we may violate upstream's requestN.
+                        break;
+                    } else if (prevSubscription == PROCESSING_ONNEXT ||
+                            (acquiredLock = subscriptionUpdater.compareAndSet(this,
+                                    prevSubscription, PROCESSING_ONNEXT))) {
+                        final long newOutstandingDemand = outstandingDemandUpdater.decrementAndGet(this);
+                        assert newOutstandingDemand >= 0; // too many items delivered from upstream!
+                        try {
+                            parent.enqueueAndDrain(r == null ? NULL_TOKEN : r);
+                        } finally {
+                            if (acquiredLock) {
+                                for (;;) {
+                                    final Subscription afterLockSubscription = subscription;
+                                    assert afterLockSubscription != PROCESSING_REQUEST;
+                                    if (afterLockSubscription == CANCEL_PENDING) {
+                                        subscription = CANCELLED; // this is a terminal state.
+                                        cancelAndGiveBack(prevSubscription);
+                                        break;
+                                    } else if (afterLockSubscription == REQUEST_PENDING) {
+                                        if (subscriptionUpdater.compareAndSet(this, REQUEST_PENDING,
+                                                PROCESSING_REQUEST)) {
+                                            doRequestMore(prevSubscription);
+                                            break;
+                                        }
+                                    } else if (afterLockSubscription == CANCELLED) {
+                                        break;
+                                    } else if (subscriptionUpdater.compareAndSet(this, PROCESSING_ONNEXT,
+                                            prevSubscription)) {
+                                        // If we have exhausted our quota, try to request more
+                                        if (newOutstandingDemand == 0) {
+                                            parent.tryRequestMore(this);
+                                        }
+                                        break; // we unlocked, so bail out.
+                                    }
+                                }
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+
+            @Override
+            public void onError(final Throwable t) {
+                // the Subscription is considered cancelled after a terminal signal.
+                subscription = CANCELLED;
+                if (!parent.source.delayError) {
+                    parent.onError0(t, true, true);
+                } else {
+                    CompositeException de = parent.delayedError;
+                    if (de == null) {
+                        de = new CompositeException(t);
+                        if (!delayedErrorUpdater.compareAndSet(parent, null, de)) {
+                            de = parent.delayedError;
+                            assert de != null;
+                            de.add(t);
+                        }
+                    } else {
+                        de.add(t);
+                    }
+                    if (giveBackUnusedRequestN()) {
+                        trySetTerminal(TerminalNotification.error(de), true, terminalNotificationUpdater, parent);
+
+                        // Since we have already added error to delayedError, we use complete() TerminalNotification
+                        // as a dummy signal to start draining and termination.
+                        parent.enqueueAndDrain(complete());
+                    }
+                }
+            }
+
+            @Override
+            public void onComplete() {
+                // the Subscription is considered cancelled after a terminal signal.
+                subscription = CANCELLED;
+                if (giveBackUnusedRequestN()) {
+                    parent.enqueueAndDrain(complete());
+                }
+            }
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
+import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.internal.ConcurrentSubscription;
 import io.servicetalk.concurrent.internal.DelayedSubscription;
 import io.servicetalk.concurrent.internal.FlowControlUtils;
@@ -25,8 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Queue;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -44,34 +43,53 @@ import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.ThrowableUtils.catchUnexpected;
 import static io.servicetalk.utils.internal.PlatformDependent.newUnboundedMpscQueue;
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static java.lang.Math.max;
 import static java.lang.Math.min;
-import static java.util.Collections.newSetFromMap;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
+/**
+ * Implementation of {@link Publisher#flatMapMerge(Function)}.
+ * <p>
+ * This implementation makes some trade-offs that may have performance/memory impacts. Demand distributed to mapped
+ * {@link Publisher}s is dynamic and correlates to downstream demand. This dynamic behavior is targeted toward use cases
+ * where:
+ * <ul>
+ *     <li>{@link Subscriber#onNext(Object) onNext Objects} consume non trivial amount of memory relative to the memory
+ *     to manage the {@link FlatMapSubscriber#hungrySubscribers} queue (e.g. network buffer, serialized POJO)</li>
+ *     <li>downstream demand is available before signals from mapped sources are available
+ *     (e.g. over a network boundary)</li>
+ * </ul>
+ * Scenarios where downstream demand is provided in small/slow increments relative to the amount of signals from mapped
+ * Sources, or mapped Sources are backed by in memory content are expected to incur some additional overhead for
+ * {@link FlatMapSubscriber#hungrySubscribers queue} management.
+ *
+ * @param <T> Type of original {@link Publisher}.
+ * @param <R> Type of {@link Publisher} returned by the operator.
+ */
 final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOperator<T, R> {
     private static final Logger LOGGER = LoggerFactory.getLogger(PublisherFlatMapMerge.class);
     private final Function<? super T, ? extends Publisher<? extends R>> mapper;
     private final int maxConcurrency;
-    private final int maxMappedDemand;
+    private final int minMappedDemand;
     private final boolean delayError;
 
     PublisherFlatMapMerge(Publisher<T> original, Function<? super T, ? extends Publisher<? extends R>> mapper,
                           boolean delayError, Executor executor) {
-        this(original, mapper, delayError, 16, 64, executor);
+        this(original, mapper, delayError, 8, 8, executor);
     }
 
     PublisherFlatMapMerge(Publisher<T> original, Function<? super T, ? extends Publisher<? extends R>> mapper,
-                          boolean delayError, int maxConcurrency, int maxMappedDemand, Executor executor) {
+                          boolean delayError, int maxConcurrency, int minMappedDemand, Executor executor) {
         super(original, executor);
         this.mapper = requireNonNull(mapper);
         if (maxConcurrency <= 0) {
             throw new IllegalArgumentException("maxConcurrency: " + maxConcurrency + " (expected >0)");
         }
-        if (maxMappedDemand <= 0) {
-            throw new IllegalArgumentException("maxMappedDemand: " + maxMappedDemand + " (expected >0)");
+        if (minMappedDemand <= 0) {
+            throw new IllegalArgumentException("minMappedDemand: " + minMappedDemand + " (expected >0)");
         }
-        this.maxMappedDemand = maxMappedDemand;
+        this.minMappedDemand = minMappedDemand;
         this.maxConcurrency = maxConcurrency;
         this.delayError = delayError;
     }
@@ -89,6 +107,12 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
         @SuppressWarnings("rawtypes")
         private static final AtomicIntegerFieldUpdater<FlatMapSubscriber> emittingLockUpdater =
                 AtomicIntegerFieldUpdater.newUpdater(FlatMapSubscriber.class, "emittingLock");
+        @SuppressWarnings("rawtypes")
+        private static final AtomicIntegerFieldUpdater<FlatMapSubscriber> requestingLockUpdater =
+                AtomicIntegerFieldUpdater.newUpdater(FlatMapSubscriber.class, "requestingLock");
+        @SuppressWarnings("rawtypes")
+        private static final AtomicLongFieldUpdater<FlatMapSubscriber> mappedDemandUpdater =
+                AtomicLongFieldUpdater.newUpdater(FlatMapSubscriber.class, "mappedDemand");
         @SuppressWarnings("rawtypes")
         private static final AtomicLongFieldUpdater<FlatMapSubscriber> pendingDemandUpdater =
                 AtomicLongFieldUpdater.newUpdater(FlatMapSubscriber.class, "pendingDemand");
@@ -108,7 +132,10 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
         @SuppressWarnings("unused")
         private volatile int emittingLock;
         private volatile int activeMappedSources;
+        @SuppressWarnings("unused")
+        private volatile int requestingLock;
         private volatile long pendingDemand;
+        private volatile long mappedDemand;
 
         // protected by emitting lock, or only accessed inside the Subscriber thread
         private boolean targetTerminated;
@@ -118,14 +145,15 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
         private final Subscriber<? super R> target;
         private final Queue<Object> signals;
         private final PublisherFlatMapMerge<T, R> source;
-        private final Set<FlatMapPublisherSubscriber<T, R>> subscribers;
+        private final DynamicCompositeCancellable cancellableSubscribers;
+        private final Queue<FlatMapPublisherSubscriber<T, R>> hungrySubscribers;
 
         FlatMapSubscriber(PublisherFlatMapMerge<T, R> source, Subscriber<? super R> target) {
             this.source = source;
             this.target = target;
-            // Start with a small capacity as maxConcurrency can be large.
-            signals = newUnboundedMpscQueue(min(2, source.maxConcurrency * source.maxMappedDemand));
-            subscribers = newSetFromMap(new ConcurrentHashMap<>(min(16, source.maxConcurrency)));
+            signals = newUnboundedMpscQueue(4);
+            hungrySubscribers = newUnboundedMpscQueue(4);
+            cancellableSubscribers = new SetDynamicCompositeCancellable(min(16, source.maxConcurrency));
         }
 
         @Override
@@ -138,9 +166,17 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
             assert subscription != null;
             if (!isRequestNValid(n)) {
                 subscription.request(n);
-            } else if (pendingDemandUpdater.getAndAccumulate(this, n,
-                    FlowControlUtils::addWithOverflowProtectionIfNotNegative) == 0) {
-                drainPending();
+            } else {
+                // If we transitioned from no demand, to some demand, then we should try to drain the queues which
+                // may have signals pending due to previous over-request.
+                if (pendingDemandUpdater.getAndAccumulate(this, n,
+                        FlowControlUtils::addWithOverflowProtectionIfNotNegative) == 0) {
+                    drainPending();
+                }
+                if (mappedDemandUpdater.getAndAccumulate(this, n,
+                        FlowControlUtils::addWithOverflowProtection) == 0) {
+                    distributeMappedDemand();
+                }
             }
         }
 
@@ -162,14 +198,15 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
         public void onNext(@Nullable final T t) {
             final Publisher<? extends R> publisher = requireNonNull(source.mapper.apply(t));
             FlatMapPublisherSubscriber<T, R> subscriber = new FlatMapPublisherSubscriber<>(this);
-            final boolean added = subscribers.add(subscriber);
-            assert added; // FlatMapPublisherSubscriber relies upon object equality and should never fail.
+            if (!cancellableSubscribers.add(subscriber)) {
+                return;
+            }
             for (;;) {
                 final int prevActiveSources = activeMappedSources;
                 if (prevActiveSources < 0) {
-                    // We have been cancelled, or already completed and the active count flipped to negative, either way
-                    // we don't want to Subscribe or retain a reference to this Publisher.
-                    subscribers.remove(subscriber);
+                    // We have been cancelled, or already completed and the active count flipped to negative, either
+                    // way we don't want to Subscribe or retain a reference to this Publisher.
+                    cancellableSubscribers.remove(subscriber);
                     break;
                 } else if (activeMappedSourcesUpdater.compareAndSet(this, prevActiveSources, prevActiveSources + 1)) {
                     publisher.subscribeInternal(subscriber);
@@ -209,8 +246,79 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
             return false;
         }
 
-        private void doCancel(boolean cancelSubscription) {
+        private long reserveMappedDemand() {
+            return mappedDemandUpdater.getAndSet(this, 0);
+        }
+
+        private int reserveMappedDemandQuota() {
+            for (;;) {
+                final long prevDemand = mappedDemand;
+                if (prevDemand <= 0) {
+                    return 0;
+                }
+                final int quota = calculateRequestNQuota(prevDemand);
+                if (mappedDemandUpdater.compareAndSet(this, prevDemand, prevDemand - quota)) {
+                    return quota;
+                }
+            }
+        }
+
+        private void distributeMappedDemand(FlatMapPublisherSubscriber<T, R> hungrySubscriber) {
+            final int quota = reserveMappedDemandQuota();
+            if (quota > 0) {
+                final int usedQuota = hungrySubscriber.request(quota);
+                if (usedQuota < quota && mappedDemandUpdater.getAndAccumulate(this, quota - usedQuota,
+                        FlowControlUtils::addWithOverflowProtection) == 0) {
+                    // If we gave some back and transitioned from 0 demand, we need to try to distribute demand
+                    // in case other hungry subscribers were added in the mean time
+                    // (since we have not acquired the requestingLock).
+                    distributeMappedDemand();
+                }
+            } else { // slow path. no demand, add to queue and process later when demand arrives.
+                hungrySubscribers.add(hungrySubscriber);
+                distributeMappedDemand();
+            }
+        }
+
+        private void distributeMappedDemand() {
             Throwable delayedCause = null;
+            boolean tryAcquire = true;
+            while (tryAcquire && tryAcquireLock(requestingLockUpdater, this)) {
+                try {
+                    final long availableRequestN = reserveMappedDemand();
+                    if (availableRequestN > 0) {
+                        long remainingRequestN = availableRequestN;
+                        final int quota = calculateRequestNQuota(availableRequestN);
+                        FlatMapPublisherSubscriber<T, R> hungrySubscriber;
+                        while ((hungrySubscriber = hungrySubscribers.poll()) != null) {
+                            remainingRequestN -= hungrySubscriber.request(quota);
+                        }
+                        if (remainingRequestN > 0) {
+                            mappedDemandUpdater.accumulateAndGet(this, remainingRequestN,
+                                    FlowControlUtils::addWithOverflowProtection);
+                        }
+                    }
+                } catch (Throwable cause) {
+                    delayedCause = catchUnexpected(delayedCause, cause);
+                } finally {
+                    tryAcquire = !releaseLock(requestingLockUpdater, this);
+                }
+            }
+            if (delayedCause != null) {
+                throwException(delayedCause);
+            }
+        }
+
+        private int calculateRequestNQuota(long availableRequestN) {
+            // Get an approximate quota to distribute to each active mapped subscriber. If
+            // activeMappedSources changes (subscriber added or terminated) we will re-distribute.
+            final int prevActiveSources = activeMappedSources;
+            return (int) min(Integer.MAX_VALUE,
+                    max(prevActiveSources > 0 ? availableRequestN / prevActiveSources : availableRequestN,
+                            source.minMappedDemand));
+        }
+
+        private void doCancel(boolean cancelSubscription) {
             // Prevent future onNext operations from adding to subscribers which otherwise may result in
             // not cancelling mapped Subscriptions. This should be Integer.MIN_VALUE to prevent subsequent mapped
             // source completion from incrementing the count to 0 or positive as terminateActiveMappedSources flips
@@ -223,26 +331,19 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
                     subscription.cancel();
                 }
             } finally {
-                for (FlatMapPublisherSubscriber<T, R> subscriber : subscribers) {
-                    try {
-                        subscriber.cancelFromUpstream();
-                    } catch (Throwable cause) {
-                        delayedCause = catchUnexpected(delayedCause, cause);
-                    }
-                }
-                subscribers.clear();
-            }
-            if (delayedCause != null) {
-                throwException(delayedCause);
+                cancellableSubscribers.cancel();
+                // Don't bother clearing out hungrySubscribers or signals (which require additional concurrency control)
+                // because it is assumed this Subscriber will be dereferenced and eligible for GC [1].
+                // [1] https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#3.13
             }
         }
 
-        private boolean tryDecrementDemand() {
+        private boolean tryDecrementPendingDemand() {
             for (;;) {
-                final long prevPendingDemand = pendingDemand;
-                if (prevPendingDemand <= 0) {
+                final long prevDemand = pendingDemand;
+                if (prevDemand <= 0) {
                     return false;
-                } else if (pendingDemandUpdater.compareAndSet(this, prevPendingDemand, prevPendingDemand - 1)) {
+                } else if (pendingDemandUpdater.compareAndSet(this, prevDemand, prevDemand - 1)) {
                     return true;
                 }
             }
@@ -251,7 +352,7 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
         private void tryEmitItem(Object item, FlatMapPublisherSubscriber<T, R> subscriber) {
             if (tryAcquireLock(emittingLockUpdater, this)) { // fast path. no concurrency, try to skip the queue.
                 try {
-                    if (subscriber.hasSignalsQueued() || (needsDemand(item) && !tryDecrementDemand())) {
+                    if (subscriber.hasSignalsQueued() || (needsDemand(item) && !tryDecrementPendingDemand())) {
                         subscriber.markSignalsQueued();
                         enqueueItem(item); // drain isn't necessary. when demand arrives a drain will be attempted.
                     } else if (item == MAPPED_SOURCE_COMPLETE) {
@@ -298,16 +399,16 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
             int mappedSourcesCompleted = 0;
             while (tryAcquire && tryAcquireLock(emittingLockUpdater, this)) {
                 try {
-                    final long prevPendingDemand = pendingDemandUpdater.getAndSet(this, 0);
+                    final long prevDemand = pendingDemandUpdater.getAndSet(this, 0);
                     long emittedCount = 0;
-                    if (prevPendingDemand < 0) {
+                    if (prevDemand < 0) {
                         // if we have been cancelled then we avoid delivering any signals, but we still deliver error
-                        // terminals below by making sure emittedCount == prevPendingDemand.
-                        pendingDemand = emittedCount = prevPendingDemand;
+                        // terminals below by making sure emittedCount == prevDemand.
+                        pendingDemand = emittedCount = prevDemand;
                         signals.clear();
                     }
                     Object t;
-                    while (emittedCount < prevPendingDemand && (t = signals.poll()) != null) {
+                    while (emittedCount < prevDemand && (t = signals.poll()) != null) {
                         try {
                             if (t == MAPPED_SOURCE_COMPLETE) {
                                 ++mappedSourcesCompleted;
@@ -320,7 +421,7 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
                     }
 
                     // check if a terminal event is pending, or give back demand.
-                    if (emittedCount == prevPendingDemand) {
+                    if (emittedCount == prevDemand) {
                         for (;;) {
                             try {
                                 t = signals.peek();
@@ -329,7 +430,10 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
                                     ++mappedSourcesCompleted;
                                 } else if (t instanceof FlatMapPublisherSubscriber) {
                                     signals.poll();
-                                    ((FlatMapPublisherSubscriber<?, ?>) t).replenishDemandAndClearSignalsQueued();
+                                    @SuppressWarnings("unchecked")
+                                    final FlatMapPublisherSubscriber<T, R> hungrySubscriber =
+                                            (FlatMapPublisherSubscriber<T, R>) t;
+                                    distributeMappedDemand(hungrySubscriber);
                                 } else {
                                     break;
                                 }
@@ -347,9 +451,9 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
                             }
                         }
                     } else {
-                        assert emittedCount < prevPendingDemand;
-                        pendingDemandUpdater.accumulateAndGet(this, prevPendingDemand - emittedCount,
-                                FlowControlUtils::addWithOverflowProtection);
+                        assert emittedCount < prevDemand;
+                        pendingDemandUpdater.accumulateAndGet(this, prevDemand - emittedCount,
+                                FlowControlUtils::addWithOverflowProtectionIfNotNegative);
                     }
                 } finally {
                     tryAcquire = !releaseLock(emittingLockUpdater, this);
@@ -388,7 +492,10 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
                 sendToTarget(terminalNotification);
                 return false;
             } else if (item instanceof FlatMapPublisherSubscriber) {
-                ((FlatMapPublisherSubscriber<?, ?>) item).replenishDemandAndClearSignalsQueued();
+                @SuppressWarnings("unchecked")
+                final FlatMapPublisherSubscriber<T, R> hungrySubscriber =
+                        (FlatMapPublisherSubscriber<T, R>) item;
+                distributeMappedDemand(hungrySubscriber);
                 return false;
             }
             target.onNext(unwrapNullUnchecked(item));
@@ -435,24 +542,29 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
             }
         }
 
-        private boolean removeSubscriber(final FlatMapPublisherSubscriber<T, R> subscriber) {
-            return subscribers.remove(subscriber) && decrementActiveMappedSources();
+        private boolean removeSubscriber(final FlatMapPublisherSubscriber<T, R> subscriber, int unusedDemand) {
+            if (cancellableSubscribers.remove(subscriber) && decrementActiveMappedSources()) {
+                return true;
+            } else if (unusedDemand > 0 && mappedDemandUpdater.getAndAccumulate(this, unusedDemand,
+                            FlowControlUtils::addWithOverflowProtection) == 0) {
+                distributeMappedDemand();
+            }
+            return false;
         }
 
-        private static final class FlatMapPublisherSubscriber<T, R> implements Subscriber<R> {
+        private static final class FlatMapPublisherSubscriber<T, R> implements Subscriber<R>, Cancellable {
             @SuppressWarnings("rawtypes")
-            private static final AtomicIntegerFieldUpdater<FlatMapPublisherSubscriber> pendingOnNextUpdater =
-                    AtomicIntegerFieldUpdater.newUpdater(FlatMapPublisherSubscriber.class, "pendingOnNext");
+            private static final AtomicIntegerFieldUpdater<FlatMapPublisherSubscriber> pendingDemandUpdater =
+                    AtomicIntegerFieldUpdater.newUpdater(FlatMapPublisherSubscriber.class, "innerPendingDemand");
 
             private final FlatMapSubscriber<T, R> parent;
             private final DelayedSubscription subscription;
-            private volatile int pendingOnNext;
+            private volatile int innerPendingDemand;
             /**
-             * visibility provided by the {@link Subscriber} thread in {@link #onNext(Object)}, and then by
-             * {@link #pendingDemand} when written to from {@link #replenishDemandAndClearSignalsQueued()} (potentially
-             * called by a different thread). Demand is exhausted before {@link #replenishDemandAndClearSignalsQueued()}
-             * is called, and that method triggers {@link #request(long)} and
-             * <a href="https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#1.1">there’s a
+             * visibility provided by the {@link Subscriber} thread in {@link #onNext(Object)}, and
+             * demand is exhausted before {@link #request(long)} is called, and that method triggers
+             * {@link Subscription#request(long)} which provides a
+             * <a href="https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#1.1">
              * happens-before relationship between requesting elements and receiving elements</a>.
              */
             private boolean signalsQueued;
@@ -462,17 +574,19 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
                 subscription = new DelayedSubscription();
             }
 
-            void cancelFromUpstream() {
+            @Override
+            public void cancel() {
                 subscription.cancel();
             }
 
-            void replenishDemandAndClearSignalsQueued() {
-                // clearSignalsQueued must be before pendingOnNext for visibility with onNext.
-                clearSignalsQueued();
-                final int prevPendingOnNext = pendingOnNextUpdater.getAndSet(this, 0);
-                if (prevPendingOnNext > 0) {
-                    subscription.request(prevPendingOnNext);
+            int request(int n) {
+                assert n > 0;
+                if (!pendingDemandUpdater.compareAndSet(this, 0, n)) {
+                    return 0;
                 }
+                clearSignalsQueued();
+                subscription.request(n);
+                return n;
             }
 
             void clearSignalsQueued() {
@@ -490,21 +604,19 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
             @Override
             public void onSubscribe(final Subscription s) {
                 subscription.delayedSubscription(ConcurrentSubscription.wrap(s));
-                subscription.request(parent.source.maxMappedDemand);
+                parent.distributeMappedDemand(this);
             }
 
             @Override
             public void onNext(@Nullable final R r) {
-                // pendingOnNext must be updated before tryEmitItem for visibility of signalsQueued. signalsQueued
-                // is updated in replenishDemandAndClearSignalsQueued (potentially from another thread) before
-                // pendingOnNext is reset and we want signalsQueued to be visible to this thread.
-                //
-                // Heuristic which triggers replenishDemandAndClearSignalsQueued when demand is consumed. It must be
-                // when all demand is consumed in order for clearSignalsQueued to work properly.
-                final boolean doReplenish = pendingOnNextUpdater.incrementAndGet(this) == parent.source.maxMappedDemand;
                 parent.tryEmitItem(wrapNull(r), this);
-                if (doReplenish) {
+                final int pendingDemand = pendingDemandUpdater.decrementAndGet(this);
+                if (pendingDemand == 0) {
+                    // Emit this item to signify this Subscriber is hungry for more demand when it is available.
                     parent.tryEmitItem(this, this);
+                } else if (pendingDemand < 0) {
+                    throw new IllegalStateException("Too many onNext signals for Subscriber: " + this +
+                            " pendingDemand: " + pendingDemand);
                 }
             }
 
@@ -524,7 +636,7 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
                     } else {
                         de.add(t);
                     }
-                    if (parent.removeSubscriber(this)) {
+                    if (parent.removeSubscriber(this, pendingDemandUpdater.getAndSet(this, -1))) {
                         trySetTerminal(TerminalNotification.error(de), true, terminalNotificationUpdater, parent);
 
                         // Since we have already added error to delayedError, we use complete() TerminalNotification
@@ -538,7 +650,7 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
 
             @Override
             public void onComplete() {
-                if (parent.removeSubscriber(this)) {
+                if (parent.removeSubscriber(this, pendingDemandUpdater.getAndSet(this, -1))) {
                     parent.enqueueAndDrain(complete());
                 } else {
                     parent.tryEmitItem(MAPPED_SOURCE_COMPLETE, this);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
@@ -1,0 +1,846 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.PublisherSource.Subscriber;
+import io.servicetalk.concurrent.internal.DeliberateException;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.PublisherSource.Subscription;
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.api.VerificationTestUtils.verifyOriginalAndSuppressedCauses;
+import static io.servicetalk.concurrent.api.VerificationTestUtils.verifySuppressed;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class PublisherFlatMapMergeTest {
+    private static final long TERMINAL_POLL_MS = 10;
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+    @Nullable
+    private static ExecutorService executorService;
+    @Nullable
+    private static Executor executor;
+
+    private final TestCollectingPublisherSubscriber<Integer> subscriber = new TestCollectingPublisherSubscriber<>();
+    private TestPublisher<Integer> publisher = new TestPublisher<>();
+
+    @BeforeClass
+    public static void beforeClass() {
+        executorService = java.util.concurrent.Executors.newFixedThreadPool(10);
+        executor = io.servicetalk.concurrent.api.Executors.from(executorService);
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        if (executor != null) {
+            executor.closeAsync().toFuture().get();
+        }
+        if (executorService != null) {
+            executorService.shutdown();
+        }
+    }
+
+    @Test
+    public void singleConcurrencyComplete() throws InterruptedException {
+        singleConcurrencyComplete(publisher.flatMapMerge(i -> from(i + 1), 1, 1));
+    }
+
+    @Test
+    public void defaultConcurrencyComplete() throws InterruptedException {
+        singleConcurrencyComplete(publisher.flatMapMerge(i -> from(i + 1)));
+    }
+
+    @Test
+    public void singleConcurrencyDelayErrorComplete() throws InterruptedException {
+        singleConcurrencyComplete(publisher.flatMapMergeDelayError(i -> from(i + 1), 1, 1));
+    }
+
+    @Test
+    public void defaultConcurrencyDelayErrorComplete() throws InterruptedException {
+        singleConcurrencyComplete(publisher.flatMapMergeDelayError(i -> from(i + 1)));
+    }
+
+    private void singleConcurrencyComplete(Publisher<Integer> flatMappedPublisher) throws InterruptedException {
+        toSource(flatMappedPublisher).subscribe(subscriber);
+        subscriber.awaitSubscription().request(1);
+        publisher.onNext(1);
+        publisher.onComplete();
+        Integer nextItem = subscriber.takeOnNext();
+        assertNotNull(nextItem);
+        assertEquals(2, nextItem.intValue());
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    public void singleConcurrencyNullComplete() throws InterruptedException {
+        toSource(publisher.flatMapMerge(i -> from((Integer) null), 1, 1)).subscribe(subscriber);
+        subscriber.awaitSubscription().request(1);
+        publisher.onNext(1);
+        publisher.onComplete();
+        Integer nextItem = subscriber.takeOnNext();
+        assertNull(nextItem);
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    public void singleItemSourceCompleteFirst() throws InterruptedException {
+        TestPublisher<Integer> mappedPublisher = new TestPublisher<>();
+        toSource(publisher.flatMapMerge(i -> mappedPublisher, 1, 1)).subscribe(subscriber);
+        subscriber.awaitSubscription().request(1);
+        publisher.onNext(1);
+        publisher.onComplete();
+        assertThat(subscriber.pollAllOnNext(), is(empty()));
+        assertFalse(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS));
+
+        mappedPublisher.onNext(2);
+        Integer nextItem = subscriber.takeOnNext();
+        assertNotNull(nextItem);
+        assertEquals(2, nextItem.intValue());
+
+        mappedPublisher.onComplete();
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    public void singleItemMappedCompleteFirst() throws InterruptedException {
+        TestPublisher<Integer> mappedPublisher = new TestPublisher<>();
+        toSource(publisher.flatMapMerge(i -> mappedPublisher, 1, 1)).subscribe(subscriber);
+        subscriber.awaitSubscription().request(1);
+        publisher.onNext(1);
+
+        mappedPublisher.onNext(2);
+        Integer nextItem = subscriber.takeOnNext();
+        assertNotNull(nextItem);
+        assertEquals(2, nextItem.intValue());
+
+        mappedPublisher.onComplete();
+        assertFalse(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS));
+
+        publisher.onComplete();
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    public void singleItemMappedError() throws InterruptedException {
+        toSource(publisher.flatMapMerge(i -> Publisher.<Integer>failed(DELIBERATE_EXCEPTION), 1, 1))
+                .subscribe(subscriber);
+        subscriber.awaitSubscription().request(1);
+        publisher.onNext(1);
+        assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    public void singleItemMappedErrorPostSourceComplete() throws InterruptedException {
+        TestPublisher<Integer> mappedPublisher = new TestPublisher<>();
+        toSource(publisher.flatMapMerge(i -> mappedPublisher, 1, 1)).subscribe(subscriber);
+        subscriber.awaitSubscription().request(1);
+        publisher.onNext(1);
+        publisher.onComplete();
+
+        mappedPublisher.onNext(2);
+        Integer nextItem = subscriber.takeOnNext();
+        assertNotNull(nextItem);
+        assertEquals(2, nextItem.intValue());
+
+        mappedPublisher.onError(DELIBERATE_EXCEPTION);
+        assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    public void sourceEmitsErrorNoOnNext() throws InterruptedException {
+        toSource(publisher.flatMapMerge(i -> from(i + 1), 1, 1)).subscribe(subscriber);
+        subscriber.awaitSubscription();
+        publisher.onError(DELIBERATE_EXCEPTION);
+        assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    public void sourceEmitsErrorPostOnNexts() throws InterruptedException {
+        toSource(publisher.flatMapMerge(i -> from(i + 1), 1, 1)).subscribe(subscriber);
+        subscriber.awaitSubscription().request(1);
+        publisher.onNext(1);
+        publisher.onError(DELIBERATE_EXCEPTION);
+
+        Integer nextItem = subscriber.takeOnNext();
+        assertNotNull(nextItem);
+        assertEquals(2, nextItem.intValue());
+        assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    public void sourceEmitsErrorPostOnNextsMappedNotCompleted() throws InterruptedException {
+        TestSubscription mappedSubscription = new TestSubscription();
+        TestPublisher<Integer> mappedPublisher = new TestPublisher.Builder<Integer>()
+                .disableAutoOnSubscribe().build();
+        toSource(publisher.flatMapMerge(i -> mappedPublisher, 1, 1)).subscribe(subscriber);
+        subscriber.awaitSubscription().request(1);
+        publisher.onNext(1);
+        assertTrue(mappedPublisher.isSubscribed());
+        mappedPublisher.onSubscribe(mappedSubscription);
+        publisher.onError(DELIBERATE_EXCEPTION);
+        assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
+        assertTrue(mappedSubscription.isCancelled());
+    }
+
+    @Test
+    public void sourceCancelAlsoCancelMapped() throws InterruptedException {
+        TestSubscription mappedSubscription = new TestSubscription();
+        TestPublisher<Integer> mappedPublisher = new TestPublisher.Builder<Integer>()
+                .disableAutoOnSubscribe().build();
+        toSource(publisher.flatMapMerge(i -> mappedPublisher, 1, 1)).subscribe(subscriber);
+        Subscription subscription = subscriber.awaitSubscription();
+        subscription.request(1);
+        publisher.onNext(1);
+        assertTrue(mappedPublisher.isSubscribed());
+        mappedPublisher.onSubscribe(mappedSubscription);
+        subscription.cancel();
+        assertTrue(mappedSubscription.isCancelled());
+    }
+
+    @Test
+    public void mappedCompletePostCancel() throws InterruptedException {
+        mappedTerminalPostCancel(false);
+    }
+
+    @Test
+    public void mappedErrorPostCancel() throws InterruptedException {
+        mappedTerminalPostCancel(true);
+    }
+
+    private void mappedTerminalPostCancel(boolean onError) throws InterruptedException {
+        TestSubscription mappedSubscription = new TestSubscription();
+        TestPublisher<Integer> mappedPublisher = new TestPublisher.Builder<Integer>()
+                .disableAutoOnSubscribe().build();
+        toSource(publisher.flatMapMerge(i -> mappedPublisher, 1, 1)).subscribe(subscriber);
+        Subscription subscription = subscriber.awaitSubscription();
+        subscription.request(1);
+        publisher.onNext(1);
+        assertTrue(mappedPublisher.isSubscribed());
+        mappedPublisher.onSubscribe(mappedSubscription);
+        subscription.cancel();
+        assertTrue(mappedSubscription.isCancelled());
+
+        mappedPublisher.onNext(2);
+        // We carefully track requestN on each mapped publisher, so we don't allow any emissions post cancel/terminal.
+        assertThat(subscriber.pollAllOnNext(), is(empty()));
+        if (onError) {
+            mappedPublisher.onError(DELIBERATE_EXCEPTION);
+            assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
+        } else {
+            mappedPublisher.onComplete();
+            // Since FlatMap needs to track the requestN amount leased to mapped Publishers, the cancel state is
+            // aggressive in suppressing onNext signals, and this currently extends to onComplete.
+            assertFalse(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS));
+        }
+    }
+
+    @Test
+    public void maxConcurrencyNotExceeded() throws InterruptedException {
+        List<TestSubscriptionPublisherPair<Integer>> mappedPublishers = new ArrayList<>();
+        TestSubscription upstreamSubscription = new TestSubscription();
+        publisher = new TestPublisher.Builder<Integer>()
+                .disableAutoOnSubscribe().build(subscriber1 -> {
+                    subscriber1.onSubscribe(upstreamSubscription);
+                    return subscriber1;
+                });
+        toSource(publisher.flatMapMerge(i -> {
+            TestSubscriptionPublisherPair<Integer> pair = new TestSubscriptionPublisherPair<>(i);
+            mappedPublishers.add(pair);
+            return pair.mappedPublisher;
+        }, 2, 1)).subscribe(subscriber);
+        Subscription subscription = subscriber.awaitSubscription();
+        subscription.request(3);
+
+        verifyCumulativeDemand(upstreamSubscription, 2);
+        publisher.onNext(1);
+        publisher.onNext(2);
+
+        // Verify there are two mapped Publishers, and each is given 1 requestN.
+        assertThat(mappedPublishers, hasSize(2));
+        TestSubscriptionPublisherPair<Integer> first = mappedPublishers.get(0);
+        first.doOnSubscribe(1);
+        first.verifyCumulativeDemand(1);
+
+        TestSubscriptionPublisherPair<Integer> second = mappedPublishers.get(1);
+        second.doOnSubscribe(2);
+        second.verifyCumulativeDemand(1);
+
+        // Emit an item from the second publisher, there is 1 downstream demand outstanding and it should be given
+        // to the second Publisher.
+        second.mappedPublisher.onNext(21);
+        second.verifyCumulativeDemand(2);
+
+        Integer next = subscriber.takeOnNext();
+        assertThat(next, is(21));
+
+        // Emit an item from the first Publisher, however all 3 of the downstream demand is accounted for, so no more
+        // requestN will be given to first Publisher.
+        first.mappedPublisher.onNext(11);
+        first.verifyCumulativeDemand(1);
+
+        next = subscriber.takeOnNext();
+        assertThat(next, is(11));
+
+        // The second publisher is completed, but still has 1 outstanding request n. This demand should be redistributed
+        // to the first publisher
+        second.mappedPublisher.onComplete();
+        first.verifyCumulativeDemand(2);
+
+        // FlatMap should also request another item from upstream, because there is now only 1 active mapped Publisher.
+        verifyCumulativeDemand(upstreamSubscription, 3);
+
+        publisher.onNext(3);
+        assertThat(mappedPublishers, hasSize(3));
+        TestSubscriptionPublisherPair<Integer> third = mappedPublishers.get(2);
+        third.doOnSubscribe(3);
+        third.verifyCumulativeDemand(0);
+
+        // Use the last of the 3 demand we started with to emit an item from first Publisher.
+        first.mappedPublisher.onNext(12);
+        next = subscriber.takeOnNext();
+        assertThat(next, is(12));
+
+        // Request 3 more, and verify this demand gets distributed to first and third.
+        subscription.request(3);
+        first.verifyCumulativeDemand(3);
+        third.verifyCumulativeDemand(1);
+
+        // Complete outstanding publishers and verify completion.
+        first.mappedPublisher.onComplete();
+        third.mappedPublisher.onComplete();
+        assertFalse(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS));
+
+        publisher.onComplete();
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    public void mapperThrows() throws InterruptedException {
+        TestSubscription upstreamSubscription = new TestSubscription();
+        publisher = new TestPublisher.Builder<Integer>()
+                .disableAutoOnSubscribe().build(subscriber1 -> {
+                    subscriber1.onSubscribe(upstreamSubscription);
+                    return subscriber1;
+                });
+        toSource(publisher.<Integer>flatMapMerge(i -> {
+            throw DELIBERATE_EXCEPTION;
+        }, 1, 1)).subscribe(subscriber);
+        subscriber.awaitSubscription().request(1);
+
+        try {
+            publisher.onNext(1);
+            fail();
+        } catch (Throwable cause) {
+            assertSame(DELIBERATE_EXCEPTION, cause);
+
+            // Now simulate failing the publisher by emit onError(...)
+            publisher.onError(cause);
+        }
+
+        assertFalse(upstreamSubscription.isCancelled());
+        assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    public void requestLongMax() throws InterruptedException {
+        List<TestSubscriptionPublisherPair<Integer>> mappedPublishers = new ArrayList<>();
+        TestSubscription upstreamSubscription = new TestSubscription();
+        publisher = new TestPublisher.Builder<Integer>()
+                .disableAutoOnSubscribe().build(subscriber1 -> {
+                    subscriber1.onSubscribe(upstreamSubscription);
+                    return subscriber1;
+                });
+        toSource(publisher.flatMapMerge(i -> {
+            TestSubscriptionPublisherPair<Integer> pair = new TestSubscriptionPublisherPair<>(i);
+            mappedPublishers.add(pair);
+            return pair.mappedPublisher;
+        }, 2, 5)).subscribe(subscriber);
+        subscriber.awaitSubscription().request(Long.MAX_VALUE);
+
+        // Should not request more than max concurrency.
+        verifyCumulativeDemand(upstreamSubscription, 2);
+
+        publisher.onNext(1);
+        publisher.onNext(2);
+
+        // Verify there are two mapped Publishers, and each is given 1 requestN.
+        assertThat(mappedPublishers, hasSize(2));
+        TestSubscriptionPublisherPair<Integer> first = mappedPublishers.get(0);
+        first.doOnSubscribe(1);
+        first.verifyCumulativeDemand(5);
+
+        TestSubscriptionPublisherPair<Integer> second = mappedPublishers.get(1);
+        second.doOnSubscribe(2);
+        second.verifyCumulativeDemand(5);
+
+        // Use all the quota provided to first, and verify there is no re-distribution after.
+        first.mappedPublisher.onNext(1, 2, 3, 4, 5);
+        assertThat(subscriber.pollAllOnNext(), contains(1, 2, 3, 4, 5));
+        second.verifyCumulativeDemand(5);
+
+        first.mappedPublisher.onComplete();
+        verifyCumulativeDemand(upstreamSubscription, 3);
+
+        // Emit a third item, and it should be given the max quota.
+        publisher.onNext(3);
+        assertThat(mappedPublishers, hasSize(3));
+        TestSubscriptionPublisherPair<Integer> third = mappedPublishers.get(2);
+        third.doOnSubscribe(3);
+        third.verifyCumulativeDemand(5);
+
+        // terminate the Publisher, verify mapped items still emitted and termination delayed.
+        publisher.onComplete();
+        assertFalse(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS));
+
+        second.mappedPublisher.onNext(6, 7);
+        third.mappedPublisher.onNext(8, 9, 10);
+        assertThat(subscriber.pollAllOnNext(), contains(6, 7, 8, 9, 10));
+
+        second.mappedPublisher.onComplete();
+        assertFalse(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS));
+        third.mappedPublisher.onComplete();
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    public void requestLongMaxMultipleTimes() throws InterruptedException {
+        TestSubscription upstreamSubscription = new TestSubscription();
+        publisher = new TestPublisher.Builder<Integer>()
+                .disableAutoOnSubscribe().build(subscriber1 -> {
+                    subscriber1.onSubscribe(upstreamSubscription);
+                    return subscriber1;
+                });
+        toSource(publisher.flatMapMerge(Publisher::from, 2, 1)).subscribe(subscriber);
+        Subscription subscription = subscriber.awaitSubscription();
+        subscription.request(Long.MAX_VALUE);
+
+        verifyCumulativeDemand(upstreamSubscription, 2);
+        publisher.onNext(1);
+        verifyCumulativeDemand(upstreamSubscription, 3);
+        subscription.request(Long.MAX_VALUE);
+        verifyCumulativeDemand(upstreamSubscription, 3);
+    }
+
+    @Test
+    public void accumulateToLongMax() throws InterruptedException {
+        accumulateToMax(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void accumulateToIntMax() throws InterruptedException {
+        accumulateToMax(Integer.MAX_VALUE);
+    }
+
+    private void accumulateToMax(long max) throws InterruptedException {
+        TestSubscription upstreamSubscription = new TestSubscription();
+        publisher = new TestPublisher.Builder<Integer>()
+                .disableAutoOnSubscribe().build(subscriber1 -> {
+                    subscriber1.onSubscribe(upstreamSubscription);
+                    return subscriber1;
+                });
+        toSource(publisher.flatMapMerge(Publisher::from, 2, 1)).subscribe(subscriber);
+        Subscription subscription = subscriber.awaitSubscription();
+        subscription.request(max - 1);
+
+        verifyCumulativeDemand(upstreamSubscription, 2);
+        subscription.request(2);
+        verifyCumulativeDemand(upstreamSubscription, 2);
+        publisher.onNext(1, 3);
+        verifyCumulativeDemand(upstreamSubscription, 4);
+    }
+
+    @Test
+    public void requestAfterMappedError() throws InterruptedException {
+        TestSubscription upstreamSubscription = new TestSubscription();
+        publisher = new TestPublisher.Builder<Integer>()
+                .disableAutoOnSubscribe().build(subscriber1 -> {
+                    subscriber1.onSubscribe(upstreamSubscription);
+                    return subscriber1;
+                });
+        toSource(publisher.<Integer>flatMapMergeDelayError(i -> Publisher.failed(DELIBERATE_EXCEPTION), 2, 1))
+                .subscribe(subscriber);
+        subscriber.awaitSubscription().request(3);
+        verifyCumulativeDemand(upstreamSubscription, 2);
+
+        publisher.onNext(1, 2);
+        assertFalse(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS));
+        publisher.onComplete();
+        verifySuppressed(subscriber.awaitOnError(), DELIBERATE_EXCEPTION);
+    }
+
+    @Test
+    public void requestMultipleTimes() throws InterruptedException {
+        TestSubscription upstreamSubscription = new TestSubscription();
+        publisher = new TestPublisher.Builder<Integer>()
+                .disableAutoOnSubscribe().build(subscriber1 -> {
+                    subscriber1.onSubscribe(upstreamSubscription);
+                    return subscriber1;
+                });
+        toSource(publisher.flatMapMerge(Publisher::from, 10, 1)).subscribe(subscriber);
+        Subscription subscription = subscriber.awaitSubscription();
+        subscription.request(2);
+        verifyCumulativeDemand(upstreamSubscription, 10);
+
+        publisher.onNext(1, 2);
+        assertThat(subscriber.pollAllOnNext(), contains(1, 2));
+        verifyCumulativeDemand(upstreamSubscription, 12);
+
+        subscription.request(2);
+        publisher.onNext(3, 4);
+        assertThat(subscriber.pollAllOnNext(), contains(3, 4));
+        verifyCumulativeDemand(upstreamSubscription, 14);
+
+        subscription.request(2);
+        publisher.onNext(5, 6);
+        assertThat(subscriber.pollAllOnNext(), contains(5, 6));
+        verifyCumulativeDemand(upstreamSubscription, 16);
+    }
+
+    @Test
+    public void requestMultipleTimesBreachMaxConcurrency() throws InterruptedException {
+        TestSubscription upstreamSubscription = new TestSubscription();
+        publisher = new TestPublisher.Builder<Integer>()
+                .disableAutoOnSubscribe().build(subscriber1 -> {
+                    subscriber1.onSubscribe(upstreamSubscription);
+                    return subscriber1;
+                });
+        toSource(publisher.flatMapMerge(Publisher::from, 2, 1)).subscribe(subscriber);
+        Subscription subscription = subscriber.awaitSubscription();
+        subscription.request(2);
+        subscription.request(2);
+        verifyCumulativeDemand(upstreamSubscription, 2);
+
+        publisher.onNext(1, 2);
+        verifyCumulativeDemand(upstreamSubscription, 4);
+        publisher.onNext(3, 4);
+        verifyCumulativeDemand(upstreamSubscription, 6);
+
+        publisher.onComplete();
+        assertThat(subscriber.pollAllOnNext(), contains(1, 2, 3, 4));
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    public void multipleMappedErrors() throws InterruptedException {
+        List<DeliberateException> errors = new ArrayList<>();
+        toSource(publisher.<Integer>flatMapMergeDelayError(i -> {
+            DeliberateException de = new DeliberateException();
+            errors.add(de);
+            return Publisher.failed(de);
+        }, 2, 1)).subscribe(subscriber);
+        subscriber.awaitSubscription().request(3);
+
+        publisher.onNext(1, 2);
+        publisher.onComplete();
+        assertThat(errors, hasSize(2));
+        DeliberateException first = errors.remove(0);
+        for (DeliberateException error : errors) {
+            verifyOriginalAndSuppressedCauses(subscriber.awaitOnError(), first, error);
+        }
+    }
+
+    @Test
+    public void subscriptionReentry() throws InterruptedException {
+        Queue<Integer> resultsQueue = new ConcurrentLinkedQueue<>();
+        AtomicReference<Throwable> causeRef = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        final int maxRange = 1000000;
+        toSource(publisher.flatMapMerge(i -> Publisher.range(0, maxRange), 10, 1)).subscribe(
+                new Subscriber<Integer>() {
+                    @Nullable
+                    private Subscription subscription;
+                    @Override
+                    public void onSubscribe(final Subscription subscription) {
+                        this.subscription = subscription;
+                        subscription.request(1);
+                    }
+
+                    @Override
+                    public void onNext(@Nullable final Integer integer) {
+                        assert subscription != null;
+                        resultsQueue.add(integer);
+                        subscription.request(1);
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        causeRef.set(t);
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        latch.countDown();
+                    }
+                });
+
+        publisher.onNext(1);
+        publisher.onComplete();
+        latch.await();
+        assertNull(causeRef.get());
+        for (int i = 0; i < maxRange; ++i) {
+            assertThat(resultsQueue.poll(), is(i));
+        }
+        assertTrue(resultsQueue.isEmpty());
+    }
+
+    @Test
+    public void emitFromExecutor() throws InterruptedException, ExecutionException {
+        List<TestSubscriptionPublisherPair<Integer>> mappedPublishers = new ArrayList<>();
+        TestSubscription upstreamSubscription = new TestSubscription();
+        publisher = new TestPublisher.Builder<Integer>()
+                .disableAutoOnSubscribe().build(subscriber1 -> {
+                    subscriber1.onSubscribe(upstreamSubscription);
+                    return subscriber1;
+                });
+        toSource(publisher.flatMapMerge(i -> {
+            TestSubscriptionPublisherPair<Integer> pair = new TestSubscriptionPublisherPair<>(i);
+            mappedPublishers.add(pair);
+            return pair.mappedPublisher;
+        }, 2, 5)).subscribe(subscriber);
+        subscriber.awaitSubscription().request(Long.MAX_VALUE);
+        verifyCumulativeDemand(upstreamSubscription, 2);
+
+        publisher.onNext(1, 2);
+
+        assertThat(mappedPublishers, hasSize(2));
+        TestSubscriptionPublisherPair<Integer> first = mappedPublishers.get(0);
+        TestSubscriptionPublisherPair<Integer> second = mappedPublishers.get(1);
+
+        first.doOnSubscribe(1);
+        first.verifyCumulativeDemand(5);
+        second.doOnSubscribe(2);
+        second.verifyCumulativeDemand(5);
+
+        assert executorService != null;
+        Future<?> firstEmitFuture = executorService.submit(() -> {
+            first.mappedPublisher.onNext(1, 2, 3);
+            first.mappedPublisher.onComplete();
+        });
+
+        Future<?> secondEmitFuture = executorService.submit(() -> {
+            second.mappedPublisher.onNext(4, 5, 6);
+            second.mappedPublisher.onComplete();
+        });
+
+        publisher.onComplete();
+        firstEmitFuture.get();
+        secondEmitFuture.get();
+
+        subscriber.awaitOnComplete(false);
+        assertThat(subscriber.pollAllOnNext(), containsInAnyOrder(1, 2, 3, 4, 5, 6));
+    }
+
+    @Test
+    public void requestAndEmitConcurrency() throws Exception {
+        int totalToRequest = 1000;
+        List<Integer> received = new ArrayList<>(totalToRequest);
+        CountDownLatch requestingStarting = new CountDownLatch(1);
+        TestSubscription upstreamSubscription = new TestSubscription();
+        publisher = new TestPublisher.Builder<Integer>()
+                .disableAutoOnSubscribe().build(subscriber1 -> {
+                    subscriber1.onSubscribe(upstreamSubscription);
+                    return subscriber1;
+                });
+        toSource(publisher.flatMapMerge(Publisher::from, 2, 5).beforeOnNext(received::add))
+                .subscribe(subscriber);
+        Subscription subscription = subscriber.awaitSubscription();
+        assert executorService != null;
+        Future<?> submitFuture = executorService.submit(() -> {
+            requestingStarting.countDown();
+            for (int i = 0; i < totalToRequest; i++) {
+                subscription.request(1);
+            }
+        });
+
+        // Just to make sure we have both threads running concurrently.
+        requestingStarting.await();
+        for (int i = 0; i < totalToRequest; i++) {
+            upstreamSubscription.awaitRequestN(i + 1);
+            publisher.onNext(i);
+        }
+
+        submitFuture.get();
+        assertThat("Unexpected items emitted.", received, hasSize(totalToRequest));
+        assertThat(received, containsInAnyOrder(IntStream.range(0, totalToRequest).boxed().toArray()));
+    }
+
+    @Test
+    public void concurrentMappedAndPublisherTermination() throws Exception {
+        assert executor != null;
+        Single<List<Integer>> single = Publisher.range(0, 1000)
+                .flatMapMerge(i -> executor.submit(() -> i).toPublisher(), 1024, 10)
+                .collect(ArrayList::new, (ints, i) -> {
+                    ints.add(i);
+                    return ints;
+                });
+        for (int i = 0; i < 10; i++) {
+            List<Integer> list = single.toFuture().get();
+            assertThat("Unexpected items received", list, hasSize(1000));
+        }
+    }
+
+    @Test
+    public void concurrentMappedDeliversAllData() throws InterruptedException {
+        assert executor != null;
+        final int upstreamItems = 10000;
+        final int mappedItems = 5;
+        Publisher<Integer> publisher = Publisher.range(0, upstreamItems)
+                .flatMapMerge(i -> Publisher.range(0, mappedItems).publishAndSubscribeOn(executor), upstreamItems,
+                        mappedItems);
+
+        toSource(publisher).subscribe(subscriber);
+        subscriber.awaitSubscription().request(upstreamItems * mappedItems);
+        subscriber.awaitOnComplete(false);
+        assertThat(subscriber.pollAllOnNext(), hasSize(upstreamItems * mappedItems));
+    }
+
+    @Test
+    public void concurrentMappedErrorAndPublisherTermination() throws Exception {
+        assert executor != null;
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        Single<List<Integer>> single = Publisher.range(0, 1000)
+                .flatMapMergeDelayError(i -> executor.submit(() -> {
+                    if (i % 2 == 0) {
+                        return i;
+                    }
+                    throw new DeliberateException();
+                }).toPublisher(), 1024, 10)
+                .recoverWith(t -> {
+                    error.set(t);
+                    return Publisher.empty();
+                }).collect(ArrayList::new, (ints, s) -> {
+                    ints.add(s);
+                    return ints;
+                });
+
+        for (int i = 0; i < 10; i++) {
+            List<Integer> list = single.toFuture().get();
+            assertThat("Unexpected items received", list, hasSize(500));
+            Throwable cause = error.get();
+            assertThat("Unexpected exception.", cause, instanceOf(CompositeException.class));
+            assertThat("Unexpected exception.", cause.getCause(), instanceOf(DeliberateException.class));
+            assertThat("Unexpected exception.", cause.getSuppressed().length,
+                    equalTo(499/*everything but the first error is suppressed*/));
+        }
+    }
+
+    @Test
+    public void mappedQuotaIsRenewedAfterExhausted() throws InterruptedException {
+        List<TestSubscriptionPublisherPair<Integer>> mappedPublishers = new ArrayList<>();
+        TestSubscription upstreamSubscription = new TestSubscription();
+        publisher = new TestPublisher.Builder<Integer>()
+                .disableAutoOnSubscribe().build(subscriber1 -> {
+                    subscriber1.onSubscribe(upstreamSubscription);
+                    return subscriber1;
+                });
+        toSource(publisher.flatMapMerge(i -> {
+            TestSubscriptionPublisherPair<Integer> pair = new TestSubscriptionPublisherPair<>(i);
+            mappedPublishers.add(pair);
+            return pair.mappedPublisher;
+        }, 2, 2)).subscribe(subscriber);
+        subscriber.awaitSubscription().request(Long.MAX_VALUE);
+
+        publisher.onNext(1, 2);
+
+        assertThat(mappedPublishers, hasSize(2));
+        TestSubscriptionPublisherPair<Integer> first = mappedPublishers.get(0);
+        TestSubscriptionPublisherPair<Integer> second = mappedPublishers.get(1);
+
+        first.doOnSubscribe(1);
+        first.verifyCumulativeDemand(2);
+        second.doOnSubscribe(2);
+        second.verifyCumulativeDemand(2);
+
+        first.mappedPublisher.onNext(1, 2);
+        first.verifyCumulativeDemand(4);
+
+        second.mappedPublisher.onNext(3, 4);
+        second.verifyCumulativeDemand(4);
+
+        assertThat(subscriber.pollAllOnNext(), contains(1, 2, 3, 4));
+        first.mappedPublisher.onComplete();
+        second.mappedPublisher.onComplete();
+        assertFalse(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS));
+
+        publisher.onComplete();
+        subscriber.awaitOnComplete();
+    }
+
+    private static final class TestSubscriptionPublisherPair<T> {
+        @Nullable
+        final T item;
+        final TestSubscription mappedSubscription = new TestSubscription();
+        final TestPublisher<T> mappedPublisher = new TestPublisher.Builder<T>()
+                .disableAutoOnSubscribe().build();
+
+        TestSubscriptionPublisherPair(@Nullable T item) {
+            this.item = item;
+        }
+
+        private void doOnSubscribe(T expectedItem) {
+            assertThat(item, is(expectedItem));
+            assertThat(mappedSubscription.requested(), is(0L));
+            mappedPublisher.onSubscribe(mappedSubscription);
+        }
+
+        private void verifyCumulativeDemand(long totalRequestN) throws InterruptedException {
+            PublisherFlatMapMergeTest.verifyCumulativeDemand(mappedSubscription, totalRequestN);
+        }
+    }
+
+    private static void verifyCumulativeDemand(TestSubscription testSubscription, long totalRequestN)
+            throws InterruptedException {
+        testSubscription.awaitRequestN(totalRequestN);
+        assertThat(testSubscription.requested(), is(totalRequestN));
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
@@ -95,7 +95,7 @@ public class PublisherFlatMapMergeTest {
 
     @Test
     public void singleConcurrencyComplete() throws InterruptedException {
-        singleConcurrencyComplete(publisher.flatMapMerge(i -> from(i + 1), 1, 1));
+        singleConcurrencyComplete(publisher.flatMapMerge(i -> from(i + 1), 1));
     }
 
     @Test
@@ -105,7 +105,7 @@ public class PublisherFlatMapMergeTest {
 
     @Test
     public void singleConcurrencyDelayErrorComplete() throws InterruptedException {
-        singleConcurrencyComplete(publisher.flatMapMergeDelayError(i -> from(i + 1), 1, 1));
+        singleConcurrencyComplete(publisher.flatMapMergeDelayError(i -> from(i + 1), 1));
     }
 
     @Test
@@ -126,7 +126,7 @@ public class PublisherFlatMapMergeTest {
 
     @Test
     public void singleConcurrencyNullComplete() throws InterruptedException {
-        toSource(publisher.flatMapMerge(i -> from((Integer) null), 1, 1)).subscribe(subscriber);
+        toSource(publisher.flatMapMerge(i -> from((Integer) null), 1)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         publisher.onNext(1);
         publisher.onComplete();
@@ -138,7 +138,7 @@ public class PublisherFlatMapMergeTest {
     @Test
     public void singleItemSourceCompleteFirst() throws InterruptedException {
         TestPublisher<Integer> mappedPublisher = new TestPublisher<>();
-        toSource(publisher.flatMapMerge(i -> mappedPublisher, 1, 1)).subscribe(subscriber);
+        toSource(publisher.flatMapMerge(i -> mappedPublisher, 1)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         publisher.onNext(1);
         publisher.onComplete();
@@ -157,7 +157,7 @@ public class PublisherFlatMapMergeTest {
     @Test
     public void singleItemMappedCompleteFirst() throws InterruptedException {
         TestPublisher<Integer> mappedPublisher = new TestPublisher<>();
-        toSource(publisher.flatMapMerge(i -> mappedPublisher, 1, 1)).subscribe(subscriber);
+        toSource(publisher.flatMapMerge(i -> mappedPublisher, 1)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         publisher.onNext(1);
 
@@ -175,7 +175,7 @@ public class PublisherFlatMapMergeTest {
 
     @Test
     public void singleItemMappedError() throws InterruptedException {
-        toSource(publisher.flatMapMerge(i -> Publisher.<Integer>failed(DELIBERATE_EXCEPTION), 1, 1))
+        toSource(publisher.flatMapMerge(i -> Publisher.<Integer>failed(DELIBERATE_EXCEPTION), 1))
                 .subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         publisher.onNext(1);
@@ -185,7 +185,7 @@ public class PublisherFlatMapMergeTest {
     @Test
     public void singleItemMappedErrorPostSourceComplete() throws InterruptedException {
         TestPublisher<Integer> mappedPublisher = new TestPublisher<>();
-        toSource(publisher.flatMapMerge(i -> mappedPublisher, 1, 1)).subscribe(subscriber);
+        toSource(publisher.flatMapMerge(i -> mappedPublisher, 1)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         publisher.onNext(1);
         publisher.onComplete();
@@ -201,7 +201,7 @@ public class PublisherFlatMapMergeTest {
 
     @Test
     public void sourceEmitsErrorNoOnNext() throws InterruptedException {
-        toSource(publisher.flatMapMerge(i -> from(i + 1), 1, 1)).subscribe(subscriber);
+        toSource(publisher.flatMapMerge(i -> from(i + 1), 1)).subscribe(subscriber);
         subscriber.awaitSubscription();
         publisher.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
@@ -209,7 +209,7 @@ public class PublisherFlatMapMergeTest {
 
     @Test
     public void sourceEmitsErrorPostOnNexts() throws InterruptedException {
-        toSource(publisher.flatMapMerge(i -> from(i + 1), 1, 1)).subscribe(subscriber);
+        toSource(publisher.flatMapMerge(i -> from(i + 1), 1)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         publisher.onNext(1);
         publisher.onError(DELIBERATE_EXCEPTION);
@@ -225,7 +225,7 @@ public class PublisherFlatMapMergeTest {
         TestSubscription mappedSubscription = new TestSubscription();
         TestPublisher<Integer> mappedPublisher = new TestPublisher.Builder<Integer>()
                 .disableAutoOnSubscribe().build();
-        toSource(publisher.flatMapMerge(i -> mappedPublisher, 1, 1)).subscribe(subscriber);
+        toSource(publisher.flatMapMerge(i -> mappedPublisher, 1)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         publisher.onNext(1);
         assertTrue(mappedPublisher.isSubscribed());
@@ -240,7 +240,7 @@ public class PublisherFlatMapMergeTest {
         TestSubscription mappedSubscription = new TestSubscription();
         TestPublisher<Integer> mappedPublisher = new TestPublisher.Builder<Integer>()
                 .disableAutoOnSubscribe().build();
-        toSource(publisher.flatMapMerge(i -> mappedPublisher, 1, 1)).subscribe(subscriber);
+        toSource(publisher.flatMapMerge(i -> mappedPublisher, 1)).subscribe(subscriber);
         Subscription subscription = subscriber.awaitSubscription();
         subscription.request(1);
         publisher.onNext(1);
@@ -264,7 +264,7 @@ public class PublisherFlatMapMergeTest {
         TestSubscription mappedSubscription = new TestSubscription();
         TestPublisher<Integer> mappedPublisher = new TestPublisher.Builder<Integer>()
                 .disableAutoOnSubscribe().build();
-        toSource(publisher.flatMapMerge(i -> mappedPublisher, 1, 1)).subscribe(subscriber);
+        toSource(publisher.flatMapMerge(i -> mappedPublisher, 1)).subscribe(subscriber);
         Subscription subscription = subscriber.awaitSubscription();
         subscription.request(1);
         publisher.onNext(1);
@@ -298,7 +298,7 @@ public class PublisherFlatMapMergeTest {
             TestSubscriptionPublisherPair<Integer> pair = new TestSubscriptionPublisherPair<>(i);
             mappedPublishers.add(pair);
             return pair.mappedPublisher;
-        }, 2, 2)).subscribe(subscriber);
+        }, 2)).subscribe(subscriber);
         Subscription subscription = subscriber.awaitSubscription();
         subscription.request(1);
 
@@ -310,9 +310,9 @@ public class PublisherFlatMapMergeTest {
         TestSubscriptionPublisherPair<Integer> second = mappedPublishers.get(1);
 
         first.doOnSubscribe(1);
-        first.mappedSubscription.awaitRequestN(2);
+        first.mappedSubscription.awaitRequestN(1);
         second.doOnSubscribe(2);
-        second.mappedSubscription.awaitRequestN(2);
+        second.mappedSubscription.awaitRequestN(1);
 
         // Exhaust outstanding requestN from downstream
         first.mappedPublisher.onNext(10);
@@ -339,7 +339,7 @@ public class PublisherFlatMapMergeTest {
                 });
         toSource(publisher.<Integer>flatMapMerge(i -> {
             throw DELIBERATE_EXCEPTION;
-        }, 1, 1)).subscribe(subscriber);
+        }, 1)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
 
         try {
@@ -369,7 +369,7 @@ public class PublisherFlatMapMergeTest {
             TestSubscriptionPublisherPair<Integer> pair = new TestSubscriptionPublisherPair<>(i);
             mappedPublishers.add(pair);
             return pair.mappedPublisher;
-        }, 2, 5)).subscribe(subscriber);
+        }, 2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(Long.MAX_VALUE);
 
         // Should not request more than max concurrency.
@@ -426,7 +426,7 @@ public class PublisherFlatMapMergeTest {
                     subscriber1.onSubscribe(upstreamSubscription);
                     return subscriber1;
                 });
-        toSource(publisher.flatMapMerge(Publisher::from, 2, 1)).subscribe(subscriber);
+        toSource(publisher.flatMapMerge(Publisher::from, 2)).subscribe(subscriber);
         Subscription subscription = subscriber.awaitSubscription();
 
         subscription.request(Long.MAX_VALUE);
@@ -458,7 +458,7 @@ public class PublisherFlatMapMergeTest {
                     subscriber1.onSubscribe(upstreamSubscription);
                     return subscriber1;
                 });
-        toSource(publisher.flatMapMerge(Publisher::from, 2, 1)).subscribe(subscriber);
+        toSource(publisher.flatMapMerge(Publisher::from, 2)).subscribe(subscriber);
         Subscription subscription = subscriber.awaitSubscription();
         subscription.request(max - 1);
 
@@ -477,7 +477,7 @@ public class PublisherFlatMapMergeTest {
                     subscriber1.onSubscribe(upstreamSubscription);
                     return subscriber1;
                 });
-        toSource(publisher.<Integer>flatMapMergeDelayError(i -> Publisher.failed(DELIBERATE_EXCEPTION), 2, 1))
+        toSource(publisher.<Integer>flatMapMergeDelayError(i -> Publisher.failed(DELIBERATE_EXCEPTION), 2))
                 .subscribe(subscriber);
         subscriber.awaitSubscription().request(3);
         verifyCumulativeDemand(upstreamSubscription, 2);
@@ -496,7 +496,7 @@ public class PublisherFlatMapMergeTest {
                     subscriber1.onSubscribe(upstreamSubscription);
                     return subscriber1;
                 });
-        toSource(publisher.flatMapMerge(Publisher::from, 10, 1)).subscribe(subscriber);
+        toSource(publisher.flatMapMerge(Publisher::from, 10)).subscribe(subscriber);
         Subscription subscription = subscriber.awaitSubscription();
         subscription.request(2);
         verifyCumulativeDemand(upstreamSubscription, 10);
@@ -524,7 +524,7 @@ public class PublisherFlatMapMergeTest {
                     subscriber1.onSubscribe(upstreamSubscription);
                     return subscriber1;
                 });
-        toSource(publisher.flatMapMerge(Publisher::from, 2, 1)).subscribe(subscriber);
+        toSource(publisher.flatMapMerge(Publisher::from, 2)).subscribe(subscriber);
         Subscription subscription = subscriber.awaitSubscription();
         subscription.request(2);
         subscription.request(2);
@@ -547,7 +547,7 @@ public class PublisherFlatMapMergeTest {
             DeliberateException de = new DeliberateException();
             errors.add(de);
             return Publisher.failed(de);
-        }, 2, 1)).subscribe(subscriber);
+        }, 2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(3);
 
         publisher.onNext(1, 2);
@@ -565,7 +565,7 @@ public class PublisherFlatMapMergeTest {
         AtomicReference<Throwable> causeRef = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
         final int maxRange = 1000000;
-        toSource(publisher.flatMapMerge(i -> range(0, maxRange), 10, 1)).subscribe(
+        toSource(publisher.flatMapMerge(i -> range(0, maxRange), 10)).subscribe(
                 new Subscriber<Integer>() {
                     @Nullable
                     private Subscription subscription;
@@ -617,7 +617,7 @@ public class PublisherFlatMapMergeTest {
             TestSubscriptionPublisherPair<Integer> pair = new TestSubscriptionPublisherPair<>(i);
             mappedPublishers.add(pair);
             return pair.mappedPublisher;
-        }, 2, 5)).subscribe(subscriber);
+        }, 2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(Long.MAX_VALUE);
         verifyCumulativeDemand(upstreamSubscription, 2);
 
@@ -662,7 +662,7 @@ public class PublisherFlatMapMergeTest {
                     subscriber1.onSubscribe(upstreamSubscription);
                     return subscriber1;
                 });
-        toSource(publisher.flatMapMerge(Publisher::from, 2, 5).beforeOnNext(received::add))
+        toSource(publisher.flatMapMerge(Publisher::from, 2).beforeOnNext(received::add))
                 .subscribe(subscriber);
         Subscription subscription = subscriber.awaitSubscription();
         assert executorService != null;
@@ -689,7 +689,7 @@ public class PublisherFlatMapMergeTest {
     public void concurrentMappedAndPublisherTermination() throws Exception {
         assert executor != null;
         Single<List<Integer>> single = range(0, 1000)
-                .flatMapMerge(i -> executor.submit(() -> i).toPublisher(), 1024, 10)
+                .flatMapMerge(i -> executor.submit(() -> i).toPublisher(), 1024)
                 .collect(ArrayList::new, (ints, i) -> {
                     ints.add(i);
                     return ints;
@@ -707,7 +707,7 @@ public class PublisherFlatMapMergeTest {
         final int mappedItems = 5;
         final TestCollectingPublisherSubscriber<IntPair> subscriber = new TestCollectingPublisherSubscriber<>();
         Publisher<IntPair> publisher = range(0, upstreamItems).flatMapMerge(outer -> range(0, mappedItems)
-                .map(inner -> new IntPair(outer, inner)).publishAndSubscribeOn(executor), upstreamItems, mappedItems);
+                .map(inner -> new IntPair(outer, inner)).publishAndSubscribeOn(executor), upstreamItems);
         toSource(publisher).subscribe(subscriber);
         subscriber.awaitSubscription().request(upstreamItems * mappedItems);
 
@@ -740,7 +740,7 @@ public class PublisherFlatMapMergeTest {
                         return i;
                     }
                     throw new DeliberateException();
-                }).toPublisher(), 1024, 10)
+                }).toPublisher(), 1024)
                 .recoverWith(t -> {
                     error.set(t);
                     return Publisher.empty();
@@ -773,7 +773,7 @@ public class PublisherFlatMapMergeTest {
             TestSubscriptionPublisherPair<Integer> pair = new TestSubscriptionPublisherPair<>(i);
             mappedPublishers.add(pair);
             return pair.mappedPublisher;
-        }, 2, 2)).subscribe(subscriber);
+        }, 2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(Long.MAX_VALUE);
 
         publisher.onNext(1, 2);
@@ -821,7 +821,7 @@ public class PublisherFlatMapMergeTest {
             TestSubscriptionPublisherPair<Integer> pair = new TestSubscriptionPublisherPair<>(i);
             mappedPublishers.add(pair);
             return pair.mappedPublisher;
-        }, 2, 2)).subscribe(subscriber);
+        }, 2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(Long.MAX_VALUE);
 
         publisher.onNext(1, 2);
@@ -852,32 +852,45 @@ public class PublisherFlatMapMergeTest {
 
     @Test
     public void lastActiveMappedPublisherCanDeliverData() throws Throwable {
-        CountDownLatch latch = new CountDownLatch(1);
+        final int mappedRangeBegin = 5;
+        final int mappedRangeEnd = 10;
+        CountDownLatch latch = new CountDownLatch(mappedRangeEnd - mappedRangeBegin);
         AtomicReference<Throwable> causeRef = new AtomicReference<>();
-        final int lastIndex = 2;
+        final int lastIndex = 100;
         toSource(range(0, lastIndex)
-                .flatMapMerge(i -> i == lastIndex - 1 ? from(lastIndex) : never(), lastIndex, 1)
+                .flatMapMerge(i -> i == lastIndex - 1 ? range(mappedRangeBegin, mappedRangeEnd) : never(), lastIndex)
         ).subscribe(new Subscriber<Integer>() {
+            @Nullable
+            private Subscription subscription;
             @Override
             public void onSubscribe(final Subscription subscription) {
+                this.subscription = subscription;
                 subscription.request(1);
             }
 
             @Override
             public void onNext(@Nullable final Integer integer) {
+                assert subscription != null;
                 latch.countDown();
+                subscription.request(1);
             }
 
             @Override
             public void onError(final Throwable t) {
                 causeRef.set(t);
-                latch.countDown();
+                latchToZero();
             }
 
             @Override
             public void onComplete() {
                 causeRef.set(new IllegalStateException("onComplete not expected"));
-                latch.countDown();
+                latchToZero();
+            }
+
+            private void latchToZero() {
+                while (latch.getCount() > 0) {
+                    latch.countDown();
+                }
             }
         });
         latch.await();

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FlowControlUtils.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FlowControlUtils.java
@@ -121,6 +121,24 @@ public final class FlowControlUtils {
     }
 
     /**
+     * Add two longs and prevent overflow which is defined as if both {@code x} and {@code y} have the same sign but the
+     * result of {@code x + y} has a different sign.
+     * @param x first value.
+     * @param y second value.
+     * @return
+     * <ul>
+     *     <li>{@code x + y} if no overflow</li>
+     *     <li>{@link Long#MAX_VALUE} if {@code x} is non-negative</li>
+     *     <li>{@link Long#MIN_VALUE} is negative otherwise.</li>
+     * </ul>
+     */
+    public static long addWithUnderOverflowProtection(final long x, final long y) {
+        final long sum = x + y;
+        // if overflow, sign extended right shift, then flip lower 63 bits (non-sign bits) to get 2s complement min/max.
+        return ((x ^ sum) & (y ^ sum)) < 0 ? ((x >> 63) ^ Long.MAX_VALUE) : sum;
+    }
+
+    /**
      * Increment an {@code integer} referred by {@link AtomicIntegerFieldUpdater} atomically
      * and saturate to {@link Integer#MAX_VALUE} if overflow occurs.
      *

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FlowControlUtils.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FlowControlUtils.java
@@ -121,15 +121,15 @@ public final class FlowControlUtils {
     }
 
     /**
-     * Add two longs and prevent overflow which is defined as if both {@code x} and {@code y} have the same sign but the
-     * result of {@code x + y} has a different sign.
+     * Add two longs and prevent [under|over]flow which is defined as if both {@code x} and {@code y} have the same sign
+     * but the result of {@code x + y} has a different sign.
      * @param x first value.
      * @param y second value.
      * @return
      * <ul>
      *     <li>{@code x + y} if no overflow</li>
-     *     <li>{@link Long#MAX_VALUE} if {@code x} is non-negative</li>
-     *     <li>{@link Long#MIN_VALUE} is negative otherwise.</li>
+     *     <li>{@link Long#MAX_VALUE} if overflow in the positive direction</li>
+     *     <li>{@link Long#MIN_VALUE} if otherwise in the negative direction</li>
      * </ul>
      */
     public static long addWithUnderOverflowProtection(final long x, final long y) {

--- a/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/FlowControlUtilsTests.java
+++ b/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/FlowControlUtilsTests.java
@@ -17,18 +17,58 @@ package io.servicetalk.concurrent.internal;
 
 import org.junit.Test;
 
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
+import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtectionIfPositive;
+import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithUnderOverflowProtection;
 import static org.junit.Assert.assertEquals;
 
 public class FlowControlUtilsTests {
-    private static final AtomicIntegerFieldUpdater<FlowControlUtilsTests> countUpdater =
-            AtomicIntegerFieldUpdater.newUpdater(FlowControlUtilsTests.class, "count");
-    private volatile int count;
-
     @Test
     public void addWithOverflowIfPositiveRespectsZero() {
-        countUpdater.accumulateAndGet(this, -1, FlowControlUtils::addWithOverflowProtectionIfPositive);
-        assertEquals(0, count);
+        assertEquals(0, addWithOverflowProtectionIfPositive(0, -1));
+    }
+
+    @Test
+    public void addWithUnderOverflowProtectionPositiveNoOverflow() {
+        assertEquals(3, addWithUnderOverflowProtection(1, 2));
+    }
+
+    @Test
+    public void addWithUnderOverflowProtectionNegativeNoOverflow() {
+        assertEquals(-3, addWithUnderOverflowProtection(-1, -2));
+    }
+
+    @Test
+    public void addWithUnderOverflowProtectionPositivePlusNegative() {
+        assertEquals(1, addWithUnderOverflowProtection(-1, 2));
+    }
+
+    @Test
+    public void addWithUnderOverflowProtectionZeroToMin() {
+        assertEquals(Long.MIN_VALUE, addWithUnderOverflowProtection(0, Long.MIN_VALUE));
+    }
+
+    @Test
+    public void addWithUnderOverflowProtectionNegativeOneToMin() {
+        assertEquals(Long.MIN_VALUE, addWithUnderOverflowProtection(-1, Long.MIN_VALUE));
+    }
+
+    @Test
+    public void addWithUnderOverflowProtectionMinToMin() {
+        assertEquals(Long.MIN_VALUE, addWithUnderOverflowProtection(Long.MIN_VALUE, Long.MIN_VALUE));
+    }
+
+    @Test
+    public void addWithUnderOverflowProtectionZeroToMax() {
+        assertEquals(Long.MAX_VALUE, addWithUnderOverflowProtection(0, Long.MAX_VALUE));
+    }
+
+    @Test
+    public void addWithUnderOverflowProtectionOneToMax() {
+        assertEquals(Long.MAX_VALUE, addWithUnderOverflowProtection(1, Long.MAX_VALUE));
+    }
+
+    @Test
+    public void addWithUnderOverflowProtectionMaxToMax() {
+        assertEquals(Long.MAX_VALUE, addWithUnderOverflowProtection(Long.MAX_VALUE, Long.MAX_VALUE));
     }
 }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapMergeDelayErrorTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapMergeDelayErrorTckTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+import static java.lang.Math.max;
+
+public class PublisherFlatMapMergeDelayErrorTckTest extends AbstractPublisherOperatorTckTest<Integer> {
+    @Override
+    protected Publisher<Integer> composePublisher(final Publisher<Integer> publisher, final int elements) {
+        // flatMapMerge requests the max number of concurrent elements synchronously in onSubscribe. The default
+        // publisher (e.g. from(T[]), range(..)) will synchronously complete if demand exceeds the number of items.
+        // Some TCK tests (e.g. invalid request N) assume this synchronous completion won't happen so we limit the max
+        // concurrency to be less than the total number of elements.
+        final int maxConcurrency = max(1, elements - 1);
+        return publisher.flatMapMergeDelayError(Publisher::from, maxConcurrency, maxConcurrency);
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapMergeDelayErrorTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapMergeDelayErrorTckTest.java
@@ -27,6 +27,6 @@ public class PublisherFlatMapMergeDelayErrorTckTest extends AbstractPublisherOpe
         // Some TCK tests (e.g. invalid request N) assume this synchronous completion won't happen so we limit the max
         // concurrency to be less than the total number of elements.
         final int maxConcurrency = max(1, elements - 1);
-        return publisher.flatMapMergeDelayError(Publisher::from, maxConcurrency, maxConcurrency);
+        return publisher.flatMapMergeDelayError(Publisher::from, maxConcurrency, 1);
     }
 }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapMergeDelayErrorTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapMergeDelayErrorTckTest.java
@@ -27,6 +27,6 @@ public class PublisherFlatMapMergeDelayErrorTckTest extends AbstractPublisherOpe
         // Some TCK tests (e.g. invalid request N) assume this synchronous completion won't happen so we limit the max
         // concurrency to be less than the total number of elements.
         final int maxConcurrency = max(1, elements - 1);
-        return publisher.flatMapMergeDelayError(Publisher::from, maxConcurrency, 1);
+        return publisher.flatMapMergeDelayError(Publisher::from, maxConcurrency);
     }
 }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapMergeTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapMergeTckTest.java
@@ -27,6 +27,6 @@ public class PublisherFlatMapMergeTckTest extends AbstractPublisherOperatorTckTe
         // Some TCK tests (e.g. invalid request N) assume this synchronous completion won't happen so we limit the max
         // concurrency to be less than the total number of elements.
         final int maxConcurrency = max(1, elements - 1);
-        return publisher.flatMapMerge(Publisher::from, maxConcurrency, maxConcurrency);
+        return publisher.flatMapMerge(Publisher::from, maxConcurrency, 1);
     }
 }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapMergeTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapMergeTckTest.java
@@ -27,6 +27,6 @@ public class PublisherFlatMapMergeTckTest extends AbstractPublisherOperatorTckTe
         // Some TCK tests (e.g. invalid request N) assume this synchronous completion won't happen so we limit the max
         // concurrency to be less than the total number of elements.
         final int maxConcurrency = max(1, elements - 1);
-        return publisher.flatMapMerge(Publisher::from, maxConcurrency, 1);
+        return publisher.flatMapMerge(Publisher::from, maxConcurrency);
     }
 }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapMergeTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapMergeTckTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+import static java.lang.Math.max;
+
+public class PublisherFlatMapMergeTckTest extends AbstractPublisherOperatorTckTest<Integer> {
+    @Override
+    protected Publisher<Integer> composePublisher(final Publisher<Integer> publisher, final int elements) {
+        // flatMapMerge requests the max number of concurrent elements synchronously in onSubscribe. The default
+        // publisher (e.g. from(T[]), range(..)) will synchronously complete if demand exceeds the number of items.
+        // Some TCK tests (e.g. invalid request N) assume this synchronous completion won't happen so we limit the max
+        // concurrency to be less than the total number of elements.
+        final int maxConcurrency = max(1, elements - 1);
+        return publisher.flatMapMerge(Publisher::from, maxConcurrency, maxConcurrency);
+    }
+}


### PR DESCRIPTION
Motivation:
Publisher#flatMapMerge is a basic building block for each element of a
Publisher to map into another Publisher.

Modifications:
- Add Publisher#flatMapMerge operator

Result:
Each item emitted on a Publisher can be mapped to another Publisher.