### PR TITLE
Introduce HTTP/2 keep alive

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/KeepAliveTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/KeepAliveTest.java
@@ -29,6 +29,7 @@ import io.servicetalk.grpc.netty.TesterProto.Tester.TesterClient;
 import io.servicetalk.grpc.netty.TesterProto.Tester.TesterService;
 import io.servicetalk.http.netty.H2ProtocolConfig;
 import io.servicetalk.http.netty.HttpProtocolConfigs;
+import io.servicetalk.http.netty.KeepAlivePolicies;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServiceTalkSocketOptions;
@@ -102,10 +103,11 @@ public class KeepAliveTest {
     private static Object[] newParam(final boolean keepAlivesFromClient, final Duration keepAliveIdleDuration,
                                      final Duration idleTimeoutDuration) {
         return new Object[] {keepAlivesFromClient,
-                (Function<String, H2ProtocolConfig>) frameLogger -> HttpProtocolConfigs.h2().keepAlive()
-                .idleDuration(keepAliveIdleDuration).commit()
-                .enableFrameLogging(frameLogger)
-                .build(), idleTimeoutDuration.toMillis()};
+                (Function<String, H2ProtocolConfig>) frameLogger ->
+                        HttpProtocolConfigs.h2()
+                                .keepAlivePolicy(KeepAlivePolicies.whenIdleFor(keepAliveIdleDuration))
+                                .enableFrameLogging(frameLogger).build(),
+                idleTimeoutDuration.toMillis()};
     }
 
     @After

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/KeepAliveTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/KeepAliveTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.netty;
+
+import io.servicetalk.concurrent.api.CompositeCloseable;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.grpc.api.GrpcClientBuilder;
+import io.servicetalk.grpc.api.GrpcServerBuilder;
+import io.servicetalk.grpc.api.GrpcServiceContext;
+import io.servicetalk.grpc.netty.TesterProto.TestRequest;
+import io.servicetalk.grpc.netty.TesterProto.TestResponse;
+import io.servicetalk.grpc.netty.TesterProto.Tester.ServiceFactory;
+import io.servicetalk.grpc.netty.TesterProto.Tester.TesterClient;
+import io.servicetalk.grpc.netty.TesterProto.Tester.TesterService;
+import io.servicetalk.http.netty.H2ProtocolConfig;
+import io.servicetalk.http.netty.HttpProtocolConfigs;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.ServiceTalkSocketOptions;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
+import static io.servicetalk.concurrent.api.Publisher.never;
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.time.Duration.ofSeconds;
+import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeThat;
+
+@RunWith(Parameterized.class)
+public class KeepAliveTest {
+    private final TesterClient client;
+    private final ServerContext ctx;
+
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout(1, MINUTES);
+    private final long idleTimeoutMillis;
+
+    public KeepAliveTest(final boolean keepAlivesFromClient,
+                         final Function<String, H2ProtocolConfig> protocolConfigSupplier,
+                         final long idleTimeoutMillis) throws Exception {
+        this.idleTimeoutMillis = idleTimeoutMillis;
+        GrpcServerBuilder serverBuilder = GrpcServers.forAddress(localAddress(0));
+        if (!keepAlivesFromClient) {
+            serverBuilder.protocols(protocolConfigSupplier.apply("servicetalk-tests-server-wire-logger"));
+        } else {
+            serverBuilder.socketOption(ServiceTalkSocketOptions.IDLE_TIMEOUT, idleTimeoutMillis)
+                    .protocols(HttpProtocolConfigs.h2()
+                            .enableFrameLogging("servicetalk-tests-server-wire-logger").build());
+        }
+        ctx = serverBuilder.listenAndAwait(new ServiceFactory(new InfiniteStreamsService()));
+        GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
+                GrpcClients.forAddress(serverHostAndPort(ctx));
+        if (keepAlivesFromClient) {
+            clientBuilder.protocols(protocolConfigSupplier.apply("servicetalk-tests-client-wire-logger"));
+        } else {
+            clientBuilder.socketOption(ServiceTalkSocketOptions.IDLE_TIMEOUT, idleTimeoutMillis)
+                    .protocols(HttpProtocolConfigs.h2()
+                            .enableFrameLogging("servicetalk-tests-client-wire-logger").build());
+        }
+        client = clientBuilder.build(new TesterProto.Tester.ClientFactory());
+    }
+
+    @Parameterized.Parameters(name = "keepAlivesFromClient? {0}, idleTimeout: {2}")
+    public static Collection<Object[]> data() {
+        return asList(newParam(true, ofSeconds(10), ofSeconds(12)),
+                newParam(false, ofSeconds(10), ofSeconds(12)));
+    }
+
+    private static Object[] newParam(final boolean keepAlivesFromClient, final Duration keepAliveIdleDuration,
+                                     final Duration idleTimeoutDuration) {
+        return new Object[] {keepAlivesFromClient,
+                (Function<String, H2ProtocolConfig>) frameLogger -> HttpProtocolConfigs.h2().keepAlive()
+                .idleDuration(keepAliveIdleDuration).commit()
+                .enableFrameLogging(frameLogger)
+                .build(), idleTimeoutDuration.toMillis()};
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        CompositeCloseable closeable = newCompositeCloseable().appendAll(client, ctx);
+        closeable.close();
+    }
+
+    @Test
+    public void bidiStream() throws Exception {
+        // Ignore test on CI due to high timeouts
+        assumeThat(ServiceTalkTestTimeout.CI, is(false));
+
+        try {
+            client.testBiDiStream(never()).toFuture().get(idleTimeoutMillis + 100, MILLISECONDS);
+            fail("Unexpected response available.");
+        } catch (TimeoutException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void requestStream() throws Exception {
+        // Ignore test on CI due to high timeouts
+        assumeThat(ServiceTalkTestTimeout.CI, is(false));
+
+        try {
+            client.testRequestStream(never()).toFuture().get(idleTimeoutMillis + 100, MILLISECONDS);
+            fail("Unexpected response available.");
+        } catch (TimeoutException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void responseStream() throws Exception {
+        // Ignore test on CI due to high timeouts
+        assumeThat(ServiceTalkTestTimeout.CI, is(false));
+
+        try {
+            client.testResponseStream(TestRequest.newBuilder().build())
+                    .toFuture().get(idleTimeoutMillis + 100, MILLISECONDS);
+            fail("Unexpected response available.");
+        } catch (TimeoutException e) {
+            // expected
+        }
+    }
+
+    private static final class InfiniteStreamsService implements TesterService {
+
+        @Override
+        public Publisher<TestResponse> testBiDiStream(final GrpcServiceContext ctx,
+                                                      final Publisher<TestRequest> request) {
+            return request.map(testRequest -> TestResponse.newBuilder().build());
+        }
+
+        @Override
+        public Single<TestResponse> testRequestStream(final GrpcServiceContext ctx,
+                                                      final Publisher<TestRequest> request) {
+            return request.collect(() -> null, (testResponse, testRequest) -> null)
+                    .map(__ -> TestResponse.newBuilder().build());
+        }
+
+        @Override
+        public Publisher<TestResponse> testResponseStream(final GrpcServiceContext ctx, final TestRequest request) {
+            return never();
+        }
+
+        @Override
+        public Single<TestResponse> test(final GrpcServiceContext ctx, final TestRequest request) {
+            return succeeded(TestResponse.newBuilder().build());
+        }
+    }
+}

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/KeepAliveTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/KeepAliveTest.java
@@ -27,9 +27,9 @@ import io.servicetalk.grpc.netty.TesterProto.TestResponse;
 import io.servicetalk.grpc.netty.TesterProto.Tester.ServiceFactory;
 import io.servicetalk.grpc.netty.TesterProto.Tester.TesterClient;
 import io.servicetalk.grpc.netty.TesterProto.Tester.TesterService;
+import io.servicetalk.http.netty.H2KeepAlivePolicies;
 import io.servicetalk.http.netty.H2ProtocolConfig;
 import io.servicetalk.http.netty.HttpProtocolConfigs;
-import io.servicetalk.http.netty.KeepAlivePolicies;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServiceTalkSocketOptions;
@@ -105,7 +105,7 @@ public class KeepAliveTest {
         return new Object[] {keepAlivesFromClient,
                 (Function<String, H2ProtocolConfig>) frameLogger ->
                         HttpProtocolConfigs.h2()
-                                .keepAlivePolicy(KeepAlivePolicies.whenIdleFor(keepAliveIdleDuration))
+                                .keepAlivePolicy(H2KeepAlivePolicies.whenIdleFor(keepAliveIdleDuration))
                                 .enableFrameLogging(frameLogger).build(),
                 idleTimeoutDuration.toMillis()};
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultKeepAlivePolicy.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultKeepAlivePolicy.java
@@ -20,8 +20,9 @@ import io.servicetalk.http.netty.H2ProtocolConfig.KeepAlivePolicy;
 import java.time.Duration;
 
 import static java.time.Duration.ofSeconds;
+import static java.util.Objects.requireNonNull;
 
-class DefaultKeepAlivePolicy implements KeepAlivePolicy {
+final class DefaultKeepAlivePolicy implements KeepAlivePolicy {
     static final Duration DEFAULT_IDLE_DURATION = ofSeconds(30);
     static final Duration DEFAULT_ACK_TIMEOUT = ofSeconds(30);
     static final boolean DEFAULT_WITHOUT_ACTIVE_STREAMS = false;
@@ -34,8 +35,8 @@ class DefaultKeepAlivePolicy implements KeepAlivePolicy {
     }
 
     DefaultKeepAlivePolicy(final Duration idleDuration, final Duration ackTimeout, final boolean withoutActiveStreams) {
-        this.idleDuration = idleDuration;
-        this.ackTimeout = ackTimeout;
+        this.idleDuration = requireNonNull(idleDuration);
+        this.ackTimeout = requireNonNull(ackTimeout);
         this.withoutActiveStreams = withoutActiveStreams;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultKeepAlivePolicy.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultKeepAlivePolicy.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.netty.H2ProtocolConfig.KeepAlivePolicy;
+
+import java.time.Duration;
+
+import static java.time.Duration.ofSeconds;
+
+class DefaultKeepAlivePolicy implements KeepAlivePolicy {
+    static final Duration DEFAULT_IDLE_DURATION = ofSeconds(30);
+    static final Duration DEFAULT_ACK_TIMEOUT = ofSeconds(30);
+    static final boolean DEFAULT_WITHOUT_ACTIVE_STREAMS = false;
+    private final Duration idleDuration;
+    private final Duration ackTimeout;
+    private final boolean withoutActiveStreams;
+
+    DefaultKeepAlivePolicy() {
+        this(DEFAULT_IDLE_DURATION, DEFAULT_ACK_TIMEOUT, false);
+    }
+
+    DefaultKeepAlivePolicy(final Duration idleDuration, final Duration ackTimeout, final boolean withoutActiveStreams) {
+        this.idleDuration = idleDuration;
+        this.ackTimeout = ackTimeout;
+        this.withoutActiveStreams = withoutActiveStreams;
+    }
+
+    @Override
+    public Duration idleDuration() {
+        return idleDuration;
+    }
+
+    @Override
+    public Duration ackTimeout() {
+        return ackTimeout;
+    }
+
+    @Override
+    public boolean withoutActiveStreams() {
+        return withoutActiveStreams;
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultKeepAlivePolicy.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultKeepAlivePolicy.java
@@ -19,20 +19,12 @@ import io.servicetalk.http.netty.H2ProtocolConfig.KeepAlivePolicy;
 
 import java.time.Duration;
 
-import static java.time.Duration.ofSeconds;
 import static java.util.Objects.requireNonNull;
 
 final class DefaultKeepAlivePolicy implements KeepAlivePolicy {
-    static final Duration DEFAULT_IDLE_DURATION = ofSeconds(30);
-    static final Duration DEFAULT_ACK_TIMEOUT = ofSeconds(30);
-    static final boolean DEFAULT_WITHOUT_ACTIVE_STREAMS = false;
     private final Duration idleDuration;
     private final Duration ackTimeout;
     private final boolean withoutActiveStreams;
-
-    DefaultKeepAlivePolicy() {
-        this(DEFAULT_IDLE_DURATION, DEFAULT_ACK_TIMEOUT, false);
-    }
 
     DefaultKeepAlivePolicy(final Duration idleDuration, final Duration ackTimeout, final boolean withoutActiveStreams) {
         this.idleDuration = requireNonNull(idleDuration);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -81,8 +81,9 @@ import static java.util.Objects.requireNonNull;
 final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
     private H2ClientParentConnectionContext(Channel channel, BufferAllocator allocator, Executor executor,
                                             FlushStrategy flushStrategy, @Nullable Long idleTimeoutMs,
-                                            HttpExecutionStrategy executionStrategy) {
-        super(channel, allocator, executor, flushStrategy, idleTimeoutMs, executionStrategy);
+                                            HttpExecutionStrategy executionStrategy,
+                                            final KeepAliveManager keepAliveManager) {
+        super(channel, allocator, executor, flushStrategy, idleTimeoutMs, executionStrategy, keepAliveManager);
     }
 
     interface H2ClientParentConnection extends FilterableStreamingHttpConnection, NettyConnectionContext {
@@ -103,8 +104,10 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                 final ChannelPipeline pipeline;
                 try {
                     delayedCancellable = new DelayedCancellable();
+                    KeepAliveManager keepAliveManager = new KeepAliveManager(channel, config.keepAlivePolicy());
                     H2ClientParentConnectionContext connection = new H2ClientParentConnectionContext(channel,
-                            allocator, executor, parentFlushStrategy, idleTimeoutMs, executionStrategy);
+                            allocator, executor, parentFlushStrategy, idleTimeoutMs, executionStrategy,
+                            keepAliveManager);
                     channel.attr(CHANNEL_CLOSEABLE_KEY).set(connection);
                     // We need the NettyToStChannelInboundHandler to be last in the pipeline. We accomplish that by
                     // calling the ChannelInitializer before we do addLast for the NettyToStChannelInboundHandler.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2KeepAlivePolicies.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2KeepAlivePolicies.java
@@ -99,7 +99,8 @@ public final class H2KeepAlivePolicies {
          */
         public KeepAlivePolicyBuilder idleDuration(final Duration idleDuration) {
             if (idleDuration.getSeconds() < 10 || idleDuration.toDays() > 1) {
-                throw new IllegalArgumentException("idleDuration: " + idleDuration + " (expected >= 10 seconds");
+                throw new IllegalArgumentException("idleDuration: " + idleDuration +
+                        " (expected >= 10 seconds and < 1 day)");
             }
             this.idleDuration = idleDuration;
             return this;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfig.java
@@ -19,6 +19,7 @@ import io.servicetalk.http.api.HttpProtocolConfig;
 
 import org.slf4j.event.Level;
 
+import java.time.Duration;
 import java.util.function.BiPredicate;
 import javax.annotation.Nullable;
 
@@ -53,4 +54,46 @@ public interface H2ProtocolConfig extends HttpProtocolConfig {
      */
     @Nullable
     String frameLoggerName();
+
+    /**
+     * Configured {@link KeepAlivePolicy}.
+     *
+     * @return configured {@link KeepAlivePolicy} or {@code null} if none is configured.
+     */
+    @Nullable
+    KeepAlivePolicy keepAlivePolicy();
+
+    /**
+     * A policy for sending <a href="https://tools.ietf.org/html/rfc7540#page-42">PING frames</a> to the peer.
+     */
+    interface KeepAlivePolicy {
+        /**
+         * {@link Duration} of time the connection has to be idle before which a
+         * <a href="https://tools.ietf.org/html/rfc7540#page-42">ping</a> is sent.
+         *
+         * @return {@link Duration} of time the connection has to be idle before which a
+         * <a href="https://tools.ietf.org/html/rfc7540#page-42">ping</a> is sent.
+         */
+        Duration idleDuration();
+
+        /**
+         * {@link Duration} to wait for acknowledgment from the peer after a
+         * <a href="https://tools.ietf.org/html/rfc7540#page-42">ping</a> is sent. If there is no acknowledgment
+         * is received, a closure of the connection will be initiated.
+         *
+         * @return {@link Duration} to wait for acknowledgment from the peer after a
+         * <a href="https://tools.ietf.org/html/rfc7540#page-42">ping</a> is sent.
+         */
+        Duration ackTimeout();
+
+        /**
+         * Whether this policy allows to send <a href="https://tools.ietf.org/html/rfc7540#page-42">pings</a> even if
+         * there are no streams active on the connection.
+         *
+         * @return {@code true} if this policy allows to send
+         * <a href="https://tools.ietf.org/html/rfc7540#page-42">pings</a> even if there are no streams active on the
+         * connection.
+         */
+        boolean withoutActiveStreams();
+    }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfig.java
@@ -64,35 +64,35 @@ public interface H2ProtocolConfig extends HttpProtocolConfig {
     KeepAlivePolicy keepAlivePolicy();
 
     /**
-     * A policy for sending <a href="https://tools.ietf.org/html/rfc7540#page-42">PING frames</a> to the peer.
+     * A policy for sending <a href="https://tools.ietf.org/html/rfc7540#section-6.7">PING frames</a> to the peer.
      */
     interface KeepAlivePolicy {
         /**
          * {@link Duration} of time the connection has to be idle before a
-         * <a href="https://tools.ietf.org/html/rfc7540#page-42">ping</a> is sent.
+         * <a href="https://tools.ietf.org/html/rfc7540#section-6.7">ping</a> is sent.
          *
          * @return {@link Duration} of time the connection has to be idle before a
-         * <a href="https://tools.ietf.org/html/rfc7540#page-42">ping</a> is sent.
+         * <a href="https://tools.ietf.org/html/rfc7540#section-6.7">ping</a> is sent.
          */
         Duration idleDuration();
 
         /**
          * {@link Duration} to wait for acknowledgment from the peer after a
-         * <a href="https://tools.ietf.org/html/rfc7540#page-42">ping</a> is sent. If there is no acknowledgment
+         * <a href="https://tools.ietf.org/html/rfc7540#section-6.7">ping</a> is sent. If there is no acknowledgment
          * is received, a closure of the connection will be initiated.
          *
          * @return {@link Duration} to wait for acknowledgment from the peer after a
-         * <a href="https://tools.ietf.org/html/rfc7540#page-42">ping</a> is sent.
+         * <a href="https://tools.ietf.org/html/rfc7540#section-6.7">ping</a> is sent.
          */
         Duration ackTimeout();
 
         /**
-         * Whether this policy allows to send <a href="https://tools.ietf.org/html/rfc7540#page-42">pings</a> even if
-         * there are no streams active on the connection.
+         * Whether this policy allows to send <a href="https://tools.ietf.org/html/rfc7540#section-6.7">pings</a>
+         * even if there are no streams active on the connection.
          *
          * @return {@code true} if this policy allows to send
-         * <a href="https://tools.ietf.org/html/rfc7540#page-42">pings</a> even if there are no streams active on the
-         * connection.
+         * <a href="https://tools.ietf.org/html/rfc7540#section-6.7">pings</a> even if there are no streams active on
+         * the connection.
          */
         boolean withoutActiveStreams();
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfig.java
@@ -68,10 +68,10 @@ public interface H2ProtocolConfig extends HttpProtocolConfig {
      */
     interface KeepAlivePolicy {
         /**
-         * {@link Duration} of time the connection has to be idle before which a
+         * {@link Duration} of time the connection has to be idle before a
          * <a href="https://tools.ietf.org/html/rfc7540#page-42">ping</a> is sent.
          *
-         * @return {@link Duration} of time the connection has to be idle before which a
+         * @return {@link Duration} of time the connection has to be idle before a
          * <a href="https://tools.ietf.org/html/rfc7540#page-42">ping</a> is sent.
          */
         Duration idleDuration();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfig.java
@@ -78,8 +78,8 @@ public interface H2ProtocolConfig extends HttpProtocolConfig {
 
         /**
          * {@link Duration} to wait for acknowledgment from the peer after a
-         * <a href="https://tools.ietf.org/html/rfc7540#section-6.7">ping</a> is sent. If there is no acknowledgment
-         * is received, a closure of the connection will be initiated.
+         * <a href="https://tools.ietf.org/html/rfc7540#section-6.7">ping</a> is sent. If no acknowledgment is received,
+         * a closure of the connection will be initiated.
          *
          * @return {@link Duration} to wait for acknowledgment from the peer after a
          * <a href="https://tools.ietf.org/html/rfc7540#section-6.7">ping</a> is sent.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
@@ -17,12 +17,17 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpHeadersFactory;
+import io.servicetalk.http.netty.H2ProtocolConfig.KeepAlivePolicy;
 
 import org.slf4j.event.Level;
 
+import java.time.Duration;
 import java.util.function.BiPredicate;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.http.netty.DefaultKeepAlivePolicy.DEFAULT_ACK_TIMEOUT;
+import static io.servicetalk.http.netty.DefaultKeepAlivePolicy.DEFAULT_IDLE_DURATION;
+import static io.servicetalk.http.netty.DefaultKeepAlivePolicy.DEFAULT_WITHOUT_ACTIVE_STREAMS;
 import static io.servicetalk.http.netty.H2HeadersFactory.DEFAULT_SENSITIVITY_DETECTOR;
 import static java.util.Objects.requireNonNull;
 
@@ -37,6 +42,8 @@ public final class H2ProtocolConfigBuilder {
     private BiPredicate<CharSequence, CharSequence> headersSensitivityDetector = DEFAULT_SENSITIVITY_DETECTOR;
     @Nullable
     private String frameLoggerName;
+    @Nullable
+    private KeepAlivePolicy keepAlivePolicy;
 
     H2ProtocolConfigBuilder() {
     }
@@ -82,12 +89,123 @@ public final class H2ProtocolConfigBuilder {
     }
 
     /**
+     * Configure keep alive behavior using <a href="https://tools.ietf.org/html/rfc7540#page-42">PING frames</a>.
+     *
+     * @return A {@link KeepAliveConfigurator} which adds keep-alive configuration to this {@link H2ProtocolConfig} when
+     * {@link KeepAliveConfigurator#commit() committed}.
+     */
+    public KeepAliveConfigurator keepAlive() {
+        return new KeepAliveConfigurator() {
+            private Duration idleDuration = DEFAULT_IDLE_DURATION;
+            private Duration ackTimeout = DEFAULT_ACK_TIMEOUT;
+            private boolean withoutActiveStreams = DEFAULT_WITHOUT_ACTIVE_STREAMS;
+            private boolean disable;
+
+            @Override
+            public KeepAliveConfigurator idleDuration(final Duration idleDuration) {
+                if (idleDuration.getSeconds() < 10) {
+                    throw new IllegalArgumentException("idleDuration: " + idleDuration + " (expected >= 10 seconds");
+                }
+                this.idleDuration = requireNonNull(idleDuration);
+                return this;
+            }
+
+            @Override
+            public KeepAliveConfigurator ackTimeout(final Duration ackTimeout) {
+                this.ackTimeout = requireNonNull(ackTimeout);
+                return this;
+            }
+
+            @Override
+            public KeepAliveConfigurator withoutActiveStreams(final boolean withoutActiveStreams) {
+                this.withoutActiveStreams = withoutActiveStreams;
+                return this;
+            }
+
+            @Override
+            public KeepAliveConfigurator disable() {
+                this.disable = true;
+                return this;
+            }
+
+            @Override
+            public H2ProtocolConfigBuilder commit() {
+                H2ProtocolConfigBuilder parent = H2ProtocolConfigBuilder.this;
+                if (disable) {
+                    parent.keepAlivePolicy = null;
+                } else {
+                    parent.keepAlivePolicy = new DefaultKeepAlivePolicy(idleDuration, ackTimeout, withoutActiveStreams);
+                }
+                return parent;
+            }
+        };
+    }
+
+    /**
      * Builds {@link H2ProtocolConfig}.
      *
      * @return {@link H2ProtocolConfig}
      */
     public H2ProtocolConfig build() {
-        return new DefaultH2ProtocolConfig(headersFactory, headersSensitivityDetector, frameLoggerName);
+        return new DefaultH2ProtocolConfig(headersFactory, headersSensitivityDetector, frameLoggerName,
+                keepAlivePolicy);
+    }
+
+    /**
+     * A configurator for {@link KeepAlivePolicy}.
+     */
+    public interface KeepAliveConfigurator {
+
+        /**
+         * Set the {@link Duration} of idleness on a connection after which a
+         * <a href="https://tools.ietf.org/html/rfc7540#page-42">ping</a> is sent.
+         * <strong>Too short ping durations may cause high network traffic, so implementations may enforce a minimum
+         * duration.</strong>
+         *
+         * @param idleDuration {@link Duration} of idleness on a connection after which a
+         * <a href="https://tools.ietf.org/html/rfc7540#page-42">ping</a> is sent.
+         * @return {@code this}.
+         * @see KeepAlivePolicy#idleDuration()
+         */
+        KeepAliveConfigurator idleDuration(Duration idleDuration);
+
+        /**
+         * Set the maximum {@link Duration} to wait for an acknowledgment of a previously sent
+         * <a href="https://tools.ietf.org/html/rfc7540#page-42">ping</a>. If no acknowledgment is received, the
+         * connection will be closed.
+         *
+         * @param ackTimeout {@link Duration} to wait for an acknowledgment of a previously sent
+         * <a href="https://tools.ietf.org/html/rfc7540#page-42">ping</a>.
+         * @return {@code this}.
+         * @see KeepAlivePolicy#ackTimeout()
+         */
+        KeepAliveConfigurator ackTimeout(Duration ackTimeout);
+
+        /**
+         * Allow/disallow sending or receiving <a href="https://tools.ietf.org/html/rfc7540#page-42">pings</a> even when
+         * no streams are <a href="https://tools.ietf.org/html/rfc7540#page-16">active</a>.
+         *
+         * @param withoutActiveStreams {@code true} if <a href="https://tools.ietf.org/html/rfc7540#page-42">pings</a>
+         * are expected when no streams are <a href="https://tools.ietf.org/html/rfc7540#page-16">active</a>.
+         * @return {@code this}.
+         * @see KeepAlivePolicy#withoutActiveStreams()
+         */
+        KeepAliveConfigurator withoutActiveStreams(boolean withoutActiveStreams);
+
+        /**
+         * Disables sending of <a href="https://tools.ietf.org/html/rfc7540#page-42">pings</a>.
+         *
+         * @return {@code this}.
+         */
+        KeepAliveConfigurator disable();
+
+        /**
+         * Commits all changes made to this {@link KeepAliveConfigurator} to the {@link H2ProtocolConfigBuilder} that
+         * created this {@link KeepAliveConfigurator}.
+         *
+         * @return The {@link H2ProtocolConfigBuilder} that created this {@link KeepAliveConfigurator}.
+         */
+        H2ProtocolConfigBuilder commit();
     }
 
     private static final class DefaultH2ProtocolConfig implements H2ProtocolConfig {
@@ -96,13 +214,16 @@ public final class H2ProtocolConfigBuilder {
         private final BiPredicate<CharSequence, CharSequence> headersSensitivityDetector;
         @Nullable
         private final String frameLoggerName;
+        @Nullable
+        private final KeepAlivePolicy keepAlivePolicy;
 
         DefaultH2ProtocolConfig(final HttpHeadersFactory headersFactory,
                                 final BiPredicate<CharSequence, CharSequence> headersSensitivityDetector,
-                                @Nullable final String frameLogger) {
+                                @Nullable final String frameLogger, @Nullable final KeepAlivePolicy keepAlivePolicy) {
             this.headersFactory = headersFactory;
             this.headersSensitivityDetector = headersSensitivityDetector;
             this.frameLoggerName = frameLogger;
+            this.keepAlivePolicy = keepAlivePolicy;
         }
 
         @Override
@@ -120,5 +241,11 @@ public final class H2ProtocolConfigBuilder {
         public String frameLoggerName() {
             return frameLoggerName;
         }
-    }
+
+        @Nullable
+        @Override
+        public KeepAlivePolicy keepAlivePolicy() {
+            return keepAlivePolicy;
+        }
+   }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
@@ -25,7 +25,7 @@ import java.util.function.BiPredicate;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.http.netty.H2HeadersFactory.DEFAULT_SENSITIVITY_DETECTOR;
-import static io.servicetalk.http.netty.KeepAlivePolicies.DISABLE_KEEP_ALIVE;
+import static io.servicetalk.http.netty.H2KeepAlivePolicies.DISABLE_KEEP_ALIVE;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -90,7 +90,7 @@ public final class H2ProtocolConfigBuilder {
      *
      * @param policy {@link KeepAlivePolicy} to use.
      * @return {@code this}
-     * @see KeepAlivePolicies
+     * @see H2KeepAlivePolicies
      */
     public H2ProtocolConfigBuilder keepAlivePolicy(final KeepAlivePolicy policy) {
         this.keepAlivePolicy = policy == DISABLE_KEEP_ALIVE ? null : requireNonNull(policy);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
@@ -21,14 +21,11 @@ import io.servicetalk.http.netty.H2ProtocolConfig.KeepAlivePolicy;
 
 import org.slf4j.event.Level;
 
-import java.time.Duration;
 import java.util.function.BiPredicate;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.http.netty.DefaultKeepAlivePolicy.DEFAULT_ACK_TIMEOUT;
-import static io.servicetalk.http.netty.DefaultKeepAlivePolicy.DEFAULT_IDLE_DURATION;
-import static io.servicetalk.http.netty.DefaultKeepAlivePolicy.DEFAULT_WITHOUT_ACTIVE_STREAMS;
 import static io.servicetalk.http.netty.H2HeadersFactory.DEFAULT_SENSITIVITY_DETECTOR;
+import static io.servicetalk.http.netty.KeepAlivePolicies.DISABLE_KEEP_ALIVE;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -89,56 +86,15 @@ public final class H2ProtocolConfigBuilder {
     }
 
     /**
-     * Configure keep alive behavior using <a href="https://tools.ietf.org/html/rfc7540#page-42">PING frames</a>.
+     * Sets the {@link KeepAlivePolicy} to use.
      *
-     * @return A {@link KeepAliveConfigurator} which adds keep-alive configuration to this {@link H2ProtocolConfig} when
-     * {@link KeepAliveConfigurator#commit() committed}.
+     * @param policy {@link KeepAlivePolicy} to use.
+     * @return {@code this}
+     * @see KeepAlivePolicies
      */
-    public KeepAliveConfigurator keepAlive() {
-        return new KeepAliveConfigurator() {
-            private Duration idleDuration = DEFAULT_IDLE_DURATION;
-            private Duration ackTimeout = DEFAULT_ACK_TIMEOUT;
-            private boolean withoutActiveStreams = DEFAULT_WITHOUT_ACTIVE_STREAMS;
-            private boolean disable;
-
-            @Override
-            public KeepAliveConfigurator idleDuration(final Duration idleDuration) {
-                if (idleDuration.getSeconds() < 10) {
-                    throw new IllegalArgumentException("idleDuration: " + idleDuration + " (expected >= 10 seconds");
-                }
-                this.idleDuration = requireNonNull(idleDuration);
-                return this;
-            }
-
-            @Override
-            public KeepAliveConfigurator ackTimeout(final Duration ackTimeout) {
-                this.ackTimeout = requireNonNull(ackTimeout);
-                return this;
-            }
-
-            @Override
-            public KeepAliveConfigurator withoutActiveStreams(final boolean withoutActiveStreams) {
-                this.withoutActiveStreams = withoutActiveStreams;
-                return this;
-            }
-
-            @Override
-            public KeepAliveConfigurator disable() {
-                this.disable = true;
-                return this;
-            }
-
-            @Override
-            public H2ProtocolConfigBuilder commit() {
-                H2ProtocolConfigBuilder parent = H2ProtocolConfigBuilder.this;
-                if (disable) {
-                    parent.keepAlivePolicy = null;
-                } else {
-                    parent.keepAlivePolicy = new DefaultKeepAlivePolicy(idleDuration, ackTimeout, withoutActiveStreams);
-                }
-                return parent;
-            }
-        };
+    public H2ProtocolConfigBuilder keepAlivePolicy(final KeepAlivePolicy policy) {
+        this.keepAlivePolicy = policy == DISABLE_KEEP_ALIVE ? null : requireNonNull(policy);
+        return this;
     }
 
     /**
@@ -149,63 +105,6 @@ public final class H2ProtocolConfigBuilder {
     public H2ProtocolConfig build() {
         return new DefaultH2ProtocolConfig(headersFactory, headersSensitivityDetector, frameLoggerName,
                 keepAlivePolicy);
-    }
-
-    /**
-     * A configurator for {@link KeepAlivePolicy}.
-     */
-    public interface KeepAliveConfigurator {
-
-        /**
-         * Set the {@link Duration} of idleness on a connection after which a
-         * <a href="https://tools.ietf.org/html/rfc7540#page-42">ping</a> is sent.
-         * <strong>Too short ping durations may cause high network traffic, so implementations may enforce a minimum
-         * duration.</strong>
-         *
-         * @param idleDuration {@link Duration} of idleness on a connection after which a
-         * <a href="https://tools.ietf.org/html/rfc7540#page-42">ping</a> is sent.
-         * @return {@code this}.
-         * @see KeepAlivePolicy#idleDuration()
-         */
-        KeepAliveConfigurator idleDuration(Duration idleDuration);
-
-        /**
-         * Set the maximum {@link Duration} to wait for an acknowledgment of a previously sent
-         * <a href="https://tools.ietf.org/html/rfc7540#page-42">ping</a>. If no acknowledgment is received, the
-         * connection will be closed.
-         *
-         * @param ackTimeout {@link Duration} to wait for an acknowledgment of a previously sent
-         * <a href="https://tools.ietf.org/html/rfc7540#page-42">ping</a>.
-         * @return {@code this}.
-         * @see KeepAlivePolicy#ackTimeout()
-         */
-        KeepAliveConfigurator ackTimeout(Duration ackTimeout);
-
-        /**
-         * Allow/disallow sending or receiving <a href="https://tools.ietf.org/html/rfc7540#page-42">pings</a> even when
-         * no streams are <a href="https://tools.ietf.org/html/rfc7540#page-16">active</a>.
-         *
-         * @param withoutActiveStreams {@code true} if <a href="https://tools.ietf.org/html/rfc7540#page-42">pings</a>
-         * are expected when no streams are <a href="https://tools.ietf.org/html/rfc7540#page-16">active</a>.
-         * @return {@code this}.
-         * @see KeepAlivePolicy#withoutActiveStreams()
-         */
-        KeepAliveConfigurator withoutActiveStreams(boolean withoutActiveStreams);
-
-        /**
-         * Disables sending of <a href="https://tools.ietf.org/html/rfc7540#page-42">pings</a>.
-         *
-         * @return {@code this}.
-         */
-        KeepAliveConfigurator disable();
-
-        /**
-         * Commits all changes made to this {@link KeepAliveConfigurator} to the {@link H2ProtocolConfigBuilder} that
-         * created this {@link KeepAliveConfigurator}.
-         *
-         * @return The {@link H2ProtocolConfigBuilder} that created this {@link KeepAliveConfigurator}.
-         */
-        H2ProtocolConfigBuilder commit();
     }
 
     private static final class DefaultH2ProtocolConfig implements H2ProtocolConfig {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
@@ -37,8 +37,6 @@ import static io.servicetalk.http.api.HttpHeaderValues.KEEP_ALIVE;
 import static io.servicetalk.http.netty.HeaderUtils.indexOf;
 
 final class H2ToStH1Utils {
-    static final int DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_MILLIS = 30000;
-
     private H2ToStH1Utils() {
         // no instances.
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/KeepAliveManager.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/KeepAliveManager.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.netty.H2ProtocolConfig.KeepAlivePolicy;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.EventLoop;
+import io.netty.handler.codec.http2.DefaultHttp2GoAwayFrame;
+import io.netty.handler.codec.http2.DefaultHttp2PingFrame;
+import io.netty.handler.codec.http2.Http2PingFrame;
+import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.util.concurrent.Future;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import javax.annotation.Nullable;
+
+import static io.netty.handler.codec.http2.Http2Error.NO_ERROR;
+import static io.servicetalk.http.netty.DefaultKeepAlivePolicy.DEFAULT_ACK_TIMEOUT;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * An implementation of {@link KeepAlivePolicy} per {@link Channel}.
+ */
+final class KeepAliveManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(KeepAliveManager.class);
+    private static final AtomicIntegerFieldUpdater<KeepAliveManager> activeChildChannelsUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(KeepAliveManager.class, "activeChildChannels");
+    private static final long GRACEFUL_CLOSE_PING_CONTENT = ThreadLocalRandom.current().nextLong();
+    private static final long KEEP_ALIVE_PING_CONTENT = ThreadLocalRandom.current().nextLong();
+    private static final Object CLOSED = new Object();
+    private static final Object GRACEFUL_CLOSE_START = new Object();
+    private static final Object GRACEFUL_CLOSE_SECOND_GO_AWAY_SENT = new Object();
+    private static final Object KEEP_ALIVE_ACK_PENDING = new Object();
+    private static final Object KEEP_ALIVE_ACK_TIMEDOUT = new Object();
+
+    private volatile int activeChildChannels;
+
+    private final Channel channel;
+    private final long pingAckTimeoutMillis;
+    @Nullable
+    private final boolean disallowKeepAliveWithoutActiveStreams;
+    private final Scheduler scheduler;
+
+    // below state should only be accessed from eventloop
+    /**
+     * This stores the following possible values:
+     * <ul>
+     *     <li>{@code null} if graceful close has not started.</li>
+     *     <li>{@link #GRACEFUL_CLOSE_START} if graceful close process has been initiated.</li>
+     *     <li>{@link Future} instance to timeout ack of PING sent to measure RTT.</li>
+     *     <li>{@link #GRACEFUL_CLOSE_SECOND_GO_AWAY_SENT} if we have sent the second go away frame.</li>
+     *     <li>{@link #CLOSED} if the channel is closed.</li>
+     * </ul>
+     */
+    @Nullable
+    private Object gracefulCloseState;
+
+    /**
+     * This stores the following possible values:
+     * <ul>
+     *     <li>{@code null} if keep-alive PING process is not started.</li>
+     *     <li>{@link #KEEP_ALIVE_ACK_PENDING} if a keep-alive PING has been sent but ack is not received.</li>
+     *     <li>{@link Future} instance to timeout ack of PING sent.</li>
+     *     <li>{@link #KEEP_ALIVE_ACK_TIMEDOUT} if we fail to receive a PING ack for the configured timeout.</li>
+     *     <li>{@link #CLOSED} if the channel is closed.</li>
+     * </ul>
+     */
+    @Nullable
+    private Object keepAliveState;
+
+    KeepAliveManager(final Channel channel, @Nullable final KeepAlivePolicy keepAlivePolicy) {
+        this(channel, keepAlivePolicy, (task, delayInMillis) ->
+                channel.eventLoop().schedule(task, delayInMillis, MILLISECONDS),
+                (ch, idlenessThresholdMillis, onIdle) -> ch.pipeline().addLast(
+                        new IdleStateHandler(idlenessThresholdMillis, idlenessThresholdMillis, 0) {
+                            @Override
+                            protected void channelIdle(final ChannelHandlerContext ctx, final IdleStateEvent evt) {
+                                onIdle.run();
+                            }
+                        }));
+    }
+
+    KeepAliveManager(final Channel channel, @Nullable final KeepAlivePolicy keepAlivePolicy,
+                     final Scheduler scheduler, final IdlenessDetector idlenessDetector) {
+        this.channel = channel;
+        this.scheduler = scheduler;
+        if (keepAlivePolicy != null) {
+            disallowKeepAliveWithoutActiveStreams = !keepAlivePolicy.withoutActiveStreams();
+            pingAckTimeoutMillis = keepAlivePolicy.ackTimeout().toMillis();
+            int idleInSeconds = (int) keepAlivePolicy.idleDuration().getSeconds();
+            idlenessDetector.configure(channel, idleInSeconds, this::channelIdle);
+        } else {
+            disallowKeepAliveWithoutActiveStreams = false;
+            pingAckTimeoutMillis = DEFAULT_ACK_TIMEOUT.toMillis();
+        }
+    }
+
+    void pingReceived(final Http2PingFrame pingFrame) {
+        assert channel.eventLoop().inEventLoop();
+
+        if (pingFrame.ack()) {
+            long pingAckContent = pingFrame.content();
+            if (pingAckContent == GRACEFUL_CLOSE_PING_CONTENT) {
+                LOGGER.debug("channel={}, graceful close ping ack received.", channel);
+                cancelIfStateIsAFuture(gracefulCloseState);
+                gracefulCloseWriteSecondGoAway();
+            } else if (pingAckContent == KEEP_ALIVE_PING_CONTENT) {
+                cancelIfStateIsAFuture(keepAliveState);
+                keepAliveState = null;
+            }
+        } else {
+            // Send an ack for the received ping
+            channel.writeAndFlush(new DefaultHttp2PingFrame(pingFrame.content(), true));
+        }
+    }
+
+    void trackActiveStream(final Channel streamChannel) {
+        activeChildChannelsUpdater.incrementAndGet(this);
+        streamChannel.closeFuture().addListener(f -> {
+            activeChildChannelsUpdater.decrementAndGet(this);
+            if (activeChildChannels == 0 && gracefulCloseState == GRACEFUL_CLOSE_SECOND_GO_AWAY_SENT) {
+                close0();
+            }
+        });
+    }
+
+    void channelClosed() {
+        assert channel.eventLoop().inEventLoop();
+
+        cancelIfStateIsAFuture(gracefulCloseState);
+        cancelIfStateIsAFuture(keepAliveState);
+        gracefulCloseState = CLOSED;
+        keepAliveState = CLOSED;
+    }
+
+    void initiateGracefulClose(final Runnable whenInitiated) {
+        EventLoop eventLoop = channel.eventLoop();
+        if (eventLoop.inEventLoop()) {
+            doCloseAsyncGracefully0(whenInitiated);
+        } else {
+            try {
+                eventLoop.execute(() -> doCloseAsyncGracefully0(whenInitiated));
+            } catch (Throwable cause) {
+                close0();
+                LOGGER.warn("channel={} EventLoop rejected a task for graceful shutdown, force closing connection",
+                        channel, cause);
+            }
+        }
+    }
+
+    void channelIdle() {
+        assert channel.eventLoop().inEventLoop();
+
+        if (keepAliveState == CLOSED) {
+            return;
+        }
+        if (activeChildChannels == 0 && disallowKeepAliveWithoutActiveStreams) {
+            return;
+        }
+        // idleness detected for the first time, send a ping to detect closure, if any.
+        keepAliveState = KEEP_ALIVE_ACK_PENDING;
+        channel.writeAndFlush(new DefaultHttp2PingFrame(KEEP_ALIVE_PING_CONTENT, false))
+                .addListener(future -> {
+                    if (future.isSuccess() && keepAliveState == KEEP_ALIVE_ACK_PENDING) {
+                        // Schedule a task to verify ping ack within the pingAckTimeoutMillis
+                        keepAliveState = scheduler.afterMillis(() -> {
+                            if (keepAliveState != null) {
+                                keepAliveState = KEEP_ALIVE_ACK_TIMEDOUT;
+                                LOGGER.debug(
+                                        "channel={}, timeout {}ms waiting for keep-alive PING(ACK), writing go_away.",
+                                        channel, pingAckTimeoutMillis);
+                                channel.writeAndFlush(new DefaultHttp2GoAwayFrame(NO_ERROR))
+                                        .addListener(f -> {
+                                            if (f.isSuccess()) {
+                                                LOGGER.debug("Closing channel={}, after keep-alive timeout.", channel);
+                                                close0();
+                                            }
+                                        });
+                            }
+                        }, pingAckTimeoutMillis);
+                    }
+                });
+    }
+
+    /**
+     * Scheduler of {@link Runnable}s.
+     */
+    @FunctionalInterface
+    interface Scheduler {
+
+        /**
+         * Run the passed {@link Runnable} after {@code delayInMillis} milliseconds.
+         *
+         * @param task {@link Runnable} to run.
+         * @param delayInMillis Milliseconds after which the task is to be run.
+         * @return {@link Future} for the scheduled task.
+         */
+        Future<?> afterMillis(Runnable task, long delayInMillis);
+    }
+
+    /**
+     * Scheduler of {@link Runnable}s.
+     */
+    @FunctionalInterface
+    interface IdlenessDetector {
+        /**
+         * Configure idleness detection for the passed {@code channel}.
+         *
+         * @param channel {@link Channel} for which idleness detection is to be configured.
+         * @param idlenessThresholdMillis Millis of idleness after which {@link Runnable#run()} should be called on the
+         * passed {@code onIdle}.
+         * @param onIdle {@link Runnable} to call when the channel is idle more than {@code idlenessThresholdMillis}.
+         */
+        void configure(Channel channel, int idlenessThresholdMillis, Runnable onIdle);
+    }
+
+    private void doCloseAsyncGracefully0(final Runnable whenInitiated) {
+        assert channel.eventLoop().inEventLoop();
+
+        if (gracefulCloseState != null) {
+            // either we are already closed or have already initiated graceful closure.
+            return;
+        }
+        // Set the pingState before doing the write, because we will reference the state
+        // when we receive the PING(ACK) to determine if action is necessary, and it is conceivable that the
+        // write future may not be executed which sets the timer.
+        gracefulCloseState = GRACEFUL_CLOSE_START;
+
+        try {
+            whenInitiated.run();
+        } catch (Throwable t) {
+            LOGGER.error("Failed to invoke callback for graceful closure initiation, ignoring.", t);
+        }
+
+        // The graceful close process is described in [1]. It involves sending 2 GOAWAY frames. The first
+        // GOAWAY has last-stream-id=<maximum stream ID> to indicate no new streams can be created, wait for 2 RTT
+        // time duration for inflight frames to land, and the second GOAWAY includes the maximum known stream ID.
+        // To account for 2 RTTs we can send a PING and when the PING(ACK) comes back we can send the second GOAWAY.
+        // [1] https://tools.ietf.org/html/rfc7540#section-6.8
+        DefaultHttp2GoAwayFrame goAwayFrame = new DefaultHttp2GoAwayFrame(NO_ERROR);
+        goAwayFrame.setExtraStreamIds(Integer.MAX_VALUE);
+        channel.write(goAwayFrame);
+        channel.writeAndFlush(new DefaultHttp2PingFrame(GRACEFUL_CLOSE_PING_CONTENT)).addListener(future -> {
+            // If gracefulCloseState is not GRACEFUL_CLOSE_START that means we have already received the PING(ACK) and
+            // there is no need to apply the timeout.
+            if (future.isSuccess() && gracefulCloseState == GRACEFUL_CLOSE_START) {
+                gracefulCloseState = scheduler.afterMillis(() -> {
+                    // If the PING(ACK) times out we may have under estimated the 2RTT time so we
+                    // optimistically keep the connection open and rely upon higher level timeouts to tear
+                    // down the connection.
+                    LOGGER.debug("channel={} timeout {}ms waiting for PING(ACK) during graceful close.",
+                            channel, pingAckTimeoutMillis);
+                    gracefulCloseWriteSecondGoAway();
+                }, pingAckTimeoutMillis);
+            }
+        });
+    }
+
+    private void gracefulCloseWriteSecondGoAway() {
+        assert channel.eventLoop().inEventLoop();
+
+        if (gracefulCloseState == GRACEFUL_CLOSE_SECOND_GO_AWAY_SENT) {
+            return;
+        }
+
+        gracefulCloseState = GRACEFUL_CLOSE_SECOND_GO_AWAY_SENT;
+
+        channel.writeAndFlush(new DefaultHttp2GoAwayFrame(NO_ERROR)).addListener(future -> {
+            if (activeChildChannels == 0) {
+                close0();
+            }
+        });
+    }
+
+    private void close0() {
+        assert channel.eventLoop().inEventLoop();
+
+        if (gracefulCloseState == CLOSED && keepAliveState == CLOSED) {
+            return;
+        }
+        gracefulCloseState = CLOSED;
+        keepAliveState = CLOSED;
+
+        // The way netty H2 stream state machine works, we may trigger stream closures during writes with flushes
+        // pending behind the writes. In such cases, we may close too early ignoring the writes. Hence we flush before
+        // closure, if there is no write pending then flush is a noop.
+        channel.flush();
+        channel.close();
+    }
+
+    private void cancelIfStateIsAFuture(@Nullable final Object state) {
+        if (state instanceof Future) {
+            try {
+                ((Future<?>) state).cancel(true);
+            } catch (Throwable t) {
+                LOGGER.debug("Failed to cancel {} scheduled future.",
+                        state == keepAliveState ? "keep-alive" : "graceful close", t);
+            }
+        }
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/KeepAliveManager.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/KeepAliveManager.java
@@ -37,6 +37,7 @@ import javax.annotation.Nullable;
 
 import static io.netty.handler.codec.http2.Http2Error.NO_ERROR;
 import static io.servicetalk.http.netty.H2KeepAlivePolicies.DEFAULT_ACK_TIMEOUT;
+import static java.lang.Math.min;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
@@ -129,7 +130,7 @@ final class KeepAliveManager {
                     }, pingAckTimeoutNanos, NANOSECONDS);
                 }
             };
-            int idleInSeconds = (int) keepAlivePolicy.idleDuration().getSeconds();
+            int idleInSeconds = (int) min(keepAlivePolicy.idleDuration().getSeconds(), Integer.MAX_VALUE);
             idlenessDetector.configure(channel, idleInSeconds, this::channelIdle);
         } else {
             disallowKeepAliveWithoutActiveStreams = false;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/KeepAlivePolicies.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/KeepAlivePolicies.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.netty.H2ProtocolConfig.KeepAlivePolicy;
+
+import java.time.Duration;
+
+import static io.servicetalk.http.netty.DefaultKeepAlivePolicy.DEFAULT_ACK_TIMEOUT;
+import static io.servicetalk.http.netty.DefaultKeepAlivePolicy.DEFAULT_IDLE_DURATION;
+import static java.time.Duration.ofDays;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A factory to create {@link KeepAlivePolicy} instances.
+ */
+public final class KeepAlivePolicies {
+    static final KeepAlivePolicy DISABLE_KEEP_ALIVE =
+            new DefaultKeepAlivePolicy(ofDays(365), ofDays(365), false);
+
+    private KeepAlivePolicies() {
+        // no instances.
+    }
+
+    /**
+     * Returns a {@link KeepAlivePolicy} that disables all keep alive behaviors.
+     *
+     * @return A {@link KeepAlivePolicy} that disables all keep alive behaviors.
+     */
+    public static KeepAlivePolicy disabled() {
+        return DISABLE_KEEP_ALIVE;
+    }
+
+    /**
+     * Returns a {@link KeepAlivePolicy} that sends a <a href="https://tools.ietf.org/html/rfc7540#section-6.7">
+     * ping</a> if the channel is idle for the passed {@code idleDuration}. Default values are used for other parameters
+     * of the returned {@link KeepAlivePolicy}.
+     *
+     * @param idleDuration {@link Duration} of idleness on a connection after which a
+     * <a href="https://tools.ietf.org/html/rfc7540#section-6.7">ping</a> is sent.
+     * @return A {@link KeepAlivePolicy} that disables all keep alive behaviors.
+     */
+    public static KeepAlivePolicy whenIdleFor(final Duration idleDuration) {
+        return new KeepAlivePolicyBuilder().idleDuration(idleDuration).build();
+    }
+
+    /**
+     * Returns a {@link KeepAlivePolicy} that sends a <a href="https://tools.ietf.org/html/rfc7540#section-6.7">
+     * ping</a> if the channel is idle for the passed {@code idleDuration} and waits for {@code ackTimeout} for an ack
+     * for that <a href="https://tools.ietf.org/html/rfc7540#section-6.7">ping</a>. Default values are used for other
+     * parameters of the returned {@link KeepAlivePolicy}.
+     *
+     * @param idleDuration {@link Duration} of idleness on a connection after which a
+     * <a href="https://tools.ietf.org/html/rfc7540#section-6.7">ping</a> is sent.
+     * @param ackTimeout {@link Duration} to wait for an acknowledgment of a previously sent
+     * <a href="https://tools.ietf.org/html/rfc7540#section-6.7">ping</a>.
+     * @return A {@link KeepAlivePolicy} that disables all keep alive behaviors.
+     */
+    public static KeepAlivePolicy whenIdleFor(final Duration idleDuration, final Duration ackTimeout) {
+        return new KeepAlivePolicyBuilder().idleDuration(idleDuration).ackTimeout(ackTimeout).build();
+    }
+
+    /**
+     * A builder of {@link KeepAlivePolicy}.
+     */
+    public static final class KeepAlivePolicyBuilder {
+        private Duration idleDuration = DEFAULT_IDLE_DURATION;
+        private Duration ackTimeout = DEFAULT_ACK_TIMEOUT;
+        private boolean withoutActiveStreams;
+
+        /**
+         * Set the {@link Duration} of idleness on a connection after which a
+         * <a href="https://tools.ietf.org/html/rfc7540#section-6.7">ping</a> is sent.
+         * <p>
+         * <strong>Too short ping durations may cause high network traffic, implementations may enforce a minimum
+         * duration.</strong>
+         *
+         * @param idleDuration {@link Duration} of idleness on a connection after which a
+         * <a href="https://tools.ietf.org/html/rfc7540#section-6.7">ping</a> is sent.
+         * @return {@code this}.
+         * @see KeepAlivePolicy#idleDuration()
+         */
+        public KeepAlivePolicyBuilder idleDuration(final Duration idleDuration) {
+            if (idleDuration.getSeconds() < 10) {
+                throw new IllegalArgumentException("idleDuration: " + idleDuration + " (expected >= 10 seconds");
+            }
+            this.idleDuration = idleDuration;
+            return this;
+        }
+
+        /**
+         * Set the maximum {@link Duration} to wait for an acknowledgment of a previously sent
+         * <a href="https://tools.ietf.org/html/rfc7540#section-6.7">ping</a>. If no acknowledgment is received, the
+         * connection will be closed.
+         *
+         * @param ackTimeout {@link Duration} to wait for an acknowledgment of a previously sent
+         * <a href="https://tools.ietf.org/html/rfc7540#section-6.7">ping</a>.
+         * @return {@code this}.
+         * @see KeepAlivePolicy#ackTimeout()
+         */
+        public KeepAlivePolicyBuilder ackTimeout(final Duration ackTimeout) {
+            this.ackTimeout = requireNonNull(ackTimeout);
+            return this;
+        }
+
+        /**
+         * Allow/disallow sending or receiving <a href="https://tools.ietf.org/html/rfc7540#section-6.7">pings</a> even
+         * when no streams are <a href="https://tools.ietf.org/html/rfc7540#section-5.1">active</a>.
+         *
+         * @param withoutActiveStreams {@code true} if
+         * <a href="https://tools.ietf.org/html/rfc7540#section-6.7">pings</a> are expected when no streams are
+         * <a href="https://tools.ietf.org/html/rfc7540#section-5.1">active</a>.
+         * @return {@code this}.
+         * @see KeepAlivePolicy#withoutActiveStreams()
+         */
+        public KeepAlivePolicyBuilder withoutActiveStreams(final boolean withoutActiveStreams) {
+            this.withoutActiveStreams = withoutActiveStreams;
+            return this;
+        }
+
+        /**
+         * Build a new {@link KeepAlivePolicy}.
+         *
+         * @return new {@link KeepAlivePolicy}.
+         */
+        public KeepAlivePolicy build() {
+            return new DefaultKeepAlivePolicy(idleDuration, ackTimeout, withoutActiveStreams);
+        }
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/KeepAliveManagerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/KeepAliveManagerTest.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.http.netty.H2ProtocolConfig.KeepAlivePolicy;
+
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http2.DefaultHttp2PingFrame;
+import io.netty.handler.codec.http2.Http2Error;
+import io.netty.handler.codec.http2.Http2GoAwayFrame;
+import io.netty.handler.codec.http2.Http2PingFrame;
+import io.netty.util.concurrent.Promise;
+import org.hamcrest.Matcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static java.time.Duration.ofSeconds;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class KeepAliveManagerTest {
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+
+    private final BlockingQueue<ScheduledTask> scheduledTasks;
+    private final EmbeddedChannel channel;
+
+    public KeepAliveManagerTest() {
+        scheduledTasks = new LinkedBlockingQueue<>();
+        channel = new EmbeddedChannel();
+    }
+
+    @Test
+    public void keepAliveDisallowedWithNoActiveStreams() {
+        KeepAliveManager manager = newManager(false);
+        manager.channelIdle();
+        verifyNoWrite();
+        verifyNoScheduledTasks();
+    }
+
+    @Test
+    public void keepAliveAllowedWithNoActiveStreams() {
+        KeepAliveManager manager = newManager(true);
+        manager.channelIdle();
+        verifyWrite(instanceOf(Http2PingFrame.class));
+    }
+
+    @Test
+    public void keepAliveWithActiveStreams() {
+        KeepAliveManager manager = newManager(false);
+        addActiveStream(manager);
+        manager.channelIdle();
+        verifyWrite(instanceOf(Http2PingFrame.class));
+    }
+
+    @Test
+    public void keepAlivePingAckReceived() {
+        KeepAliveManager manager = newManager(false);
+        addActiveStream(manager);
+        manager.channelIdle();
+        Http2PingFrame ping = verifyWrite(instanceOf(Http2PingFrame.class));
+        ScheduledTask ackTimeoutTask = scheduledTasks.poll();
+        assertThat("Ping ack timeout not scheduled.", ackTimeoutTask, is(notNullValue()));
+
+        manager.pingReceived(new DefaultHttp2PingFrame(ping.content(), true));
+        assertThat("Ping ack timeout task not cancelled.", ackTimeoutTask.promise.isCancelled(), is(true));
+
+        ackTimeoutTask.task.run();
+        verifyNoWrite();
+        verifyNoScheduledTasks();
+        assertThat("Channel unexpectedly closed.", channel.isOpen(), is(true));
+    }
+
+    @Test
+    public void keepAlivePingAckWithUnknownContent() {
+        KeepAliveManager manager = newManager(false);
+        addActiveStream(manager);
+        manager.channelIdle();
+        Http2PingFrame ping = verifyWrite(instanceOf(Http2PingFrame.class));
+        ScheduledTask ackTimeoutTask = scheduledTasks.poll();
+        assertThat("Ping ack timeout not scheduled.", ackTimeoutTask, is(notNullValue()));
+
+        manager.pingReceived(new DefaultHttp2PingFrame(ping.content() + 1, true));
+        assertThat("Ping ack timeout task cancelled.", ackTimeoutTask.promise.isCancelled(), is(false));
+
+        verifyChannelCloseOnMissingPingAck(ackTimeoutTask);
+    }
+
+    @Test
+    public void keepAliveMissingPingAck() {
+        KeepAliveManager manager = newManager(false);
+        addActiveStream(manager);
+        manager.channelIdle();
+        verifyWrite(instanceOf(Http2PingFrame.class));
+        ScheduledTask ackTimeoutTask = scheduledTasks.poll();
+        assertThat("Ping ack timeout not scheduled.", ackTimeoutTask, is(notNullValue()));
+        verifyChannelCloseOnMissingPingAck(ackTimeoutTask);
+    }
+
+    @Test
+    public void gracefulCloseNoActiveStreams() throws Exception {
+        KeepAliveManager manager = newManager(false);
+        Http2PingFrame pingFrame = initiateGracefulCloseVerifyGoAwayAndPing(manager);
+
+        sendGracefulClosePingAckAndVerifySecondGoAway(manager, pingFrame);
+
+        channel.closeFuture().sync().await();
+    }
+
+    @Test
+    public void gracefulCloseWithActiveStreams() throws Exception {
+        KeepAliveManager manager = newManager(false);
+        EmbeddedChannel activeStream = addActiveStream(manager);
+        Http2PingFrame pingFrame = initiateGracefulCloseVerifyGoAwayAndPing(manager);
+
+        sendGracefulClosePingAckAndVerifySecondGoAway(manager, pingFrame);
+
+        assertThat("Channel not closed.", channel.isOpen(), is(true));
+        activeStream.close().sync().await();
+
+        channel.closeFuture().sync().await();
+    }
+
+    @Test
+    public void gracefulCloseNoActiveStreamsMissingPingAck() throws Exception {
+        KeepAliveManager manager = newManager(false);
+        initiateGracefulCloseVerifyGoAwayAndPing(manager);
+
+        ScheduledTask pingAckTimeoutTask = scheduledTasks.take();
+        pingAckTimeoutTask.task.run();
+        verifySecondGoAway();
+
+        channel.closeFuture().sync().await();
+    }
+
+    @Test
+    public void gracefulCloseActiveStreamsMissingPingAck() throws Exception {
+        KeepAliveManager manager = newManager(false);
+        EmbeddedChannel activeStream = addActiveStream(manager);
+        initiateGracefulCloseVerifyGoAwayAndPing(manager);
+
+        ScheduledTask pingAckTimeoutTask = scheduledTasks.take();
+        pingAckTimeoutTask.task.run();
+        verifySecondGoAway();
+
+        assertThat("Channel closed.", channel.isOpen(), is(true));
+
+        activeStream.close().sync().await();
+
+        channel.closeFuture().sync().await();
+    }
+
+    @Test
+    public void gracefulClosePendingPingsCloseConnection() throws Exception {
+        KeepAliveManager manager = newManager(false);
+        addActiveStream(manager);
+        Http2PingFrame pingFrame = initiateGracefulCloseVerifyGoAwayAndPing(manager);
+
+        sendGracefulClosePingAckAndVerifySecondGoAway(manager, pingFrame);
+        assertThat("Channel closed.", channel.isOpen(), is(true));
+
+        manager.channelIdle();
+        verifyWrite(instanceOf(Http2PingFrame.class));
+        ScheduledTask ackTimeoutTask = scheduledTasks.poll();
+        assertThat("Ping ack timeout not scheduled.", ackTimeoutTask, is(notNullValue()));
+        verifyChannelCloseOnMissingPingAck(ackTimeoutTask);
+    }
+
+    @Test
+    public void pingsAreAcked() {
+        KeepAliveManager manager = newManager(false);
+        long pingContent = ThreadLocalRandom.current().nextLong();
+        manager.pingReceived(new DefaultHttp2PingFrame(pingContent, false));
+        Http2PingFrame pingFrame = verifyWrite(instanceOf(Http2PingFrame.class));
+        assertThat("Unexpected ping ack content.", pingFrame.content(), is(pingContent));
+        assertThat("Unexpected ping ack content.", pingFrame.ack(), is(true));
+    }
+
+    @Test
+    public void channelClosedDuringGracefulClose() throws Exception {
+        KeepAliveManager manager = newManager(false);
+        addActiveStream(manager);
+        initiateGracefulCloseVerifyGoAwayAndPing(manager);
+        ScheduledTask pingAckTimeoutTask = scheduledTasks.take();
+        assertThat("Ping ack timeout not scheduled.", pingAckTimeoutTask, is(notNullValue()));
+
+        manager.channelClosed();
+        assertThat("Graceful close ping ack timeout not cancelled.", pingAckTimeoutTask.promise.isCancelled(),
+                is(true));
+
+        verifyNoOtherActionPostClose(manager);
+    }
+
+    @Test
+    public void channelClosedDuringPing() {
+        KeepAliveManager manager = newManager(false);
+        addActiveStream(manager);
+        manager.channelIdle();
+        verifyWrite(instanceOf(Http2PingFrame.class));
+        ScheduledTask ackTimeoutTask = scheduledTasks.poll();
+        assertThat("Ping ack timeout not scheduled.", ackTimeoutTask, is(notNullValue()));
+
+        manager.channelClosed();
+        assertThat("Keep alive ping ack timeout not cancelled.", ackTimeoutTask.promise.isCancelled(),
+                is(true));
+
+        verifyNoOtherActionPostClose(manager);
+    }
+
+    private void verifyNoOtherActionPostClose(final KeepAliveManager manager) {
+        manager.channelIdle();
+        verifyNoWrite();
+        verifyNoScheduledTasks();
+
+        manager.initiateGracefulClose(() -> { });
+        verifyNoWrite();
+        verifyNoScheduledTasks();
+    }
+
+    private void sendGracefulClosePingAckAndVerifySecondGoAway(final KeepAliveManager manager,
+                                                               final Http2PingFrame pingFrame) throws Exception {
+        ScheduledTask pingAckTimeoutTask = scheduledTasks.take();
+        manager.pingReceived(new DefaultHttp2PingFrame(pingFrame.content(), true));
+        assertThat("Ping ack task not cancelled.", pingAckTimeoutTask.promise.isCancelled(), is(true));
+        verifySecondGoAway();
+
+        pingAckTimeoutTask.task.run();
+
+        verifyNoWrite();
+        verifyNoScheduledTasks();
+    }
+
+    private void verifySecondGoAway() {
+        Http2GoAwayFrame secondGoAway = verifyWrite(instanceOf(Http2GoAwayFrame.class));
+        assertThat("Unexpected error in go_away", secondGoAway.errorCode(), is(Http2Error.NO_ERROR.code()));
+        verifyNoScheduledTasks();
+    }
+
+    private Http2PingFrame initiateGracefulCloseVerifyGoAwayAndPing(final KeepAliveManager manager) {
+        manager.initiateGracefulClose(() -> { });
+        Http2GoAwayFrame firstGoAway = verifyWrite(instanceOf(Http2GoAwayFrame.class));
+        assertThat("Unexpected error in go_away", firstGoAway.errorCode(), is(Http2Error.NO_ERROR.code()));
+        Http2PingFrame pingFrame = verifyWrite(instanceOf(Http2PingFrame.class));
+        verifyNoWrite();
+        return pingFrame;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T verifyWrite(Matcher<Object> writeMatcher) {
+        Object written = channel.outboundMessages().poll();
+        assertThat("Unexpected frame written.", written, is(notNullValue()));
+        assertThat("Unexpected frame written.", written, writeMatcher);
+        return (T) written;
+    }
+
+    private void verifyNoWrite() {
+        assertThat("Unexpected frame written.", channel.outboundMessages().poll(), is(nullValue()));
+    }
+
+    private void verifyNoScheduledTasks() {
+        assertThat("Unexpected tasks scheduled.", scheduledTasks.poll(), is(nullValue()));
+    }
+
+    private EmbeddedChannel addActiveStream(final KeepAliveManager manager) {
+        EmbeddedChannel stream = new EmbeddedChannel();
+        manager.trackActiveStream(stream);
+        return stream;
+    }
+
+    private void verifyChannelCloseOnMissingPingAck(final ScheduledTask ackTimeoutTask) {
+        ackTimeoutTask.task.run();
+        verifyWrite(instanceOf(Http2GoAwayFrame.class));
+        verifyNoScheduledTasks();
+        assertThat("Channel not closed.", channel.isOpen(), is(false));
+    }
+
+    private KeepAliveManager newManager(final boolean allowPingWithoutActiveStreams) {
+        KeepAlivePolicy policy = mock(KeepAlivePolicy.class);
+        when(policy.idleDuration()).thenReturn(ofSeconds(10));
+        when(policy.ackTimeout()).thenReturn(ofSeconds(30));
+        when(policy.withoutActiveStreams()).thenReturn(allowPingWithoutActiveStreams);
+        return new KeepAliveManager(channel, policy,
+                (task, delayMillis) -> {
+                    ChannelPromise promise = channel.newPromise();
+                    ScheduledTask scheduledTask = new ScheduledTask(task, promise, delayMillis);
+                    scheduledTasks.add(scheduledTask);
+                    return scheduledTask.promise;
+                },
+                (__, ___, ____) -> { });
+    }
+
+    private static final class ScheduledTask {
+        final Runnable task;
+        final Promise<?> promise;
+        final long delayMillis;
+
+        ScheduledTask(final Runnable task, final Promise<?> promise, final long delayMillis) {
+            this.task = task;
+            this.promise = promise;
+            this.delayMillis = delayMillis;
+        }
+    }
+}

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelListenableAsyncCloseable.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelListenableAsyncCloseable.java
@@ -82,7 +82,13 @@ public class NettyChannelListenableAsyncCloseable implements ListenableAsyncClos
             @Override
             protected void handleSubscribe(final Subscriber subscriber) {
                 if (stateUpdater.compareAndSet(NettyChannelListenableAsyncCloseable.this, OPEN, GRACEFULLY_CLOSING)) {
-                    doCloseAsyncGracefully();
+                    try {
+                        doCloseAsyncGracefully();
+                    } catch (Throwable t) {
+                        subscriber.onSubscribe(IGNORE_CANCEL);
+                        subscriber.onError(t);
+                        return;
+                    }
                 }
                 toSource(onClose()).subscribe(subscriber);
             }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelListenableAsyncCloseable.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelListenableAsyncCloseable.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 import static io.servicetalk.transport.netty.internal.CloseStates.CLOSING;
 import static io.servicetalk.transport.netty.internal.CloseStates.GRACEFULLY_CLOSING;
 import static io.servicetalk.transport.netty.internal.CloseStates.OPEN;
@@ -85,8 +86,7 @@ public class NettyChannelListenableAsyncCloseable implements ListenableAsyncClos
                     try {
                         doCloseAsyncGracefully();
                     } catch (Throwable t) {
-                        subscriber.onSubscribe(IGNORE_CANCEL);
-                        subscriber.onError(t);
+                        deliverTerminalFromSource(subscriber, t);
                         return;
                     }
                 }


### PR DESCRIPTION
__Motivation__

HTTP/2 PING frames are useful to keep a connection alive relatively cheaply in presence of long running streams. ServiceTalk should support adding this functionality for both clients and servers.

__Modification__

- Add `KeepAlivePolicy` to `H2ProtocolConfig` that can be configured to enable keep-alive behavior on either clients or servers. Following features are provided:
    -- Specify an idleness threshold, after which a PING frame will be sent on the connection to detect liveness.
    -- Specify an ack timeout, within which we expect an ack for the sent PING. If no ack is received, the connection is closed.
    -- Specify whether PING frames should be sent even when there are no active streams. This defaults to `false`.

__Result__

Keep alive behavior can be enabled for either client or server.