### PR TITLE
Add `Publisher#buffer` operator

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BufferStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BufferStrategies.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.CompletableSource.Subscriber;
+import io.servicetalk.concurrent.api.BufferStrategy.Accumulator;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
+import static io.servicetalk.concurrent.api.ImmediateExecutor.IMMEDIATE_EXECUTOR;
+import static io.servicetalk.concurrent.api.Publisher.defer;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
+
+/**
+ * A static factory of {@link BufferStrategy} instances.
+ */
+public final class BufferStrategies {
+    private BufferStrategies() {
+        // no instances
+    }
+
+    /**
+     * Returns a {@link BufferStrategy} that creates buffer boundaries based on number of items buffered or time elapsed
+     * since the current buffer boundary started. This does not guarantee that the emitted buffers after applying the
+     * returned {@link BufferStrategy} will have exactly {@code count} number of items. The emitted buffers may have
+     * less or more items than the {@code count}.
+     *
+     * @param count Number of items to add before closing the current buffer boundary, if not already closed. The
+     * emitted buffers may have less or more items than this {@code count}.
+     * @param duration {@link Duration} after which the current buffer boundary is closed, if not already closed.
+     * @param <T> Type of items added to the buffer.
+     * @return {@link BufferStrategy} that creates buffer boundaries based on number of items buffered or time elapsed
+     * since the current buffer boundary started.
+     */
+    public static <T> BufferStrategy<T, Accumulator<T, Iterable<T>>, Iterable<T>> forCountOrTime(
+            final int count, final Duration duration) {
+        return forCountOrTime(count, duration, IMMEDIATE_EXECUTOR);
+    }
+
+    /**
+     * Returns a {@link BufferStrategy} that creates buffer boundaries based on number of items buffered or time elapsed
+     * since the current buffer boundary started. This does not guarantee that the emitted buffers after applying the
+     * returned {@link BufferStrategy} will have exactly {@code count} number of items. The emitted buffers may have
+     * less or more items than the {@code count}.
+     *
+     * @param count Number of items to add before closing the current buffer boundary, if not already closed.
+     * @param duration {@link Duration} after which the current buffer boundary is closed, if not already closed.
+     * @param executor {@link Executor} to use for recording the passed {@code duration}.
+     * @param <T> Type of items added to the buffer.
+     * @return {@link BufferStrategy} that creates buffer boundaries based on number of items buffered or time elapsed
+     * since the current buffer boundary started.
+     */
+    public static <T> BufferStrategy<T, Accumulator<T, Iterable<T>>, Iterable<T>> forCountOrTime(
+            final int count, final Duration duration, final Executor executor) {
+        return forCountOrTime(count, duration, () -> new Accumulator<T, Iterable<T>>() {
+            private final List<T> accumulate = new ArrayList<>();
+
+            @Override
+            public void accumulate(final T t) {
+                accumulate.add(t);
+            }
+
+            @Override
+            public Iterable<T> finish() {
+                return accumulate;
+            }
+        }, executor);
+    }
+
+    /**
+     * Returns a {@link BufferStrategy} that creates buffer boundaries based on number of items buffered or time elapsed
+     * since the current buffer boundary started. This does not guarantee that the emitted buffers after applying the
+     * returned {@link BufferStrategy} will have exactly {@code count} number of items. The emitted buffers may have
+     * less or more items than the {@code count}.
+     *
+     * @param count Number of items to add before closing the current buffer boundary, if not already closed.
+     * @param duration {@link Duration} after which the current buffer boundary is closed, if not already closed.
+     * @param accumulatorSupplier A {@link Supplier} of {@link Accumulator} every time a buffer boundary is closed.
+     * Methods on the {@link Accumulator} returned from this {@link Supplier} may or may not be called.
+     * @param <T> Type of items added to the buffer.
+     * @param <BC> Type of {@link Accumulator} used to accumulate items in a buffer.
+     * @param <B> Type of object created after an {@link Accumulator} is {@link Accumulator#finish() finished}.
+     * @return {@link BufferStrategy} that creates buffer boundaries based on number of items buffered or time elapsed
+     * since the current buffer boundary started.
+     */
+    public static <T, BC extends Accumulator<T, B>, B> BufferStrategy<T, Accumulator<T, B>, B> forCountOrTime(
+            final int count, final Duration duration, Supplier<BC> accumulatorSupplier) {
+        return forCountOrTime(count, duration, accumulatorSupplier, IMMEDIATE_EXECUTOR);
+    }
+
+    /**
+     * Returns a {@link BufferStrategy} that creates buffer boundaries based on number of items buffered or time elapsed
+     * since the current buffer boundary started. This does not guarantee that the emitted buffers after applying the
+     * returned {@link BufferStrategy} will have exactly {@code count} number of items. The emitted buffers may have
+     * less or more items than the {@code count}.
+     *
+     * @param count Number of items to add before closing the current buffer boundary, if not already closed.
+     * @param duration {@link Duration} after which the current buffer boundary is closed, if not already closed.
+     * @param accumulatorSupplier A {@link Supplier} of {@link Accumulator} every time a buffer boundary is closed.
+     * Methods on the {@link Accumulator} returned from this {@link Supplier} may or may not be called.
+     * @param executor {@link Executor} to use for recording the passed {@code duration}.
+     * @param <T> Type of items added to the buffer.
+     * @param <BC> Type of {@link Accumulator} used to accumulate items in a buffer.
+     * @param <B> Type of object created after an {@link Accumulator} is {@link Accumulator#finish() finished}.
+     * @return {@link BufferStrategy} that creates buffer boundaries based on number of items buffered or time elapsed
+     * since the current buffer boundary started.
+     */
+    public static <T, BC extends Accumulator<T, B>, B> BufferStrategy<T, Accumulator<T, B>, B> forCountOrTime(
+            final int count, final Duration duration, Supplier<BC> accumulatorSupplier,
+            final Executor executor) {
+        if (count <= 0) {
+            throw new IllegalArgumentException("count: " + count + " (expected > 0)");
+        }
+        requireNonNull(duration);
+        requireNonNull(accumulatorSupplier);
+        requireNonNull(executor);
+        return new BufferStrategy<T, Accumulator<T, B>, B>() {
+            @Override
+            public Publisher<Accumulator<T, B>> boundaries() {
+                return defer(() -> {
+                    State<T, B> state = new State<>();
+                    CountingAccumulator<T, B> firstAccum =
+                            new CountingAccumulator<>(state, accumulatorSupplier.get(), count);
+                    state.beforeNewAccumulatorEmitted(firstAccum);
+                    return Single.succeeded(firstAccum).concat(new Completable() {
+                        @Override
+                        protected void handleSubscribe(final Subscriber subscriber) {
+                            // We ignore cancel and expect ambWith to ignore if we delay emit
+                            try {
+                                subscriber.onSubscribe(IGNORE_CANCEL);
+                            } catch (Throwable t) {
+                                handleExceptionFromOnSubscribe(subscriber, t);
+                                return;
+                            }
+                            state.countCompletableSubscribed(subscriber);
+                        }
+                    }
+                    .ambWith(executor.timer(duration))
+                    .toSingle()
+                    .map(__ -> {
+                        CountingAccumulator<T, B> accum =
+                                new CountingAccumulator<>(state, accumulatorSupplier.get(), count);
+                        state.beforeNewAccumulatorEmitted(accum);
+                        return accum;
+                    })
+                    .repeat(__ -> true));
+                });
+            }
+
+            @Override
+            public int bufferSizeHint() {
+                return count;
+            }
+        };
+    }
+
+    private static final class State<T, B> {
+        private static final Object THRESHOLD_BREACHED_BEFORE_SUBSCRIBE = new Object();
+        @SuppressWarnings("rawtypes")
+        private static final AtomicReferenceFieldUpdater<State, Object> stateUpdater =
+                newUpdater(State.class, Object.class, "state");
+
+        /**
+         * The following values can be set to this state:
+         * <ul>
+         *     <li>{@code null} if neither an active accumulator is present nor a subscriber.</li>
+         *     <li>An {@link Accumulator} which is expected to accumulating items for the current boundary.</li>
+         *     <li>{@link AccumulatorAndSubscriber} instance when an active accumulator and {@link Subscriber} both are
+         *     active.</li>
+         *     <li>{@link Subscriber} if the size threshold {@link Completable} is subscribed and there is no
+         *     accumulator present.</li>
+         * </ul>
+         */
+        @Nullable
+        private volatile Object state;
+
+        void countThresholdBreached(final Accumulator<T, B> breachedAccumulator) {
+            for (;;) {
+                final Object cState = state;
+                if (cState == THRESHOLD_BREACHED_BEFORE_SUBSCRIBE || cState == null) {
+                    // multiple breaches
+                    return;
+                }
+                if (cState instanceof Accumulator) {
+                    if (cState != breachedAccumulator ||
+                            stateUpdater.compareAndSet(this, cState, THRESHOLD_BREACHED_BEFORE_SUBSCRIBE)) {
+                        // Either the threshold was breached for a stale accumulator or threshold was breached before
+                        // the accumulator could be set.
+                        return;
+                    }
+                } else if (cState instanceof Subscriber) {
+                    if (stateUpdater.compareAndSet(this, cState, null)) {
+                        Subscriber subscriber = (Subscriber) cState;
+                        subscriber.onComplete();
+                        return;
+                    }
+                } else if (cState instanceof AccumulatorAndSubscriber) {
+                    @SuppressWarnings("unchecked")
+                    final AccumulatorAndSubscriber<T, B> accumulatorAndSubscriber =
+                            (AccumulatorAndSubscriber<T, B>) cState;
+                    if (accumulatorAndSubscriber.accumulator != breachedAccumulator ||
+                            stateUpdater.compareAndSet(this, cState, null)) {
+                        return;
+                    }
+                }
+            }
+        }
+
+        void countCompletableSubscribed(final Subscriber countSubscriber) {
+            for (;;) {
+                final Object cState = state;
+                // Ordering of subscriber and accumulator is provided by repeat() operator such that a new accumulator
+                // is emitted and then the original source is subscribed again (repeat). As neither the accumulator nor
+                // the subscribers are skipped, an accumulator that breaches threshold, always indicates completion
+                // of the associated Subscriber.
+                if (cState == THRESHOLD_BREACHED_BEFORE_SUBSCRIBE) {
+                    if (stateUpdater.compareAndSet(this, cState, null)) {
+                        countSubscriber.onComplete();
+                        return;
+                    }
+                } else if (cState instanceof Accumulator) {
+                    @SuppressWarnings("unchecked")
+                    final Accumulator<T, B> accumulator = (Accumulator<T, B>) cState;
+                    if (stateUpdater.compareAndSet(
+                            this, cState, new AccumulatorAndSubscriber<>(accumulator, countSubscriber))) {
+                        return;
+                    }
+                } else if (stateUpdater.compareAndSet(this, cState, countSubscriber)) {
+                    return;
+                }
+            }
+        }
+
+        void beforeNewAccumulatorEmitted(final Accumulator<T, B> newAccumulator) {
+            // We always expect Accumulator followed by the Subscriber. So, we blindly overwrite whenever a new
+            // accumulator is emitted.
+            state = newAccumulator;
+        }
+    }
+
+    private static final class CountingAccumulator<T, B> implements Accumulator<T, B> {
+        private final State<T, B> state;
+        private final Accumulator<T, B> delegate;
+        private final int sizeThreshold;
+        private int size;
+
+        CountingAccumulator(final State<T, B> state, final Accumulator<T, B> delegate, final int sizeThreshold) {
+            this.state = state;
+            this.delegate = delegate;
+            this.sizeThreshold = sizeThreshold;
+        }
+
+        @Override
+        public void accumulate(@Nullable final T item) {
+            size++;
+            delegate.accumulate(item);
+            if (size == sizeThreshold) {
+                state.countThresholdBreached(this);
+            }
+        }
+
+        @Override
+        public B finish() {
+            return delegate.finish();
+        }
+    }
+
+    private static final class AccumulatorAndSubscriber<T, B> {
+        final Accumulator<T, B> accumulator;
+        final Subscriber subscriber;
+
+        AccumulatorAndSubscriber(final Accumulator<T, B> accumulator, final Subscriber subscriber) {
+            this.accumulator = accumulator;
+            this.subscriber = subscriber;
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BufferStrategy.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BufferStrategy.java
@@ -37,7 +37,7 @@ public interface BufferStrategy<T, BC extends BufferStrategy.Accumulator<T, B>, 
 
     /**
      * Returns a {@link Publisher} representing asynchronous buffer boundaries. This {@link Publisher} is expected to be
-     * an infinite {@link Publisher}. Hence, it should never terminates any {@link Subscriber} subscribed to it. Instead
+     * an infinite {@link Publisher}. Hence, it should never terminate any {@link Subscriber} subscribed to it. Instead
      * {@link Subscriber}s will always {@link Subscription#cancel() cancel} their {@link Subscription}. If this
      * expectation is violated, buffered items may be discarded.
      *

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BufferStrategy.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BufferStrategy.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.PublisherSource.Subscriber;
+import io.servicetalk.concurrent.PublisherSource.Subscription;
+
+import javax.annotation.Nullable;
+
+/**
+ * A strategy for {@link Publisher#buffer(BufferStrategy) buffering} items emitted from a {@link Publisher}.
+ * <p>
+ * A buffer strategy represents {@link #boundaries() asynchronous buffer boundaries} over which items from a
+ * {@link Publisher} are buffered. Each item emitted from the boundary {@link Publisher} represents the end of the
+ * last boundary and start of the next boundary. The first item emitted from this {@link Publisher} is treated as the
+ * start of the first boundary and {@link Publisher#buffer(BufferStrategy)} may decide to defer requesting items from
+ * the {@link Publisher} on which that operator is applied.
+ *
+ * @param <T> items emitted from the {@link Publisher} which are to be buffered using this {@link BufferStrategy}.
+ * @param <BC> An intermediate mutable object that holds the items into a buffer before it is emitted.
+ * @param <B> The buffer of items.
+ */
+public interface BufferStrategy<T, BC extends BufferStrategy.Accumulator<T, B>, B> {
+
+    /**
+     * Returns a {@link Publisher} representing asynchronous buffer boundaries. This {@link Publisher} is expected to be
+     * an infinite {@link Publisher}. Hence, it should never terminates any {@link Subscriber} subscribed to it. Instead
+     * {@link Subscriber}s will always {@link Subscription#cancel() cancel} their {@link Subscription}. If this
+     * expectation is violated, buffered items may be discarded.
+     *
+     * @return A {@link Publisher} representing asynchronous buffer boundaries.
+     */
+    Publisher<BC> boundaries();
+
+    /**
+     * A rough estimate of the number of items in a buffer.
+     *
+     * @return A rough estimate of the number of items in a buffer.
+     */
+    int bufferSizeHint();
+
+    /**
+     * An intermediate mutable object that holds items till it is {@link #finish() finished}.
+     * <p>
+     * None of the methods on an instance of an {@link Accumulator} will be invoked concurrently and no other method
+     * will be called after {@link #finish()} returns.
+     *
+     * @param <T> Type of items added to this {@link Accumulator}.
+     * @param <B> Type of item created when an accumulation is {@link #finish() finished}.
+     */
+    interface Accumulator<T, B> {
+        /**
+         * Adds the passed {@code item} to this {@link Accumulator}.
+         *
+         * @param item to add to this {@link Accumulator}.
+         */
+        void accumulate(@Nullable T item);
+
+        /**
+         * Finishes accumulation and returns the accumulated value.
+         *
+         * @return Accumulated value.
+         */
+        B finish();
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherBuffer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherBuffer.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.api.BufferStrategy.Accumulator;
+import io.servicetalk.concurrent.internal.ConcurrentSubscription;
+import io.servicetalk.concurrent.internal.DelayedCancellable;
+import io.servicetalk.concurrent.internal.DelayedSubscription;
+import io.servicetalk.concurrent.internal.FlowControlUtils;
+import io.servicetalk.concurrent.internal.TerminalNotification;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.ConcurrentSubscription.wrap;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnComplete;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnError;
+import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
+import static io.servicetalk.concurrent.internal.TerminalNotification.error;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
+
+final class PublisherBuffer<T, B> extends AbstractAsynchronousPublisherOperator<T, B> {
+    private final BufferStrategy<T, ?, B> bufferStrategy;
+
+    PublisherBuffer(final Publisher<T> original, final Executor executor,
+                    final BufferStrategy<T, ?, B> bufferStrategy) {
+        super(original, executor);
+        this.bufferStrategy = requireNonNull(bufferStrategy);
+    }
+
+    @Override
+    public Subscriber<? super T> apply(final Subscriber<? super B> subscriber) {
+        final int bufferSizeHint = bufferStrategy.bufferSizeHint();
+        if (bufferSizeHint <= 0) {
+            deliverErrorFromSource(subscriber,
+                    new IllegalArgumentException("bufferSizeHint: " + bufferSizeHint + " (expected > 0)"));
+        }
+        return new ItemsSubscriber<>(bufferStrategy.boundaries(), subscriber, bufferSizeHint);
+    }
+
+    private static final class ItemsSubscriber<T, B> implements Subscriber<T> {
+        @SuppressWarnings("rawtypes")
+        private static final AtomicLongFieldUpdater<ItemsSubscriber> pendingUpdater =
+                newUpdater(ItemsSubscriber.class, "pending");
+
+        private final Subscriber<? super B> target;
+        private final State state;
+        private final DelayedSubscription tSubscription;
+        private final int bufferSizeHint;
+        private final DelayedCancellable bCancellable;
+
+        @Nullable
+        private ConcurrentSubscription subscription;
+        private volatile long pending;
+
+        ItemsSubscriber(final Publisher<? extends Accumulator<T, B>> boundaries,
+                        final Subscriber<? super B> target, final int bufferSizeHint) {
+            this.target = target;
+            state = new State(bufferSizeHint);
+            tSubscription = new DelayedSubscription();
+            this.bufferSizeHint = bufferSizeHint;
+            // Request-n is delayed till we receive the first boundary but we will request bufferSizeHint.
+            // This is done here to localize state management (pending count) in this subscriber but still drive the
+            // first request-n from inside State.
+            pending = bufferSizeHint;
+            final BoundariesSubscriber<T, B> bSubscriber = new BoundariesSubscriber<>(state, target, tSubscription);
+            bCancellable = bSubscriber;
+            toSource(boundaries).subscribe(bSubscriber);
+        }
+
+        @Override
+        public void onSubscribe(final Subscription subscription) {
+            this.subscription = wrap(subscription);
+            tSubscription.delayedSubscription(this.subscription);
+        }
+
+        @Override
+        public void onNext(@Nullable final T t) {
+            final long pending = pendingUpdater.decrementAndGet(this);
+            state.accumulate(t, target);
+            if (pending == 0) {
+                assert subscription != null;
+                requestMoreItems(subscription);
+            }
+        }
+
+        @Override
+        public void onError(final Throwable t) {
+            state.itemsTerminated(error(t), target, bCancellable);
+        }
+
+        @Override
+        public void onComplete() {
+            state.itemsTerminated(complete(), target, bCancellable);
+        }
+
+        private void requestMoreItems(final Subscription subscription) {
+            pendingUpdater.accumulateAndGet(this, bufferSizeHint, FlowControlUtils::addWithOverflowProtection);
+            subscription.request(bufferSizeHint);
+        }
+    }
+
+    private static final class BoundariesSubscriber<T, B> extends DelayedCancellable
+            implements Subscriber<Accumulator<T, B>> {
+        @SuppressWarnings("rawtypes")
+        private static final AtomicLongFieldUpdater<BoundariesSubscriber> pendingUpdater =
+                newUpdater(BoundariesSubscriber.class, "pending");
+        private final State state;
+        private final Subscriber<? super B> target;
+        private final Subscription tSubscription;
+
+        private volatile long pending;
+        @Nullable
+        private ConcurrentSubscription subscription;
+
+        BoundariesSubscriber(final State state, final Subscriber<? super B> target, final Subscription tSubscription) {
+            this.state = state;
+            this.target = target;
+            this.tSubscription = tSubscription;
+        }
+
+        @Override
+        public void onSubscribe(final Subscription bSubscription) {
+            subscription = wrap(new Subscription() {
+                @Override
+                public void request(final long n) {
+                    if (isRequestNValid(n)) {
+                        pendingUpdater.accumulateAndGet(BoundariesSubscriber.this, n,
+                                FlowControlUtils::addWithOverflowProtection);
+                    }
+                    bSubscription.request(n);
+                }
+
+                @Override
+                public void cancel() {
+                    try {
+                        bSubscription.cancel();
+                    } finally {
+                        tSubscription.cancel();
+                    }
+                }
+            });
+            delayedCancellable(subscription);
+            target.onSubscribe(subscription);
+        }
+
+        @Override
+        public void onNext(@Nonnull final Accumulator<T, B> accumulator) {
+            requireNonNull(accumulator);
+            pendingUpdater.decrementAndGet(this);
+            assert subscription != null;
+            if (!state.nextAccumulator(accumulator, target, subscription, tSubscription)) {
+                pendingUpdater.incrementAndGet(this);
+                subscription.request(1);
+            }
+        }
+
+        @Override
+        public void onError(final Throwable t) {
+            try {
+                state.boundariesTerminated(t, target);
+            } finally {
+                tSubscription.cancel();
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            try {
+                state.boundariesTerminated(new IllegalStateException("Boundaries source completed unexpectedly."),
+                        target);
+            } finally {
+                tSubscription.cancel();
+            }
+        }
+    }
+
+    private static final class State {
+        private static final Object ADDING = new Object();
+        private static final Object TERMINATED = new Object();
+        private static final AtomicReferenceFieldUpdater<State, Object> maybeAccumulatorUpdater =
+                AtomicReferenceFieldUpdater.newUpdater(State.class, Object.class, "maybeAccumulator");
+
+        private final int firstItemsRequestN;
+        /**
+         * Following values are assigned to this variable:
+         * <ul>
+         *     <li>{@code null} till the first accumulator arrives.</li>
+         *     <li>{@link #ADDING} if an item is being added to the currently active {@link Accumulator}</li>
+         *     <li>{@link ItemsTerminated} if the items source terminated but the target is not yet terminated.</li>
+         *     <li>{@link #TERMINATED} if the target subscriber has been terminated (or cancelled).</li>
+         *     <li>{@link Accumulator} which is emitted by the boundaries source.</li>
+         * </ul>
+         */
+        @Nullable
+        private volatile Object maybeAccumulator;
+
+        State(final int firstItemsRequestN) {
+            this.firstItemsRequestN = firstItemsRequestN;
+        }
+
+        <T, B> void accumulate(@Nullable final T item, final Subscriber<? super B> target) {
+            Accumulator<T, B> missedAccumulator = null;
+            for (;;) {
+                final Object cMaybeAccumulator = maybeAccumulator;
+                assert cMaybeAccumulator != null;
+
+                // This method is called when a new item is received.
+                // The subscription for items source is local to this operator and could never be interacted from an
+                // external entity. This means we neither re-enter this method nor the items source can terminate
+                // when we are inside this method (onNext and onError/onComplete can not be concurrent).
+                if (cMaybeAccumulator == TERMINATED || cMaybeAccumulator instanceof ItemsTerminated) {
+                    return;
+                }
+                assert cMaybeAccumulator != ADDING;
+                // If we are ADDING and maybeAccumulatorUpdater has changed then either it should have terminated or
+                // a new accumulator has been received. If a new accumulator is received, we could have never added to
+                // that accumulator (as we were adding to an old accumulator), so we discard that accumulator.
+                if (maybeAccumulatorUpdater.compareAndSet(this, cMaybeAccumulator, ADDING)) {
+                    assert cMaybeAccumulator instanceof Accumulator;
+                    @SuppressWarnings("unchecked")
+                    final Accumulator<T, B> accumulator = (Accumulator<T, B>) cMaybeAccumulator;
+                    if (missedAccumulator != null) {
+                        target.onNext(missedAccumulator.finish());
+                    } else {
+                        accumulator.accumulate(item);
+                    }
+                    if (maybeAccumulatorUpdater.compareAndSet(this, ADDING, accumulator)) {
+                        return;
+                    } else if (missedAccumulator == null) {
+                        missedAccumulator = accumulator;
+                    } else {
+                        // we have added an item to the accumulator and emitted the missedAccumulator. The accumulator
+                        // in maybeAccumulator is now the current to which subsequent items must be added.
+                        return;
+                    }
+                }
+            }
+        }
+
+        <T, B> boolean nextAccumulator(final Accumulator<T, B> nextAccumulator, final Subscriber<? super B> target,
+                                       final Cancellable boundariesCancellable, final Subscription itemsSubscription) {
+            requireNonNull(nextAccumulator);
+            for (;;) {
+                final Object cMaybeAccumulator = maybeAccumulator;
+                if (cMaybeAccumulator == TERMINATED) {
+                    return true;
+                }
+                if (cMaybeAccumulator == null) {
+                    // This is the first received accumulator (first boundary start); so we just store the accumulator
+                    // to accumulate and request items from itemsSubscription.
+                    if (maybeAccumulatorUpdater.compareAndSet(this, null, nextAccumulator)) {
+                        itemsSubscription.request(firstItemsRequestN);
+                        return false;
+                    }
+                } else if (cMaybeAccumulator == ADDING) {
+                    // Hand-off emission of nextAccumulator to the thread that is ADDING
+                    if (maybeAccumulatorUpdater.compareAndSet(this, ADDING, nextAccumulator)) {
+                        // ADDING thread will emit nextAccumulator.
+                        return true;
+                    }
+                } else if (cMaybeAccumulator instanceof ItemsTerminated) {
+                    if (maybeAccumulatorUpdater.compareAndSet(this, cMaybeAccumulator, TERMINATED)) {
+                        @SuppressWarnings("unchecked")
+                        ItemsTerminated<T, B> itemsTerminated = (ItemsTerminated<T, B>) cMaybeAccumulator;
+                        terminateTarget(itemsTerminated.accumulator, target, itemsTerminated.terminalNotification,
+                                boundariesCancellable);
+                        return true;
+                    }
+                } else {
+                    assert cMaybeAccumulator instanceof Accumulator;
+                    if (maybeAccumulatorUpdater.compareAndSet(this, cMaybeAccumulator, nextAccumulator)) {
+                        @SuppressWarnings("unchecked")
+                        Accumulator<T, B> oldAccumulator = (Accumulator<T, B>) cMaybeAccumulator;
+                        target.onNext(oldAccumulator.finish());
+                        return true;
+                    }
+                }
+            }
+        }
+
+        <B> void itemsTerminated(final TerminalNotification terminalNotification, final Subscriber<? super B> target,
+                                 final Cancellable bCancellable) {
+            for (;;) {
+                final Object cMaybeAccumulator = maybeAccumulator;
+                if (cMaybeAccumulator == TERMINATED) {
+                    return;
+                }
+                assert !(cMaybeAccumulator instanceof ItemsTerminated);
+
+                if (cMaybeAccumulator == ADDING || cMaybeAccumulator == null) {
+                    // we threw from onNext or items source completed before request-n
+                    if (maybeAccumulatorUpdater.compareAndSet(this, cMaybeAccumulator, TERMINATED)) {
+                        terminalNotification.terminate(target);
+                        return;
+                    }
+                } else if (cMaybeAccumulator instanceof Accumulator &&
+                        maybeAccumulatorUpdater.compareAndSet(this, cMaybeAccumulator, TERMINATED)) {
+                    @SuppressWarnings("unchecked")
+                    Accumulator<?, B> accumulator = (Accumulator<?, B>) cMaybeAccumulator;
+                    terminateTarget(accumulator, target, terminalNotification, bCancellable);
+                    return;
+                }
+            }
+        }
+
+        void boundariesTerminated(final Throwable cause, final Subscriber<?> target) {
+            maybeAccumulator = TERMINATED;
+            target.onError(cause);
+        }
+
+        private static <T, B> void terminateTarget(@Nullable final Accumulator<T, B> accumulator,
+                                                   final Subscriber<? super B> target,
+                                                   final TerminalNotification terminalNotification,
+                                                   final Cancellable bCancellable) {
+            try {
+                if (accumulator != null) {
+                    try {
+                        target.onNext(accumulator.finish());
+                    } catch (Throwable t) {
+                        target.onError(t);
+                        return;
+                    }
+                }
+                Throwable cause = terminalNotification.cause();
+                if (cause == null) {
+                    safeOnComplete(target);
+                } else {
+                    safeOnError(target, cause);
+                }
+            } finally {
+                bCancellable.cancel();
+            }
+        }
+    }
+
+    private static final class ItemsTerminated<T, B> {
+        @Nullable
+        final Accumulator<T, B> accumulator;
+        final TerminalNotification terminalNotification;
+
+        ItemsTerminated(final Object maybeAccumulator, final TerminalNotification terminalNotification) {
+            if (maybeAccumulator instanceof Accumulator) {
+                @SuppressWarnings("unchecked")
+                Accumulator<T, B> accumulator = (Accumulator<T, B>) maybeAccumulator;
+                this.accumulator = accumulator;
+            } else {
+                accumulator = null;
+            }
+            this.terminalNotification = terminalNotification;
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/BufferStrategiesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/BufferStrategiesTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.api.BufferStrategy.Accumulator;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static io.servicetalk.concurrent.api.BufferStrategies.forCountOrTime;
+import static io.servicetalk.concurrent.api.Completable.defer;
+import static io.servicetalk.concurrent.api.Publisher.range;
+import static java.time.Duration.ofDays;
+import static java.util.Collections.unmodifiableCollection;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BufferStrategiesTest {
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+
+    private final BlockingQueue<TestCompletable> timers = new LinkedBlockingDeque<>();
+    private final Executor executor = mock(Executor.class);
+    private final java.util.concurrent.ExecutorService jdkExecutor = Executors.newCachedThreadPool();
+
+    public BufferStrategiesTest() {
+        when(executor.timer(any(Duration.class))).thenAnswer(invocation -> defer(() -> {
+            TestCompletable timer = new TestCompletable();
+            timers.add(timer);
+            return timer;
+        }));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        jdkExecutor.shutdownNow();
+    }
+
+    @Test
+    public void sizeOrDurationConcurrent() throws Exception {
+        final int maxBoundaries = 1_000;
+        final Collection<Integer> items = unmodifiableCollection(range(1, 1_000).toFuture().get());
+        final List<Integer> receivedFromBoundaries = new ArrayList<>(items.size());
+
+        BufferStrategy<Integer, Accumulator<Integer, Iterable<Integer>>, Iterable<Integer>> strategy =
+                forCountOrTime(1, ofDays(1), executor);
+        CountDownLatch boundariesDone = new CountDownLatch(1);
+        BlockingQueue<Accumulator<Integer, Iterable<Integer>>> boundaries = new LinkedBlockingQueue<>();
+        BlockingQueue<Accumulator<Integer, Iterable<Integer>>> boundariesToFinish = new LinkedBlockingQueue<>();
+
+        strategy.boundaries()
+                .beforeOnNext(boundaries::add)
+                .takeAtMost(maxBoundaries)
+                .afterFinally(boundariesDone::countDown)
+                .ignoreElements().subscribe();
+        CyclicBarrier accumulateAndTimerStarted = new CyclicBarrier(2);
+
+        Future<Object> timersFuture = jdkExecutor.submit(() -> {
+            accumulateAndTimerStarted.await();
+            while (boundariesDone.getCount() > 0) {
+                timers.take().onComplete();
+            }
+            return null;
+        });
+
+        Future<Object> accumulateFuture = jdkExecutor.submit(() -> {
+            accumulateAndTimerStarted.await();
+            int boundariesReceived = 0;
+            Iterator<Integer> itemsToPopulate = items.iterator();
+            while (itemsToPopulate.hasNext()) {
+                Accumulator<Integer, Iterable<Integer>> boundary = boundaries.take();
+                if (++boundariesReceived < maxBoundaries) {
+                    boundary.accumulate(itemsToPopulate.next());
+                } else {
+                    // add all items to the last boundary
+                    do {
+                        boundary.accumulate(itemsToPopulate.next());
+                    } while (itemsToPopulate.hasNext());
+                }
+                boundariesToFinish.add(boundary);
+            }
+            return null;
+        });
+
+        boundariesDone.await();
+        timersFuture.get();
+        accumulateFuture.get();
+        Accumulator<Integer, Iterable<Integer>> boundary;
+        while ((boundary = boundariesToFinish.poll()) != null) {
+            for (Integer item : boundary.finish()) {
+                receivedFromBoundaries.add(item);
+            }
+        }
+        assertThat("Unexpected items received.", receivedFromBoundaries, contains(items.toArray()));
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferConcurrencyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferConcurrencyTest.java
@@ -49,7 +49,7 @@ public class PublisherBufferConcurrencyTest {
     private static final String THREAD_NAME_PREFIX = "buffer-concurrency-test";
     private static final Key<Integer> CTX_KEY = Key.newKey("foo");
 
-    //@Rule
+    @Rule
     public final Timeout timeout = new ServiceTalkTestTimeout();
     @Rule
     public final ExecutorRule<Executor> executorRule = withNamePrefix(THREAD_NAME_PREFIX);
@@ -135,9 +135,12 @@ public class PublisherBufferConcurrencyTest {
         boundaries.onNext(new SummingAccumulator());
         waitForBoundary.countDown();
         waitForOnNextReturn.await();
+
+        boundaries.onNext(new SummingAccumulator()); // Last accumulator will be overwritten by add()
         assertThat("Unexpected result.", subscriber.takeItems(), contains(1));
 
         original.onComplete();
+        boundaries.onNext(new SummingAccumulator()); // Boundary has to complete for terminal to be emitted
         assertThat("Unexpected result.", subscriber.takeItems(), contains(0)); // empty accumulator
 
         TerminalNotification term = subscriber.takeTerminal();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferConcurrencyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferConcurrencyTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.api.AsyncContextMap.Key;
+import io.servicetalk.concurrent.api.BufferStrategy.Accumulator;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TerminalNotification;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.Completable.failed;
+import static io.servicetalk.concurrent.api.ExecutorRule.withNamePrefix;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static java.time.Duration.ofMillis;
+import static java.util.function.UnaryOperator.identity;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.fail;
+
+public class PublisherBufferConcurrencyTest {
+    private static final String THREAD_NAME_PREFIX = "buffer-concurrency-test";
+    private static final Key<Integer> CTX_KEY = Key.newKey("foo");
+
+    //@Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+    @Rule
+    public final ExecutorRule<Executor> executorRule = withNamePrefix(THREAD_NAME_PREFIX);
+
+    @Test
+    public void largeRun() throws Exception {
+        runTest(identity(), identity());
+    }
+
+    @Test
+    public void executorIsPreserved() throws Exception {
+        final Executor executor = executorRule.executor();
+        runTest(beforeBuffer -> beforeBuffer.publishOn(executor),
+                afterBuffer -> afterBuffer.beforeOnNext(__ ->
+                        assertThat("Unexpected thread in onNext.", Thread.currentThread().getName(),
+                                startsWith(THREAD_NAME_PREFIX)))
+                        .beforeOnComplete(() ->
+                                assertThat("Unexpected thread in onComplete.", Thread.currentThread().getName(),
+                                        startsWith(THREAD_NAME_PREFIX))
+        ));
+    }
+
+    @Test
+    public void contextIsPreserved() throws Exception {
+        AsyncContext.put(CTX_KEY, 0);
+        runTest(beforeBuffer -> beforeBuffer.beforeOnSubscribe(__ -> AsyncContext.put(CTX_KEY, 1)),
+                afterBuffer -> afterBuffer.beforeOnNext(__ ->
+                        assertThat("Unexpected value in context.", AsyncContext.get(CTX_KEY),
+                                is(1)))
+                        .beforeOnComplete(() ->
+                            assertThat("Unexpected value in context.", AsyncContext.get(CTX_KEY),
+                                    is(1))));
+    }
+
+    @Test
+    public void addingAndBoundaryEmission() throws Exception {
+        TestPublisher<Integer> original = new TestPublisher<>();
+        TestPublisher<Accumulator<Integer, Integer>> boundaries = new TestPublisher<>();
+        TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
+        CountDownLatch waitForBoundary = new CountDownLatch(1);
+        CountDownLatch waitForAdd = new CountDownLatch(1);
+        Accumulator<Integer, Integer> accumulator = new Accumulator<Integer, Integer>() {
+            private int added;
+            @Override
+            public void accumulate(@Nullable final Integer integer) {
+                waitForAdd.countDown();
+                try {
+                    waitForBoundary.await();
+                    if (integer == null) {
+                        return;
+                    }
+                    added = integer;
+                } catch (InterruptedException e) {
+                    fail();
+                }
+            }
+
+            @Override
+            public Integer finish() {
+                return added;
+            }
+        };
+        toSource(original.buffer(new BufferStrategy<Integer, Accumulator<Integer, Integer>, Integer>() {
+            @Override
+            public Publisher<Accumulator<Integer, Integer>> boundaries() {
+                return boundaries;
+            }
+
+            @Override
+            public int bufferSizeHint() {
+                return 8;
+            }
+        })).subscribe(subscriber);
+        subscriber.request(1);
+        boundaries.onNext(accumulator); // initial boundary
+        assertThat("Unexpected result.", subscriber.takeItems(), hasSize(0));
+
+        CountDownLatch waitForOnNextReturn = new CountDownLatch(1);
+        executorRule.executor().submit(() -> original.onNext(1))
+                .beforeFinally(waitForOnNextReturn::countDown).subscribe();
+        waitForAdd.await();
+        subscriber.request(1);
+        boundaries.onNext(new SummingAccumulator());
+        waitForBoundary.countDown();
+        waitForOnNextReturn.await();
+        assertThat("Unexpected result.", subscriber.takeItems(), contains(1));
+
+        original.onComplete();
+        assertThat("Unexpected result.", subscriber.takeItems(), contains(0)); // empty accumulator
+
+        TerminalNotification term = subscriber.takeTerminal();
+        assertThat("Unexpected result.", term, is(notNullValue()));
+        assertThat("Unexpected result.", term.cause(), is(nullValue()));
+    }
+
+    private void runTest(final UnaryOperator<Publisher<Integer>> beforeBuffer,
+                         final UnaryOperator<Publisher<Iterable<Integer>>> afterBuffer) throws Exception {
+        final int maxRange = 1000;
+        final int repeatMax = 100;
+        final Executor executor = executorRule.executor();
+        Publisher<Integer> original = Publisher.range(0, maxRange)
+                .repeatWhen(count -> count == repeatMax ? failed(DELIBERATE_EXCEPTION) :
+                        executor.timer(ofMillis(1)));
+
+        Publisher<Iterable<Integer>> buffered = beforeBuffer.apply(original)
+                .buffer(BufferStrategies.forCountOrTime(maxRange / 20, ofMillis(500)));
+
+        afterBuffer.apply(buffered).beforeOnNext(new Consumer<Iterable<Integer>>() {
+            private int lastValue = -1;
+
+            @Override
+            public void accept(final Iterable<Integer> ints) {
+                for (Integer anInt : ints) {
+                    assertThat("Unexpected value", anInt, greaterThan(lastValue));
+                    lastValue = anInt == (maxRange - 1) ? -1 : anInt;
+                }
+            }
+        })
+                .ignoreElements()
+                .toFuture()
+                .get();
+    }
+
+    private static class SummingAccumulator implements Accumulator<Integer, Integer> {
+        private int sum;
+
+        @Override
+        public void accumulate(@Nullable final Integer item) {
+            if (item == null) {
+                return;
+            }
+            sum += item;
+        }
+
+        @Override
+        public Integer finish() {
+            return sum;
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.api.BufferStrategy.Accumulator;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TerminalNotification;
+
+import org.hamcrest.Matcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class PublisherBufferTest {
+    private static final int EMPTY_ACCUMULATOR_VAL = -1;
+    public static final int BUFFER_SIZE_HINT = 8;
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+
+    private final TestPublisher<Integer> original = new TestPublisher<>();
+    private final TestPublisher<SumAccumulator> boundaries = new TestPublisher<>();
+    private final TestPublisherSubscriber<Integer> bufferSubscriber = new TestPublisherSubscriber<>();
+
+    public PublisherBufferTest() {
+        toSource(original.buffer(new BufferStrategy<Integer, SumAccumulator, Integer>() {
+            @Override
+            public Publisher<SumAccumulator> boundaries() {
+                return boundaries;
+            }
+
+            @Override
+            public int bufferSizeHint() {
+                return BUFFER_SIZE_HINT;
+            }
+        })).subscribe(bufferSubscriber);
+        assertThat("Subscription not received for buffer subscriber.", bufferSubscriber.subscriptionReceived(),
+                is(true));
+        bufferSubscriber.request(1); // get first boundary
+        boundaries.onNext(new SumAccumulator(boundaries));
+        assertThat("Unexpected boundary received.", bufferSubscriber.takeItems(), hasSize(0));
+    }
+
+    @Test
+    public void emptyBuffer() {
+        bufferSubscriber.request(1);
+        verifyNoBuffersNoTerminal();
+
+        emitBoundary();
+        verifyEmptyBufferReceived();
+        verifyNoBuffersNoTerminal();
+    }
+
+    @Test
+    public void originalCompleteBeforeBufferRequested() {
+        verifyNoBuffersNoTerminal();
+
+        original.onComplete();
+        bufferSubscriber.request(1);
+
+        emitBoundary();
+        verifyEmptyBufferReceived();
+        verifyBufferSubCompleted();
+    }
+
+    @Test
+    public void originalFailedBeforeBufferRequested() {
+        verifyNoBuffersNoTerminal();
+
+        original.onError(DELIBERATE_EXCEPTION);
+        bufferSubscriber.request(1);
+
+        emitBoundary();
+        verifyEmptyBufferReceived();
+        verifyBufferSubFailed(sameInstance(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    public void bufferContainsItemsBeforeBoundaryClose() {
+        verifyNoBuffersNoTerminal();
+
+        original.onNext(1, 2, 3, 4);
+        bufferSubscriber.request(1);
+
+        emitBoundary();
+        verifyBufferReceived(contains(1 + 2 + 3 + 4));
+    }
+
+    @Test
+    public void multipleBoundaries() {
+        verifyNoBuffersNoTerminal();
+        bufferSubscriber.request(2);
+
+        original.onNext(1, 2, 3, 4);
+
+        emitBoundary();
+        verifyBufferReceived(contains(1 + 2 + 3 + 4));
+
+        original.onNext(1, 2, 3, 4);
+        original.onComplete();
+
+        emitBoundary();
+    }
+
+    @Test
+    public void bufferSubCancel() {
+        bufferSubscriber.cancel();
+        verifyCancelled(original);
+        verifyCancelled(boundaries);
+    }
+
+    @Test
+    public void itemsBufferedTillBoundariesRequested() {
+        verifyNoBuffersNoTerminal();
+
+        original.onNext(1, 2, 3, 4);
+        bufferSubscriber.request(1);
+        emitBoundary();
+        verifyBufferReceived(contains(1 + 2 + 3 + 4));
+    }
+
+    @Test
+    public void itemsAndCompletionBufferedTillBoundariesRequested() {
+        verifyNoBuffersNoTerminal();
+
+        original.onNext(1, 2, 3, 4);
+        original.onComplete();
+        bufferSubscriber.request(1);
+        emitBoundary();
+        verifyBufferReceived(contains(1 + 2 + 3 + 4));
+        verifyBufferSubCompleted();
+        verifyCancelled(boundaries);
+    }
+
+    @Test
+    public void itemsAndFailureBufferedTillBoundariesRequested() {
+        verifyNoBuffersNoTerminal();
+
+        original.onNext(1, 2, 3, 4);
+        original.onError(DELIBERATE_EXCEPTION);
+        bufferSubscriber.request(1);
+        emitBoundary();
+        verifyBufferReceived(contains(1 + 2 + 3 + 4));
+        verifyBufferSubFailed(sameInstance(DELIBERATE_EXCEPTION));
+        verifyCancelled(boundaries);
+    }
+
+    @Test
+    public void boundariesCompletion() {
+        verifyNoBuffersNoTerminal();
+
+        original.onNext(1, 2, 3, 4);
+        boundaries.onComplete();
+        verifyBufferSubFailed(instanceOf(IllegalStateException.class));
+
+        verifyCancelled(original);
+    }
+
+    @Test
+    public void boundariesFailure() {
+        verifyNoBuffersNoTerminal();
+
+        original.onNext(1, 2, 3, 4);
+        boundaries.onError(DELIBERATE_EXCEPTION);
+        verifyBufferSubFailed(sameInstance(DELIBERATE_EXCEPTION));
+        verifyCancelled(original);
+    }
+
+    @Test
+    public void accumulateEmitsBoundary() {
+        bufferSubscriber.request(1);
+        boundaries.onNext(new SumAccumulator(boundaries, true));
+        verifyEmptyBufferReceived();
+        original.onNext(1);
+        verifyBufferReceived(contains(1));
+    }
+
+    private void verifyCancelled(TestPublisher<?> source) {
+        TestSubscription subscription = new TestSubscription();
+        source.onSubscribe(subscription);
+        assertThat("Original source not cancelled.", subscription.isCancelled(), is(true));
+    }
+
+    private void verifyBufferReceived(final Matcher<Iterable<? extends Integer>> bufferMatcher) {
+        assertThat("Unexpected buffers received.", bufferSubscriber.takeItems(), bufferMatcher);
+    }
+
+    private void verifyEmptyBufferReceived() {
+        assertThat("Unexpected buffers received.", bufferSubscriber.takeItems(), contains(EMPTY_ACCUMULATOR_VAL));
+    }
+
+    private void verifyNoBuffersNoTerminal() {
+        assertThat("Unexpected buffers received.", bufferSubscriber.items(), hasSize(0));
+        assertThat("Unexpected termination of buffer subscriber.", bufferSubscriber.isTerminated(), is(false));
+    }
+
+    private void emitBoundary() {
+        boundaries.onNext(new SumAccumulator(boundaries));
+    }
+
+    private void verifyBufferSubCompleted() {
+        TerminalNotification term = bufferSubscriber.takeTerminal();
+        assertThat("Unexpected termination of buffer subscriber.", term, is(notNullValue()));
+        assertThat("Unexpected termination of buffer subscriber.", term.cause(), is(nullValue()));
+    }
+
+    private void verifyBufferSubFailed(final Matcher<Throwable> causeMatcher) {
+        TerminalNotification term = bufferSubscriber.takeTerminal();
+        assertThat("Unexpected termination of buffer subscriber.", term, is(notNullValue()));
+        assertThat("Unexpected termination of buffer subscriber.", term.cause(), causeMatcher);
+    }
+
+    private static final class SumAccumulator implements Accumulator<Integer, Integer> {
+        private final TestPublisher<SumAccumulator> boundaries;
+        private int sum = EMPTY_ACCUMULATOR_VAL;
+        private final boolean emitBoundaryOnAccumulate;
+
+        SumAccumulator(final TestPublisher<SumAccumulator> boundaries) {
+            this(boundaries, false);
+        }
+
+        SumAccumulator(final TestPublisher<SumAccumulator> boundaries, final boolean emitBoundaryOnAccumulate) {
+            this.boundaries = boundaries;
+            this.emitBoundaryOnAccumulate = emitBoundaryOnAccumulate;
+        }
+
+        @Override
+        public void accumulate(@Nullable final Integer integer) {
+            if (integer == null) {
+                return;
+            }
+            if (sum == EMPTY_ACCUMULATOR_VAL) {
+                sum = 0;
+            }
+            sum += integer;
+            if (emitBoundaryOnAccumulate) {
+                boundaries.onNext(new SumAccumulator(boundaries));
+            }
+        }
+
+        @Override
+        public Integer finish() {
+            return sum;
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferTest.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.internal.TerminalNotification;
 
 import org.hamcrest.Matcher;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -112,6 +113,24 @@ public class PublisherBufferTest {
     }
 
     @Test
+    public void itemCompletionCancelsBoundaries() {
+        verifyNoBuffersNoTerminal();
+        original.onComplete();
+        emitBoundary();
+        verifyBufferSubCompleted();
+        verifyCancelled(boundaries);
+    }
+
+    @Test
+    public void itemFailureCancelsBoundaries() {
+        verifyNoBuffersNoTerminal();
+        original.onError(DELIBERATE_EXCEPTION);
+        emitBoundary();
+        verifyBufferSubFailed(sameInstance(DELIBERATE_EXCEPTION));
+        verifyCancelled(boundaries);
+    }
+
+    @Test
     public void multipleBoundaries() {
         verifyNoBuffersNoTerminal();
         bufferSubscriber.request(2);
@@ -191,6 +210,7 @@ public class PublisherBufferTest {
         verifyCancelled(original);
     }
 
+    @Ignore("Accumulator will not emit boundary ATM")
     @Test
     public void accumulateEmitsBoundary() {
         bufferSubscriber.request(1);

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherBufferTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherBufferTckTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+import org.testng.annotations.Test;
+
+import static io.servicetalk.concurrent.api.BufferStrategies.forCountOrTime;
+import static java.time.Duration.ofMillis;
+import static java.util.function.Function.identity;
+
+@Test
+public class PublisherBufferTckTest extends AbstractPublisherOperatorTckTest<Integer> {
+
+    @Override
+    protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
+        return publisher.buffer(forCountOrTime(1, ofMillis(1)))
+                .flatMapConcatIterable(identity());
+    }
+}


### PR DESCRIPTION
__Motivation__

[`buffer`](http://reactivex.io/documentation/operators/buffer.html) operator is useful for batching.

__Modification__

Add `buffer()` operator for `Publisher` to buffer based on arbitrary buffer boundaries or based on size + time duration.

__Result__

Users can buffer events from a `Publisher`.