### PR TITLE
CompositeException rename finishAndThrow to transferPendingToSuppressed

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompositeException.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompositeException.java
@@ -23,7 +23,7 @@ import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 
 /**
  * A {@link RuntimeException} that allows to add {@link Throwable} instances at a lower cost than
- * {@link #addSuppressed(Throwable)}. {@link #finishAndThrow()} will add all pending {@link Throwable}s as
+ * {@link #addSuppressed(Throwable)}. {@link #transferPendingToSuppressed()} will add all pending {@link Throwable}s as
  * {@link #addSuppressed(Throwable)}.
  */
 final class CompositeException extends RuntimeException {
@@ -41,7 +41,7 @@ final class CompositeException extends RuntimeException {
 
     /**
      * Add a {@link Throwable} to be added as {@link #addSuppressed(Throwable)} on the next call to
-     * {@link #finishAndThrow()}.
+     * {@link #transferPendingToSuppressed()}.
      *
      * @param toAdd {@link Throwable} to finally add as {@link #addSuppressed(Throwable)}.
      */
@@ -59,7 +59,7 @@ final class CompositeException extends RuntimeException {
      * <p>
      * It is assumed that {@link #add(Throwable)} won't be called after this method.
      */
-    void finishAndThrow() {
+    void transferPendingToSuppressed() {
         Throwable delayedCause = null;
         Throwable next;
         while ((next = suppressed.poll()) != null) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
@@ -330,7 +330,7 @@ final class PublisherFlatMapSingle<T, R> extends AbstractAsynchronousPublisherOp
                 assert terminalNotification != null;
                 CompositeException de = this.delayedError;
                 if (de != null) {
-                    de.finishAndThrow();
+                    de.transferPendingToSuppressed();
                     if (terminalNotification.cause() == de) {
                         terminalNotification.terminate(target);
                     } else {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompositeExceptionTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompositeExceptionTest.java
@@ -32,7 +32,7 @@ public class CompositeExceptionTest {
         e.add(suppressed1);
         DeliberateException suppressed2 = new DeliberateException();
         e.add(suppressed2);
-        e.finishAndThrow();
+        e.transferPendingToSuppressed();
         verifyOriginalAndSuppressedCauses(e, DELIBERATE_EXCEPTION, suppressed1);
         verifyOriginalAndSuppressedCauses(e, DELIBERATE_EXCEPTION, suppressed2);
     }


### PR DESCRIPTION
Motivation:
CompositeException's finishAndThrow method implies that it directly
throws an exception. While this is possible if the internal transfer
encounters an exception, it is not the expected use case. The method
name causes confusion on first glance and requires more investigation to
understand throwing is not expected.

Modifications:
- CompositeException rename finishAndThrow to
transferPendingToSuppressed

Result:
CompositeException method name is clarified and more readable.