### PR TITLE
Avoid blocking JDK DNS resolutions

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -34,7 +34,7 @@ import java.net.InetSocketAddress;
 import java.util.function.Function;
 
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.forUnknownHostAndPort;
-import static java.net.InetSocketAddress.createUnresolved;
+import static io.servicetalk.transport.netty.internal.BuilderUtils.toInetSocketAddress;
 
 /**
  * Factory methods for building {@link HttpClient} (and other API variations) instances.
@@ -204,8 +204,7 @@ public final class HttpClients {
      */
     public static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forResolvedAddress(
             final HostAndPort address) {
-        return DefaultSingleAddressHttpClientBuilder.forResolvedAddress(address,
-                createUnresolved(address.hostName(), address.port()));
+        return DefaultSingleAddressHttpClientBuilder.forResolvedAddress(address, toInetSocketAddress(address));
     }
 
     /**
@@ -222,7 +221,7 @@ public final class HttpClients {
     public static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forResolvedAddressViaProxy(
             final HostAndPort address, final HostAndPort proxyAddress) {
         return DefaultSingleAddressHttpClientBuilder.forResolvedAddressViaProxy(address,
-                createUnresolved(address.hostName(), address.port()), proxyAddress);
+                toInetSocketAddress(address), proxyAddress);
     }
 
     /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -34,6 +34,7 @@ import java.net.InetSocketAddress;
 import java.util.function.Function;
 
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.forUnknownHostAndPort;
+import static java.net.InetSocketAddress.createUnresolved;
 
 /**
  * Factory methods for building {@link HttpClient} (and other API variations) instances.
@@ -204,7 +205,7 @@ public final class HttpClients {
     public static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forResolvedAddress(
             final HostAndPort address) {
         return DefaultSingleAddressHttpClientBuilder.forResolvedAddress(address,
-                new InetSocketAddress(address.hostName(), address.port()));
+                createUnresolved(address.hostName(), address.port()));
     }
 
     /**
@@ -221,7 +222,7 @@ public final class HttpClients {
     public static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forResolvedAddressViaProxy(
             final HostAndPort address, final HostAndPort proxyAddress) {
         return DefaultSingleAddressHttpClientBuilder.forResolvedAddressViaProxy(address,
-                new InetSocketAddress(address.hostName(), address.port()), proxyAddress);
+                createUnresolved(address.hostName(), address.port()), proxyAddress);
     }
 
     /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -34,7 +34,7 @@ import java.net.InetSocketAddress;
 import java.util.function.Function;
 
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.forUnknownHostAndPort;
-import static io.servicetalk.transport.netty.internal.BuilderUtils.toInetSocketAddress;
+import static io.servicetalk.transport.netty.internal.BuilderUtils.toResolvedInetSocketAddress;
 
 /**
  * Factory methods for building {@link HttpClient} (and other API variations) instances.
@@ -204,7 +204,7 @@ public final class HttpClients {
      */
     public static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forResolvedAddress(
             final HostAndPort address) {
-        return DefaultSingleAddressHttpClientBuilder.forResolvedAddress(address, toInetSocketAddress(address));
+        return DefaultSingleAddressHttpClientBuilder.forResolvedAddress(address, toResolvedInetSocketAddress(address));
     }
 
     /**
@@ -221,7 +221,7 @@ public final class HttpClients {
     public static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forResolvedAddressViaProxy(
             final HostAndPort address, final HostAndPort proxyAddress) {
         return DefaultSingleAddressHttpClientBuilder.forResolvedAddressViaProxy(address,
-                toInetSocketAddress(address), proxyAddress);
+                toResolvedInetSocketAddress(address), proxyAddress);
     }
 
     /**

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BuilderUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BuilderUtils.java
@@ -49,6 +49,8 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
+import static java.net.InetSocketAddress.createUnresolved;
+
 /**
  * Utilities which are used for builders.
  */
@@ -159,7 +161,7 @@ public final class BuilderUtils {
         }
         if (address instanceof HostAndPort) {
             HostAndPort hostAndPort = (HostAndPort) address;
-            return new InetSocketAddress(hostAndPort.hostName(), hostAndPort.port());
+            return createUnresolved(hostAndPort.hostName(), hostAndPort.port());
         }
         throw new IllegalArgumentException("Unsupported address: " + address);
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BuilderUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BuilderUtils.java
@@ -163,7 +163,7 @@ public final class BuilderUtils {
             return (SocketAddress) address;
         }
         if (address instanceof HostAndPort) {
-            return toInetSocketAddress((HostAndPort) address);
+            return toResolvedInetSocketAddress((HostAndPort) address);
         }
         throw new IllegalArgumentException("Unsupported address: " + address);
     }
@@ -174,7 +174,7 @@ public final class BuilderUtils {
      * @param resolvedAddress the resolved address to convert.
      * @return {@link InetSocketAddress} from the passed resolved {@link HostAndPort}.
      */
-    public static InetSocketAddress toInetSocketAddress(final HostAndPort resolvedAddress) {
+    public static InetSocketAddress toResolvedInetSocketAddress(final HostAndPort resolvedAddress) {
         try {
             return new InetSocketAddress(getByAddress(createByteArrayFromIpAddressString(
                     resolvedAddress.hostName())), resolvedAddress.port());

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BuilderUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BuilderUtils.java
@@ -51,7 +51,6 @@ import java.net.UnknownHostException;
 import javax.annotation.Nullable;
 
 import static io.netty.util.NetUtil.createByteArrayFromIpAddressString;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.net.InetAddress.getByAddress;
 
 /**
@@ -179,8 +178,8 @@ public final class BuilderUtils {
             return new InetSocketAddress(getByAddress(createByteArrayFromIpAddressString(
                     resolvedAddress.hostName())), resolvedAddress.port());
         } catch (UnknownHostException e) {
-            return throwException(new UnknownHostException("Invalid resolved address: " + resolvedAddress.hostName() +
-                    ", expected IP-address."));
+            throw new IllegalArgumentException("Invalid resolved address: " + resolvedAddress.hostName() +
+                    ", expected IP-address.", e);
         }
     }
 

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/BuilderUtilsTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/BuilderUtilsTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 
-import static io.servicetalk.transport.netty.internal.BuilderUtils.toInetSocketAddress;
+import static io.servicetalk.transport.netty.internal.BuilderUtils.toResolvedInetSocketAddress;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -34,7 +34,7 @@ public class BuilderUtilsTest {
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     public void toInetSocketAddressFromIPv4() {
         final String localhostIp4Address = NetUtil.LOCALHOST4.getHostAddress();
-        InetSocketAddress address = toInetSocketAddress(HostAndPort.of(localhostIp4Address, 8080));
+        InetSocketAddress address = toResolvedInetSocketAddress(HostAndPort.of(localhostIp4Address, 8080));
         assertThat(address.isUnresolved(), is(false));
         assertThat(address.getHostString(), equalTo(localhostIp4Address));
         assertThat(address.getPort(), is(8080));
@@ -44,7 +44,7 @@ public class BuilderUtilsTest {
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     public void toInetSocketAddressFromIPv6() {
         final String localhostIp6Address = NetUtil.LOCALHOST6.getHostAddress();
-        InetSocketAddress address = toInetSocketAddress(HostAndPort.of(localhostIp6Address, 8080));
+        InetSocketAddress address = toResolvedInetSocketAddress(HostAndPort.of(localhostIp6Address, 8080));
         assertThat(address.isUnresolved(), is(false));
         assertThat(address.getHostString(), equalTo(localhostIp6Address));
         assertThat(address.getPort(), is(8080));
@@ -52,6 +52,6 @@ public class BuilderUtilsTest {
 
     @Test(expected = UnknownHostException.class)
     public void toInetSocketAddressFromUnresolved() {
-        toInetSocketAddress(HostAndPort.of("unresolved-hostname", 8080));
+        toResolvedInetSocketAddress(HostAndPort.of("unresolved-hostname", 8080));
     }
 }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/BuilderUtilsTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/BuilderUtilsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.servicetalk.transport.api.HostAndPort;
+
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+import static io.servicetalk.transport.netty.internal.BuilderUtils.toInetSocketAddress;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class BuilderUtilsTest {
+
+    @Test
+    public void toInetSocketAddressFromIPv4() {
+        InetSocketAddress address = toInetSocketAddress(HostAndPort.of("192.168.1.1", 8080));
+        assertThat(address.isUnresolved(), is(false));
+        assertThat(address.getHostString(), equalTo("192.168.1.1"));
+        assertThat(address.getPort(), is(8080));
+    }
+
+    @Test
+    public void toInetSocketAddressFromIPv6() {
+        InetSocketAddress address = toInetSocketAddress(HostAndPort.of("2001:db8:0:0:0:0:0:abcd", 8080));
+        assertThat(address.isUnresolved(), is(false));
+        assertThat(address.getHostString(), equalTo("2001:db8:0:0:0:0:0:abcd"));
+        assertThat(address.getPort(), is(8080));
+    }
+
+    @Test(expected = UnknownHostException.class)
+    public void toInetSocketAddressFromUnresolved() {
+        toInetSocketAddress(HostAndPort.of("unresolved-hostname", 8080));
+    }
+}

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/BuilderUtilsTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/BuilderUtilsTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.Matchers.is;
 public class BuilderUtilsTest {
 
     @Test
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     public void toInetSocketAddressFromIPv4() {
         InetSocketAddress address = toInetSocketAddress(HostAndPort.of("192.168.1.1", 8080));
         assertThat(address.isUnresolved(), is(false));
@@ -38,6 +39,7 @@ public class BuilderUtilsTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     public void toInetSocketAddressFromIPv6() {
         InetSocketAddress address = toInetSocketAddress(HostAndPort.of("2001:db8:0:0:0:0:0:abcd", 8080));
         assertThat(address.isUnresolved(), is(false));

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/BuilderUtilsTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/BuilderUtilsTest.java
@@ -17,6 +17,7 @@ package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.transport.api.HostAndPort;
 
+import io.netty.util.NetUtil;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
@@ -32,18 +33,20 @@ public class BuilderUtilsTest {
     @Test
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     public void toInetSocketAddressFromIPv4() {
-        InetSocketAddress address = toInetSocketAddress(HostAndPort.of("192.168.1.1", 8080));
+        final String localhostIp4Address = NetUtil.LOCALHOST4.getHostAddress();
+        InetSocketAddress address = toInetSocketAddress(HostAndPort.of(localhostIp4Address, 8080));
         assertThat(address.isUnresolved(), is(false));
-        assertThat(address.getHostString(), equalTo("192.168.1.1"));
+        assertThat(address.getHostString(), equalTo(localhostIp4Address));
         assertThat(address.getPort(), is(8080));
     }
 
     @Test
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     public void toInetSocketAddressFromIPv6() {
-        InetSocketAddress address = toInetSocketAddress(HostAndPort.of("2001:db8:0:0:0:0:0:abcd", 8080));
+        final String localhostIp6Address = NetUtil.LOCALHOST6.getHostAddress();
+        InetSocketAddress address = toInetSocketAddress(HostAndPort.of(localhostIp6Address, 8080));
         assertThat(address.isUnresolved(), is(false));
-        assertThat(address.getHostString(), equalTo("2001:db8:0:0:0:0:0:abcd"));
+        assertThat(address.getHostString(), equalTo(localhostIp6Address));
         assertThat(address.getPort(), is(8080));
     }
 

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/BuilderUtilsTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/BuilderUtilsTest.java
@@ -26,13 +26,15 @@ import java.net.UnknownHostException;
 import static io.servicetalk.transport.netty.internal.BuilderUtils.toResolvedInetSocketAddress;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
 
 public class BuilderUtilsTest {
 
     @Test
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
-    public void toInetSocketAddressFromIPv4() {
+    public void toResolvedInetSocketAddressFromIPv4() {
         final String localhostIp4Address = NetUtil.LOCALHOST4.getHostAddress();
         InetSocketAddress address = toResolvedInetSocketAddress(HostAndPort.of(localhostIp4Address, 8080));
         assertThat(address.isUnresolved(), is(false));
@@ -42,7 +44,7 @@ public class BuilderUtilsTest {
 
     @Test
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
-    public void toInetSocketAddressFromIPv6() {
+    public void toResolvedInetSocketAddressFromIPv6() {
         final String localhostIp6Address = NetUtil.LOCALHOST6.getHostAddress();
         InetSocketAddress address = toResolvedInetSocketAddress(HostAndPort.of(localhostIp6Address, 8080));
         assertThat(address.isUnresolved(), is(false));
@@ -50,8 +52,10 @@ public class BuilderUtilsTest {
         assertThat(address.getPort(), is(8080));
     }
 
-    @Test(expected = UnknownHostException.class)
-    public void toInetSocketAddressFromUnresolved() {
-        toResolvedInetSocketAddress(HostAndPort.of("unresolved-hostname", 8080));
+    @Test
+    public void toResolvedInetSocketAddressFromUnresolved() {
+        Throwable t = assertThrows(IllegalArgumentException.class,
+                () -> toResolvedInetSocketAddress(HostAndPort.of("unresolved-hostname", 8080)));
+        assertThat(t.getCause(), instanceOf(UnknownHostException.class));
     }
 }


### PR DESCRIPTION
Motivation:

Users of `HttpClients.forResolvedAddress(HostAndPort)` API could end up
using blocking JDK DNS resolution if they pass unresolved hostname.

Modification:

- Add `BuilderUtils.toResolvedInetSocketAddress(HostAndPort)` that creates
a resolved `InetSocketAddress` without DNS resolution;
- Add tests for new utility method;
- Use this new utility for `HttpClients. forResolvedAddress` instead of
`new java.net.InetSocketAddress`;

Result:

Users who pass unresolved hostname will see `IllegalArgumentException`
with `UnknownHostException` cause and should use `HttpClients.forAddress`
instead that performs async DNS resolutions using netty-dns-resolver.