### PR TITLE
Adding TerminalSignalConsumer for Single.whenFinally et al

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AfterFinallySingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AfterFinallySingle.java
@@ -23,28 +23,29 @@ import static java.util.Objects.requireNonNull;
 
 final class AfterFinallySingle<T> extends AbstractSynchronousSingleOperator<T, T> {
 
-    private final SingleTerminalSignalConsumer<T> doFinally;
+    private final SingleTerminalSignalConsumer<? super T> doFinally;
 
-    AfterFinallySingle(Single<T> original, SingleTerminalSignalConsumer<T> doFinally, Executor executor) {
+    AfterFinallySingle(Single<T> original, SingleTerminalSignalConsumer<? super T> doFinally, Executor executor) {
         super(original, executor);
         this.doFinally = requireNonNull(doFinally);
     }
 
     @Override
     public Subscriber<? super T> apply(final Subscriber<? super T> subscriber) {
-        return new AfterFinallySingleSubscriber<>(subscriber, doFinally);
+        return new AfterFinallySingleSubscriber<T>(subscriber, doFinally);
     }
 
     private static final class AfterFinallySingleSubscriber<T> implements Subscriber<T> {
         private final Subscriber<? super T> original;
-        private final SingleTerminalSignalConsumer<T> doFinally;
+        private final SingleTerminalSignalConsumer<? super T> doFinally;
 
         private static final AtomicIntegerFieldUpdater<AfterFinallySingleSubscriber> doneUpdater =
                 AtomicIntegerFieldUpdater.newUpdater(AfterFinallySingleSubscriber.class, "done");
         @SuppressWarnings("unused")
         private volatile int done;
 
-        AfterFinallySingleSubscriber(Subscriber<? super T> original, SingleTerminalSignalConsumer<T> doFinally) {
+        AfterFinallySingleSubscriber(Subscriber<? super T> original,
+                                     SingleTerminalSignalConsumer<? super T> doFinally) {
             this.original = original;
             this.doFinally = doFinally;
         }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BeforeFinallySingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BeforeFinallySingle.java
@@ -23,28 +23,29 @@ import static java.util.Objects.requireNonNull;
 
 final class BeforeFinallySingle<T> extends AbstractSynchronousSingleOperator<T, T> {
 
-    private final SingleTerminalSignalConsumer<T> doFinally;
+    private final SingleTerminalSignalConsumer<? super T> doFinally;
 
-    BeforeFinallySingle(Single<T> original, SingleTerminalSignalConsumer<T> doFinally, Executor executor) {
+    BeforeFinallySingle(Single<T> original, SingleTerminalSignalConsumer<? super T> doFinally, Executor executor) {
         super(original, executor);
         this.doFinally = requireNonNull(doFinally);
     }
 
     @Override
     public Subscriber<? super T> apply(final Subscriber<? super T> subscriber) {
-        return new BeforeFinallySingleSubscriber<>(subscriber, doFinally);
+        return new BeforeFinallySingleSubscriber<T>(subscriber, doFinally);
     }
 
     private static final class BeforeFinallySingleSubscriber<T> implements Subscriber<T> {
         private final Subscriber<? super T> original;
-        private final SingleTerminalSignalConsumer<T> doFinally;
+        private final SingleTerminalSignalConsumer<? super T> doFinally;
 
         private static final AtomicIntegerFieldUpdater<BeforeFinallySingleSubscriber> doneUpdater =
                 AtomicIntegerFieldUpdater.newUpdater(BeforeFinallySingleSubscriber.class, "done");
         @SuppressWarnings("unused")
         private volatile int done;
 
-        BeforeFinallySingleSubscriber(Subscriber<? super T> original, SingleTerminalSignalConsumer<T> doFinally) {
+        BeforeFinallySingleSubscriber(Subscriber<? super T> original,
+                                      SingleTerminalSignalConsumer<? super T> doFinally) {
             this.original = original;
             this.doFinally = doFinally;
         }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TerminalSingleTerminalSignalConsumer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TerminalSingleTerminalSignalConsumer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import javax.annotation.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+final class TerminalSingleTerminalSignalConsumer<T> implements SingleTerminalSignalConsumer<T> {
+    private final TerminalSignalConsumer onFinally;
+
+    TerminalSingleTerminalSignalConsumer(final TerminalSignalConsumer onFinally) {
+        this.onFinally = requireNonNull(onFinally);
+    }
+
+    @Override
+    public void onSuccess(@Nullable final T result) {
+        onFinally.onComplete();
+    }
+
+    @Override
+    public void onError(final Throwable throwable) {
+        onFinally.onError(throwable);
+    }
+
+    @Override
+    public void cancel() {
+        onFinally.cancel();
+    }
+}


### PR DESCRIPTION
Motivation:

Not every consumer needs the onSuccess value.

Modifications:

- Added whenFinally/beforeFinally/afterFinally that takes a TerminalSignalConsumer
- Extended the type bounds for SingleTerminalSignalConsumer

Result:

- Can now call Single.whenFinally(TerminalSignalConsumer) if users don't need the onSuccess value
- Compiler will allow you to pass a SingleTerminalSignalConsumer typed with a super type to whenFinally/etc