### PR TITLE
ServiceTalkThreadContextMap to support null values

### DIFF
--- a/servicetalk-log4j2-mdc-utils/build.gradle
+++ b/servicetalk-log4j2-mdc-utils/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   testImplementation project(":servicetalk-test-resources")
   testImplementation "junit:junit:$junitVersion"
   testImplementation "org.slf4j:slf4j-api:$slf4jVersion"
+  testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
 
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/servicetalk-log4j2-mdc-utils/src/main/java/io/servicetalk/log4j2/mdc/utils/ServiceTalkThreadContextMap.java
+++ b/servicetalk-log4j2-mdc-utils/src/main/java/io/servicetalk/log4j2/mdc/utils/ServiceTalkThreadContextMap.java
@@ -22,7 +22,6 @@ import io.servicetalk.concurrent.api.AsyncContextMap.Key;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.spi.CleanableThreadContextMap;
 import org.apache.logging.log4j.spi.ReadOnlyThreadContextMap;
-import org.apache.logging.log4j.spi.ThreadContextMap;
 import org.apache.logging.log4j.util.BiConsumer;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.StringMap;
@@ -40,16 +39,18 @@ import static java.util.Collections.unmodifiableMap;
  */
 public class ServiceTalkThreadContextMap implements ReadOnlyThreadContextMap, CleanableThreadContextMap {
     private static final Key<Map<String, String>> key = Key.newKey("log4j2Mdc");
+    @SuppressWarnings("RedundantStringConstructorCall")
+    private static final String NULL_STRING = new String("");
 
     @Override
     public final void put(String key, String value) {
-        getStorage().put(key, value);
+        getStorage().put(key, wrapNull(value));
     }
 
     @Nullable
     @Override
     public String get(String key) {
-        return getStorage().get(key);
+        return unwrapNull(getStorage().get(key));
     }
 
     @Override
@@ -72,36 +73,18 @@ public class ServiceTalkThreadContextMap implements ReadOnlyThreadContextMap, Cl
         return getCopy(getStorage());
     }
 
-    /**
-     * Get a copy of this {@link ThreadContextMap} given the underlying {@link Map} storage.
-     * @param storage the underlying {@link Map} storage.
-     * @return a copy of this {@link ThreadContextMap}.
-     */
-    protected Map<String, String> getCopy(Map<String, String> storage) {
-        return new HashMap<>(storage);
-    }
-
     @Nullable
     @Override
-    public final Map<String, String> getImmutableMapOrNull() {
-        return getImmutableMapOrNull(getStorage());
-    }
-
-    /**
-     * Provide the implementation for {@link #getImmutableMapOrNull()} given then underlying {@link Map} storage.
-     * @param storage the underlying {@link Map} storage.
-     * @return An immutable {@link Map} or {@code null} if empty.
-     */
-    @Nullable
-    protected Map<String, String> getImmutableMapOrNull(Map<String, String> storage) {
+    public Map<String, String> getImmutableMapOrNull() {
+        Map<String, String> storage = getStorage();
         if (storage.isEmpty()) {
             return null;
         }
         // We use a ConcurrentMap for the storage. So we make a best effort check to avoid a copy first, but it is
         // possible that the map was modified after this check. Then we make a copy and check if the copy is actually
         // empty before returning the unmodifiable map.
-        final Map<String, String> copy = getCopy(storage);
-        return copy.isEmpty() ? null : unmodifiableMap(copy);
+        final Map<String, String> copy = getCopyOrNull(storage, true);
+        return copy == null ? null : unmodifiableMap(copy);
     }
 
     @Override
@@ -117,20 +100,15 @@ public class ServiceTalkThreadContextMap implements ReadOnlyThreadContextMap, Cl
 
     @Override
     public final void putAll(Map<String, String> map) {
-        getStorage().putAll(map);
+        final Map<String, String> storage = getStorage();
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            storage.put(entry.getKey(), wrapNull(entry.getValue()));
+        }
     }
 
     @Override
-    public final StringMap getReadOnlyContextData() {
-        return getReadOnlyContextData(getStorage());
-    }
-
-    /**
-     * Create a new read-only {@link StringMap}.
-     * @param storage The underlying storage for this {@link ThreadContextMap}.
-     * @return a new read-only {@link StringMap}.
-     */
-    protected StringMap getReadOnlyContextData(final Map<String, String> storage) {
+    public StringMap getReadOnlyContextData() {
+        final Map<String, String> storage = getStorage();
         return new StringMap() {
             private static final long serialVersionUID = -1707426073379541244L;
 
@@ -176,19 +154,20 @@ public class ServiceTalkThreadContextMap implements ReadOnlyThreadContextMap, Cl
             @SuppressWarnings("unchecked")
             @Override
             public <V> void forEach(BiConsumer<String, ? super V> action) {
-                storage.forEach((key, value) -> action.accept(key, (V) value));
+                storage.forEach((key, value) -> action.accept(key, (V) unwrapNull(value)));
             }
 
             @SuppressWarnings("unchecked")
             @Override
             public <V, S> void forEach(TriConsumer<String, ? super V, S> action, S state) {
-                storage.forEach((key, value) -> action.accept(key, (V) value, state));
+                storage.forEach((key, value) -> action.accept(key, (V) unwrapNull(value), state));
             }
 
+            @Nullable
             @SuppressWarnings("unchecked")
             @Override
             public <V> V getValue(String key) {
-                return (V) storage.get(key);
+                return (V) unwrapNull(storage.get(key));
             }
 
             @Override
@@ -203,6 +182,11 @@ public class ServiceTalkThreadContextMap implements ReadOnlyThreadContextMap, Cl
         };
     }
 
+    @Nullable
+    protected Map<String, String> getCopyOrNull() {
+        return getCopyOrNull(getStorage(), true);
+    }
+
     static Map<String, String> getStorage() {
         AsyncContextMap context = AsyncContext.current();
         Map<String, String> ret = context.get(key);
@@ -213,5 +197,34 @@ public class ServiceTalkThreadContextMap implements ReadOnlyThreadContextMap, Cl
             AsyncContext.put(key, ret);
         }
         return ret;
+    }
+
+    @Nullable
+    private static Map<String, String> getCopyOrNull(Map<String, String> storage, boolean emptyReturnNull) {
+        final int size = storage.size();
+        if (size == 0) {
+            return emptyReturnNull ? null : new HashMap<>(2);
+        }
+        Map<String, String> copy = new HashMap<>(size + (int) (size * 0.25f + 1), 0.75f);
+        for (Map.Entry<String, String> entry : storage.entrySet()) {
+            copy.put(entry.getKey(), unwrapNull(entry.getValue()));
+        }
+        return copy;
+    }
+
+    private static Map<String, String> getCopy(Map<String, String> storage) {
+        Map<String, String> copy = getCopyOrNull(storage, false);
+        assert copy != null;
+        return copy;
+    }
+
+    private static String wrapNull(@Nullable String value) {
+        return value == null ? NULL_STRING : value;
+    }
+
+    @SuppressWarnings("StringEquality")
+    @Nullable
+    private static String unwrapNull(String value) {
+        return value == NULL_STRING ? null : value;
     }
 }

--- a/servicetalk-log4j2-mdc-utils/src/test/java/io/servicetalk/log4j2/mdc/utils/ServiceTalkThreadContextMapTest.java
+++ b/servicetalk-log4j2-mdc-utils/src/test/java/io/servicetalk/log4j2/mdc/utils/ServiceTalkThreadContextMapTest.java
@@ -18,6 +18,8 @@ package io.servicetalk.log4j2.mdc.utils;
 import io.servicetalk.concurrent.SingleSource.Subscriber;
 import io.servicetalk.concurrent.api.Single;
 
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,14 +32,22 @@ import java.util.concurrent.Executors;
 
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.log4j2.mdc.utils.ServiceTalkThreadContextMap.getStorage;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeThat;
 
 public class ServiceTalkThreadContextMapTest {
     private static final Logger logger = LoggerFactory.getLogger(ServiceTalkThreadContextMapTest.class);
+
+    @Before
+    public void verifyMDCSetup() {
+        assumeThat(ThreadContext.getThreadContextMap(), is(instanceOf(ServiceTalkThreadContextMap.class)));
+    }
 
     @Test
     public void testSimpleExecution() {

--- a/servicetalk-opentracing-log4j2/src/test/java/io/servicetalk/opentracing/log4j2/ServiceTalkTracingThreadContextMapLog4jProviderTest.java
+++ b/servicetalk-opentracing-log4j2/src/test/java/io/servicetalk/opentracing/log4j2/ServiceTalkTracingThreadContextMapLog4jProviderTest.java
@@ -17,14 +17,22 @@ package io.servicetalk.opentracing.log4j2;
 
 import org.apache.logging.log4j.ThreadContext;
 import org.junit.Test;
+import org.slf4j.MDC;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNull;
 
 public class ServiceTalkTracingThreadContextMapLog4jProviderTest {
     @Test
     public void testProviderLoadsClass() {
         assertThat(ThreadContext.getThreadContextMap(), is(instanceOf(ServiceTalkTracingThreadContextMap.class)));
+    }
+
+    @Test
+    public void testNullValues() {
+        MDC.put("foo", null);
+        assertNull(MDC.get("foo"));
     }
 }

--- a/servicetalk-opentracing-log4j2/src/test/java/io/servicetalk/opentracing/log4j2/ServiceTalkTracingThreadContextMapTest.java
+++ b/servicetalk-opentracing-log4j2/src/test/java/io/servicetalk/opentracing/log4j2/ServiceTalkTracingThreadContextMapTest.java
@@ -25,11 +25,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import static io.servicetalk.log4j2.mdc.utils.LoggerStringWriter.assertContainsMdcPair;
 import static io.servicetalk.log4j2.mdc.utils.LoggerStringWriter.stableAccumulated;
 import static io.servicetalk.opentracing.asynccontext.AsyncContextInMemoryScopeManager.SCOPE_MANAGER;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class ServiceTalkTracingThreadContextMapTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(ServiceTalkTracingThreadContextMapTest.class);
@@ -42,6 +44,12 @@ public class ServiceTalkTracingThreadContextMapTest {
     @After
     public void tearDown() {
         LoggerStringWriter.remove();
+    }
+
+    @Test
+    public void testNullValues() {
+        MDC.put("foo", null);
+        assertNull(MDC.get("foo"));
     }
 
     @Test


### PR DESCRIPTION
Motivation:
The MDC API permits for not supporting null [1] but the log4j2
ThreadContextMap API [2] doesn't specify the behavior for null keys. It
is possible direct usage of ThreadContextMap API may assume null values
are permitted as the default implemetnations support null values.

[1] https://www.javadoc.io/doc/org.slf4j/slf4j-api/1.7.30/org/slf4j/MDC.html#put-java.lang.String-java.lang.String-
[2] https://logging.apache.org/log4j/2.x/log4j-api/apidocs/org/apache/logging/log4j/spi/ThreadContextMap.html#put-java.lang.String-java.lang.String-

Modifications:
- Modify ServiceTalkThreadContextMap and
ServiceTalkTracingThreadContextMap to support null values

Result:
ServiceTalkThreadContextMap permits null values