### PR TITLE
Improve `LoadBalancerFactory#newLoadBalancer()` generics

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancerFactory.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancerFactory.java
@@ -33,9 +33,10 @@ public interface LoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConn
      * @param connectionFactory {@link ConnectionFactory} that the returned {@link LoadBalancer} will use to generate
      * new connections. Returned {@link LoadBalancer} will own the responsibility for this {@link ConnectionFactory}
      * and hence will call {@link ConnectionFactory#closeAsync()} when {@link LoadBalancer#closeAsync()} is called.
+     * @param <T> Type of connections created by the passed {@link ConnectionFactory}.
      * @return a new {@link LoadBalancer}.
      */
-    LoadBalancer<? extends C> newLoadBalancer(
+    <T extends C> LoadBalancer<T> newLoadBalancer(
             Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
-            ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory);
+            ConnectionFactory<ResolvedAddress, T> connectionFactory);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
@@ -30,9 +30,9 @@ public interface HttpLoadBalancerFactory<ResolvedAddress>
         extends LoadBalancerFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> {
 
     @Override
-    LoadBalancer<? extends FilterableStreamingHttpLoadBalancedConnection> newLoadBalancer(
+    <T extends FilterableStreamingHttpLoadBalancedConnection> LoadBalancer<T> newLoadBalancer(
             Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
-            ConnectionFactory<ResolvedAddress, ? extends FilterableStreamingHttpLoadBalancedConnection> cf);
+            ConnectionFactory<ResolvedAddress, T> cf);
 
     /**
      * Converts the passed {@link FilterableStreamingHttpConnection} to a

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
@@ -59,9 +59,9 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
     }
 
     @Override
-    public LoadBalancer<? extends FilterableStreamingHttpLoadBalancedConnection> newLoadBalancer(
+    public <T extends FilterableStreamingHttpLoadBalancedConnection> LoadBalancer<T> newLoadBalancer(
             final Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
-            final ConnectionFactory<ResolvedAddress, ? extends FilterableStreamingHttpLoadBalancedConnection> cf) {
+            final ConnectionFactory<ResolvedAddress, T> cf) {
         return rawFactory.newLoadBalancer(eventPublisher, cf);
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -298,10 +298,9 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
                         connectionFactoryFilter, ctx.builder.loadBalancerFactory::toLoadBalancedConnection);
             }
 
-            @SuppressWarnings("unchecked")
             final LoadBalancer<LoadBalancedStreamingHttpConnection> lb =
-                    (LoadBalancer<LoadBalancedStreamingHttpConnection>) closeOnException.prepend(
-                            ctx.builder.loadBalancerFactory.newLoadBalancer(sdEvents, connectionFactory));
+                    closeOnException.prepend(ctx.builder.loadBalancerFactory.newLoadBalancer(sdEvents,
+                            connectionFactory));
 
             StreamingHttpClientFilterFactory currClientFilterFactory = ctx.builder.clientFilterFactory;
             if (roConfig.hasProxy() && sslContext == null) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AutoRetryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AutoRetryTest.java
@@ -119,9 +119,9 @@ public class AutoRetryTest {
                 newRoundRobinFactory();
 
         @Override
-        public LoadBalancer<? extends C> newLoadBalancer(
+        public <T extends C> LoadBalancer<T> newLoadBalancer(
                 final Publisher<? extends ServiceDiscovererEvent<InetSocketAddress>> eventPublisher,
-                final ConnectionFactory<InetSocketAddress, ? extends C> connectionFactory) {
+                final ConnectionFactory<InetSocketAddress, T> connectionFactory) {
             return new InspectingLoadBalancer<>(rr.newLoadBalancer(eventPublisher, connectionFactory));
         }
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -607,10 +607,9 @@ public class ClientEffectiveStrategyTest {
     private static class LoadBalancerFactoryImpl
             implements LoadBalancerFactory<InetSocketAddress, FilterableStreamingHttpLoadBalancedConnection> {
         @Override
-        public LoadBalancer<? extends FilterableStreamingHttpLoadBalancedConnection>
+        public <T extends FilterableStreamingHttpLoadBalancedConnection> LoadBalancer<T>
         newLoadBalancer(final Publisher<? extends ServiceDiscovererEvent<InetSocketAddress>> eventPublisher,
-                        final ConnectionFactory<InetSocketAddress,
-                                ? extends FilterableStreamingHttpLoadBalancedConnection> connectionFactory) {
+                        final ConnectionFactory<InetSocketAddress, T> connectionFactory) {
             return RoundRobinLoadBalancer.<InetSocketAddress,
                     FilterableStreamingHttpLoadBalancedConnection>newRoundRobinFactory()
                     .newLoadBalancer(eventPublisher, connectionFactory);

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -317,9 +317,9 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
             implements LoadBalancerFactory<ResolvedAddress, C> {
 
         @Override
-        public LoadBalancer<? extends C> newLoadBalancer(
+        public <T extends C> LoadBalancer<T> newLoadBalancer(
                 final Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
-                final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory) {
+                final ConnectionFactory<ResolvedAddress, T> connectionFactory) {
             return new RoundRobinLoadBalancer<>(eventPublisher, connectionFactory);
         }
     }


### PR DESCRIPTION
__Motivation__

`LoadBalancerFactory#newLoadBalancer()` does not allow for the passed `ConnectionFactory` to influence type of the `LoadBalancedConnection` managed by the returned `LoadBalancer`. This forces users of this API (Http client builder implementations) to do an explicit cast.

__Modification__

Improve generics of `LoadBalancerFactory#newLoadBalancer()` to infer the returned `LoadBalancer` generics from the passed `ConnectionFactory`

__Result__

No explicit casts while using `LoadBalancerFactory#newLoadBalancer()`.