### PR TITLE
More robust exception handling from Subscribers

### DIFF
--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/DefaultPartitionedClientGroup.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/DefaultPartitionedClientGroup.java
@@ -43,9 +43,9 @@ import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -241,8 +241,7 @@ public final class DefaultPartitionedClientGroup<U, R, Client extends Listenable
                     if (oldClient != null && oldClient != closed) {
                         toSource(((C) oldClient).closeAsync()).subscribe(subscriber);
                     } else {
-                        subscriber.onSubscribe(IGNORE_CANCEL);
-                        subscriber.onComplete();
+                        deliverTerminalFromSource(subscriber);
                     }
                 }
             };

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/DefaultPartitionedClientGroup.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/DefaultPartitionedClientGroup.java
@@ -45,7 +45,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverCompleteFromSource;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -241,7 +241,7 @@ public final class DefaultPartitionedClientGroup<U, R, Client extends Listenable
                     if (oldClient != null && oldClient != closed) {
                         toSource(((C) oldClient).closeAsync()).subscribe(subscriber);
                     } else {
-                        deliverTerminalFromSource(subscriber);
+                        deliverCompleteFromSource(subscriber);
                     }
                 }
             };

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LimitingConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LimitingConnectionFactoryFilter.java
@@ -26,8 +26,8 @@ import java.net.ConnectException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 
@@ -151,8 +151,7 @@ public final class LimitingConnectionFactoryFilter<ResolvedAddress, C extends Li
                         toSource(original.newConnection(resolvedAddress))
                                 .subscribe(new CountingSubscriber<>(subscriber, limiter, resolvedAddress));
                     } else {
-                        subscriber.onSubscribe(IGNORE_CANCEL);
-                        subscriber.onError(limiter.newConnectionRefusedException(resolvedAddress));
+                        deliverTerminalFromSource(subscriber, limiter.newConnectionRefusedException(resolvedAddress));
                     }
                 }
             };

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LimitingConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LimitingConnectionFactoryFilter.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 
@@ -151,7 +151,7 @@ public final class LimitingConnectionFactoryFilter<ResolvedAddress, C extends Li
                         toSource(original.newConnection(resolvedAddress))
                                 .subscribe(new CountingSubscriber<>(subscriber, limiter, resolvedAddress));
                     } else {
-                        deliverTerminalFromSource(subscriber, limiter.newConnectionRefusedException(resolvedAddress));
+                        deliverErrorFromSource(subscriber, limiter.newConnectionRefusedException(resolvedAddress));
                     }
                 }
             };

--- a/servicetalk-concurrent-api-internal/src/main/java/io/servicetalk/concurrent/api/internal/ConnectablePayloadWriter.java
+++ b/servicetalk-concurrent-api-internal/src/main/java/io/servicetalk/concurrent/api/internal/ConnectablePayloadWriter.java
@@ -33,7 +33,8 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverCompleteFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
@@ -261,9 +262,9 @@ public final class ConnectablePayloadWriter<T> implements PayloadWriter<T> {
         protected void handleSubscribe(final Subscriber<? super T> subscriber) {
             if (!stateUpdater.compareAndSet(outer, State.CONNECTING, State.CONNECTED)) {
                 if (stateUpdater.compareAndSet(outer, State.TERMINATING, State.TERMINATED)) {
-                    deliverTerminalFromSource(subscriber);
+                    deliverCompleteFromSource(subscriber);
                 } else {
-                    deliverTerminalFromSource(subscriber, new DuplicateSubscribeException(outer.state, subscriber));
+                    deliverErrorFromSource(subscriber, new DuplicateSubscribeException(outer.state, subscriber));
                 }
                 return;
             }

--- a/servicetalk-concurrent-api-internal/src/main/java/io/servicetalk/concurrent/api/internal/SpScPublisherProcessor.java
+++ b/servicetalk-concurrent-api-internal/src/main/java/io/servicetalk/concurrent/api/internal/SpScPublisherProcessor.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
 import static io.servicetalk.utils.internal.PlatformDependent.newUnboundedSpscQueue;
@@ -99,7 +99,7 @@ public final class SpScPublisherProcessor<T> extends SubscribablePublisher<T> {
         for (;;) {
             final Subscriber<? super T> subscriber = this.subscriber;
             if (subscriber != null) {
-                deliverTerminalFromSource(s, new DuplicateSubscribeException(subscriber, s));
+                deliverErrorFromSource(s, new DuplicateSubscribeException(subscriber, s));
                 return;
             } else if (subscriberUpdater.compareAndSet(this, null, CALLING_ON_SUBSCRIBE)) {
                 s.onSubscribe(new Subscription() {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribeCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribeCompletable.java
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.internal.SignalOffloader;
 
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 
 /**
  * A {@link Completable} that does not expect to receive a call to {@link #handleSubscribe(Subscriber)} since it
@@ -39,9 +39,8 @@ abstract class AbstractNoHandleSubscribeCompletable extends Completable implemen
 
     @Override
     protected final void handleSubscribe(Subscriber subscriber) {
-        subscriber.onSubscribe(IGNORE_CANCEL);
-        subscriber.onError(new UnsupportedOperationException("Subscribe with no executor is not supported for "
-                + getClass()));
+        deliverTerminalFromSource(subscriber,
+                new UnsupportedOperationException("Subscribe with no executor is not supported for " + getClass()));
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribeCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribeCompletable.java
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.internal.SignalOffloader;
 
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 
 /**
  * A {@link Completable} that does not expect to receive a call to {@link #handleSubscribe(Subscriber)} since it
@@ -39,7 +39,7 @@ abstract class AbstractNoHandleSubscribeCompletable extends Completable implemen
 
     @Override
     protected final void handleSubscribe(Subscriber subscriber) {
-        deliverTerminalFromSource(subscriber,
+        deliverErrorFromSource(subscriber,
                 new UnsupportedOperationException("Subscribe with no executor is not supported for " + getClass()));
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribePublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribePublisher.java
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.internal.RejectedSubscribeException;
 import io.servicetalk.concurrent.internal.SignalOffloader;
 
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 
 /**
  * A {@link Publisher} that does not expect to receive a call to {@link #handleSubscribe(Subscriber)} since it overrides
@@ -42,7 +42,7 @@ abstract class AbstractNoHandleSubscribePublisher<T> extends Publisher<T> implem
 
     @Override
     protected final void handleSubscribe(Subscriber<? super T> subscriber) {
-        deliverTerminalFromSource(subscriber,
+        deliverErrorFromSource(subscriber,
                 new RejectedSubscribeException("Subscribe with no executor is not supported for " + getClass()));
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribePublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribePublisher.java
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.internal.RejectedSubscribeException;
 import io.servicetalk.concurrent.internal.SignalOffloader;
 
-import static io.servicetalk.concurrent.internal.EmptySubscription.EMPTY_SUBSCRIPTION;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 
 /**
  * A {@link Publisher} that does not expect to receive a call to {@link #handleSubscribe(Subscriber)} since it overrides
@@ -42,9 +42,8 @@ abstract class AbstractNoHandleSubscribePublisher<T> extends Publisher<T> implem
 
     @Override
     protected final void handleSubscribe(Subscriber<? super T> subscriber) {
-        subscriber.onSubscribe(EMPTY_SUBSCRIPTION);
-        subscriber.onError(new RejectedSubscribeException("Subscribe with no executor is not supported for "
-                + getClass()));
+        deliverTerminalFromSource(subscriber,
+                new RejectedSubscribeException("Subscribe with no executor is not supported for " + getClass()));
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribeSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribeSingle.java
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.internal.SignalOffloader;
 
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 
 /**
  * A {@link Single} that does not expect to receive a call to {@link #handleSubscribe(Subscriber)} since it overrides
@@ -41,7 +41,7 @@ abstract class AbstractNoHandleSubscribeSingle<T> extends Single<T> implements S
 
     @Override
     protected final void handleSubscribe(Subscriber<? super T> subscriber) {
-        deliverTerminalFromSource(subscriber,
+        deliverErrorFromSource(subscriber,
                 new UnsupportedOperationException("Subscribe with no executor is not supported for " + getClass()));
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribeSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribeSingle.java
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.internal.SignalOffloader;
 
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 
 /**
  * A {@link Single} that does not expect to receive a call to {@link #handleSubscribe(Subscriber)} since it overrides
@@ -41,9 +41,8 @@ abstract class AbstractNoHandleSubscribeSingle<T> extends Single<T> implements S
 
     @Override
     protected final void handleSubscribe(Subscriber<? super T> subscriber) {
-        subscriber.onSubscribe(IGNORE_CANCEL);
-        subscriber.onError(new UnsupportedOperationException("Subscribe with no executor is not supported for "
-                + getClass()));
+        deliverTerminalFromSource(subscriber,
+                new UnsupportedOperationException("Subscribe with no executor is not supported for " + getClass()));
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPublisherGroupBy.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPublisherGroupBy.java
@@ -43,7 +43,7 @@ import static io.servicetalk.concurrent.api.SubscriberApiUtils.SUBSCRIBER_STATE_
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.SUBSCRIBER_STATE_ON_NEXT;
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.SUBSCRIBER_STATE_TERMINATED;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateSubscription;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static java.util.Objects.requireNonNull;
@@ -444,7 +444,7 @@ abstract class AbstractPublisherGroupBy<Key, T>
                     requireNonNull(subscriber);
                     final Subscriber<? super T> target = GroupSink.this.target;
                     if (target != null) {
-                        deliverTerminalFromSource(subscriber, new DuplicateSubscribeException(target, subscriber));
+                        deliverErrorFromSource(subscriber, new DuplicateSubscribeException(target, subscriber));
                         return;
                     }
                     // We have to call onSubscribe before we set groupSinkTarget, because otherwise we may deliver data

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPublisherGroupBy.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPublisherGroupBy.java
@@ -42,8 +42,8 @@ import static io.servicetalk.concurrent.api.MulticastUtils.drainToSubscriber;
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.SUBSCRIBER_STATE_IDLE;
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.SUBSCRIBER_STATE_ON_NEXT;
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.SUBSCRIBER_STATE_TERMINATED;
-import static io.servicetalk.concurrent.internal.EmptySubscription.EMPTY_SUBSCRIPTION;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateSubscription;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static java.util.Objects.requireNonNull;
@@ -444,8 +444,7 @@ abstract class AbstractPublisherGroupBy<Key, T>
                     requireNonNull(subscriber);
                     final Subscriber<? super T> target = GroupSink.this.target;
                     if (target != null) {
-                        subscriber.onSubscribe(EMPTY_SUBSCRIPTION);
-                        subscriber.onError(new DuplicateSubscribeException(target, subscriber));
+                        deliverTerminalFromSource(subscriber, new DuplicateSubscribeException(target, subscriber));
                         return;
                     }
                     // We have to call onSubscribe before we set groupSinkTarget, because otherwise we may deliver data

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -37,7 +37,6 @@ import java.util.function.IntFunction;
 import java.util.function.IntPredicate;
 import java.util.function.Supplier;
 
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.CompletableDoOnUtils.doOnCompleteSupplier;
 import static io.servicetalk.concurrent.api.CompletableDoOnUtils.doOnErrorSupplier;
 import static io.servicetalk.concurrent.api.CompletableDoOnUtils.doOnSubscribeSupplier;
@@ -1802,8 +1801,7 @@ public abstract class Completable {
             // We also want to make sure the AsyncContext is saved/restored for all interactions with the Subscription.
             offloadedSubscriber = signalOffloader.offloadCancellable(provider.wrapCancellable(subscriber, contextMap));
         } catch (Throwable t) {
-            subscriber.onSubscribe(IGNORE_CANCEL);
-            subscriber.onError(t);
+            deliverTerminalFromSource(subscriber, t);
             return;
         }
         signalOffloader.offloadSubscribe(offloadedSubscriber, provider.wrapConsumer(

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -44,7 +44,7 @@ import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Publisher.fromIterable;
 import static io.servicetalk.concurrent.internal.SignalOffloaders.newOffloaderFor;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static java.util.Arrays.spliterator;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
@@ -1801,7 +1801,7 @@ public abstract class Completable {
             // We also want to make sure the AsyncContext is saved/restored for all interactions with the Subscription.
             offloadedSubscriber = signalOffloader.offloadCancellable(provider.wrapCancellable(subscriber, contextMap));
         } catch (Throwable t) {
-            deliverTerminalFromSource(subscriber, t);
+            deliverErrorFromSource(subscriber, t);
             return;
         }
         signalOffloader.offloadSubscribe(offloadedSubscriber, provider.wrapConsumer(
@@ -1841,7 +1841,7 @@ public abstract class Completable {
             // 1) Rule 2.12: onSubscribe() MUST be called at most once.
             // 2) Rule 1.7: Once a terminal state has been signaled (onError, onComplete) it is REQUIRED that no
             // further signals occur.
-            deliverTerminalFromSource(subscriber, t);
+            deliverErrorFromSource(subscriber, t);
         }
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableDefer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableDefer.java
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.CompletableSource;
 
 import java.util.function.Supplier;
 
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -38,7 +38,7 @@ final class CompletableDefer extends Completable implements CompletableSource {
         try {
             completable = requireNonNull(completableFactory.get());
         } catch (Throwable cause) {
-            deliverTerminalFromSource(subscriber, cause);
+            deliverErrorFromSource(subscriber, cause);
             return;
         }
         // There are technically two sources, this one and the one returned by the factory.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletedCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletedCompletable.java
@@ -15,14 +15,9 @@
  */
 package io.servicetalk.concurrent.api;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 
 final class CompletedCompletable extends AbstractSynchronousCompletable {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CompletedCompletable.class);
     static final CompletedCompletable INSTANCE = new CompletedCompletable();
 
     private CompletedCompletable() {
@@ -31,16 +26,6 @@ final class CompletedCompletable extends AbstractSynchronousCompletable {
 
     @Override
     void doSubscribe(final Subscriber subscriber) {
-        try {
-            subscriber.onSubscribe(IGNORE_CANCEL);
-        } catch (Throwable t) {
-            handleExceptionFromOnSubscribe(subscriber, t);
-            return;
-        }
-        try {
-            subscriber.onComplete();
-        } catch (Throwable t) {
-            LOGGER.info("Ignoring exception from onComplete of Subscriber {}.", subscriber, t);
-        }
+        deliverTerminalFromSource(subscriber);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletedCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletedCompletable.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverCompleteFromSource;
 
 final class CompletedCompletable extends AbstractSynchronousCompletable {
     static final CompletedCompletable INSTANCE = new CompletedCompletable();
@@ -26,6 +26,6 @@ final class CompletedCompletable extends AbstractSynchronousCompletable {
 
     @Override
     void doSubscribe(final Subscriber subscriber) {
-        deliverTerminalFromSource(subscriber);
+        deliverCompleteFromSource(subscriber);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/EmptyPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/EmptyPublisher.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverCompleteFromSource;
 
 final class EmptyPublisher<T> extends AbstractSynchronousPublisher<T> {
     private static final EmptyPublisher EMPTY_PUBLISHER = new EmptyPublisher();
@@ -26,7 +26,7 @@ final class EmptyPublisher<T> extends AbstractSynchronousPublisher<T> {
 
     @Override
     void doSubscribe(Subscriber<? super T> subscriber) {
-        deliverTerminalFromSource(subscriber);
+        deliverCompleteFromSource(subscriber);
     }
 
     @SuppressWarnings("unchecked")

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ErrorPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ErrorPublisher.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static java.util.Objects.requireNonNull;
 
 final class ErrorPublisher<T> extends AbstractSynchronousPublisher<T> {
@@ -27,6 +27,6 @@ final class ErrorPublisher<T> extends AbstractSynchronousPublisher<T> {
 
     @Override
     void doSubscribe(Subscriber<? super T> subscriber) {
-        deliverTerminalFromSource(subscriber, cause);
+        deliverErrorFromSource(subscriber, cause);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FailedCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FailedCompletable.java
@@ -15,9 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.CompletableSource.Subscriber;
-
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static java.util.Objects.requireNonNull;
 
 final class FailedCompletable extends AbstractSynchronousCompletable {
@@ -29,6 +27,6 @@ final class FailedCompletable extends AbstractSynchronousCompletable {
 
     @Override
     void doSubscribe(final Subscriber subscriber) {
-        deliverTerminalFromSource(subscriber, cause);
+        deliverErrorFromSource(subscriber, cause);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FailedSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FailedSingle.java
@@ -15,9 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.SingleSource.Subscriber;
-
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static java.util.Objects.requireNonNull;
 
 final class FailedSingle<T> extends AbstractSynchronousSingle<T> {
@@ -29,6 +27,6 @@ final class FailedSingle<T> extends AbstractSynchronousSingle<T> {
 
     @Override
     void doSubscribe(final Subscriber<? super T> subscriber) {
-        deliverTerminalFromSource(subscriber, cause);
+        deliverErrorFromSource(subscriber, cause);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromArrayPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromArrayPublisher.java
@@ -19,7 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverCompleteFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
@@ -48,7 +48,7 @@ final class FromArrayPublisher<T> extends AbstractSynchronousPublisher<T> {
                 handleExceptionFromOnSubscribe(s, t);
             }
         } else {
-            deliverTerminalFromSource(s);
+            deliverCompleteFromSource(s);
         }
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromInputStreamPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromInputStreamPublisher.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
@@ -86,7 +86,7 @@ final class FromInputStreamPublisher extends Publisher<byte[]> implements Publis
                 handleExceptionFromOnSubscribe(subscriber, t);
             }
         } else {
-            deliverTerminalFromSource(subscriber, new DuplicateSubscribeException(null, subscriber));
+            deliverErrorFromSource(subscriber, new DuplicateSubscribeException(null, subscriber));
         }
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/LiftSynchronousPublisherToSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/LiftSynchronousPublisherToSingle.java
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.internal.SignalOffloader;
 
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 import static java.util.Objects.requireNonNull;
 
 final class LiftSynchronousPublisherToSingle<T, R> extends Single<R> implements SingleSource<R> {
@@ -34,9 +34,8 @@ final class LiftSynchronousPublisherToSingle<T, R> extends Single<R> implements 
 
     @Override
     protected void handleSubscribe(final SingleSource.Subscriber<? super R> subscriber) {
-        subscriber.onSubscribe(IGNORE_CANCEL);
-        subscriber.onError(new UnsupportedOperationException("Subscribe with no executor is not supported for "
-                + getClass()));
+        deliverTerminalFromSource(subscriber,
+                new UnsupportedOperationException("Subscribe with no executor is not supported for " + getClass()));
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/LiftSynchronousPublisherToSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/LiftSynchronousPublisherToSingle.java
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.internal.SignalOffloader;
 
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static java.util.Objects.requireNonNull;
 
 final class LiftSynchronousPublisherToSingle<T, R> extends Single<R> implements SingleSource<R> {
@@ -34,7 +34,7 @@ final class LiftSynchronousPublisherToSingle<T, R> extends Single<R> implements 
 
     @Override
     protected void handleSubscribe(final SingleSource.Subscriber<? super R> subscriber) {
-        deliverTerminalFromSource(subscriber,
+        deliverErrorFromSource(subscriber,
                 new UnsupportedOperationException("Subscribe with no executor is not supported for " + getClass()));
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/NeverPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/NeverPublisher.java
@@ -19,6 +19,7 @@ import static io.servicetalk.concurrent.internal.EmptySubscription.EMPTY_SUBSCRI
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 
 final class NeverPublisher<T> extends AbstractSynchronousPublisher<T> {
+    @SuppressWarnings("rawtypes")
     private static final NeverPublisher NEVER_PUBLISHER = new NeverPublisher();
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnCompletables.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnCompletables.java
@@ -18,9 +18,9 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.CompletableSource.Subscriber;
 import io.servicetalk.concurrent.internal.SignalOffloader;
 
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.MergedExecutors.mergeAndOffloadPublish;
 import static io.servicetalk.concurrent.api.MergedExecutors.mergeAndOffloadSubscribe;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 
 /**
  * A set of factory methods that provides implementations for the various publish/subscribeOn methods on
@@ -35,10 +35,9 @@ final class PublishAndSubscribeOnCompletables {
     static void deliverOnSubscribeAndOnError(Subscriber subscriber, SignalOffloader signalOffloader,
                                              AsyncContextMap contextMap, AsyncContextProvider contextProvider,
                                              Throwable cause) {
-        subscriber = signalOffloader.offloadSubscriber(
-                contextProvider.wrapCompletableSubscriber(subscriber, contextMap));
-        subscriber.onSubscribe(IGNORE_CANCEL);
-        subscriber.onError(cause);
+        deliverTerminalFromSource(
+                signalOffloader.offloadSubscriber(contextProvider.wrapCompletableSubscriber(subscriber, contextMap)),
+                cause);
     }
 
     static Completable publishAndSubscribeOn(Completable original, Executor executor) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnCompletables.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnCompletables.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.internal.SignalOffloader;
 
 import static io.servicetalk.concurrent.api.MergedExecutors.mergeAndOffloadPublish;
 import static io.servicetalk.concurrent.api.MergedExecutors.mergeAndOffloadSubscribe;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 
 /**
  * A set of factory methods that provides implementations for the various publish/subscribeOn methods on
@@ -35,7 +35,7 @@ final class PublishAndSubscribeOnCompletables {
     static void deliverOnSubscribeAndOnError(Subscriber subscriber, SignalOffloader signalOffloader,
                                              AsyncContextMap contextMap, AsyncContextProvider contextProvider,
                                              Throwable cause) {
-        deliverTerminalFromSource(
+        deliverErrorFromSource(
                 signalOffloader.offloadSubscriber(contextProvider.wrapCompletableSubscriber(subscriber, contextMap)),
                 cause);
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnPublishers.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnPublishers.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.internal.SignalOffloader;
 
 import static io.servicetalk.concurrent.api.MergedExecutors.mergeAndOffloadPublish;
 import static io.servicetalk.concurrent.api.MergedExecutors.mergeAndOffloadSubscribe;
-import static io.servicetalk.concurrent.internal.EmptySubscription.EMPTY_SUBSCRIPTION;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 
 /**
  * A set of factory methods that provides implementations for the various publish/subscribeOn methods on
@@ -35,9 +35,9 @@ final class PublishAndSubscribeOnPublishers {
     static <T> void deliverOnSubscribeAndOnError(Subscriber<? super T> subscriber, SignalOffloader signalOffloader,
                                                  AsyncContextMap contextMap, AsyncContextProvider contextProvider,
                                                  Throwable cause) {
-        subscriber = signalOffloader.offloadSubscriber(contextProvider.wrapPublisherSubscriber(subscriber, contextMap));
-        subscriber.onSubscribe(EMPTY_SUBSCRIPTION);
-        subscriber.onError(cause);
+        deliverTerminalFromSource(
+                signalOffloader.offloadSubscriber(contextProvider.wrapPublisherSubscriber(subscriber, contextMap)),
+                cause);
     }
 
     static <T> Publisher<T> publishAndSubscribeOn(Publisher<T> original, Executor executor) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnPublishers.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnPublishers.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.internal.SignalOffloader;
 
 import static io.servicetalk.concurrent.api.MergedExecutors.mergeAndOffloadPublish;
 import static io.servicetalk.concurrent.api.MergedExecutors.mergeAndOffloadSubscribe;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 
 /**
  * A set of factory methods that provides implementations for the various publish/subscribeOn methods on
@@ -35,7 +35,7 @@ final class PublishAndSubscribeOnPublishers {
     static <T> void deliverOnSubscribeAndOnError(Subscriber<? super T> subscriber, SignalOffloader signalOffloader,
                                                  AsyncContextMap contextMap, AsyncContextProvider contextProvider,
                                                  Throwable cause) {
-        deliverTerminalFromSource(
+        deliverErrorFromSource(
                 signalOffloader.offloadSubscriber(contextProvider.wrapPublisherSubscriber(subscriber, contextMap)),
                 cause);
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnSingles.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnSingles.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.internal.SignalOffloader;
 
 import static io.servicetalk.concurrent.api.MergedExecutors.mergeAndOffloadPublish;
 import static io.servicetalk.concurrent.api.MergedExecutors.mergeAndOffloadSubscribe;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 
 /**
  * A set of factory methods that provides implementations for the various publish/subscribeOn methods on
@@ -35,7 +35,7 @@ final class PublishAndSubscribeOnSingles {
     static <T> void deliverOnSubscribeAndOnError(SingleSource.Subscriber<? super T> subscriber,
                                                  SignalOffloader signalOffloader, AsyncContextMap contextMap,
                                                  AsyncContextProvider contextProvider, Throwable cause) {
-        deliverTerminalFromSource(
+        deliverErrorFromSource(
                 signalOffloader.offloadSubscriber(contextProvider.wrapSingleSubscriber(subscriber, contextMap)), cause);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnSingles.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnSingles.java
@@ -18,9 +18,9 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.internal.SignalOffloader;
 
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.MergedExecutors.mergeAndOffloadPublish;
 import static io.servicetalk.concurrent.api.MergedExecutors.mergeAndOffloadSubscribe;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 
 /**
  * A set of factory methods that provides implementations for the various publish/subscribeOn methods on
@@ -35,9 +35,8 @@ final class PublishAndSubscribeOnSingles {
     static <T> void deliverOnSubscribeAndOnError(SingleSource.Subscriber<? super T> subscriber,
                                                  SignalOffloader signalOffloader, AsyncContextMap contextMap,
                                                  AsyncContextProvider contextProvider, Throwable cause) {
-        subscriber = signalOffloader.offloadSubscriber(contextProvider.wrapSingleSubscriber(subscriber, contextMap));
-        subscriber.onSubscribe(IGNORE_CANCEL);
-        subscriber.onError(cause);
+        deliverTerminalFromSource(
+                signalOffloader.offloadSubscriber(contextProvider.wrapSingleSubscriber(subscriber, contextMap)), cause);
     }
 
     static <T> Single<T> publishAndSubscribeOn(Single<T> original, Executor executor) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -59,7 +59,7 @@ import static io.servicetalk.concurrent.api.PublisherDoOnUtils.doOnNextSupplier;
 import static io.servicetalk.concurrent.api.PublisherDoOnUtils.doOnRequestSupplier;
 import static io.servicetalk.concurrent.api.PublisherDoOnUtils.doOnSubscribeSupplier;
 import static io.servicetalk.concurrent.internal.SignalOffloaders.newOffloaderFor;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -2615,7 +2615,7 @@ public abstract class Publisher<T> {
             offloadedSubscriber =
                     signalOffloader.offloadSubscription(provider.wrapSubscription(subscriber, contextMap));
         } catch (Throwable t) {
-            deliverTerminalFromSource(subscriber, t);
+            deliverErrorFromSource(subscriber, t);
             return;
         }
         signalOffloader.offloadSubscribe(offloadedSubscriber, provider.wrapConsumer(
@@ -2655,7 +2655,7 @@ public abstract class Publisher<T> {
             // 1) Rule 2.12: onSubscribe() MUST be called at most once.
             // 2) Rule 1.7: Once a terminal state has been signaled (onError, onComplete) it is REQUIRED that no
             // further signals occur.
-            deliverTerminalFromSource(subscriber, t);
+            deliverErrorFromSource(subscriber, t);
         }
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -58,7 +58,6 @@ import static io.servicetalk.concurrent.api.PublisherDoOnUtils.doOnErrorSupplier
 import static io.servicetalk.concurrent.api.PublisherDoOnUtils.doOnNextSupplier;
 import static io.servicetalk.concurrent.api.PublisherDoOnUtils.doOnRequestSupplier;
 import static io.servicetalk.concurrent.api.PublisherDoOnUtils.doOnSubscribeSupplier;
-import static io.servicetalk.concurrent.internal.EmptySubscription.EMPTY_SUBSCRIPTION;
 import static io.servicetalk.concurrent.internal.SignalOffloaders.newOffloaderFor;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 import static java.util.Objects.requireNonNull;
@@ -2616,8 +2615,7 @@ public abstract class Publisher<T> {
             offloadedSubscriber =
                     signalOffloader.offloadSubscription(provider.wrapSubscription(subscriber, contextMap));
         } catch (Throwable t) {
-            subscriber.onSubscribe(EMPTY_SUBSCRIPTION);
-            subscriber.onError(t);
+            deliverTerminalFromSource(subscriber, t);
             return;
         }
         signalOffloader.offloadSubscribe(offloadedSubscriber, provider.wrapConsumer(

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherDefer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherDefer.java
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.PublisherSource;
 
 import java.util.function.Supplier;
 
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -40,7 +40,7 @@ final class PublisherDefer<T> extends Publisher<T> implements PublisherSource<T>
         try {
             publisher = requireNonNull(publisherFactory.get());
         } catch (Throwable cause) {
-            deliverTerminalFromSource(subscriber, cause);
+            deliverErrorFromSource(subscriber, cause);
             return;
         }
         // There are technically two sources, this one and the one returned by the factory.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -47,7 +47,7 @@ import static io.servicetalk.concurrent.api.SingleDoOnUtils.doOnErrorSupplier;
 import static io.servicetalk.concurrent.api.SingleDoOnUtils.doOnSubscribeSupplier;
 import static io.servicetalk.concurrent.api.SingleDoOnUtils.doOnSuccessSupplier;
 import static io.servicetalk.concurrent.internal.SignalOffloaders.newOffloaderFor;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 
@@ -1923,7 +1923,7 @@ public abstract class Single<T> {
             // We also want to make sure the AsyncContext is saved/restored for all interactions with the Subscription.
             offloadedSubscriber = signalOffloader.offloadCancellable(provider.wrapCancellable(subscriber, contextMap));
         } catch (Throwable t) {
-            deliverTerminalFromSource(subscriber, t);
+            deliverErrorFromSource(subscriber, t);
             return;
         }
         signalOffloader.offloadSubscribe(offloadedSubscriber, provider.wrapConsumer(
@@ -1964,7 +1964,7 @@ public abstract class Single<T> {
             // 1) Rule 2.12: onSubscribe() MUST be called at most once.
             // 2) Rule 1.7: Once a terminal state has been signaled (onError, onComplete) it is REQUIRED that no
             // further signals occur.
-            deliverTerminalFromSource(subscriber, t);
+            deliverErrorFromSource(subscriber, t);
         }
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -39,7 +39,6 @@ import java.util.function.IntPredicate;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.NeverSingle.neverSingle;
 import static io.servicetalk.concurrent.api.Publisher.from;
@@ -1924,8 +1923,7 @@ public abstract class Single<T> {
             // We also want to make sure the AsyncContext is saved/restored for all interactions with the Subscription.
             offloadedSubscriber = signalOffloader.offloadCancellable(provider.wrapCancellable(subscriber, contextMap));
         } catch (Throwable t) {
-            subscriber.onSubscribe(IGNORE_CANCEL);
-            subscriber.onError(t);
+            deliverTerminalFromSource(subscriber, t);
             return;
         }
         signalOffloader.offloadSubscribe(offloadedSubscriber, provider.wrapConsumer(

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleDefer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleDefer.java
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.SingleSource;
 
 import java.util.function.Supplier;
 
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -40,7 +40,7 @@ final class SingleDefer<T> extends Single<T> implements SingleSource<T> {
         try {
             single = requireNonNull(singleFactory.get());
         } catch (Throwable cause) {
-            deliverTerminalFromSource(subscriber, cause);
+            deliverErrorFromSource(subscriber, cause);
             return;
         }
         // There are technically two sources, this one and the one returned by the factory.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SucceededSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SucceededSingle.java
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnComplete;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 
 final class SucceededSingle<T> extends AbstractSynchronousSingle<T> {
     @Nullable
@@ -29,6 +29,6 @@ final class SucceededSingle<T> extends AbstractSynchronousSingle<T> {
 
     @Override
     void doSubscribe(final Subscriber<? super T> subscriber) {
-        safeOnComplete(subscriber, value);
+        deliverTerminalFromSource(subscriber, value);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SucceededSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SucceededSingle.java
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverSuccessFromSource;
 
 final class SucceededSingle<T> extends AbstractSynchronousSingle<T> {
     @Nullable
@@ -29,6 +29,6 @@ final class SucceededSingle<T> extends AbstractSynchronousSingle<T> {
 
     @Override
     void doSubscribe(final Subscriber<? super T> subscriber) {
-        deliverTerminalFromSource(subscriber, value);
+        deliverSuccessFromSource(subscriber, value);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SucceededSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SucceededSingle.java
@@ -15,16 +15,11 @@
  */
 package io.servicetalk.concurrent.api;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnComplete;
 
 final class SucceededSingle<T> extends AbstractSynchronousSingle<T> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SucceededSingle.class);
     @Nullable
     private final T value;
 
@@ -34,16 +29,6 @@ final class SucceededSingle<T> extends AbstractSynchronousSingle<T> {
 
     @Override
     void doSubscribe(final Subscriber<? super T> subscriber) {
-        try {
-            subscriber.onSubscribe(IGNORE_CANCEL);
-        } catch (Throwable t) {
-            handleExceptionFromOnSubscribe(subscriber, t);
-            return;
-        }
-        try {
-            subscriber.onSuccess(value);
-        } catch (Throwable t) {
-            LOGGER.info("Ignoring exception from onSuccess of Subscriber {}.", subscriber, t);
-        }
+        safeOnComplete(subscriber, value);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutCompletable.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.PublishAndSubscribeOnCompletables.deliverOnSubscribeAndOnError;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
@@ -193,7 +193,7 @@ final class TimeoutCompletable extends AbstractNoHandleSubscribeCompletable {
                     // If there is no Cancellable, that means this.onSubscribe wasn't called before the timeout. In this
                     // case there is no risk of concurrent invocation on target because we won't invoke
                     // target.onSubscribe from this.onSubscribe.
-                    deliverTerminalFromSource(offloadedTarget, newTimeoutException());
+                    deliverErrorFromSource(offloadedTarget, newTimeoutException());
                 }
             }
         }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutSingle.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.PublishAndSubscribeOnSingles.deliverOnSubscribeAndOnError;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
@@ -194,7 +194,7 @@ final class TimeoutSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
                     // If there is no Cancellable, that means this.onSubscribe wasn't called before the timeout. In this
                     // case there is no risk of concurrent invocation on target because we won't invoke
                     // target.onSubscribe from this.onSubscribe.
-                    deliverTerminalFromSource(offloadedTarget, newTimeoutException());
+                    deliverErrorFromSource(offloadedTarget, newTimeoutException());
                 }
             }
         }

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/SubscriberUtils.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/SubscriberUtils.java
@@ -159,7 +159,7 @@ public final class SubscriberUtils {
      * @param subscriber The {@link Subscriber} to terminate.
      * @param <T> The type of {@link Subscriber}.
      */
-    public static <T> void deliverTerminalFromSource(Subscriber<T> subscriber) {
+    public static <T> void deliverCompleteFromSource(Subscriber<T> subscriber) {
         try {
             subscriber.onSubscribe(EMPTY_SUBSCRIPTION);
         } catch (Throwable t) {
@@ -176,14 +176,14 @@ public final class SubscriberUtils {
      * @param value The value to pass to {@link SingleSource.Subscriber#onSuccess(Object)}.
      * @param <T> The type of {@link SingleSource.Subscriber}.
      */
-    public static <T> void deliverTerminalFromSource(SingleSource.Subscriber<T> subscriber, @Nullable T value) {
+    public static <T> void deliverSuccessFromSource(SingleSource.Subscriber<T> subscriber, @Nullable T value) {
         try {
             subscriber.onSubscribe(IGNORE_CANCEL);
         } catch (Throwable t) {
             handleExceptionFromOnSubscribe(subscriber, t);
             return;
         }
-        safeOnComplete(subscriber, value);
+        safeOnSuccess(subscriber, value);
     }
 
     /**
@@ -192,7 +192,7 @@ public final class SubscriberUtils {
      * @param subscriber The {@link CompletableSource.Subscriber} to terminate.
      * @param <T> The type of {@link CompletableSource.Subscriber}.
      */
-    public static <T> void deliverTerminalFromSource(CompletableSource.Subscriber subscriber) {
+    public static <T> void deliverCompleteFromSource(CompletableSource.Subscriber subscriber) {
         try {
             subscriber.onSubscribe(IGNORE_CANCEL);
         } catch (Throwable t) {
@@ -209,7 +209,7 @@ public final class SubscriberUtils {
      * @param cause The terminal event.
      * @param <T> The type of {@link Subscriber}.
      */
-    public static <T> void deliverTerminalFromSource(Subscriber<T> subscriber, Throwable cause) {
+    public static <T> void deliverErrorFromSource(Subscriber<T> subscriber, Throwable cause) {
         try {
             subscriber.onSubscribe(EMPTY_SUBSCRIPTION);
         } catch (Throwable t) {
@@ -226,7 +226,7 @@ public final class SubscriberUtils {
      * @param cause The terminal event.
      * @param <T> The type of {@link SingleSource.Subscriber}.
      */
-    public static <T> void deliverTerminalFromSource(SingleSource.Subscriber<T> subscriber, Throwable cause) {
+    public static <T> void deliverErrorFromSource(SingleSource.Subscriber<T> subscriber, Throwable cause) {
         try {
             subscriber.onSubscribe(IGNORE_CANCEL);
         } catch (Throwable t) {
@@ -242,7 +242,7 @@ public final class SubscriberUtils {
      * @param subscriber The {@link CompletableSource.Subscriber} to terminate.
      * @param cause The terminal event.
      */
-    public static void deliverTerminalFromSource(CompletableSource.Subscriber subscriber, Throwable cause) {
+    public static void deliverErrorFromSource(CompletableSource.Subscriber subscriber, Throwable cause) {
         try {
             subscriber.onSubscribe(IGNORE_CANCEL);
         } catch (Throwable t) {
@@ -371,9 +371,10 @@ public final class SubscriberUtils {
      * Invokes {@link SingleSource.Subscriber#onSuccess(Object)} ignoring an occurred exception if any.
      * @param subscriber The {@link SingleSource.Subscriber} that may throw an exception from
      * {@link SingleSource.Subscriber#onSuccess(Object)}.
+     * @param value The value to pass to {@link SingleSource.Subscriber#onSuccess(Object)}.
      * @param <T> The type of {@link SingleSource.Subscriber}.
      */
-    public static <T> void safeOnComplete(SingleSource.Subscriber<T> subscriber, @Nullable T value) {
+    public static <T> void safeOnSuccess(SingleSource.Subscriber<T> subscriber, @Nullable T value) {
         try {
             subscriber.onSuccess(value);
         } catch (Throwable t) {
@@ -385,9 +386,8 @@ public final class SubscriberUtils {
      * Invokes {@link CompletableSource.Subscriber#onComplete()} ignoring an occurred exception if any.
      * @param subscriber The {@link CompletableSource.Subscriber} that may throw an exception from
      * {@link CompletableSource.Subscriber#onComplete()}.
-     * @param <T> The type of {@link CompletableSource.Subscriber}.
      */
-    public static <T> void safeOnComplete(CompletableSource.Subscriber subscriber) {
+    public static void safeOnComplete(CompletableSource.Subscriber subscriber) {
         try {
             subscriber.onComplete();
         } catch (Throwable t) {

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/SubscriberUtils.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/SubscriberUtils.java
@@ -170,6 +170,23 @@ public final class SubscriberUtils {
     }
 
     /**
+     * Invokes {@link SingleSource.Subscriber#onSuccess(Object)} ignoring an occurred exception if any.
+     * @param subscriber The {@link SingleSource.Subscriber} that may throw an exception from
+     * {@link SingleSource.Subscriber#onSuccess(Object)}.
+     * @param value The value to pass to {@link SingleSource.Subscriber#onSuccess(Object)}.
+     * @param <T> The type of {@link SingleSource.Subscriber}.
+     */
+    public static <T> void deliverTerminalFromSource(SingleSource.Subscriber<T> subscriber, @Nullable T value) {
+        try {
+            subscriber.onSubscribe(IGNORE_CANCEL);
+        } catch (Throwable t) {
+            handleExceptionFromOnSubscribe(subscriber, t);
+            return;
+        }
+        safeOnComplete(subscriber, value);
+    }
+
+    /**
      * Deliver a terminal complete to a {@link CompletableSource.Subscriber} that has not yet had
      * {@link CompletableSource.Subscriber#onSubscribe(Cancellable)} called.
      * @param subscriber The {@link CompletableSource.Subscriber} to terminate.
@@ -354,16 +371,9 @@ public final class SubscriberUtils {
      * Invokes {@link SingleSource.Subscriber#onSuccess(Object)} ignoring an occurred exception if any.
      * @param subscriber The {@link SingleSource.Subscriber} that may throw an exception from
      * {@link SingleSource.Subscriber#onSuccess(Object)}.
-     * @param value The value to pass to {@link SingleSource.Subscriber#onSuccess(Object)}.
      * @param <T> The type of {@link SingleSource.Subscriber}.
      */
     public static <T> void safeOnComplete(SingleSource.Subscriber<T> subscriber, @Nullable T value) {
-        try {
-            subscriber.onSubscribe(IGNORE_CANCEL);
-        } catch (Throwable t) {
-            handleExceptionFromOnSubscribe(subscriber, t);
-            return;
-        }
         try {
             subscriber.onSuccess(value);
         } catch (Throwable t) {

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/TaskBasedSignalOffloader.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/TaskBasedSignalOffloader.java
@@ -33,7 +33,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.internal.EmptySubscription.EMPTY_SUBSCRIPTION;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.utils.internal.PlatformDependent.newUnboundedSpscQueue;
 import static java.util.Objects.requireNonNull;
@@ -107,7 +107,7 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
             executor.execute(() -> handleSubscribe.accept(subscriber));
         } catch (Throwable throwable) {
             // We assume that if executor accepted the task, it was run and no exception will be thrown from accept.
-            deliverTerminalFromSource(subscriber, throwable);
+            deliverErrorFromSource(subscriber, throwable);
         }
     }
 
@@ -118,7 +118,7 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
             executor.execute(() -> handleSubscribe.accept(subscriber));
         } catch (Throwable throwable) {
             // We assume that if executor accepted the task, it was run and no exception will be thrown from accept.
-            deliverTerminalFromSource(subscriber, throwable);
+            deliverErrorFromSource(subscriber, throwable);
         }
     }
 
@@ -129,7 +129,7 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
             executor.execute(() -> handleSubscribe.accept(subscriber));
         } catch (Throwable throwable) {
             // We assume that if executor accepted the task, it was run and no exception will be thrown from accept.
-            deliverTerminalFromSource(subscriber, throwable);
+            deliverErrorFromSource(subscriber, throwable);
         }
     }
 

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/TaskBasedSignalOffloader.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/TaskBasedSignalOffloader.java
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.internal.EmptySubscription.EMPTY_SUBSCRIPTION;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.utils.internal.PlatformDependent.newUnboundedSpscQueue;
 import static java.util.Objects.requireNonNull;
@@ -106,8 +107,7 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
             executor.execute(() -> handleSubscribe.accept(subscriber));
         } catch (Throwable throwable) {
             // We assume that if executor accepted the task, it was run and no exception will be thrown from accept.
-            subscriber.onSubscribe(EMPTY_SUBSCRIPTION);
-            subscriber.onError(throwable);
+            deliverTerminalFromSource(subscriber, throwable);
         }
     }
 
@@ -118,8 +118,7 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
             executor.execute(() -> handleSubscribe.accept(subscriber));
         } catch (Throwable throwable) {
             // We assume that if executor accepted the task, it was run and no exception will be thrown from accept.
-            subscriber.onSubscribe(IGNORE_CANCEL);
-            subscriber.onError(throwable);
+            deliverTerminalFromSource(subscriber, throwable);
         }
     }
 
@@ -130,8 +129,7 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
             executor.execute(() -> handleSubscribe.accept(subscriber));
         } catch (Throwable throwable) {
             // We assume that if executor accepted the task, it was run and no exception will be thrown from accept.
-            subscriber.onSubscribe(IGNORE_CANCEL);
-            subscriber.onError(throwable);
+            deliverTerminalFromSource(subscriber, throwable);
         }
     }
 

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThreadBasedSignalOffloader.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThreadBasedSignalOffloader.java
@@ -33,8 +33,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
-import static io.servicetalk.concurrent.internal.EmptySubscription.EMPTY_SUBSCRIPTION;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
@@ -141,8 +140,7 @@ final class ThreadBasedSignalOffloader implements SignalOffloader, Runnable {
         } catch (EnqueueForOffloadingFailed e) {
             // Since we failed to enqueue for offloading, we are sure that Subscriber has not been signalled and hence
             // safe to send the error.
-            subscriber.onSubscribe(EMPTY_SUBSCRIPTION);
-            subscriber.onError(e.getCause());
+            deliverTerminalFromSource(subscriber, e.getCause());
         }
     }
 
@@ -154,8 +152,7 @@ final class ThreadBasedSignalOffloader implements SignalOffloader, Runnable {
         } catch (EnqueueForOffloadingFailed e) {
             // Since we failed to enqueue for offloading, we are sure that Subscriber has not been signalled and hence
             // safe to send the error.
-            subscriber.onSubscribe(IGNORE_CANCEL);
-            subscriber.onError(e.getCause());
+            deliverTerminalFromSource(subscriber, e.getCause());
         }
     }
 
@@ -167,8 +164,7 @@ final class ThreadBasedSignalOffloader implements SignalOffloader, Runnable {
         } catch (EnqueueForOffloadingFailed e) {
             // Since we failed to enqueue for offloading, we are sure that Subscriber has not been signalled and hence
             // safe to send the error.
-            subscriber.onSubscribe(IGNORE_CANCEL);
-            subscriber.onError(e.getCause());
+            deliverTerminalFromSource(subscriber, e.getCause());
         }
     }
 

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThreadBasedSignalOffloader.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThreadBasedSignalOffloader.java
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
@@ -140,7 +140,7 @@ final class ThreadBasedSignalOffloader implements SignalOffloader, Runnable {
         } catch (EnqueueForOffloadingFailed e) {
             // Since we failed to enqueue for offloading, we are sure that Subscriber has not been signalled and hence
             // safe to send the error.
-            deliverTerminalFromSource(subscriber, e.getCause());
+            deliverErrorFromSource(subscriber, e.getCause());
         }
     }
 
@@ -152,7 +152,7 @@ final class ThreadBasedSignalOffloader implements SignalOffloader, Runnable {
         } catch (EnqueueForOffloadingFailed e) {
             // Since we failed to enqueue for offloading, we are sure that Subscriber has not been signalled and hence
             // safe to send the error.
-            deliverTerminalFromSource(subscriber, e.getCause());
+            deliverErrorFromSource(subscriber, e.getCause());
         }
     }
 
@@ -164,7 +164,7 @@ final class ThreadBasedSignalOffloader implements SignalOffloader, Runnable {
         } catch (EnqueueForOffloadingFailed e) {
             // Since we failed to enqueue for offloading, we are sure that Subscriber has not been signalled and hence
             // safe to send the error.
-            deliverTerminalFromSource(subscriber, e.getCause());
+            deliverErrorFromSource(subscriber, e.getCause());
         }
     }
 

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -65,7 +65,7 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.toAsyncCloseable;
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnComplete;
@@ -389,11 +389,9 @@ final class DefaultDnsClient implements DnsClient {
             assertInEventloop();
 
             if (subscription != null) {
-                deliverTerminalFromSource(subscriber,
-                        new DuplicateSubscribeException(subscription, subscriber));
+                deliverErrorFromSource(subscriber, new DuplicateSubscribeException(subscription, subscriber));
             } else if (closed) {
-                deliverTerminalFromSource(subscriber,
-                        new ClosedServiceDiscovererException(DefaultDnsClient.this +
+                deliverErrorFromSource(subscriber, new ClosedServiceDiscovererException(DefaultDnsClient.this +
                                 " has been closed!"));
             } else {
                 subscription = newSubscription(subscriber);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FunctionToSingle.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FunctionToSingle.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.api.internal.SubscribableSingle;
 import java.util.function.Function;
 
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 
 final class FunctionToSingle<T, R> extends SubscribableSingle<R> {
     private final Function<T, R> func;
@@ -32,7 +33,13 @@ final class FunctionToSingle<T, R> extends SubscribableSingle<R> {
 
     @Override
     protected void handleSubscribe(final Subscriber<? super R> subscriber) {
-        subscriber.onSubscribe(IGNORE_CANCEL);
+        try {
+            subscriber.onSubscribe(IGNORE_CANCEL);
+        } catch (Throwable cause) {
+            handleExceptionFromOnSubscribe(subscriber, cause);
+            return;
+        }
+
         final R result;
         try {
             result = func.apply(orig);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnChannelSingle.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnChannelSingle.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 import static io.servicetalk.http.netty.AlpnIds.HTTP_1_1;
 
 /**
@@ -56,8 +56,7 @@ final class AlpnChannelSingle extends SubscribableSingle<String> {
             channelInitializer.init(channel);
         } catch (Throwable cause) {
             channel.close();
-            subscriber.onSubscribe(IGNORE_CANCEL);
-            subscriber.onError(cause);
+            deliverTerminalFromSource(subscriber, cause);
             return;
         }
         subscriber.onSubscribe(channel::close);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnChannelSingle.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnChannelSingle.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.http.netty.AlpnIds.HTTP_1_1;
 
 /**
@@ -56,7 +56,7 @@ final class AlpnChannelSingle extends SubscribableSingle<String> {
             channelInitializer.init(channel);
         } catch (Throwable cause) {
             channel.close();
-            deliverTerminalFromSource(subscriber, cause);
+            deliverErrorFromSource(subscriber, cause);
             return;
         }
         subscriber.onSubscribe(channel::close);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -66,7 +66,7 @@ import static io.netty.handler.codec.http.HttpScheme.HTTPS;
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.concurrent.api.AsyncCloseables.toListenableAsyncCloseable;
 import static io.servicetalk.concurrent.api.Single.defer;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverCompleteFromSource;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -182,7 +182,7 @@ final class DefaultMultiAddressUrlHttpClientBuilder
                 @Override
                 protected void handleSubscribe(final Subscriber subscriber) {
                     urlKeyCache.clear();
-                    deliverTerminalFromSource(subscriber);
+                    deliverCompleteFromSource(subscriber);
                 }
             };
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -63,10 +63,10 @@ import javax.annotation.Nullable;
 
 import static io.netty.handler.codec.http.HttpScheme.HTTP;
 import static io.netty.handler.codec.http.HttpScheme.HTTPS;
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.concurrent.api.AsyncCloseables.toListenableAsyncCloseable;
 import static io.servicetalk.concurrent.api.Single.defer;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -181,9 +181,8 @@ final class DefaultMultiAddressUrlHttpClientBuilder
             return new SubscribableCompletable() {
                 @Override
                 protected void handleSubscribe(final Subscriber subscriber) {
-                    subscriber.onSubscribe(IGNORE_CANCEL);
                     urlKeyCache.clear();
-                    subscriber.onComplete();
+                    deliverTerminalFromSource(subscriber);
                 }
             };
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -65,7 +65,6 @@ import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.SMALLEST_MAX_CONCURRENT_STREAMS;
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
@@ -121,8 +120,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                             NettyPipelineSslUtils.isSslEnabled(pipeline), config.headersFactory(), reqRespFactory);
                 } catch (Throwable cause) {
                     channel.close();
-                    subscriber.onSubscribe(IGNORE_CANCEL);
-                    subscriber.onError(cause);
+                    deliverTerminalFromSource(subscriber, cause);
                     return;
                 }
                 subscriber.onSubscribe(delayedCancellable);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -67,7 +67,7 @@ import javax.net.ssl.SSLSession;
 import static io.netty.handler.codec.http2.Http2CodecUtil.SMALLEST_MAX_CONCURRENT_STREAMS;
 import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.HeaderUtils.LAST_CHUNK_PREDICATE;
@@ -120,7 +120,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                             NettyPipelineSslUtils.isSslEnabled(pipeline), config.headersFactory(), reqRespFactory);
                 } catch (Throwable cause) {
                     channel.close();
-                    deliverTerminalFromSource(subscriber, cause);
+                    deliverErrorFromSource(subscriber, cause);
                     return;
                 }
                 subscriber.onSubscribe(delayedCancellable);
@@ -222,7 +222,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                         bs.open(promise);
                         sequentialCancellable = new SequentialCancellable(() -> promise.cancel(true));
                     } catch (Throwable cause) {
-                        deliverTerminalFromSource(subscriber, cause);
+                        deliverErrorFromSource(subscriber, cause);
                         return;
                     }
                     subscriber.onSubscribe(sequentialCancellable);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.HeaderUtils.LAST_CHUNK_PREDICATE;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
@@ -167,7 +167,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                     }).init(channel);
                 } catch (Throwable cause) {
                     channel.close();
-                    deliverTerminalFromSource(subscriber, cause);
+                    deliverErrorFromSource(subscriber, cause);
                     return;
                 }
                 subscriber.onSubscribe(delayedCancellable);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.HeaderUtils.LAST_CHUNK_PREDICATE;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
@@ -167,8 +167,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                     }).init(channel);
                 } catch (Throwable cause) {
                     channel.close();
-                    subscriber.onSubscribe(IGNORE_CANCEL);
-                    subscriber.onError(cause);
+                    deliverTerminalFromSource(subscriber, cause);
                     return;
                 }
                 subscriber.onSubscribe(delayedCancellable);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyPipelinedConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyPipelinedConnection.java
@@ -42,7 +42,7 @@ import javax.net.ssl.SSLSession;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.releaseLock;
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.tryAcquireLock;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.utils.internal.PlatformDependent.newUnboundedMpscQueue;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
@@ -276,7 +276,7 @@ final class NettyPipelinedConnection<Req, Resp> implements NettyConnectionContex
         do {
             WriteTask nextWriteTask;
             while ((nextWriteTask = writeQueue.poll()) != null) {
-                deliverTerminalFromSource(nextWriteTask.subscriber, cause);
+                deliverErrorFromSource(nextWriteTask.subscriber, cause);
             }
         } while (!releaseLock(writeQueueLockUpdater, this) && tryAcquireLock(writeQueueLockUpdater, this));
     }
@@ -288,7 +288,7 @@ final class NettyPipelinedConnection<Req, Resp> implements NettyConnectionContex
         do {
             Subscriber<? super Resp> nextSubscriber;
             while ((nextSubscriber = readQueue.poll()) != null) {
-                deliverTerminalFromSource(nextSubscriber, cause);
+                deliverErrorFromSource(nextSubscriber, cause);
             }
         } while (!releaseLock(readQueueLockUpdater, this) && tryAcquireLock(readQueueLockUpdater, this));
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyPipelinedConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyPipelinedConnectionTest.java
@@ -58,7 +58,7 @@ import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverCompleteFromSource;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
 import static io.servicetalk.transport.netty.internal.FlushStrategies.defaultFlushStrategy;
@@ -379,7 +379,7 @@ public class NettyPipelinedConnectionTest {
                 if (thrownError.compareAndSet(false, true)) {
                     throw DELIBERATE_EXCEPTION;
                 } else {
-                    deliverTerminalFromSource(subscriber);
+                    deliverCompleteFromSource(subscriber);
                 }
             }
         };

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -55,7 +55,6 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
-import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.Processors.newCompletableProcessor;
 import static io.servicetalk.concurrent.api.Processors.newSingleProcessor;
@@ -255,8 +254,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
                             delayedCancellable, NettyPipelineSslUtils.isSslEnabled(pipeline));
                 } catch (Throwable cause) {
                     channel.close();
-                    subscriber.onSubscribe(IGNORE_CANCEL);
-                    subscriber.onError(cause);
+                    deliverTerminalFromSource(subscriber, cause);
                     return;
                 }
                 subscriber.onSubscribe(delayedCancellable);

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -61,7 +61,7 @@ import static io.servicetalk.concurrent.api.Processors.newSingleProcessor;
 import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.transport.netty.internal.ChannelSet.CHANNEL_CLOSEABLE_KEY;
 import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
 import static io.servicetalk.transport.netty.internal.Flush.composeFlushes;
@@ -254,7 +254,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
                             delayedCancellable, NettyPipelineSslUtils.isSslEnabled(pipeline));
                 } catch (Throwable cause) {
                     channel.close();
-                    deliverTerminalFromSource(subscriber, cause);
+                    deliverErrorFromSource(subscriber, cause);
                     return;
                 }
                 subscriber.onSubscribe(delayedCancellable);
@@ -413,8 +413,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
             }
             return true;
         }
-        deliverTerminalFromSource(subscriber,
-                new IllegalStateException("A write is already active on this connection."));
+        deliverErrorFromSource(subscriber, new IllegalStateException("A write is already active on this connection."));
         return false;
     }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/Flush.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/Flush.java
@@ -74,8 +74,9 @@ final class Flush {
             try {
                 writeEventsListener.writeStarted();
             } finally {
-                // As long as we call onSubscribe we can let exceptions propagate and the source should terminate
-                // this Subscriber for cleanup.
+                // Any exceptions that occur will escape this method and bubble up to the Source. If this occurs the
+                // Subscription is considered cancelled and the Source should terminate this Subscriber with an onError.
+                // Before the exception propagates we must call onSubscribe so subscriber is ready for onError.
                 subscriber.onSubscribe(new Subscription() {
                     @Override
                     public void request(long n) {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelListenableAsyncCloseable.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelListenableAsyncCloseable.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static io.servicetalk.transport.netty.internal.CloseStates.CLOSING;
 import static io.servicetalk.transport.netty.internal.CloseStates.GRACEFULLY_CLOSING;
@@ -92,7 +92,7 @@ public class NettyChannelListenableAsyncCloseable implements ListenableAsyncClos
                     try {
                         doCloseAsyncGracefully();
                     } catch (Throwable t) {
-                        deliverTerminalFromSource(subscriber, t);
+                        deliverErrorFromSource(subscriber, t);
                         return;
                     }
                 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
@@ -28,8 +28,8 @@ import java.util.Queue;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.internal.EmptySubscription.EMPTY_SUBSCRIPTION;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
 import static java.util.Objects.requireNonNull;
@@ -294,8 +294,8 @@ final class NettyChannelPublisher<T> extends SubscribablePublisher<T> {
     private void subscribe0(Subscriber<? super T> subscriber) {
         SubscriptionImpl subscription = this.subscription;
         if (subscription != null) {
-            subscriber.onSubscribe(EMPTY_SUBSCRIPTION);
-            subscriber.onError(new DuplicateSubscribeException(subscription.associatedSub, subscriber));
+            deliverTerminalFromSource(subscriber,
+                    new DuplicateSubscribeException(subscription.associatedSub, subscriber));
         } else {
             assert requestCount == 0;
             subscription = new SubscriptionImpl(subscriber);

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
@@ -29,7 +29,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverTerminalFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
 import static java.util.Objects.requireNonNull;
@@ -294,7 +294,7 @@ final class NettyChannelPublisher<T> extends SubscribablePublisher<T> {
     private void subscribe0(Subscriber<? super T> subscriber) {
         SubscriptionImpl subscription = this.subscription;
         if (subscription != null) {
-            deliverTerminalFromSource(subscriber,
+            deliverErrorFromSource(subscriber,
                     new DuplicateSubscribeException(subscription.associatedSub, subscriber));
         } else {
             assert requestCount == 0;


### PR DESCRIPTION
Motivation:
The ReactiveStreams specification states that Publisher#subscribe must
not throw [1] and also that Subscriber methods must not throw [2].
However in practice these methods may throw and we need to make a best
effort to propagate exceptions and preserve the asynchronous control
flow. SubscriberUtils has utility methods deliverTerminalFromSource and
handleExceptionFromOnSubscribe to help with this task. However the
latter method may propagate exceptions which will result in our error
recovery code delivering multiple onSubscribe and onError calls which
further violates the ReactiveStreams specification [1][3]. Here is an
example:

```
NeverPublisher#subscribe()
subscriber.onSubscribe(..)
catch(cause)
handleExceptionFromOnSubscribe(..)
subscriber.onError(cause)
catch(cause2)  (in Publisher#handleSubscribe(..))
deliverTerminalFromSource(..)
subscriber.onSubscribe(..) // duplicate call by our error recovery
catch(cause3)
handleExceptionFromOnSubscribe(..)
subscriber.onError(cause3) // duplicate call by our error recovery
```

[1] https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#1.9
[2] https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#2.13
[3] https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#1.7

Modifications:
- SubscriberUtils#handleExceptionFromOnSubscribe should not re-throw
- Usage of IGNORE_CANCEL and EMPTY_SUBSCRIPTION should be investigated
to utilize the SubscriberUtils methods to minimize impact of invalid
Subscribers and preserve asynchronous control flow

Result:
More robust best-effort error recovery in the event of invalid
Subscribers throwing exceptions.