### PR TITLE
Mark `ProxyResponseException` as retryable `IOException`

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyResponseException.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyResponseException.java
@@ -16,11 +16,14 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.transport.api.RetryableException;
+
+import java.io.IOException;
 
 /**
  * A proxy response exception, that indicates an unexpected response status from a proxy.
  */
-public final class ProxyResponseException extends RuntimeException {
+public final class ProxyResponseException extends IOException implements RetryableException {
     private final HttpResponseStatus status;
 
     ProxyResponseException(final String message, final HttpResponseStatus status) {


### PR DESCRIPTION
Motivation:

Non 2xx response codes from the proxy fail the connection initialization.
Therefore, it should be a subclass of `IOException`.
Also, `ProxyResponseException` means that client did not start writing
the request and should be marked as `RetryableException`.

Modifications:
- Change the parent class of `ProxyResponseException` from
`RuntimeException` to `IOException`;
- Add `RetryableException` marker interface for `ProxyResponseException`;

Result:

`ProxyResponseException` will indicate problems with the IO and will be
automatically retried by default retrying filter.