### PR TITLE
Remove Project Communication section from CONTRIBUTORS.adoc ToC

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -13,7 +13,6 @@ get involved. Pull requests to update and expand this guide are welcome.
 ** <<Scope of the ServiceTalk Organization>>
 ** <<Opening a Pull Request>>
 ** <<Reporting Issues>>
-* <<Project Communication>>
 
 == Before you get started
 === Community Guidelines


### PR DESCRIPTION
Motivation:
d8ac3002939a5739803631b128fcbe2cf717afcc moved the Project Communication section from CONTRIBUTORS.adoc to README.adoc. The table of contents is not auto generated so the corresponding entry needs to be removed.