### PR TITLE
Publisher#flatMapMergeSingle avoid queue if no concurrency

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
@@ -251,11 +251,8 @@ final class PublisherFlatMapSingle<T, R> extends AbstractAsynchronousPublisherOp
         private void tryEmitItem(final Object item) {
             if (tryAcquireLock(emittingUpdater, this)) { // fast path. no concurrency, avoid the queue and emit.
                 try {
-                    try {
-                        sendToTarget(item);
-                    } finally {
-                        doDrainPostProcessing(1);
-                    }
+                    sendToTarget(item);
+                    doDrainPostProcessing(1);
                 } finally {
                     if (!releaseLock(emittingUpdater, this)) {
                         drainPending();
@@ -293,12 +290,12 @@ final class PublisherFlatMapSingle<T, R> extends AbstractAsynchronousPublisherOp
                 }
             }
 
-            if (drainCount != 0) {
-                doDrainPostProcessing(drainCount);
-            }
-
             if (delayedCause != null) {
                 throwException(delayedCause);
+            }
+
+            if (drainCount != 0) {
+                doDrainPostProcessing(drainCount);
             }
         }
 


### PR DESCRIPTION
Motivation:
Publisher#flatMapMergeSingle currently enqueues all signals before
emitting to the downstream Subscriber. Going through the queue leverages
the concurrency controls around the queue to prevent concurrent
emissions and also provides an ordering of emissions. The ordering of
emissions is only necessary for terminal completion events to ensure we
process all outstanding signals before terminating, and otherwise there
is no ordering requirements between independent mapped Singles.

Modifications:
- add PublisherFlatMapSingle#tryEmitSignal which supports a fast path
for direct emission without going through the queue if there is no
concurrency detected.

Result:
Publisher#flatMapMergeSingle uses less memory and avoids queuing signals
if no concurrency.