### PR TITLE
Method to create PUT requests for [Blocking]StreamingHttpRequestFactory

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequestFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequestFactory.java
@@ -22,6 +22,7 @@ import static io.servicetalk.http.api.HttpRequestMethod.HEAD;
 import static io.servicetalk.http.api.HttpRequestMethod.OPTIONS;
 import static io.servicetalk.http.api.HttpRequestMethod.PATCH;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
+import static io.servicetalk.http.api.HttpRequestMethod.PUT;
 import static io.servicetalk.http.api.HttpRequestMethod.TRACE;
 
 /**
@@ -52,6 +53,15 @@ public interface BlockingStreamingHttpRequestFactory {
      */
     default BlockingStreamingHttpRequest post(String requestTarget) {
         return newRequest(POST, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethod#PUT} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethod#PUT} request.
+     */
+    default BlockingStreamingHttpRequest put(String requestTarget) {
+        return newRequest(PUT, requestTarget);
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequestFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequestFactory.java
@@ -22,6 +22,7 @@ import static io.servicetalk.http.api.HttpRequestMethod.HEAD;
 import static io.servicetalk.http.api.HttpRequestMethod.OPTIONS;
 import static io.servicetalk.http.api.HttpRequestMethod.PATCH;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
+import static io.servicetalk.http.api.HttpRequestMethod.PUT;
 import static io.servicetalk.http.api.HttpRequestMethod.TRACE;
 
 /**
@@ -52,6 +53,15 @@ public interface StreamingHttpRequestFactory {
      */
     default StreamingHttpRequest post(String requestTarget) {
         return newRequest(POST, requestTarget);
+    }
+
+    /**
+     * Create a new {@link HttpRequestMethod#PUT} request.
+     * @param requestTarget The <a href="https://tools.ietf.org/html/rfc7230#section-5.3">request target</a>.
+     * @return a new {@link HttpRequestMethod#PUT} request.
+     */
+    default StreamingHttpRequest put(String requestTarget) {
+        return newRequest(PUT, requestTarget);
     }
 
     /**


### PR DESCRIPTION
Motivation:

`StreamingHttpRequestFactory` and `BlockingStreamingHttpRequestFactory`
miss a method that creates `HttpRequestMethod#PUT` request.

Modifications:

- Add `put(String)` method for `StreamingHttpRequestFactory` and
`BlockingStreamingHttpRequestFactory`;

Result:

Users can use a short cut method to create `HttpRequestMethod#PUT`
requests for `StreamingHttpClient` and `BlockingStreamingHttpClient`.