### PR TITLE
Remove keep alive duration limits

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/KeepAliveTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/KeepAliveTest.java
@@ -56,9 +56,7 @@ import static java.time.Duration.ofSeconds;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeThat;
 
 @RunWith(Parameterized.class)
 public class KeepAliveTest {
@@ -96,8 +94,8 @@ public class KeepAliveTest {
 
     @Parameterized.Parameters(name = "keepAlivesFromClient? {0}, idleTimeout: {2}")
     public static Collection<Object[]> data() {
-        return asList(newParam(true, ofSeconds(10), ofSeconds(12)),
-                newParam(false, ofSeconds(10), ofSeconds(12)));
+        return asList(newParam(true, ofSeconds(1), ofSeconds(2)),
+                newParam(false, ofSeconds(1), ofSeconds(2)));
     }
 
     private static Object[] newParam(final boolean keepAlivesFromClient, final Duration keepAliveIdleDuration,
@@ -118,9 +116,6 @@ public class KeepAliveTest {
 
     @Test
     public void bidiStream() throws Exception {
-        // Ignore test on CI due to high timeouts
-        assumeThat(ServiceTalkTestTimeout.CI, is(false));
-
         try {
             client.testBiDiStream(never()).toFuture().get(idleTimeoutMillis + 100, MILLISECONDS);
             fail("Unexpected response available.");
@@ -131,9 +126,6 @@ public class KeepAliveTest {
 
     @Test
     public void requestStream() throws Exception {
-        // Ignore test on CI due to high timeouts
-        assumeThat(ServiceTalkTestTimeout.CI, is(false));
-
         try {
             client.testRequestStream(never()).toFuture().get(idleTimeoutMillis + 100, MILLISECONDS);
             fail("Unexpected response available.");
@@ -144,9 +136,6 @@ public class KeepAliveTest {
 
     @Test
     public void responseStream() throws Exception {
-        // Ignore test on CI due to high timeouts
-        assumeThat(ServiceTalkTestTimeout.CI, is(false));
-
         try {
             client.testResponseStream(TestRequest.newBuilder().build())
                     .toFuture().get(idleTimeoutMillis + 100, MILLISECONDS);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2KeepAlivePolicies.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2KeepAlivePolicies.java
@@ -88,9 +88,6 @@ public final class H2KeepAlivePolicies {
         /**
          * Set the {@link Duration} of idleness on a connection after which a
          * <a href="https://tools.ietf.org/html/rfc7540#section-6.7">ping</a> is sent.
-         * <p>
-         * <strong>Too short ping durations may cause high network traffic, so a minimum duration may be
-         * enforced.</strong>
          *
          * @param idleDuration {@link Duration} of idleness on a connection after which a
          * <a href="https://tools.ietf.org/html/rfc7540#section-6.7">ping</a> is sent.
@@ -98,11 +95,7 @@ public final class H2KeepAlivePolicies {
          * @see KeepAlivePolicy#idleDuration()
          */
         public KeepAlivePolicyBuilder idleDuration(final Duration idleDuration) {
-            if (idleDuration.getSeconds() < 10 || idleDuration.toDays() > 1) {
-                throw new IllegalArgumentException("idleDuration: " + idleDuration +
-                        " (expected >= 10 seconds and < 1 day)");
-            }
-            this.idleDuration = idleDuration;
+            this.idleDuration = requireNonNull(idleDuration);
             return this;
         }
 


### PR DESCRIPTION
__Motivation__

`H2KeepAlivePolicies` enforces limits on the idle timeout duration which is limiting for users. We should avoid providing synthetic limits and trust users to use sensible values.

__Modification__

- Remove the synthetic limits.
- Reduce timeouts for `KeepAliveTest` and enable the test for CI
__Result__

No synthetic limits.