### PR TITLE
Remove bintray plugin

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -69,8 +69,6 @@ services:
     depends_on: [runtime-setup]
     environment:
       - CI
-      - BINTRAY_USER
-      - BINTRAY_KEY
       - ORG_GRADLE_PROJECT_signingKey
       - ORG_GRADLE_PROJECT_signingPassword
       - SONATYPE_USER
@@ -84,8 +82,6 @@ services:
     depends_on: [runtime-setup]
     environment:
       - CI
-      - BINTRAY_USER
-      - BINTRAY_KEY
       - ORG_GRADLE_PROJECT_signingKey
       - ORG_GRADLE_PROJECT_signingPassword
       - SONATYPE_USER

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,6 @@ javaPoetVersion=1.12.1
 grpcVersion=1.29.0
 
 # Gradle Plugins
-bintrayPluginVersion=1.8.4
 spotbugsPluginVersion=4.3.0
 shadowPluginVersion=4.0.4
 

--- a/servicetalk-gradle-plugin-internal/plugin-config.gradle
+++ b/servicetalk-gradle-plugin-internal/plugin-config.gradle
@@ -21,7 +21,6 @@ props.load(new FileInputStream("$project.projectDir/../gradle.properties"))
 dependencies {
   implementation gradleApi()
   implementation localGroovy()
-  implementation "com.jfrog.bintray.gradle:gradle-bintray-plugin:$props.bintrayPluginVersion"
   implementation "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:$props.spotbugsPluginVersion"
 }
 


### PR DESCRIPTION
Motivation:

Starting from version 0.20.0 we publish ServiceTalk artifacts to
Maven Central and do not use Bintray anymore.

Modifications:

- Remove commented dead code related to Bintray plugin configuration
that we do not use;

Result:

Less code in `servicetalk-gradle-plugin-internal`.