### PR TITLE
Disable SHA256 and SHA512 checksums for published artifacts

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -63,3 +63,9 @@ javaPoetVersion=1.12.1
 bintrayPluginVersion=1.8.4
 spotbugsPluginVersion=4.0.5
 shadowPluginVersion=4.0.4
+
+# Disable SHA256 and SHA512 checksums until Sonatype and Maven Central supports them:
+# https://issues.sonatype.org/browse/NEXUS-21802
+# https://issues.sonatype.org/browse/MVNCENTRAL-5276
+# https://issues.apache.org/jira/browse/INFRA-14923
+systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
Motivation:

Sonatype/Nexus/Maven Central do not support SHA256 and SHA512 checksums.
Therefore, staging repo can not be promoted to Maven Central because it
can not override the following files for each artifact:
maven-metadata.xml.sha256
maven-metadata.xml.sha512

Modifications:

- Use Gradle's system property to disable SHA256 and SHA512 checksums;

Result:

Published artifacts can be promoted to Maven Central.