### PR TITLE
RoundRobinLoadBalancer to allow duplicate addresses

### DIFF
--- a/servicetalk-benchmarks/build.gradle
+++ b/servicetalk-benchmarks/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   implementation project(":servicetalk-http-api")
   implementation project(":servicetalk-http-netty")
   implementation project(":servicetalk-transport-netty-internal")
+  implementation project(":servicetalk-loadbalancer")
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
   implementation "io.netty:netty-codec-http:$nettyVersion"
   implementation "org.openjdk.jmh:jmh-core:$jmhCoreVersion"

--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/loadbalancer/RoundRobinLoadBalancerSDEventsBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/loadbalancer/RoundRobinLoadBalancerSDEventsBenchmark.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.benchmark.loadbalancer;
+
+import io.servicetalk.client.api.ConnectionFactory;
+import io.servicetalk.client.api.DefaultServiceDiscovererEvent;
+import io.servicetalk.client.api.LoadBalancedConnection;
+import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.loadbalancer.RoundRobinLoadBalancer;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.servicetalk.concurrent.api.Completable.completed;
+import static io.servicetalk.concurrent.api.Publisher.fromIterable;
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static java.net.InetSocketAddress.createUnresolved;
+
+@Fork(1)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 5)
+@Measurement(iterations = 5, time = 5)
+public class RoundRobinLoadBalancerSDEventsBenchmark {
+    @Param({"5", "10", "100"})
+    public int ops;
+
+    private List<ServiceDiscovererEvent<InetSocketAddress>> availableEvents;
+    private List<ServiceDiscovererEvent<InetSocketAddress>> mixedEvents;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        final int removalStride = 5;
+        availableEvents = new ArrayList<>(ops);
+        mixedEvents = new ArrayList<>(ops);
+        for (int i = 1; i <= ops; ++i) {
+            if (i % removalStride == 0) {
+                mixedEvents.add(new DefaultServiceDiscovererEvent<>(createUnresolved("127.0.0." + (i - 1), 0), false));
+            } else {
+                mixedEvents.add(new DefaultServiceDiscovererEvent<>(createUnresolved("127.0.0." + i, 0), true));
+            }
+            availableEvents.add(new DefaultServiceDiscovererEvent<>(createUnresolved("127.0.0." + i, 0), true));
+        }
+    }
+
+    @Benchmark
+    public RoundRobinLoadBalancer<InetSocketAddress, LoadBalancedConnection> mixed() {
+        // RR load balancer synchronously subscribes and will consume all events during construction.
+        return new RoundRobinLoadBalancer<>(fromIterable(mixedEvents), ConnFactory.INSTANCE);
+    }
+
+    @Benchmark
+    public RoundRobinLoadBalancer<InetSocketAddress, LoadBalancedConnection> available() {
+        // RR load balancer synchronously subscribes and will consume all events during construction.
+        return new RoundRobinLoadBalancer<>(fromIterable(availableEvents), ConnFactory.INSTANCE);
+    }
+
+    private static final class ConnFactory implements ConnectionFactory<InetSocketAddress, LoadBalancedConnection> {
+        static final ConnFactory INSTANCE = new ConnFactory();
+
+        private ConnFactory() {
+        }
+
+        @Override
+        public Single<LoadBalancedConnection> newConnection(final InetSocketAddress inetSocketAddress) {
+            return succeeded(new LoadBalancedConnection() {
+                @Override
+                public int score() {
+                    return 0;
+                }
+
+                @Override
+                public Completable onClose() {
+                    return completed();
+                }
+
+                @Override
+                public Completable closeAsync() {
+                    return completed();
+                }
+
+                @Override
+                public Completable closeAsyncGracefully() {
+                    return completed();
+                }
+            });
+        }
+
+        @Override
+        public Completable onClose() {
+            return completed();
+        }
+
+        @Override
+        public Completable closeAsync() {
+            return completed();
+        }
+    }
+}

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -173,12 +173,12 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
                                     for (int x = i + 1; x < oldHostsTyped.size(); ++x) {
                                         newHosts.add(oldHostsTyped.get(x));
                                     }
-                                    break;
+                                    return newHosts.isEmpty() ? emptyList() : newHosts;
                                 } else {
                                     newHosts.add(host);
                                 }
                             }
-                            return newHosts.isEmpty() ? emptyList() : newHosts;
+                            return newHosts;
                         }
                     });
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -150,40 +150,39 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
                         event);
                 @SuppressWarnings("unchecked")
                 final List<Host<ResolvedAddress, C>> activeAddresses =
-                        activeHostsUpdater.updateAndGet(RoundRobinLoadBalancer.this, oldHosts -> {
-                            final ResolvedAddress addr = requireNonNull(event.address());
-                            @SuppressWarnings("unchecked")
-                            final List<Host<ResolvedAddress, C>> oldHostsTyped =
-                                    (List<Host<ResolvedAddress, C>>) oldHosts;
-                            if (event.isAvailable()) {
-                                if (oldHosts.isEmpty()) {
-                                    return singletonList(new Host<>(addr));
-                                }
-                                final List<Host<ResolvedAddress, C>> newHosts = new ArrayList<>(oldHosts.size() + 1);
-                                newHosts.addAll(oldHostsTyped);
-                                newHosts.add(new Host<>(addr));
-                                return newHosts;
-                            } else if (oldHosts.isEmpty()) {
-                                return emptyList();
-                            } else {
-                                final List<Host<ResolvedAddress, C>> newHosts = new ArrayList<>(oldHosts.size() - 1);
-                                int i = 0;
-                                for (; i < oldHostsTyped.size(); ++i) {
-                                    final Host<ResolvedAddress, C> host = oldHostsTyped.get(i);
-                                    if (host.address.equals(addr)) {
-                                        host.markInactive();
-                                        ++i;
-                                        break;
-                                    } else {
-                                        newHosts.add(host);
-                                    }
-                                }
-                                for (; i < oldHostsTyped.size(); ++i) {
-                                    newHosts.add(oldHostsTyped.get(i));
-                                }
-                                return newHosts.isEmpty() ? emptyList() : newHosts;
+                    activeHostsUpdater.updateAndGet(RoundRobinLoadBalancer.this, oldHosts -> {
+                        final ResolvedAddress addr = requireNonNull(event.address());
+                        @SuppressWarnings("unchecked")
+                        final List<Host<ResolvedAddress, C>> oldHostsTyped = (List<Host<ResolvedAddress, C>>) oldHosts;
+                        if (event.isAvailable()) {
+                            if (oldHostsTyped.isEmpty()) {
+                                return singletonList(new Host<>(addr));
                             }
-                        });
+                            final List<Host<ResolvedAddress, C>> newHosts = new ArrayList<>(oldHostsTyped.size() + 1);
+                            newHosts.addAll(oldHostsTyped);
+                            newHosts.add(new Host<>(addr));
+                            return newHosts;
+                        } else if (oldHostsTyped.isEmpty()) {
+                            return emptyList();
+                        } else {
+                            final List<Host<ResolvedAddress, C>> newHosts = new ArrayList<>(oldHostsTyped.size() - 1);
+                            int i = 0;
+                            for (; i < oldHostsTyped.size(); ++i) {
+                                final Host<ResolvedAddress, C> host = oldHostsTyped.get(i);
+                                if (host.address.equals(addr)) {
+                                    host.markInactive();
+                                    ++i;
+                                    break;
+                                } else {
+                                    newHosts.add(host);
+                                }
+                            }
+                            for (; i < oldHostsTyped.size(); ++i) {
+                                newHosts.add(oldHostsTyped.get(i));
+                            }
+                            return newHosts.isEmpty() ? emptyList() : newHosts;
+                        }
+                    });
 
                 LOGGER.debug("Load balancer {} now using {} addresses: {}", RoundRobinLoadBalancer.this,
                         activeAddresses.size(), activeAddresses);

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -157,7 +157,7 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
                                 refreshedAddresses.addAll(currentAddresses);
                                 refreshedAddresses.add(new Host<>(addr));
                             } else if (currentAddresses.isEmpty()) {
-                                refreshedAddresses = currentAddresses;
+                                refreshedAddresses = emptyList();
                             } else {
                                 refreshedAddresses = new ArrayList<>(currentAddresses.size() - 1);
                                 for (Host<ResolvedAddress, C> host :

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -144,28 +144,29 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
                 discoveryCancellable.nextCancellable(s);
             }
 
-            @SuppressWarnings("unchecked")
             @Override
             public void onNext(final ServiceDiscovererEvent<ResolvedAddress> event) {
                 LOGGER.debug("Load balancer {}, received new ServiceDiscoverer event {}.", RoundRobinLoadBalancer.this,
                         event);
+                @SuppressWarnings("unchecked")
                 final List<Host<ResolvedAddress, C>> activeAddresses =
                         activeHostsUpdater.updateAndGet(RoundRobinLoadBalancer.this, oldHosts -> {
                             final ResolvedAddress addr = requireNonNull(event.address());
+                            @SuppressWarnings("unchecked")
+                            final List<Host<ResolvedAddress, C>> oldHostsTyped =
+                                    (List<Host<ResolvedAddress, C>>) oldHosts;
                             if (event.isAvailable()) {
                                 if (oldHosts.isEmpty()) {
                                     return singletonList(new Host<>(addr));
                                 }
                                 final List<Host<ResolvedAddress, C>> newHosts = new ArrayList<>(oldHosts.size() + 1);
-                                newHosts.addAll(oldHosts);
+                                newHosts.addAll(oldHostsTyped);
                                 newHosts.add(new Host<>(addr));
                                 return newHosts;
                             } else if (oldHosts.isEmpty()) {
                                 return emptyList();
                             } else {
                                 final List<Host<ResolvedAddress, C>> newHosts = new ArrayList<>(oldHosts.size() - 1);
-                                final List<Host<ResolvedAddress, C>> oldHostsTyped =
-                                        (List<Host<ResolvedAddress, C>>) oldHosts;
                                 int i = 0;
                                 for (; i < oldHostsTyped.size(); ++i) {
                                     final Host<ResolvedAddress, C> host = oldHostsTyped.get(i);

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -164,12 +164,21 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
                                 return emptyList();
                             } else {
                                 final List<Host<ResolvedAddress, C>> newHosts = new ArrayList<>(oldHosts.size() - 1);
-                                for (Host<ResolvedAddress, C> host : (List<Host<ResolvedAddress, C>>) oldHosts) {
+                                final List<Host<ResolvedAddress, C>> oldHostsTyped =
+                                        (List<Host<ResolvedAddress, C>>) oldHosts;
+                                int i = 0;
+                                for (; i < oldHostsTyped.size(); ++i) {
+                                    final Host<ResolvedAddress, C> host = oldHostsTyped.get(i);
                                     if (host.address.equals(addr)) {
                                         host.markInactive();
+                                        ++i;
+                                        break;
                                     } else {
                                         newHosts.add(host);
                                     }
+                                }
+                                for (; i < oldHostsTyped.size(); ++i) {
+                                    newHosts.add(oldHostsTyped.get(i));
                                 }
                                 return newHosts.isEmpty() ? emptyList() : newHosts;
                             }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -166,19 +166,17 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
                             return emptyList();
                         } else {
                             final List<Host<ResolvedAddress, C>> newHosts = new ArrayList<>(oldHostsTyped.size() - 1);
-                            int i = 0;
-                            for (; i < oldHostsTyped.size(); ++i) {
+                            for (int i = 0; i < oldHostsTyped.size(); ++i) {
                                 final Host<ResolvedAddress, C> host = oldHostsTyped.get(i);
                                 if (host.address.equals(addr)) {
                                     host.markInactive();
-                                    ++i;
+                                    for (int x = i + 1; x < oldHostsTyped.size(); ++x) {
+                                        newHosts.add(oldHostsTyped.get(x));
+                                    }
                                     break;
                                 } else {
                                     newHosts.add(host);
                                 }
-                            }
-                            for (; i < oldHostsTyped.size(); ++i) {
-                                newHosts.add(oldHostsTyped.get(i));
                             }
                             return newHosts.isEmpty() ? emptyList() : newHosts;
                         }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -243,6 +243,15 @@ public class RoundRobinLoadBalancerTest {
     }
 
     @Test
+    public void addressIsAddedTwice() {
+        assertThat(lb.activeAddresses(), is(empty()));
+        sendServiceDiscoveryEvents(upEvent("address-1"));
+        assertThat(lb.activeAddresses(), hasSize(1));
+        sendServiceDiscoveryEvents(upEvent("address-1"));
+        assertThat(lb.activeAddresses(), hasSize(2));
+    }
+
+    @Test
     public void noServiceDiscoveryEvent() {
         selectConnectionListener.listen(lb.selectConnection(any()));
         selectConnectionListener.verifyFailure(NoAvailableHostException.class);

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -249,6 +249,11 @@ public class RoundRobinLoadBalancerTest {
         assertThat(lb.activeAddresses(), hasSize(1));
         sendServiceDiscoveryEvents(upEvent("address-1"));
         assertThat(lb.activeAddresses(), hasSize(2));
+
+        sendServiceDiscoveryEvents(downEvent("address-1"));
+        assertThat(lb.activeAddresses(), hasSize(1));
+        sendServiceDiscoveryEvents(downEvent("address-1"));
+        assertThat(lb.activeAddresses(), hasSize(0));
     }
 
     @Test

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -243,15 +243,6 @@ public class RoundRobinLoadBalancerTest {
     }
 
     @Test
-    public void addressIsAddedTwice() {
-        assertThat(lb.activeAddresses(), is(empty()));
-        sendServiceDiscoveryEvents(upEvent("address-1"));
-        assertThat(lb.activeAddresses(), hasSize(1));
-        sendServiceDiscoveryEvents(upEvent("address-1"));
-        assertThat(lb.activeAddresses(), hasSize(1));
-    }
-
-    @Test
     public void noServiceDiscoveryEvent() {
         selectConnectionListener.listen(lb.selectConnection(any()));
         selectConnectionListener.verifyFailure(NoAvailableHostException.class);


### PR DESCRIPTION
Motivation:
RoundRobinLoadBalancer currently prevents duplicates from being
inserted. However the ServiceDiscoverer is responsible for filtering
duplicates in the typical use case. Allowing duplicates at the LB layer
allows to give more weight to specific addresses if desired.

Modifications:
- RoundRobinLoadBalancer simplify addition/removal to forgo duplicate
detection

Result:
RoundRobinLoadBalancer code simplified to ignore duplicate detection,
addition doesn't require linear search.