### PR TITLE
CollectTest remove assumption about subscribe ordering

### DIFF
--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CollectTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CollectTest.java
@@ -54,14 +54,11 @@ public class CollectTest {
 
     @Test
     public void collectVarArgFailure() throws Exception {
-        AtomicBoolean secondSubscribed = new AtomicBoolean();
-        Future<Void> future = mergeAll(failed(DELIBERATE_EXCEPTION),
-                completed().beforeOnSubscribe(__ -> secondSubscribed.set(true))).toFuture();
+        Future<Void> future = mergeAll(failed(DELIBERATE_EXCEPTION), completed()).toFuture();
         try {
             future.get();
             fail();
         } catch (ExecutionException e) {
-            assertThat("Second source subscribed.", secondSubscribed.get(), is(false));
             assertThat("Unexpected exception.", e.getCause(), is(DELIBERATE_EXCEPTION));
         }
     }
@@ -109,14 +106,11 @@ public class CollectTest {
 
     @Test
     public void collectIterableFailure() throws Exception {
-        AtomicBoolean secondSubscribed = new AtomicBoolean();
-        Future<Void> future = mergeAll(asList(failed(DELIBERATE_EXCEPTION),
-                completed().beforeOnSubscribe(__ -> secondSubscribed.set(true)))).toFuture();
+        Future<Void> future = mergeAll(asList(failed(DELIBERATE_EXCEPTION), completed())).toFuture();
         try {
             future.get();
             fail();
         } catch (ExecutionException e) {
-            assertThat("Second source subscribed.", secondSubscribed.get(), is(false));
             assertThat("Unexpected exception.", e.getCause(), is(DELIBERATE_EXCEPTION));
         }
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CollectTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CollectTest.java
@@ -58,14 +58,12 @@ public class CollectTest {
 
     @Test
     public void collectVarArgFailure() throws Exception {
-        AtomicBoolean secondSubscribed = new AtomicBoolean();
-        Future<? extends Collection<Integer>> future = collectUnordered(failed(DELIBERATE_EXCEPTION),
-                succeeded(2).beforeOnSubscribe(__ -> secondSubscribed.set(true))).toFuture();
+        Future<? extends Collection<Integer>> future =
+                collectUnordered(failed(DELIBERATE_EXCEPTION), succeeded(2)).toFuture();
         try {
             future.get();
             fail();
         } catch (ExecutionException e) {
-            assertThat("Second source subscribed.", secondSubscribed.get(), is(false));
             assertThat("Unexpected exception.", e.getCause(), is(DELIBERATE_EXCEPTION));
         }
     }
@@ -115,14 +113,12 @@ public class CollectTest {
 
     @Test
     public void collectIterableFailure() throws Exception {
-        AtomicBoolean secondSubscribed = new AtomicBoolean();
-        Future<? extends Collection<Integer>> future = collectUnordered(asList(failed(DELIBERATE_EXCEPTION),
-                succeeded(2).beforeOnSubscribe(__ -> secondSubscribed.set(true)))).toFuture();
+        Future<? extends Collection<Integer>> future =
+                collectUnordered(asList(failed(DELIBERATE_EXCEPTION), succeeded(2))).toFuture();
         try {
             future.get();
             fail();
         } catch (ExecutionException e) {
-            assertThat("Second source subscribed.", secondSubscribed.get(), is(false));
             assertThat("Unexpected exception.", e.getCause(), is(DELIBERATE_EXCEPTION));
         }
     }


### PR DESCRIPTION
Motivation:
There are 2 CollectTests (one for Completable, one for Single) that make
assumptions about the second source not being subscribed to if the first
source fails. However there is no guarantee from the operator about
subscribe ordering so this test criteria can be relaxed.

Modifications:
- remove assumption that collect/merge operators subscribe in a
sequential manner

Result:
CollectTests focused on verifying API contract instead of current
implementation.