### PR TITLE
Introduce HTTP Zipkin reporter

### DIFF
--- a/servicetalk-opentracing-zipkin-publisher/build.gradle
+++ b/servicetalk-opentracing-zipkin-publisher/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   api project(":servicetalk-opentracing-inmemory-api")
   api project(":servicetalk-concurrent-api")
   api project(":servicetalk-transport-api")
+  api project(":servicetalk-http-api")
   api "io.zipkin.zipkin2:zipkin:$zipkinVersion"
   api "io.zipkin.reporter2:zipkin-reporter:$zipkinReporterVersion"
 
@@ -41,6 +42,7 @@ dependencies {
   testImplementation project(":servicetalk-opentracing-asynccontext")
   testImplementation project(":servicetalk-opentracing-inmemory")
   testImplementation project(":servicetalk-test-resources")
+  testImplementation project(":servicetalk-http-netty")
   testImplementation "junit:junit:$junitVersion"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"

--- a/servicetalk-opentracing-zipkin-publisher/build.gradle
+++ b/servicetalk-opentracing-zipkin-publisher/build.gradle
@@ -43,6 +43,7 @@ dependencies {
   testImplementation project(":servicetalk-opentracing-inmemory")
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-http-netty")
+  testImplementation project(":servicetalk-utils-internal")
   testImplementation "junit:junit:$junitVersion"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/ZipkinPublisher.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/ZipkinPublisher.java
@@ -45,8 +45,7 @@ import static java.util.Objects.requireNonNull;
  * A publisher of {@link io.opentracing.Span}s to the zipkin transport.
  */
 public final class ZipkinPublisher implements InMemorySpanEventListener, AsyncCloseable, Closeable {
-
-    private static final Logger logger = LoggerFactory.getLogger(ZipkinPublisher.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZipkinPublisher.class);
 
     private final Reporter<Span> reporter;
     private final Endpoint endpoint;
@@ -65,7 +64,7 @@ public final class ZipkinPublisher implements InMemorySpanEventListener, AsyncCl
                     try {
                         ((Flushable) reporter).flush();
                     } catch (IOException e) {
-                        logger.error("Exception while flushing reporter: {}", e.getMessage(), e);
+                        LOGGER.error("Exception while flushing reporter: {}", e.getMessage(), e);
                     }
                 });
             }
@@ -79,7 +78,7 @@ public final class ZipkinPublisher implements InMemorySpanEventListener, AsyncCl
                     try {
                         ((Closeable) reporter).close();
                     } catch (IOException e) {
-                        logger.error("Exception while closing reporter: {}", e.getMessage(), e);
+                        LOGGER.error("Exception while closing reporter: {}", e.getMessage(), e);
                     }
                 });
             }
@@ -182,7 +181,11 @@ public final class ZipkinPublisher implements InMemorySpanEventListener, AsyncCl
         }
 
         Span s = builder.build();
-        reporter.report(s);
+        try {
+            reporter.report(s);
+        } catch (Throwable t) {
+            LOGGER.error("Failed to report a span {}", s, t);
+        }
     }
 
     /**

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/Codec.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/Codec.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.opentracing.zipkin.publisher.reporter;
+
+import zipkin2.Span;
+import zipkin2.codec.SpanBytesEncoder;
+
+/**
+ * Zipkin data formats for reporting of {@link Span}s.
+ */
+public enum Codec {
+    /**
+     * Zipkin V1 JSON format.
+     */
+    JSON_V1(SpanBytesEncoder.JSON_V1),
+    /**
+     * Zipkin V2 JSON format.
+     */
+    JSON_V2(SpanBytesEncoder.JSON_V2),
+    /**
+     * Zipkin V2 THRIFT format.
+     */
+    THRIFT(SpanBytesEncoder.THRIFT),
+    /**
+     * Zipkin V2 protocol buffers V3 format.
+     */
+    PROTO3(SpanBytesEncoder.PROTO3);
+
+    private final SpanBytesEncoder encoder;
+
+    Codec(SpanBytesEncoder encoder) {
+        this.encoder = encoder;
+    }
+
+    SpanBytesEncoder spanBytesEncoder() {
+        return encoder;
+    }
+}

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporter.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporter.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.opentracing.zipkin.publisher.reporter;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.concurrent.CompletableSource;
+import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.api.AsyncCloseable;
+import io.servicetalk.concurrent.api.BufferStrategy.Accumulator;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.CompositeCloseable;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import zipkin2.Component;
+import zipkin2.Span;
+import zipkin2.codec.SpanBytesEncoder;
+import zipkin2.reporter.Reporter;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
+import static io.servicetalk.concurrent.api.AsyncCloseables.toAsyncCloseable;
+import static io.servicetalk.concurrent.api.BufferStrategies.forCountOrTime;
+import static io.servicetalk.concurrent.api.Completable.completed;
+import static io.servicetalk.concurrent.api.Processors.newCompletableProcessor;
+import static io.servicetalk.concurrent.api.Processors.newPublisherProcessorDropHeadOnOverflow;
+import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
+import static io.servicetalk.http.api.CharSequences.newAsciiString;
+import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
+import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_JSON;
+import static java.time.Duration.ofSeconds;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A {@link Span} {@link Reporter} that will publish to an HTTP endpoint with a configurable encoding {@link Codec}.
+ */
+public final class HttpReporter extends Component implements Reporter<Span>, AsyncCloseable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpReporter.class);
+    static final String V1_PATH = "/api/v1/spans";
+    static final String V2_PATH = "/api/v2/spans";
+    static final CharSequence THRIFT_CONTENT_TYPE = newAsciiString("application/x-thrift");
+    static final CharSequence PROTO_CONTENT_TYPE = newAsciiString("application/protobuf");
+
+    private final PublisherSource.Processor<Span, Span> buffer;
+    private final AsyncCloseable closeable;
+
+    private volatile boolean closeInitiated;
+
+    private HttpReporter(final Builder builder) {
+        final HttpClient client = builder.clientBuilder.build();
+        SpanBytesEncoder spanEncoder = builder.codec.spanBytesEncoder();
+        final String path;
+        final CharSequence contentType;
+        switch (builder.codec) {
+            case JSON_V1:
+                path = V1_PATH;
+                contentType = APPLICATION_JSON;
+                break;
+            case JSON_V2:
+                path = V2_PATH;
+                contentType = APPLICATION_JSON;
+                break;
+            case THRIFT:
+                path = V2_PATH;
+                contentType = THRIFT_CONTENT_TYPE;
+                break;
+            case PROTO3:
+                path = V2_PATH;
+                contentType = PROTO_CONTENT_TYPE;
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown codec: " + builder.codec);
+        }
+        final BufferAllocator allocator = client.executionContext().bufferAllocator();
+        Publisher<Buffer> spans;
+        if (builder.disableBatching) {
+            buffer = newPublisherProcessorDropHeadOnOverflow(builder.maxConcurrentReports);
+            spans = fromSource(buffer).map(span -> allocator.wrap(spanEncoder.encode(span)));
+        } else {
+            buffer = newPublisherProcessorDropHeadOnOverflow(builder.batchSizeHint * builder.maxConcurrentReports);
+            spans = fromSource(buffer)
+                    .buffer(forCountOrTime(builder.batchSizeHint, builder.maxBatchDuration,
+                            () -> new ListAccumulator(builder.batchSizeHint), client.executionContext().executor()))
+                    .filter(accumulate -> !accumulate.isEmpty())
+                    .map(bufferedSpans -> allocator.wrap(spanEncoder.encodeList(bufferedSpans)));
+        }
+
+        final CompletableSource.Processor spansTerminated = newCompletableProcessor();
+        toSource(spans.flatMapCompletable(encodedSpans -> reportSpans(client, encodedSpans, path, contentType),
+                builder.maxConcurrentReports)).subscribe(spansTerminated);
+
+        CompositeCloseable closeable = newCompositeCloseable();
+        closeable.append(toAsyncCloseable(graceful -> {
+            closeInitiated = true;
+            try {
+                buffer.onComplete();
+            } catch (Throwable t) {
+                LOGGER.error("Failed to dispose request buffer. Ignoring.", t);
+            }
+            return graceful ? fromSource(spansTerminated) : completed();
+        }));
+        closeable.append(client);
+        this.closeable = closeable;
+    }
+
+    private Completable reportSpans(final HttpClient client, final Buffer encodedSpans, final String path,
+                                    final CharSequence contentType) {
+        return client.request(client.post(path).addHeader(CONTENT_TYPE, contentType).payloadBody(encodedSpans))
+                .ignoreElement()
+                .onErrorResume(cause -> {
+                    LOGGER.error("Failed to send a span, ignoring.", cause);
+                    return completed();
+                });
+    }
+
+    /**
+     * A builder to create a new {@link HttpReporter}.
+     */
+    public static final class Builder {
+        private Codec codec = Codec.JSON_V2;
+        private final SingleAddressHttpClientBuilder<?, ?> clientBuilder;
+        private boolean disableBatching;
+        private int batchSizeHint = 16;
+        private int maxConcurrentReports = 32;
+        private Duration maxBatchDuration = ofSeconds(30);
+
+        /**
+         * Create a new {@link Builder} using the passed {@link SingleAddressHttpClientBuilder}.
+         *
+         * @param clientBuilder the collector SocketAddress
+         */
+        public Builder(final SingleAddressHttpClientBuilder<?, ?> clientBuilder) {
+            this.clientBuilder = clientBuilder;
+        }
+
+        /**
+         * Sets the {@link Codec} to encode the Spans with.
+         *
+         * @param codec the codec to use for this span.
+         * @return {@code this}
+         */
+        public Builder codec(Codec codec) {
+            this.codec = requireNonNull(codec);
+            return this;
+        }
+
+        public Builder maxConcurrentReports(final int maxConcurrentReports) {
+            this.maxConcurrentReports = maxConcurrentReports;
+            return this;
+        }
+
+        /**
+         * Configure batching of spans before sending it to the zipkin collector.
+         *
+         * @param batchSizeHint Hint of how many spans should be batched together.
+         * @param maxBatchDuration {@link Duration} of time to wait for {@code batchSizeHint} spans in a batch.
+         * @return {@code this}.
+         */
+        public Builder batchSpans(final int batchSizeHint, final Duration maxBatchDuration) {
+            if (batchSizeHint <= 0) {
+                throw new IllegalArgumentException("batchSizeHint: " + batchSizeHint + " (expected > 0)");
+            }
+            disableBatching = false;
+            this.batchSizeHint = batchSizeHint;
+            this.maxBatchDuration = requireNonNull(maxBatchDuration);
+            return this;
+        }
+
+        /**
+         * Disable batching of spans before sending them to the zipkin collector.
+         *
+         * @return {@code this}.
+         */
+        public Builder disableSpanBatching() {
+            disableBatching = true;
+            return this;
+        }
+
+        /**
+         * Builds a new {@link HttpReporter} instance with this builder's options.
+         *
+         * @return a new {@link HttpReporter}
+         */
+        public HttpReporter build() {
+            return new HttpReporter(this);
+        }
+    }
+
+    @Override
+    public void report(final Span span) {
+        if (closeInitiated) {
+            throw new IllegalStateException("Span: " + span + " reported after reporter " + this + " is closed.");
+        }
+        buffer.onNext(span);
+    }
+
+    @Override
+    public void close() {
+        awaitTermination(closeable.closeAsync().toFuture());
+    }
+
+    @Override
+    public Completable closeAsync() {
+        return closeable.closeAsync();
+    }
+
+    @Override
+    public Completable closeAsyncGracefully() {
+        return closeable.closeAsyncGracefully();
+    }
+
+    private static final class ListAccumulator implements Accumulator<Span, List<Span>> {
+        private final List<Span> accumulate;
+
+        ListAccumulator(final int size) {
+            accumulate = new ArrayList<>(size);
+        }
+
+        @Override
+        public void accumulate(@Nonnull final Span item) {
+            accumulate.add(requireNonNull(item));
+        }
+
+        @Override
+        public List<Span> finish() {
+            return accumulate;
+        }
+    }
+}

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporter.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporter.java
@@ -95,7 +95,7 @@ public final class HttpReporter extends Component implements Reporter<Span>, Asy
                 throw new IllegalArgumentException("Unknown codec: " + builder.codec);
         }
         final BufferAllocator allocator = client.executionContext().bufferAllocator();
-        Publisher<Buffer> spans;
+        final Publisher<Buffer> spans;
         if (builder.disableBatching) {
             buffer = newPublisherProcessorDropHeadOnOverflow(builder.maxConcurrentReports);
             spans = fromSource(buffer).map(span -> allocator.wrap(spanEncoder.encode(span)));

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporter.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporter.java
@@ -18,7 +18,6 @@ package io.servicetalk.opentracing.zipkin.publisher.reporter;
 import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.netty.internal.NettyChannelListenableAsyncCloseable;
 import io.servicetalk.transport.netty.internal.StacklessClosedChannelException;
@@ -60,14 +59,14 @@ import static java.util.Objects.requireNonNull;
  */
 public final class UdpReporter extends Component implements Reporter<Span>, AsyncCloseable {
 
-    private static final Logger logger = LoggerFactory.getLogger(UdpReporter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(UdpReporter.class);
 
     private static final int DEFAULT_MAX_DATAGRAM_PACKET_SIZE = 2048; // 2Kib
     private static final MaxMessagesRecvByteBufAllocator DEFAULT_RECV_BUF_ALLOCATOR =
             new FixedRecvByteBufAllocator(DEFAULT_MAX_DATAGRAM_PACKET_SIZE);
 
     private final Channel channel;
-    private final ListenableAsyncCloseable closeable;
+    private final AsyncCloseable closeable;
 
     private UdpReporter(final Builder builder) {
         EventLoopGroup group = toEventLoopAwareNettyIoExecutor(
@@ -81,7 +80,7 @@ public final class UdpReporter extends Component implements Reporter<Span>, Asyn
             currentThread().interrupt(); // Reset the interrupted flag.
             throw new IllegalStateException("Failed to create UDP client");
         } catch (Exception e) {
-            logger.warn("Failed to create UDP client", e);
+            LOGGER.warn("Failed to create UDP client", e);
             throw e;
         }
         Executor executor = builder.executor != null ? builder.executor :

--- a/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporterTest.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporterTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.opentracing.zipkin.publisher.reporter;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.concurrent.api.AsyncCloseables;
+import io.servicetalk.concurrent.api.CompositeCloseable;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.opentracing.zipkin.publisher.reporter.HttpReporter.Builder;
+import io.servicetalk.transport.api.ServerContext;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import zipkin2.Span;
+import zipkin2.codec.SpanBytesDecoder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.UnaryOperator;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
+import static io.servicetalk.http.netty.HttpServers.forAddress;
+import static io.servicetalk.opentracing.zipkin.publisher.reporter.HttpReporter.V1_PATH;
+import static io.servicetalk.opentracing.zipkin.publisher.reporter.HttpReporter.V2_PATH;
+import static io.servicetalk.opentracing.zipkin.publisher.reporter.SpanUtils.newSpan;
+import static io.servicetalk.opentracing.zipkin.publisher.reporter.SpanUtils.verifySpan;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.time.Duration.ofMillis;
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThrows;
+
+@RunWith(Parameterized.class)
+public class HttpReporterTest {
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+
+    private final BlockingQueue<HttpRequest> receivedRequests;
+    private final ServerContext context;
+    private final Codec codec;
+    @Nullable
+    private HttpReporter reporter;
+
+    public HttpReporterTest(final Codec codec) throws Exception {
+        this.codec = codec;
+        receivedRequests = new LinkedBlockingQueue<>();
+        this.context = forAddress(localAddress(0))
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> {
+                    receivedRequests.add(request);
+                    return responseFactory.ok();
+                });
+    }
+
+    @Parameterized.Parameters(name = "codec: {0}")
+    public static Collection<Codec> data() {
+        return asList(Codec.values());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        CompositeCloseable closeable = AsyncCloseables.newCompositeCloseable();
+        if (reporter != null) {
+            closeable.append(reporter);
+        }
+        closeable.append(context);
+        closeable.closeGracefully();
+    }
+
+    @Test
+    public void disableBatching() throws Exception {
+        HttpReporter reporter = initReporter(Builder::disableSpanBatching);
+        reporter.report(newSpan());
+        List<Span> spans = verifyRequest(receivedRequests.take(), false);
+        assertThat("Unexpected spans received.", spans, hasSize(1));
+        verifySpan(spans.get(0));
+        reporter.report(newSpan());
+        assertThat("Unexpected spans received.", spans, hasSize(1));
+        verifySpan(spans.get(0));
+    }
+
+    @Test
+    public void batching() throws Exception {
+        HttpReporter reporter = initReporter(builder -> builder.batchSpans(2, ofMillis(200)));
+        reporter.report(newSpan());
+        reporter.report(newSpan());
+        List<Span> spans = verifyRequest(receivedRequests.take(), true);
+        assertThat("Unexpected spans received.", spans, hasSize(2));
+        verifySpan(spans.get(0));
+        verifySpan(spans.get(0));
+    }
+
+    @Test
+    public void reportAfterClose() {
+        HttpReporter reporter = initReporter(Builder::disableSpanBatching);
+        reporter.close();
+        assertThrows("Report post close accepted.", IllegalStateException.class, () -> reporter.report(newSpan()));
+    }
+
+    private List<Span> verifyRequest(final HttpRequest request, final boolean multipleSpans) {
+        SpanBytesDecoder decoder;
+        switch (codec) {
+            case JSON_V1:
+                assertThat("Unexpected path.", request.path(), equalTo(V1_PATH));
+                decoder = SpanBytesDecoder.JSON_V1;
+                break;
+            case JSON_V2:
+                assertThat("Unexpected path.", request.path(), equalTo(V2_PATH));
+                decoder = SpanBytesDecoder.JSON_V2;
+                break;
+            case THRIFT:
+                assertThat("Unexpected path.", request.path(), equalTo(V2_PATH));
+                decoder = SpanBytesDecoder.THRIFT;
+                break;
+            case PROTO3:
+                assertThat("Unexpected path.", request.path(), equalTo(V2_PATH));
+                decoder = SpanBytesDecoder.PROTO3;
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown codec: " + codec);
+        }
+        Buffer buffer = request.payloadBody();
+        byte[] data = new byte[buffer.readableBytes()];
+        buffer.readBytes(data);
+        List<Span> decoded = new ArrayList<>();
+        if (multipleSpans) {
+            decoder.decodeList(data, decoded);
+        } else {
+            decoder.decode(data, decoded);
+        }
+        return decoded;
+    }
+
+    private HttpReporter initReporter(UnaryOperator<Builder> configurator) {
+        reporter = configurator.apply(new Builder(forSingleAddress(serverHostAndPort(context))).codec(codec)).build();
+        return reporter;
+    }
+}

--- a/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/SpanUtils.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/SpanUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.opentracing.zipkin.publisher.reporter;
+
+import zipkin2.Span;
+
+import java.util.Map;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+final class SpanUtils {
+    private SpanUtils() {
+        // no instances
+    }
+
+    static Span newSpan() {
+        return Span.newBuilder()
+                .name("test operation")
+                .traceId("1234")
+                .id(2)
+                .timestamp(123456789L)
+                .duration(SECONDS.toMicros(1))
+                .putTag("stringKey", "string")
+                .putTag("boolKey", String.valueOf(true))
+                .putTag("shortKey", String.valueOf(Short.MAX_VALUE))
+                .putTag("intKey", String.valueOf(Integer.MAX_VALUE))
+                .putTag("longKey", String.valueOf(Long.MAX_VALUE))
+                .putTag("floatKey", String.valueOf(Float.MAX_VALUE))
+                .putTag("doubleKey", String.valueOf(Double.MAX_VALUE))
+                .addAnnotation(System.currentTimeMillis() * 1000, "some event happened")
+                .build();
+    }
+
+    static void verifySpan(final Span span) {
+        assertEquals("test operation", span.name());
+        assertEquals("0000000000001234", span.traceId());
+        assertEquals("0000000000000002", span.id());
+        assertEquals(123456789L, (long) span.timestamp());
+        assertEquals(1000 * 1000, (long) span.duration());
+        Map<String, String> tags = span.tags();
+        assertEquals("string", tags.get("stringKey"));
+        assertEquals(Boolean.TRUE.toString(), tags.get("boolKey"));
+        assertEquals(String.valueOf(Short.MAX_VALUE), tags.get("shortKey"));
+        assertEquals(String.valueOf(Integer.MAX_VALUE), tags.get("intKey"));
+        assertEquals(String.valueOf(Long.MAX_VALUE), tags.get("longKey"));
+        assertEquals(String.valueOf(Float.MAX_VALUE), tags.get("floatKey"));
+        assertEquals(String.valueOf(Double.MAX_VALUE), tags.get("doubleKey"));
+        assertTrue(span.annotations().stream().anyMatch(a -> a.value().equals("some event happened")));
+    }
+}

--- a/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/SpanUtils.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/SpanUtils.java
@@ -28,7 +28,6 @@ final class SpanUtils {
     private static final long TIMESTAMP = 123456789L;
     private static final String TRACE_ID = "0000000000001234";
     private static final String SPAN_ID = "0000000000000002";
-    private static final String NAME = "test operation";
     private static final long DURATION = SECONDS.toMicros(1);
     private static final String STRING_KEY_TAG_NAME = "stringKey";
     private static final String STRING_KEY_TAG_VALUE = "string";
@@ -44,9 +43,9 @@ final class SpanUtils {
         // no instances
     }
 
-    static Span newSpan() {
+    static Span newSpan(final String name) {
         return Span.newBuilder()
-                .name(NAME)
+                .name(name)
                 .traceId(TRACE_ID)
                 .id(SPAN_ID)
                 .timestamp(TIMESTAMP)
@@ -62,8 +61,8 @@ final class SpanUtils {
                 .build();
     }
 
-    static void verifySpan(final Span span) {
-        assertEquals(NAME, span.name());
+    static void verifySpan(final Span span, final String expectedName) {
+        assertEquals(expectedName, span.name());
         assertEquals(TRACE_ID, span.traceId());
         assertEquals(SPAN_ID, span.id());
         assertEquals(TIMESTAMP, (long) span.timestamp());

--- a/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/SpanUtils.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/SpanUtils.java
@@ -24,42 +24,58 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 final class SpanUtils {
+
+    private static final long TIMESTAMP = 123456789L;
+    private static final String TRACE_ID = "0000000000001234";
+    private static final String SPAN_ID = "0000000000000002";
+    private static final String NAME = "test operation";
+    private static final long DURATION = SECONDS.toMicros(1);
+    private static final String STRING_KEY_TAG_NAME = "stringKey";
+    private static final String STRING_KEY_TAG_VALUE = "string";
+    private static final String BOOL_KEY_TAG_NAME = "boolKey";
+    private static final String SHORT_KEY_TAG_NAME = "shortKey";
+    private static final String INT_KEY_TAG_NAME = "intKey";
+    private static final String LONG_KEY_TAG_NAME = "longKey";
+    private static final String FLOAT_KEY_TAG_NAME = "floatKey";
+    private static final String DOUBLE_KEY_TAG_NAME = "doubleKey";
+    private static final String ANNOTATION_VAL = "some event happened";
+
     private SpanUtils() {
         // no instances
     }
 
     static Span newSpan() {
         return Span.newBuilder()
-                .name("test operation")
-                .traceId("1234")
-                .id(2)
-                .timestamp(123456789L)
-                .duration(SECONDS.toMicros(1))
-                .putTag("stringKey", "string")
-                .putTag("boolKey", String.valueOf(true))
-                .putTag("shortKey", String.valueOf(Short.MAX_VALUE))
-                .putTag("intKey", String.valueOf(Integer.MAX_VALUE))
-                .putTag("longKey", String.valueOf(Long.MAX_VALUE))
-                .putTag("floatKey", String.valueOf(Float.MAX_VALUE))
-                .putTag("doubleKey", String.valueOf(Double.MAX_VALUE))
-                .addAnnotation(System.currentTimeMillis() * 1000, "some event happened")
+                .name(NAME)
+                .traceId(TRACE_ID)
+                .id(SPAN_ID)
+                .timestamp(TIMESTAMP)
+                .duration(DURATION)
+                .putTag(STRING_KEY_TAG_NAME, STRING_KEY_TAG_VALUE)
+                .putTag(BOOL_KEY_TAG_NAME, String.valueOf(true))
+                .putTag(SHORT_KEY_TAG_NAME, String.valueOf(Short.MAX_VALUE))
+                .putTag(INT_KEY_TAG_NAME, String.valueOf(Integer.MAX_VALUE))
+                .putTag(LONG_KEY_TAG_NAME, String.valueOf(Long.MAX_VALUE))
+                .putTag(FLOAT_KEY_TAG_NAME, String.valueOf(Float.MAX_VALUE))
+                .putTag(DOUBLE_KEY_TAG_NAME, String.valueOf(Double.MAX_VALUE))
+                .addAnnotation(System.currentTimeMillis() * 1000, ANNOTATION_VAL)
                 .build();
     }
 
     static void verifySpan(final Span span) {
-        assertEquals("test operation", span.name());
-        assertEquals("0000000000001234", span.traceId());
-        assertEquals("0000000000000002", span.id());
-        assertEquals(123456789L, (long) span.timestamp());
-        assertEquals(1000 * 1000, (long) span.duration());
+        assertEquals(NAME, span.name());
+        assertEquals(TRACE_ID, span.traceId());
+        assertEquals(SPAN_ID, span.id());
+        assertEquals(TIMESTAMP, (long) span.timestamp());
+        assertEquals(DURATION, (long) span.duration());
         Map<String, String> tags = span.tags();
-        assertEquals("string", tags.get("stringKey"));
-        assertEquals(Boolean.TRUE.toString(), tags.get("boolKey"));
-        assertEquals(String.valueOf(Short.MAX_VALUE), tags.get("shortKey"));
-        assertEquals(String.valueOf(Integer.MAX_VALUE), tags.get("intKey"));
-        assertEquals(String.valueOf(Long.MAX_VALUE), tags.get("longKey"));
-        assertEquals(String.valueOf(Float.MAX_VALUE), tags.get("floatKey"));
-        assertEquals(String.valueOf(Double.MAX_VALUE), tags.get("doubleKey"));
-        assertTrue(span.annotations().stream().anyMatch(a -> a.value().equals("some event happened")));
+        assertEquals(STRING_KEY_TAG_VALUE, tags.get(STRING_KEY_TAG_NAME));
+        assertEquals(Boolean.TRUE.toString(), tags.get(BOOL_KEY_TAG_NAME));
+        assertEquals(String.valueOf(Short.MAX_VALUE), tags.get(SHORT_KEY_TAG_NAME));
+        assertEquals(String.valueOf(Integer.MAX_VALUE), tags.get(INT_KEY_TAG_NAME));
+        assertEquals(String.valueOf(Long.MAX_VALUE), tags.get(LONG_KEY_TAG_NAME));
+        assertEquals(String.valueOf(Float.MAX_VALUE), tags.get(FLOAT_KEY_TAG_NAME));
+        assertEquals(String.valueOf(Double.MAX_VALUE), tags.get(DOUBLE_KEY_TAG_NAME));
+        assertTrue(span.annotations().stream().anyMatch(a -> a.value().equals(ANNOTATION_VAL)));
     }
 }


### PR DESCRIPTION
__Motivation__

We do not currently provide a zipkin reporter implementation for HTTP collectors. Providing an HTTP reporter using ServiceTalk HTTP client will be useful when ServiceTalk HTTP client is used otherwise in applications.

__Modification__

Add an `HttpReporter` with configurable batching strategy.

__Result__

Users can use ServiceTalk HTTP client to publish spans to a Zipkin collector.