### PR TITLE
Zipkin Publisher remove explicit io.zipkin.zipkin2:zipkin dependency

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,6 @@ jcToolsVersion=3.0.0
 jacksonVersion=2.10.4
 
 openTracingVersion=0.31.0
-zipkinVersion=2.20.1
 zipkinReporterVersion=2.12.2
 
 # Used for testing DNS ServiceDiscoverer

--- a/servicetalk-opentracing-zipkin-publisher/build.gradle
+++ b/servicetalk-opentracing-zipkin-publisher/build.gradle
@@ -21,7 +21,6 @@ dependencies {
   api project(":servicetalk-concurrent-api")
   api project(":servicetalk-transport-api")
   api project(":servicetalk-http-api")
-  api "io.zipkin.zipkin2:zipkin:$zipkinVersion"
   api "io.zipkin.reporter2:zipkin-reporter:$zipkinReporterVersion"
 
   implementation project(":servicetalk-annotations")


### PR DESCRIPTION
Motivation:
servicetalk-opentracing-zipkin-publisher has an explicit dependency on
io.zipkin.reporter2:zipkin-reporter and io.zipkin.zipkin2:zipkin.
However the former has a transitive dependency on the latter and exposes
its APIs. Adding an explicit dependency on both means we have to make
sure the versions are properly synchronized or build tools may have
issues resolving the version conflicts.

Modifications:
- remove explicit io.zipkin.zipkin2:zipkin dependency from
servicetalk-opentracing-zipkin-publisher

Result:
No need to keep zipkin versions synchronized in ServiceTalk.