### PR TITLE
Unwrap the cause only for `DecoderException`

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -537,8 +537,8 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
          * Unwraps certain types of netty exceptions to directly expose its cause to improve debuggability.
          */
         private static Throwable unwrapThrowable(final Throwable t) {
-            final Throwable cause = t.getCause();
-            if (t instanceof DecoderException && cause instanceof SSLException) {
+            final Throwable cause;
+            if (t instanceof DecoderException && (cause = t.getCause()) instanceof SSLException) {
                 return cause;
             }
             return t;


### PR DESCRIPTION
Motivation:

`Throwable.getCause()` may be expensive.

Modifications:

- Unwrap the cause only when the original exception is an instance of
`DecoderException`.

Result:

Do not access cause of exceptions that we are not interested in unwrapping.

Follow-up for #1075.