### PR TITLE
Consolidate concurrent.api NULL_TOKEN usage

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractProcessorBuffer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractProcessorBuffer.java
@@ -20,29 +20,19 @@ import io.servicetalk.concurrent.internal.TerminalNotification;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNull;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
 abstract class AbstractProcessorBuffer {
     private static final AtomicReferenceFieldUpdater<AbstractProcessorBuffer,
             TerminalNotification> terminalUpdater = newUpdater(AbstractProcessorBuffer.class,
             TerminalNotification.class, "terminal");
-    private static final Object NULL_ITEM = new Object();
 
     @Nullable
     private volatile TerminalNotification terminal;
 
     final boolean tryTerminate(final TerminalNotification notification) {
         return terminalUpdater.compareAndSet(this, null, notification);
-    }
-
-    static <T> Object maskNull(@Nullable final T item) {
-        return item == null ? NULL_ITEM : item;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Nullable
-    private static <T> T unmaskNull(final Object item) {
-        return item == NULL_ITEM ? null : (T) item;
     }
 
     /**
@@ -81,8 +71,7 @@ abstract class AbstractProcessorBuffer {
         if (nextItem == null) {
             return false;
         }
-        T t = unmaskNull(nextItem);
-        consumer.consumeItem(t);
+        consumer.consumeItem(unwrapNull(nextItem));
         return true;
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractProcessorBuffer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractProcessorBuffer.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.internal.TerminalNotification;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNull;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNullUnchecked;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
 abstract class AbstractProcessorBuffer {
@@ -71,7 +71,7 @@ abstract class AbstractProcessorBuffer {
         if (nextItem == null) {
             return false;
         }
-        consumer.consumeItem(unwrapNull(nextItem));
+        consumer.consumeItem(unwrapNullUnchecked(nextItem));
         return true;
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPubToSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPubToSingle.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
-import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNull;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNullUnchecked;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateSubscription;
 
 abstract class AbstractPubToSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
@@ -129,7 +129,7 @@ abstract class AbstractPubToSingle<T> extends AbstractNoHandleSubscribeSingle<T>
             if (terminal instanceof Throwable) {
                 subscriber.onError((Throwable) terminal);
             } else {
-                subscriber.onSuccess(unwrapNull(terminal));
+                subscriber.onSuccess(unwrapNullUnchecked(terminal));
             }
         }
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPubToSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPubToSingle.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNull;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateSubscription;
 
 abstract class AbstractPubToSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
@@ -53,7 +54,6 @@ abstract class AbstractPubToSingle<T> extends AbstractNoHandleSubscribeSingle<T>
 
     abstract static class AbstractPubToSingleSubscriber<T> implements PublisherSource.Subscriber<T> {
         private static final Logger LOGGER = LoggerFactory.getLogger(AbstractPubToSingleSubscriber.class);
-        private static final Object NULL_VALUE = new Object();
         private static final byte STATE_WAITING_FOR_SUBSCRIBE = 0;
         /**
          * We have called {@link PublisherSource.Subscriber#onSubscribe(Subscription)}.
@@ -129,14 +129,8 @@ abstract class AbstractPubToSingle<T> extends AbstractNoHandleSubscribeSingle<T>
             if (terminal instanceof Throwable) {
                 subscriber.onError((Throwable) terminal);
             } else {
-                @SuppressWarnings("unchecked")
-                final T t = terminal == NULL_VALUE ? null : (T) terminal;
-                subscriber.onSuccess(t);
+                subscriber.onSuccess(unwrapNull(terminal));
             }
-        }
-
-        Object wrapNull(@Nullable T t) {
-            return t == null ? NULL_VALUE : t;
         }
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPublisherProcessorSignalsHolder.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPublisherProcessorSignalsHolder.java
@@ -22,6 +22,7 @@ import java.util.Queue;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
 import static java.util.Objects.requireNonNull;
@@ -50,9 +51,9 @@ abstract class AbstractPublisherProcessorSignalsHolder<T, Q extends Queue<Object
     public void add(@Nullable final T item) {
         if (bufferedUpdater.getAndAccumulate(this, 1,
                 (prev, next) -> prev == maxBuffer ? maxBuffer : (prev + next)) == maxBuffer) {
-            offerPastBufferSize(maskNull(item), signals);
+            offerPastBufferSize(wrapNull(item), signals);
         } else {
-            offerSignal(maskNull(item));
+            offerSignal(wrapNull(item));
         }
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultBlockingProcessorSignalsHolder.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultBlockingProcessorSignalsHolder.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
 
@@ -36,7 +37,7 @@ final class DefaultBlockingProcessorSignalsHolder<T> extends AbstractProcessorBu
 
     @Override
     public void add(@Nullable final T item) throws InterruptedException {
-        signals.put(maskNull(item));
+        signals.put(wrapNull(item));
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MulticastPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MulticastPublisher.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.PublishAndSubscribeOnPublishers.deliverOnSubscribeAndOnError;
-import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNull;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNullUnchecked;
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
 import static io.servicetalk.concurrent.internal.ConcurrentSubscription.wrap;
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
@@ -188,7 +188,7 @@ final class MulticastPublisher<T> extends AbstractNoHandleSubscribePublisher<T> 
                                 return;
                             }
 
-                            onNext0(unwrapNull(next));
+                            onNext0(unwrapNullUnchecked(next));
                         }
 
                         if (reentryQueue.peek() instanceof TerminalNotification) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MulticastPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MulticastPublisher.java
@@ -35,7 +35,8 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.PublishAndSubscribeOnPublishers.deliverOnSubscribeAndOnError;
-import static io.servicetalk.concurrent.api.SubscriberApiUtils.NULL_TOKEN;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNull;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
 import static io.servicetalk.concurrent.internal.ConcurrentSubscription.wrap;
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.lang.Math.min;
@@ -142,7 +143,7 @@ final class MulticastPublisher<T> extends AbstractNoHandleSubscribePublisher<T> 
 
     private boolean offerNext(@Nullable Object o) {
         assert reentryQueue != null;
-        return reentryQueue.size() < maxQueueSize && reentryQueue.offer(o == null ? NULL_TOKEN : o);
+        return reentryQueue.size() < maxQueueSize && reentryQueue.offer(wrapNull(o));
     }
 
     private void offerTerminal(TerminalNotification notification) {
@@ -187,9 +188,7 @@ final class MulticastPublisher<T> extends AbstractNoHandleSubscribePublisher<T> 
                                 return;
                             }
 
-                            @SuppressWarnings("unchecked")
-                            final T nextT = (T) (next == NULL_TOKEN ? null : next);
-                            onNext0(nextT);
+                            onNext0(unwrapNull(next));
                         }
 
                         if (reentryQueue.peek() instanceof TerminalNotification) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MulticastUtils.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MulticastUtils.java
@@ -32,9 +32,10 @@ import java.util.function.IntConsumer;
 import java.util.function.LongSupplier;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.SubscriberApiUtils.NULL_TOKEN;
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.SUBSCRIBER_STATE_IDLE;
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.SUBSCRIBER_STATE_ON_NEXT;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNull;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.calculateSourceRequested;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.utils.internal.PlatformDependent.newUnboundedSpscQueue;
@@ -356,7 +357,7 @@ final class MulticastUtils {
                     break;
                 }
             }
-            unboundedSpsc.offer(item == null ? NULL_TOKEN : item);
+            unboundedSpsc.offer(wrapNull(item));
             return true;
         }
 
@@ -445,14 +446,12 @@ final class MulticastUtils {
                         return -totalDrainCount;
                     }
 
-                    @SuppressWarnings("unchecked")
-                    final T t = (T) (next == NULL_TOKEN ? null : next);
                     ++i;
                     // We should always keep the queue count accurate because otherwise if there is re-entry we may
                     // throw an exception due to the queue being full, but there should be at least 1 space remaining.
                     toDrain.decrementSize();
                     try {
-                        target.onNext(t);
+                        target.onNext(unwrapNull(next));
                     } catch (Throwable cause) {
                         nonTerminalErrorConsumer.accept(cause);
                         break;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MulticastUtils.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MulticastUtils.java
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.SUBSCRIBER_STATE_IDLE;
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.SUBSCRIBER_STATE_ON_NEXT;
-import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNull;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNullUnchecked;
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.calculateSourceRequested;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
@@ -451,7 +451,7 @@ final class MulticastUtils {
                     // throw an exception due to the queue being full, but there should be at least 1 space remaining.
                     toDrain.decrementSize();
                     try {
-                        target.onNext(unwrapNull(next));
+                        target.onNext(unwrapNullUnchecked(next));
                     } catch (Throwable cause) {
                         nonTerminalErrorConsumer.accept(cause);
                         break;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PubFirstOrError.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PubFirstOrError.java
@@ -20,6 +20,8 @@ import io.servicetalk.concurrent.PublisherSource;
 import java.util.NoSuchElementException;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
+
 final class PubFirstOrError<T> extends AbstractPubToSingle<T> {
 
     PubFirstOrError(Publisher<T> source) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterable.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNull;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNullUnchecked;
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
@@ -254,7 +254,7 @@ final class PublisherAsBlockingIterable<T> implements BlockingIterable<T> {
                 }
                 throw new RuntimeException(cause);
             }
-            return unwrapNull(signal);
+            return unwrapNullUnchecked(signal);
         }
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNull;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNullUnchecked;
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.releaseLock;
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.tryAcquireLock;
@@ -340,7 +340,7 @@ final class PublisherFlatMapSingle<T, R> extends AbstractAsynchronousPublisherOp
                     terminalNotification.terminate(target);
                 }
             } else {
-                target.onNext(unwrapNull(item));
+                target.onNext(unwrapNullUnchecked(item));
             }
         }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
@@ -32,7 +32,8 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.SubscriberApiUtils.NULL_TOKEN;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNull;
+import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.releaseLock;
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.tryAcquireLock;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.calculateSourceRequested;
@@ -338,12 +339,8 @@ final class PublisherFlatMapSingle<T, R> extends AbstractAsynchronousPublisherOp
                 } else {
                     terminalNotification.terminate(target);
                 }
-            } else if (item == NULL_TOKEN) {
-                target.onNext(null);
             } else {
-                @SuppressWarnings("unchecked")
-                final R rItem = (R) item;
-                target.onNext(rItem);
+                target.onNext(unwrapNull(item));
             }
         }
 
@@ -366,7 +363,7 @@ final class PublisherFlatMapSingle<T, R> extends AbstractAsynchronousPublisherOp
                 // First enqueue the result and then decrement active count. Since onComplete() checks for active count,
                 // if we decrement count before enqueuing, onComplete() may emit the terminal event without emitting
                 // the result.
-                enqueueAndDrain(result == null ? NULL_TOKEN : result);
+                enqueueAndDrain(wrapNull(result));
                 if (onSingleTerminated()) {
                     enqueueAndDrain(complete());
                 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SubscriberApiUtils.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SubscriberApiUtils.java
@@ -33,7 +33,7 @@ final class SubscriberApiUtils {
 
     @SuppressWarnings("unchecked")
     @Nullable
-    static <T> T unwrapNull(Object o) {
+    static <T> T unwrapNullUnchecked(Object o) {
         return o == NULL_TOKEN ? null : (T) o;
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SubscriberApiUtils.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SubscriberApiUtils.java
@@ -15,13 +15,25 @@
  */
 package io.servicetalk.concurrent.api;
 
+import javax.annotation.Nullable;
+
 final class SubscriberApiUtils {
-    static final Object NULL_TOKEN = new Object();
+    private static final Object NULL_TOKEN = new Object();
     static final int SUBSCRIBER_STATE_IDLE = 0;
     static final int SUBSCRIBER_STATE_ON_NEXT = 1;
     static final int SUBSCRIBER_STATE_TERMINATED = 2;
 
     private SubscriberApiUtils() {
         // no instances
+    }
+
+    static Object wrapNull(@Nullable Object o) {
+        return o == null ? NULL_TOKEN : o;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    static <T> T unwrapNull(Object o) {
+        return o == NULL_TOKEN ? null : (T) o;
     }
 }


### PR DESCRIPTION
Motivation:
SubscriberApiUtils exposes a NULL_TOKEN to the concurrent.api package
and usages share common code to wrap/unwrap the null token. This could
could be shared into methods instead of duplicated.

Modifications:
- Make SubscriberApiUtils#NULL_TOKEN private
- Add SubscriberApiUtils wrapNull and unwrapNull methods

Result:
More shared code in concurrent.api for wrapping/unwrapping NULL_TOKEN.