### PR TITLE
`RoundRobinLoadBalancer` should close connections gracefully

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -378,7 +378,7 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
             @SuppressWarnings("unchecked")
             List<C> toRemove = connectionsUpdater.getAndSet(this, INACTIVE);
             for (C conn : toRemove) {
-                conn.closeAsync().subscribe();
+                conn.closeAsyncGracefully().subscribe();
             }
         }
 


### PR DESCRIPTION
__Motivation__

When a host used by `RoundRobinLoadBalancer` is unregistered from service discovery, we force close the connection. This means any outstanding requests on the connection will get interrupted. Since service discovery status is a hint we should err on the side of caution and let the outstanding requests complete gracefully.
A fallout of this decision is that a connection may actually be dead and an absence of writes may mean that the we will never detect closure hence graceful closure will never complete.
This is a trade-off between interrupting requests which may otherwise be successfully completed vs not force closing requests that may never complete. As requests could be infinitely latent in general, we assume that users have configured timeouts on the requests and hence all in-flight requests will eventually complete.

__Modification__

Use `closeAsyncGracefully()` instead of `closeAsync()` when a host turns inactive.

__Result__

Host inactivation does not interrupt in-flight requests.