### PR TITLE
ReactiveStreams TCK tests to use Publisher#range() instead of Publish…

### DIFF
--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFromBlockingIterableTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFromBlockingIterableTckTest.java
@@ -19,15 +19,15 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TestIterableToBlockingIterable;
 
 import static io.servicetalk.concurrent.api.Publisher.fromIterable;
-import static io.servicetalk.concurrent.reactivestreams.tck.TckUtils.newArray;
 import static io.servicetalk.concurrent.reactivestreams.tck.TckUtils.requestNToInt;
-import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.IntStream.range;
 
 public class PublisherFromBlockingIterableTckTest extends AbstractPublisherTckTest<Integer> {
     @Override
     public Publisher<Integer> createServiceTalkPublisher(final long elements) {
         return fromIterable(new TestIterableToBlockingIterable<>(
-                asList(newArray(requestNToInt(elements))),
+                range(0, requestNToInt(elements)).boxed().collect(toList()),
                 (timeout, unit) -> { }, (timeout, unit) -> { }, () -> { }));
     }
 

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFromIterableTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFromIterableTckTest.java
@@ -20,15 +20,14 @@ import io.servicetalk.concurrent.api.Publisher;
 import org.testng.annotations.Test;
 
 import static io.servicetalk.concurrent.api.Publisher.fromIterable;
-import static io.servicetalk.concurrent.reactivestreams.tck.TckUtils.newArray;
 import static io.servicetalk.concurrent.reactivestreams.tck.TckUtils.requestNToInt;
-import static java.util.Arrays.asList;
+import static java.util.stream.IntStream.range;
 
 @Test
 public class PublisherFromIterableTckTest extends AbstractPublisherTckTest<Integer> {
     @Override
     public Publisher<Integer> createServiceTalkPublisher(final long elements) {
-        return fromIterable(() -> asList(newArray(requestNToInt(elements))).iterator());
+        return fromIterable(() -> range(0, requestNToInt(elements)).iterator());
     }
 
     @Override

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/TckUtils.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/TckUtils.java
@@ -16,7 +16,9 @@
 package io.servicetalk.concurrent.reactivestreams.tck;
 
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.internal.DeliberateException;
+
+import static io.servicetalk.concurrent.api.Publisher.range;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 
 final class TckUtils {
 
@@ -30,15 +32,7 @@ final class TckUtils {
      * @return the publisher.
      */
     static Publisher<Integer> newPublisher(int numElements) {
-        return Publisher.from(newArray(numElements));
-    }
-
-    static Integer[] newArray(int numElements) {
-        Integer[] values = new Integer[numElements];
-        for (int i = 0; i < values.length; i++) {
-            values[i] = i;
-        }
-        return values;
+        return range(0, numElements);
     }
 
     static int maxElementsFromPublisher() {
@@ -52,6 +46,6 @@ final class TckUtils {
     }
 
     static <T> Publisher<T> newFailedPublisher() {
-        return Publisher.failed(DeliberateException.DELIBERATE_EXCEPTION);
+        return Publisher.failed(DELIBERATE_EXCEPTION);
     }
 }


### PR DESCRIPTION
…er#from(Integer[])

Motivation:
ReactiveStreams TCK use Publisher#from(Integer[]) because
Publisher#range() didn't originally exist. The range() source doesn't
require array allocation/initialization and is a more direct fit for the
use case.

Modifications:
- Use Publisher#range() instead of Publisher#from(Integer[]) in the TCK
tests

Result:
More canonical usage of async sources in the TCK tests.