### PR TITLE
ConcurrentSubscripiton avoid concurrent access for invalid demand

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/concurrent/ConcurrentSubscriptionBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/concurrent/ConcurrentSubscriptionBenchmark.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.benchmark.concurrent;
+
+import io.servicetalk.concurrent.PublisherSource.Subscription;
+import io.servicetalk.concurrent.internal.ConcurrentSubscription;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Fork(value = 1)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 3)
+@Measurement(iterations = 5, time = 3)
+@BenchmarkMode(Mode.Throughput)
+public class ConcurrentSubscriptionBenchmark {
+    private long requestN;
+    private final Subscription noReentrantSubscription = ConcurrentSubscription.wrap(new Subscription() {
+        @Override
+        public void request(final long n) {
+            requestN += n;
+        }
+
+        @Override
+        public void cancel() {
+        }
+    });
+
+    private final Subscription reentrantSubscription = ConcurrentSubscription.wrap(new Subscription() {
+        @Override
+        public void request(final long n) {
+            requestN += n;
+            if (requestN < 100) {
+                reentrantSubscription.request(1);
+            }
+        }
+
+        @Override
+        public void cancel() {
+        }
+    });
+
+    @Benchmark
+    public long noReentrant() {
+        requestN = 0;
+        noReentrantSubscription.request(1);
+        return requestN;
+    }
+
+    @Benchmark
+    public long reentrant() {
+        requestN = 0;
+        reentrantSubscription.request(1);
+        return requestN;
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcurrentUtilsTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcurrentUtilsTest.java
@@ -77,6 +77,7 @@ public final class ConcurrentUtilsTest {
         assertThat(acquireId, greaterThan(0L));
         long acquireId2 = tryAcquireReentrantLock(reentrantLockUpdater, this);
         assertThat(acquireId2, is(-acquireId));
+        assertTrue(releaseReentrantLock(reentrantLockUpdater, acquireId2, this));
         assertTrue(releaseReentrantLock(reentrantLockUpdater, acquireId, this));
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcurrentUtilsTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcurrentUtilsTest.java
@@ -25,23 +25,33 @@ import org.junit.rules.Timeout;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.releaseLock;
+import static io.servicetalk.concurrent.internal.ConcurrentUtils.releaseReentrantLock;
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.tryAcquireLock;
+import static io.servicetalk.concurrent.internal.ConcurrentUtils.tryAcquireReentrantLock;
 import static io.servicetalk.concurrent.internal.ServiceTalkTestTimeout.DEFAULT_TIMEOUT_SECONDS;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public final class ConcurrentUtilsTest {
     private static final AtomicIntegerFieldUpdater<ConcurrentUtilsTest> lockUpdater =
             AtomicIntegerFieldUpdater.newUpdater(ConcurrentUtilsTest.class, "lock");
+    private static final AtomicLongFieldUpdater<ConcurrentUtilsTest> reentrantLockUpdater =
+            AtomicLongFieldUpdater.newUpdater(ConcurrentUtilsTest.class, "reentrantLock");
     @Rule
     public final Timeout timeout = new ServiceTalkTestTimeout();
 
     @SuppressWarnings("unused")
     private volatile int lock;
+    @SuppressWarnings("unused")
+    private volatile long reentrantLock;
     private ExecutorService executor;
 
     @Before
@@ -56,13 +66,22 @@ public final class ConcurrentUtilsTest {
     }
 
     @Test
-    public void singleThread() {
+    public void lockSingleThread() {
         assertTrue(tryAcquireLock(lockUpdater, this));
         assertTrue(releaseLock(lockUpdater, this));
     }
 
     @Test
-    public void pendingFromDifferentThread() throws Exception {
+    public void reentrantLockSingleThread() {
+        long acquireId = tryAcquireReentrantLock(reentrantLockUpdater, this);
+        assertThat(acquireId, greaterThan(0L));
+        long acquireId2 = tryAcquireReentrantLock(reentrantLockUpdater, this);
+        assertThat(acquireId2, is(-acquireId));
+        assertTrue(releaseReentrantLock(reentrantLockUpdater, acquireId, this));
+    }
+
+    @Test
+    public void lockFromDifferentThread() throws Exception {
         assertTrue(tryAcquireLock(lockUpdater, this));
         executor.submit(() -> assertFalse(tryAcquireLock(lockUpdater, this))).get();
 
@@ -75,7 +94,22 @@ public final class ConcurrentUtilsTest {
     }
 
     @Test
-    public void pendingFromDifferentThreadReAcquireFromDifferentThread() throws Exception {
+    public void reentrantLockFromDifferentThread() throws Exception {
+        long acquireId = tryAcquireReentrantLock(reentrantLockUpdater, this);
+        assertThat(acquireId, greaterThan(0L));
+        executor.submit(() -> assertThat(tryAcquireReentrantLock(reentrantLockUpdater, this), is(0L))).get();
+
+        // we expect false because we are expected to re-acquire and release the lock. This is a feature of the lock
+        // that requires checking the condition protected by the lock again.
+        assertFalse(releaseReentrantLock(reentrantLockUpdater, acquireId, this));
+
+        acquireId = tryAcquireReentrantLock(reentrantLockUpdater, this);
+        assertThat(acquireId, greaterThan(0L));
+        assertTrue(releaseReentrantLock(reentrantLockUpdater, acquireId, this));
+    }
+
+    @Test
+    public void lockFromDifferentThreadReAcquireFromDifferentThread() throws Exception {
         assertTrue(tryAcquireLock(lockUpdater, this));
         executor.submit(() -> assertFalse(tryAcquireLock(lockUpdater, this))).get();
 
@@ -86,6 +120,23 @@ public final class ConcurrentUtilsTest {
         executor.submit(() -> {
             assertTrue(tryAcquireLock(lockUpdater, this));
             assertTrue(releaseLock(lockUpdater, this));
+        }).get();
+    }
+
+    @Test
+    public void reentrantLockFromDifferentThreadReAcquireFromDifferentThread() throws Exception {
+        long acquireId = tryAcquireReentrantLock(reentrantLockUpdater, this);
+        assertThat(acquireId, greaterThan(0L));
+        executor.submit(() -> assertThat(tryAcquireReentrantLock(reentrantLockUpdater, this), is(0L))).get();
+
+        // we expect false because we are expected to re-acquire and release the lock. This is a feature of the lock
+        // that requires checking the condition protected by the lock again.
+        assertFalse(releaseReentrantLock(reentrantLockUpdater, acquireId, this));
+
+        executor.submit(() -> {
+            long acquireId2 = tryAcquireReentrantLock(reentrantLockUpdater, this);
+            assertThat(acquireId2, greaterThan(0L));
+            assertTrue(releaseReentrantLock(reentrantLockUpdater, acquireId2, this));
         }).get();
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MulticastPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MulticastPublisherTest.java
@@ -219,9 +219,7 @@ public class MulticastPublisherTest {
             barrier.await();
 
             for (int i = 0; i < expectedSubscribers; ++i) {
-                while (subscription.requested() - i <= 0) {
-                    Thread.yield();
-                }
+                subscription.awaitRequestN(i + 1);
                 source.onNext(i);
             }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentSubscriptionTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentSubscriptionTest.java
@@ -34,6 +34,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
@@ -161,7 +162,7 @@ public class ConcurrentSubscriptionTest {
     }
 
     @Test
-    public void multiThreadCancelDeliveredIfRequestThrows() throws Exception {
+    public void multiThreadCancelNotDeliveredIfRequestThrows() throws Exception {
         ExecutorService executorService = newFixedThreadPool(1);
         try {
             CyclicBarrier barrier = new CyclicBarrier(2);
@@ -198,7 +199,7 @@ public class ConcurrentSubscriptionTest {
             } catch (ExecutionException e) {
                 assertSame(DELIBERATE_EXCEPTION, e.getCause());
             }
-            cancelledLatch.await();
+            assertFalse(cancelledLatch.await(10, MILLISECONDS));
         } finally {
             executorService.shutdown();
         }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentSubscriptionTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentSubscriptionTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.internal;
+
+import io.servicetalk.concurrent.PublisherSource.Subscription;
+import io.servicetalk.concurrent.api.TestSubscription;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ConcurrentSubscriptionTest {
+    private final TestSubscription subscription = new TestSubscription();
+
+    @Test
+    public void singleThreadSingleRequest() throws InterruptedException {
+        Subscription concurrent = ConcurrentSubscription.wrap(subscription);
+        final long demand = Long.MAX_VALUE;
+        concurrent.request(demand);
+        subscription.awaitRequestN(demand);
+        assertFalse(subscription.isCancelled());
+    }
+
+    @Test
+    public void singleThreadMultipleRequest() throws InterruptedException {
+        Subscription concurrent = ConcurrentSubscription.wrap(subscription);
+        final int demand = 100;
+        for (int i = 0; i < demand; ++i) {
+            concurrent.request(1);
+        }
+        subscription.awaitRequestN(demand);
+        assertFalse(subscription.isCancelled());
+    }
+
+    @Test
+    public void singleThreadCancel() {
+        Subscription concurrent = ConcurrentSubscription.wrap(subscription);
+        concurrent.cancel();
+        assertTrue(subscription.isCancelled());
+    }
+
+    @Test
+    public void multiThreadRequest() throws ExecutionException, InterruptedException {
+        multiThread(300, false);
+    }
+
+    @Test
+    public void multiThreadCancel() throws ExecutionException, InterruptedException {
+        multiThread(250, true);
+    }
+
+    private void multiThread(final int threads, boolean cancel) throws ExecutionException, InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(threads);
+        try {
+            List<Future<?>> futures = new ArrayList<>(threads);
+            Subscription concurrent = ConcurrentSubscription.wrap(subscription);
+            CyclicBarrier barrier = new CyclicBarrier(threads);
+            for (int i = 0; i < threads; ++i) {
+                final int finalI = i;
+                futures.add(executorService.submit(() -> {
+                    try {
+                        barrier.await();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                    concurrent.request(1);
+                    if (cancel && finalI % 2 == 0) {
+                        concurrent.cancel();
+                    }
+                }));
+            }
+
+            for (Future<?> f : futures) {
+                f.get();
+            }
+            if (cancel) {
+                assertTrue(subscription.isCancelled());
+            } else {
+                subscription.awaitRequestN(threads);
+                assertFalse(subscription.isCancelled());
+            }
+        } finally {
+            executorService.shutdown();
+        }
+    }
+}

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ConcurrentSubscription.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ConcurrentSubscription.java
@@ -19,10 +19,12 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.internal.ConcurrentUtils.releaseReentrantLock;
+import static io.servicetalk.concurrent.internal.ConcurrentUtils.tryAcquireReentrantLock;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -33,21 +35,18 @@ import static java.util.Objects.requireNonNull;
  * </a> rule. It also allows a custom {@link Cancellable} to be used in the event that there maybe multiple cancel
  * operations which are linked, but we still need to prevent concurrent invocation of the {@link Subscription#cancel()}
  * and {@link Subscription#cancel()} methods.
- * <p>
- * Be aware with invalid input to {@link #request(long)} we don't attempt to enforce concurrency and rely upon the
- * subscription to enforce the specification
- * <a href="https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.1/README.md#3.9">3.9</a> rule.
  */
 public class ConcurrentSubscription implements Subscription {
-    private static final AtomicLongFieldUpdater<ConcurrentSubscription> subscriptionRequestQueueUpdater =
-            AtomicLongFieldUpdater.newUpdater(ConcurrentSubscription.class, "subscriptionRequestQueue");
-    private static final AtomicReferenceFieldUpdater<ConcurrentSubscription, Thread> subscriptionLockOwnerUpdater =
-            AtomicReferenceFieldUpdater.newUpdater(ConcurrentSubscription.class, Thread.class, "subscriptionLockOwner");
+    private static final AtomicLongFieldUpdater<ConcurrentSubscription> pendingDemandUpdater =
+            AtomicLongFieldUpdater.newUpdater(ConcurrentSubscription.class, "pendingDemand");
+    private static final AtomicLongFieldUpdater<ConcurrentSubscription> subscriptionLockUpdater =
+            AtomicLongFieldUpdater.newUpdater(ConcurrentSubscription.class, "subscriptionLock");
+    private static final long CANCELLED = Long.MIN_VALUE;
+
     private final Subscription subscription;
+    private volatile long pendingDemand;
     @SuppressWarnings("unused")
-    private volatile long subscriptionRequestQueue;
-    @Nullable
-    private volatile Thread subscriptionLockOwner;
+    private volatile long subscriptionLock;
 
     /**
      * New instance.
@@ -71,74 +70,58 @@ public class ConcurrentSubscription implements Subscription {
     @Override
     public void request(long n) {
         if (!isRequestNValid(n)) {
-            // With invalid input we don't attempt to enforce concurrency and rely upon the subscription
-            // to enforce the specification rules [1].
-            // [1] https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.1/README.md#3.9.
-            subscription.request(n);
-            return;
+            pendingDemand = mapInvalidRequestN(n);
+        } else {
+            for (;;) {
+                final long prevPendingDemand = pendingDemand;
+                if (prevPendingDemand < 0 ||
+                        pendingDemandUpdater.compareAndSet(this, prevPendingDemand,
+                                prevPendingDemand + min(Long.MAX_VALUE - prevPendingDemand, n))) {
+                    break;
+                }
+            }
         }
-        final Thread currentThread = Thread.currentThread();
-        if (currentThread == subscriptionLockOwner) {
-            subscriptionRequestQueueUpdater.accumulateAndGet(this, n,
-                    FlowControlUtils::addWithOverflowProtectionIfNotNegative);
-            return;
-        }
+        Throwable delayedCause = null;
+        boolean tryAcquire;
         do {
-            if (!subscriptionLockOwnerUpdater.compareAndSet(this, null, currentThread)) {
-                // It is possible that we picked up a negative value from the queue on the previous iteration because
-                // we have been cancelled in another thread, and in this case we don't want to increment the queue and
-                // instead we just set to MIN_VALUE again and try to re-acquire the lock in case we raced again.
-                if (n < 0) {
-                    subscriptionRequestQueueUpdater.set(this, Long.MIN_VALUE);
-                } else {
-                    subscriptionRequestQueueUpdater.accumulateAndGet(this, n,
-                            FlowControlUtils::addWithOverflowProtectionIfNotNegative);
-                }
-                if (!subscriptionLockOwnerUpdater.compareAndSet(this, null, currentThread)) {
-                    return;
-                }
-                // We previously added our n contribution to the queue, but now that we have acquired the lock
-                // we are responsible for draining the queue.
-                n = subscriptionRequestQueueUpdater.getAndSet(this, 0);
-                if (n == 0) {
-                    // It is possible that the previous consumer has released the lock, and drained the queue before we
-                    // acquired the lock and drained the queue. This means we have acquired the lock, but the queue has
-                    // already been drained to 0. We should release the lock, try to drain the queue again, and then
-                    // loop to acquire the lock if there are elements to drain.
-                    subscriptionLockOwner = null;
-                    n = subscriptionRequestQueueUpdater.getAndSet(this, 0);
-                    if (n == 0) {
-                        return;
-                    } else {
-                        continue;
-                    }
-                }
+            final long acquireId = tryAcquireReentrantLock(subscriptionLockUpdater, this);
+            if (acquireId == 0) {
+                break;
             }
-            if (n < 0) {
-                subscription.cancel();
-                return; // Don't set subscriptionLockOwner = 0 ... we don't want to request any more!
-            }
+
             try {
-                subscription.request(n);
+                final long prevPendingDemand = pendingDemandUpdater.getAndSet(this, 0);
+                if (prevPendingDemand == CANCELLED) {
+                    subscription.cancel();
+                } else if (prevPendingDemand != 0) {
+                    subscription.request(prevPendingDemand);
+                }
+            } catch (Throwable cause) {
+                if (delayedCause == null) {
+                    delayedCause = cause;
+                }
             } finally {
-                subscriptionLockOwner = null;
+                tryAcquire = !releaseReentrantLock(subscriptionLockUpdater, acquireId, this);
             }
-            n = subscriptionRequestQueueUpdater.getAndSet(this, 0);
-        } while (n != 0);
+        } while (tryAcquire);
+
+        if (delayedCause != null) {
+            throwException(delayedCause);
+        }
     }
 
     @Override
     public void cancel() {
-        // Set the queue to MIN_VALUE and this will be detected in request(n).
-        // We unconditionally set this value just in case there is re-entry with request(n) we will avoid calling
-        // the subscription's request(n) after cancel().
-        subscriptionRequestQueueUpdater.set(this, Long.MIN_VALUE);
-
-        final Thread currentThread = Thread.currentThread();
-        final Thread subscriptionLockOwner = this.subscriptionLockOwner;
-        if (subscriptionLockOwner == currentThread || subscriptionLockOwnerUpdater.compareAndSet(this, null,
-                currentThread)) {
+        pendingDemand = CANCELLED;
+        if (tryAcquireReentrantLock(subscriptionLockUpdater, this) != 0) {
             subscription.cancel();
+            // poison subscriptionLockUpdater
         }
+    }
+
+    private static long mapInvalidRequestN(long n) {
+        // We map zero to a negative number because zero could later be overwritten by a subsequent legit value of
+        // n, and we want to ensure the invalid use gets propagated.
+        return n == CANCELLED ? CANCELLED + 1 : n == 0 ? -1 : n;
     }
 }

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ConcurrentUtils.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ConcurrentUtils.java
@@ -77,6 +77,9 @@ public final class ConcurrentUtils {
     /**
      * Acquire a lock that allows reentry and attempts to acquire the lock while it is
      * held can be detected by {@link #releaseReentrantLock(AtomicLongFieldUpdater, long, Object)}.
+     * <p>
+     * This lock <strong>must</strong> eventually be released by the same thread that acquired the lock. If the thread
+     * that acquires this lock is terminated before releasing the lock state is undefined.
      * @param lockUpdater The {@link AtomicLongFieldUpdater} used to control the lock state.
      * @param owner The owner of the lock object.
      * @param <T> The type of object that owns the lock.
@@ -107,8 +110,9 @@ public final class ConcurrentUtils {
      * {@link #tryAcquireReentrantLock(AtomicLongFieldUpdater, Object)}.
      * @param owner The owner of the lock object.
      * @param <T> The type of object that owns the lock.
-     * @return {@code true} if the lock was released, or this method call corresponds to a prior re-entrant call
-     * to {@link #tryAcquireReentrantLock(AtomicLongFieldUpdater, Object)}.
+     * @return {@code true} if the lock was released, or releases a prior re-entrant acquire, and no other attempts were
+     * made to acquire the lock while it was held. {@code false} if the lock was released but another attempt was made
+     * to acquire the lock before it was released.
      */
     public static <T> boolean releaseReentrantLock(final AtomicLongFieldUpdater<T> lockUpdater,
                                                    final long acquireId, final T owner) {

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ConcurrentUtils.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ConcurrentUtils.java
@@ -27,7 +27,7 @@ public final class ConcurrentUtils {
      * <ul>
      *     <li>{@code 0} - unlocked</li>
      *     <li>{@code >0} - locked by the {@link Thread} whose {@link Thread#getId()} matches this value</li>
-     *     <li>{@code <0} - locked by the {@link Thread} whose {@link Thread#getId()} matches this negative of this
+     *     <li>{@code <0} - locked by the {@link Thread} whose {@link Thread#getId()} matches the negative of this
      *     value. Only externally visible to the thread that owns the lock on reentrant acquires.</li>
      * </ul>
      */

--- a/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/DelayedSubscriptionTest.java
+++ b/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/DelayedSubscriptionTest.java
@@ -28,11 +28,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
 import static io.servicetalk.concurrent.internal.ServiceTalkTestTimeout.DEFAULT_TIMEOUT_SECONDS;
-import static java.lang.Long.MIN_VALUE;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.AdditionalMatchers.leq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -101,7 +101,7 @@ public class DelayedSubscriptionTest {
         delayedSubscription.request(100);
         delayedSubscription.request(0);
         delayedSubscription.delayedSubscription(s1);
-        verify(s1).request(MIN_VALUE);
+        verify(s1).request(leq(0L));
         verifyNoMoreInteractions(s1);
     }
 


### PR DESCRIPTION
Motivation:
ConcurrentSubscription currently propagates invalid demand without any
concurrency protection. In general this is invalid use of the API but
may invalidate underlying data structures that are not thread safe and
result in undefined results.

Modifications:
- Use a simpler locking scheme inspired by Publisher#flatMapMerge design
which allows for re-entry and also notification is another thread has
attempted to acquire the lock which will trigger re-processing.

Result:
ConcurrentSubscripiton no longer allows any concurrent access and uses a
more common/shareable locking utility.