### PR TITLE
Implement `Component#chek()` for `UdpReporter`

### DIFF
--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporter.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporter.java
@@ -38,6 +38,7 @@ import io.netty.handler.logging.LoggingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
+import zipkin2.CheckResult;
 import zipkin2.Component;
 import zipkin2.Span;
 import zipkin2.reporter.Reporter;
@@ -53,6 +54,8 @@ import static io.servicetalk.transport.netty.internal.EventLoopAwareNettyIoExecu
 import static io.servicetalk.transport.netty.internal.GlobalExecutionContext.globalExecutionContext;
 import static java.lang.Thread.currentThread;
 import static java.util.Objects.requireNonNull;
+import static zipkin2.CheckResult.OK;
+import static zipkin2.CheckResult.failed;
 
 /**
  * A {@link Span} {@link Reporter} that will publish to a UDP listener with a configurable encoding {@link Codec}.
@@ -198,6 +201,11 @@ public final class UdpReporter extends Component implements Reporter<Span>, Asyn
                         });
                     }
                 });
+    }
+
+    @Override
+    public CheckResult check() {
+        return channel.isActive() ? OK : failed(new IllegalStateException("Reporter is closed."));
     }
 
     @Override

--- a/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporterTest.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporterTest.java
@@ -58,6 +58,7 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThrows;
 import static zipkin2.CheckResult.OK;
@@ -128,8 +129,9 @@ public class HttpReporterTest {
     @Test
     public void reportAfterClose() {
         HttpReporter reporter = initReporter(Builder::disableSpanBatching);
+        assertThat("Unexpected check state.", reporter.check(), is(OK));
         reporter.close();
-        assertThat("Unexpected check state.", reporter.check(), not(OK));
+        assertThat("Unexpected check state.", reporter.check(), is(not(OK)));
         assertThrows("Report post close accepted.", IllegalStateException.class,
                 () -> reporter.report(newSpan("1")));
     }


### PR DESCRIPTION
Motivation:

Zipkin's `Component` has a method `check()` that verifies if the
operations on this current component are likely to succeed. But
`UdpReporter` always reports `OK`.

Modifications:

- `UdpReport` returns `OK` only when the channel is active;
- Test to verify new behavior;

Result:

When `UdpReporter` is closed and `Channel` becomes inactive,
`check()` method starts returning `CheckResult#failed`.