### PR TITLE
Fix all deprecation warnings from Gradle 6.3

### DIFF
--- a/servicetalk-examples/grpc/helloworld/build.gradle
+++ b/servicetalk-examples/grpc/helloworld/build.gradle
@@ -25,7 +25,7 @@ dependencies {
   implementation project(":servicetalk-grpc-protobuf")
 
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
-  runtime "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }
 
 serviceTalkGrpc {

--- a/servicetalk-examples/grpc/routeguide/build.gradle
+++ b/servicetalk-examples/grpc/routeguide/build.gradle
@@ -27,7 +27,7 @@ dependencies {
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
   implementation "com.google.protobuf:protobuf-java-util:$protobufVersion"
-  runtime "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }
 
 serviceTalkGrpc {

--- a/servicetalk-examples/http/helloworld/build.gradle
+++ b/servicetalk-examples/http/helloworld/build.gradle
@@ -21,5 +21,5 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-http-netty")
 
-  runtime "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }

--- a/servicetalk-examples/http/http2/build.gradle
+++ b/servicetalk-examples/http/http2/build.gradle
@@ -29,7 +29,7 @@ dependencies {
   // best SSL performance. Users who prefers to use JDK provider have to make sure their JDK or classpath supports ALPN.
   // For more information about how to enable ALPN support on JDK,
   // see https://www.eclipse.org/jetty/documentation/current/alpn-chapter.html
-  runtime "io.netty:netty-tcnative-boringssl-static:$tcnativeVersion"
+  runtimeOnly "io.netty:netty-tcnative-boringssl-static:$tcnativeVersion"
 
-  runtime "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }

--- a/servicetalk-examples/http/jaxrs/build.gradle
+++ b/servicetalk-examples/http/jaxrs/build.gradle
@@ -27,6 +27,6 @@ dependencies {
   implementation project(":servicetalk-http-router-jersey")
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
-  runtime "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
-  runtime "org.glassfish.jersey.inject:jersey-hk2:$jerseyVersion"
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+  runtimeOnly "org.glassfish.jersey.inject:jersey-hk2:$jerseyVersion"
 }

--- a/servicetalk-examples/http/metadata/build.gradle
+++ b/servicetalk-examples/http/metadata/build.gradle
@@ -21,5 +21,5 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-http-netty")
 
-  runtime "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }

--- a/servicetalk-examples/http/serialization/build.gradle
+++ b/servicetalk-examples/http/serialization/build.gradle
@@ -22,5 +22,5 @@ dependencies {
   implementation project(":servicetalk-data-jackson")
   implementation project(":servicetalk-http-netty")
 
-  runtime "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }

--- a/servicetalk-examples/http/service-composition/build.gradle
+++ b/servicetalk-examples/http/service-composition/build.gradle
@@ -26,5 +26,5 @@ dependencies {
   implementation project(":servicetalk-transport-netty")
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
-  runtime "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }

--- a/servicetalk-gradle-plugin-internal/plugin-config.gradle
+++ b/servicetalk-gradle-plugin-internal/plugin-config.gradle
@@ -19,10 +19,10 @@ Properties props = new Properties()
 props.load(new FileInputStream("$project.projectDir/../gradle.properties"))
 
 dependencies {
-  compile gradleApi()
-  compile localGroovy()
-  compile "com.jfrog.bintray.gradle:gradle-bintray-plugin:$props.bintrayPluginVersion"
-  compile "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:$props.spotbugsPluginVersion"
+  implementation gradleApi()
+  implementation localGroovy()
+  implementation "com.jfrog.bintray.gradle:gradle-bintray-plugin:$props.bintrayPluginVersion"
+  implementation "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:$props.spotbugsPluginVersion"
 }
 
 gradlePlugin {

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkCorePlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkCorePlugin.groovy
@@ -54,7 +54,7 @@ class ServiceTalkCorePlugin implements Plugin<Project> {
 
       checkstyle {
         toolVersion = CHECKSTYLE_VERSION
-        configDir = file("$buildDir/checkstyle")
+        getConfigDirectory().set file("$buildDir/checkstyle")
       }
 
       // Overwrite the default set of file for Checkstyle analysis from only java files to all files of the source set

--- a/servicetalk-grpc-gradle-plugin/plugin-config.gradle
+++ b/servicetalk-grpc-gradle-plugin/plugin-config.gradle
@@ -19,9 +19,9 @@ Properties props = new Properties()
 props.load(new FileInputStream("$project.projectDir/../gradle.properties"))
 
 dependencies {
-  compile gradleApi()
-  compile localGroovy()
-  compile "com.google.protobuf:protobuf-gradle-plugin:$props.protobufGradlePluginVersion"
+  implementation gradleApi()
+  implementation localGroovy()
+  implementation "com.google.protobuf:protobuf-gradle-plugin:$props.protobufGradlePluginVersion"
 }
 
 gradlePlugin {

--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -45,7 +45,7 @@ jar {
 }
 
 shadowJar {
-  baseName = project.name + "-all"
+  archiveBaseName = project.name + "-all"
   classifier = ''
 }
 

--- a/servicetalk-http-router-jersey/build.gradle
+++ b/servicetalk-http-router-jersey/build.gradle
@@ -39,7 +39,7 @@ dependencies {
   testImplementation "junit:junit:$junitVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 
-  testRuntime "org.glassfish.jersey.media:jersey-media-json-jackson:$jerseyVersion"
+  testRuntimeOnly "org.glassfish.jersey.media:jersey-media-json-jackson:$jerseyVersion"
 
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-http-security-jersey/build.gradle
+++ b/servicetalk-http-security-jersey/build.gradle
@@ -37,5 +37,5 @@ dependencies {
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 
-  testRuntime project(":servicetalk-test-resources")
+  testRuntimeOnly project(":servicetalk-test-resources")
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-enableFeaturePreview("GRADLE_METADATA")
-
 rootProject.name = "servicetalk"
 
 include "servicetalk-annotations",


### PR DESCRIPTION
#992 upgraded the ServiceTalk build to use Gradle 6.3. Several deprecation warnings are presented when running builds with version 6.3 (I haven't confirmed whether they were present with older versions however). A complete list is available in the details disclosure below from before the commit in this pull request is applied.

This pull request updates all usages which present deprecation warnings with their forward-compatible replacements.

### Modifications:

- Replace the `runtime` directive with the `runtimeOnly` directive for runtime inclusion of `log4j` and `boringssl` in several examples.

- Replace the `testRuntime` directive with the `testRuntimeOnly` directive in `servicetalk-http-security-jersey/.build.gradle`.

- Replace the `compile` directive with the `implementation` directive in `servicetalk-gradle-plugin-internal/plugin-config.gradle` and `servicetalk-grpc-gradle-plugin/plugin-config.gradle`

- Replace use of directly setting `configDir` in the `checkstyle` configuration with `getConfigDirectory.set`.

- Replace `baseName` directive in the `shadowJar` configuration with `archiveBaseName`.

- Remove use of enableFeaturePreview("GRADLE_METADATA"), which is no longer required.

### Result:

No deprecation warnings are now presented when running builds with Gradle 6.3.

<details>
    <summary>Deprecation warnings from before applying this patch</summary>

```
./gradlew --warning-mode all

enableFeaturePreview('GRADLE_METADATA') has been deprecated. This is scheduled to be removed in Gradle 7.0. The feature flag is no longer relevant, please remove it from your settings file. See https://docs.gradle.org/6.3/userguide/feature_lifecycle.html#feature_preview for more details.
        at settings_9g5zldhdc2zncktehyt4ot8iq.run(/Users/James/Code/java/servicetalk/settings.gradle:17)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Configure project :buildSrc
The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the implementation or api configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/6.3/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations
        at plugin_config_8wse0d9qlsn0kin3fgqnwpqha$_run_closure1.doCall(/Users/James/Code/java/servicetalk/servicetalk-grpc-gradle-plugin/plugin-config.gradle:22)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Configure project :
The CheckstyleExtension.setConfigDir() method has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the CheckstyleExtension.getConfigDirectory().set() method instead. See https://docs.gradle.org/6.3/dsl/org.gradle.api.plugins.quality.CheckstyleExtension.html#org.gradle.api.plugins.quality.CheckstyleExtension:configDir for more details.
        at build_atc98l69halarsz36ur3uo1qw.run(/Users/James/Code/java/servicetalk/build.gradle:32)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Configure project :servicetalk-grpc-protoc
The AbstractArchiveTask.baseName property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the archiveBaseName property instead. See https://docs.gradle.org/6.3/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:baseName for more details.
        at build_siux3ev8cz31pvkut4ygg20t$_run_closure3.doCall(/Users/James/Code/java/servicetalk/servicetalk-grpc-protoc/build.gradle:48)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Configure project :servicetalk-http-router-jersey
The testRuntime configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the testRuntimeOnly configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/6.3/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations
        at build_9n8devl9sx77k2s1ik11tvmix$_run_closure1.doCall(/Users/James/Code/java/servicetalk/servicetalk-http-router-jersey/build.gradle:42)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Configure project :servicetalk-examples:grpc:servicetalk-examples-grpc-helloworld
The runtime configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the runtimeOnly configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/6.3/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations
        at build_68jg3mdcij1hc6wmdy8ru04me$_run_closure1.doCall(/Users/James/Code/java/servicetalk/servicetalk-examples/grpc/helloworld/build.gradle:28)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Task :help

Welcome to Gradle 6.3.

(additional output removed)
```

</details>