### PR TITLE
Minor improvements for `servicetalk-opentracing-zipkin-publisher`

### DIFF
--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/LoggingReporter.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/LoggingReporter.java
@@ -41,9 +41,14 @@ public final class LoggingReporter implements Reporter<Span> {
      * A builder to create a new {@link LoggingReporter}.
      */
     public static final class Builder {
-        private String loggerName;
+        private final String loggerName;
         private LogLevel logLevel = LogLevel.INFO;
 
+        /**
+         * Creates a new instance.
+         *
+         * @param loggerName the name of the logger
+         */
         public Builder(String loggerName) {
             this.loggerName = requireNonNull(loggerName);
         }

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporter.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporter.java
@@ -20,7 +20,6 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.transport.api.IoExecutor;
-import io.servicetalk.transport.netty.internal.GlobalExecutionContext;
 import io.servicetalk.transport.netty.internal.NettyChannelListenableAsyncCloseable;
 import io.servicetalk.transport.netty.internal.StacklessClosedChannelException;
 
@@ -139,8 +138,7 @@ public final class UdpReporter extends Component implements Reporter<Span>, Asyn
         }
 
         /**
-         * Sets an {@link IoExecutor} to use for writing to the datagram channel. Defaults to the
-         * {@link GlobalExecutionContext} {@link IoExecutor}.
+         * Sets an {@link IoExecutor} to use for writing to the datagram channel.
          *
          * @param ioExecutor IoExecutor to use to write with.
          * @return {@code this}
@@ -186,8 +184,8 @@ public final class UdpReporter extends Component implements Reporter<Span>, Asyn
         }
     }
 
-    private Bootstrap buildBootstrap(EventLoopGroup group, Codec codec, SocketAddress collectorAddress,
-                                     @Nullable String loggerName) {
+    private static Bootstrap buildBootstrap(EventLoopGroup group, Codec codec, SocketAddress collectorAddress,
+                                            @Nullable String loggerName) {
         if (!(collectorAddress instanceof InetSocketAddress)) {
             throw new IllegalArgumentException("collectorAddress " + collectorAddress +
                     " is invalid for UDP");


### PR DESCRIPTION
Motivation:

`servicetalk-opentracing-zipkin-publisher` has a few things that
can be improved.

Modifications:

- Make `LoggingReporter.Builder.loggerName` variable final;
- Add javadoc for `LoggingReporter.Builder`;
- Make `UdpReporter.buildBootstrap` static;
- Remove info about default value from
`UdpReporter.Builder.ioExecutor` javadoc;