### PR TITLE
Do not shutdown output channel until client receives the full response

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientClosureRaceTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientClosureRaceTest.java
@@ -47,6 +47,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.api.Single.collectUnordered;
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1;
+import static java.net.InetAddress.getLoopbackAddress;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -76,7 +77,7 @@ public class ClientClosureRaceTest {
     @Before
     public void startServer() throws Exception {
         assert executor != null;
-        serverSocket = new ServerSocket(0);
+        serverSocket = new ServerSocket(0, 50, getLoopbackAddress());
 
         executor.submit(() -> {
             while (!executor.isShutdown()) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.http.api.HttpPayloadWriter;
+import io.servicetalk.http.api.ReservedStreamingHttpConnection;
+import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.IoExecutor;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.netty.internal.IoThreadFactory;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.nio.channels.ClosedChannelException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
+import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
+import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
+import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
+import static io.servicetalk.http.api.Matchers.contentEqualTo;
+import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static java.lang.String.valueOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+public class ConnectionCloseHeaderHandlingTest {
+
+    @Rule
+    public final ServiceTalkTestTimeout timeout = new ServiceTalkTestTimeout();
+
+    private final IoExecutor serverIoExecutor;
+    private final ServerContext serverContext;
+    private final StreamingHttpClient client;
+    private final ReservedStreamingHttpConnection connection;
+
+    private final CountDownLatch sendResponse = new CountDownLatch(1);
+    private final CountDownLatch responseReceived = new CountDownLatch(1);
+    private final CountDownLatch requestReceived = new CountDownLatch(1);
+    private final CountDownLatch connectionClosed = new CountDownLatch(1);
+    private final AtomicInteger requestPayloadSize = new AtomicInteger();
+
+    public ConnectionCloseHeaderHandlingTest() throws Exception {
+        serverIoExecutor = createIoExecutor(new IoThreadFactory("server-io-executor"));
+        serverContext = HttpServers.forAddress(localAddress(0))
+                .ioExecutor(serverIoExecutor)
+                .listenBlockingStreamingAndAwait((ctx, request, response) -> {
+                    requestReceived.countDown();
+                    String content = "server_content";
+                    response.addHeader(CONTENT_LENGTH, valueOf(content.length()))
+                            .addHeader(CONNECTION, CLOSE);
+
+                    sendResponse.await();
+                    try (HttpPayloadWriter<String> writer = response.sendMetaData(textSerializer())) {
+                        // Defer payload body to see how client processes "Connection: close" header
+                        request.payloadBody().forEach(chunk -> requestPayloadSize.addAndGet(chunk.readableBytes()));
+                        responseReceived.await();
+                        writer.write(content);
+                    }
+                });
+
+        client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                .buildStreaming();
+        connection = client.reserveConnection(client.get("/")).toFuture().get();
+        connection.onClose().whenFinally(connectionClosed::countDown).subscribe();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        newCompositeCloseable().appendAll(client, serverContext, serverIoExecutor).close();
+    }
+
+    @Test
+    public void serverCloseNoRequestPayloadBody() throws Exception {
+        sendRequestAndAssertResponse(connection.get("/first")
+                .addHeader(CONTENT_LENGTH, ZERO));
+    }
+
+    @Test
+    public void serverCloseRequestWithPayloadBody() throws Exception {
+        String content = "request_content";
+        sendRequestAndAssertResponse(connection.post("/first")
+                .addHeader(CONTENT_LENGTH, valueOf(content.length()))
+                .payloadBody(client.executionContext().executor().submit(() -> {
+                    try {
+                        responseReceived.await();
+                    } catch (InterruptedException e) {
+                        throwException(e);
+                    }
+                }).concat(from(content)), textSerializer()));
+    }
+
+    private void sendRequestAndAssertResponse(StreamingHttpRequest request) throws Exception {
+        sendResponse.countDown();
+        StreamingHttpResponse response = connection.request(request).toFuture().get();
+        assertResponse(response);
+        responseReceived.countDown();
+
+        assertResponsePayloadBody(response);
+        assertThat(request.headers().get(CONTENT_LENGTH), contentEqualTo(valueOf(requestPayloadSize.get())));
+
+        connectionClosed.await();
+        assertClosedChannelException("/second");
+    }
+
+    @Test
+    public void serverCloseTwoPipelinedRequestsSentBeforeFirstResponse() throws Exception {
+        sendResponse.countDown();
+        AtomicReference<StreamingHttpResponse> firstResponse = new AtomicReference<>();
+        AtomicReference<Throwable> secondRequestError = new AtomicReference<>();
+        CountDownLatch secondResponseReceived = new CountDownLatch(1);
+
+        connection.request(connection.get("/first")
+                .addHeader(CONTENT_LENGTH, ZERO)).subscribe(first -> {
+            firstResponse.set(first);
+            responseReceived.countDown();
+        });
+        connection.request(connection.get("/second")
+                .addHeader(CONTENT_LENGTH, ZERO))
+                .whenOnError(secondRequestError::set)
+                .whenFinally(secondResponseReceived::countDown)
+                .subscribe(second -> { });
+        requestReceived.await();
+        responseReceived.await();
+
+        StreamingHttpResponse response = firstResponse.get();
+        assertResponse(response);
+        assertResponsePayloadBody(response);
+
+        connectionClosed.await();
+        secondResponseReceived.await();
+        assertThat(secondRequestError.get(), instanceOf(ClosedChannelException.class));
+        assertClosedChannelException("/third");
+    }
+
+    @Test
+    public void serverCloseTwoPipelinedRequestsInSequence() throws Exception {
+        sendResponse.countDown();
+        StreamingHttpResponse response = connection.request(connection.get("/first")
+                .addHeader(CONTENT_LENGTH, ZERO)).toFuture().get();
+        assertResponse(response);
+
+        // Send another request before client reads payload body of the first request:
+        assertClosedChannelException("/second");
+
+        responseReceived.countDown();
+        assertResponsePayloadBody(response);
+        connectionClosed.await();
+    }
+
+    @Test
+    public void clientCloseTwoPipelinedRequestsSentBeforeFirstResponse() throws Exception {
+        AtomicReference<StreamingHttpResponse> firstResponse = new AtomicReference<>();
+
+        connection.request(connection.get("/first")
+                .addHeader(CONTENT_LENGTH, ZERO)
+                // Request connection closure:
+                .addHeader(CONNECTION, CLOSE)).subscribe(first -> {
+            firstResponse.set(first);
+            responseReceived.countDown();
+        });
+        // Send another request before client receives a response for the first request:
+        assertClosedChannelException("/second");
+        sendResponse.countDown();
+        responseReceived.await();
+
+        StreamingHttpResponse response = firstResponse.get();
+        assertResponse(response);
+        assertResponsePayloadBody(response);
+        connectionClosed.await();
+    }
+
+    private static void assertResponse(StreamingHttpResponse response) {
+        assertThat(response.status(), is(OK));
+        assertThat(response.headers().get(CONNECTION), contentEqualTo(CLOSE));
+    }
+
+    private static void assertResponsePayloadBody(StreamingHttpResponse response) throws Exception {
+        int actualContentLength = response.payloadBody().map(Buffer::readableBytes)
+                .collect(AtomicInteger::new, (total, current) -> {
+                    total.addAndGet(current);
+                    return total;
+                }).toFuture().get().get();
+        assertThat(response.headers().get(CONTENT_LENGTH), contentEqualTo(valueOf(actualContentLength)));
+    }
+
+    private void assertClosedChannelException(String path) {
+        Exception e = assertThrows(ExecutionException.class,
+                () -> connection.request(connection.get(path).addHeader(CONTENT_LENGTH, ZERO)).toFuture().get());
+        assertThat(e.getCause(), instanceOf(ClosedChannelException.class));
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
@@ -15,41 +15,62 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
-import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.HttpPayloadWriter;
 import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.test.resources.DefaultTestCerts;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.IoExecutor;
+import io.servicetalk.transport.api.SecurityConfigurator;
 import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.netty.internal.IoThreadFactory;
 
-import org.hamcrest.Matchers;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.concurrent.internal.AutoClosableUtils.closeAndReThrowUnchecked;
+import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
+import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
+import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
+import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
+import static io.servicetalk.http.api.Matchers.contentEqualTo;
+import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static java.lang.String.valueOf;
+import static java.net.InetAddress.getLoopbackAddress;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 public class HttpsProxyTest {
 
@@ -58,28 +79,59 @@ public class HttpsProxyTest {
     @Rule
     public final ServiceTalkTestTimeout timeout = new ServiceTalkTestTimeout();
 
-    @Rule
-    public final ExpectedException expected = ExpectedException.none();
-
     private static final String CONNECT_PREFIX = "CONNECT ";
+    @Nullable
     private ServerSocket serverSocket;
+    @Nullable
     private ExecutorService executor;
-    private int proxyPort;
-    private int serverPort;
-    private HttpClient client;
+    @Nullable
+    private HostAndPort proxyAddress;
+    @Nullable
+    private IoExecutor serverIoExecutor;
+    @Nullable
+    private ServerContext serverContext;
+    @Nullable
+    private HostAndPort serverAddress;
+    @Nullable
+    private BlockingHttpClient client;
     private final AtomicInteger connectCount = new AtomicInteger();
     private ProxyRequestHandler handler = this::handleRequest;
+    private final CountDownLatch responseReceived = new CountDownLatch(1);
+    private final AtomicInteger requestPayloadSize = new AtomicInteger();
 
     @Before
-    public void setup() throws Exception {
+    public void setUp() throws Exception {
         startProxy();
         startServer();
         createClient();
     }
 
+    @After
+    public void tearDown() throws Exception {
+        safeClose(client);
+        safeClose(serverContext);
+        safeClose(serverSocket);
+        try {
+            if (executor != null) {
+                executor.shutdown();
+                executor.awaitTermination(100, MILLISECONDS);
+            }
+        } finally {
+            if (serverIoExecutor != null) {
+                serverIoExecutor.closeAsync().toFuture().get();
+            }
+        }
+    }
+
+    static void safeClose(@Nullable AutoCloseable closeable) {
+        if (closeable != null) {
+            closeAndReThrowUnchecked(closeable);
+        }
+    }
+
     public void startProxy() throws Exception {
-        serverSocket = new ServerSocket(0);
-        proxyPort = serverSocket.getLocalPort();
+        serverSocket = new ServerSocket(0, 50, getLoopbackAddress());
+        proxyAddress = HostAndPort.of((InetSocketAddress) serverSocket.getLocalSocketAddress());
         executor = Executors.newCachedThreadPool();
 
         executor.submit(() -> {
@@ -130,6 +182,7 @@ public class HttpsProxyTest {
             out.flush();
 
             final InputStream cin = clientSocket.getInputStream();
+            assert executor != null;
             executor.submit(() -> copyStream(out, cin));
             copyStream(clientSocket.getOutputStream(), in);
         } else {
@@ -138,39 +191,99 @@ public class HttpsProxyTest {
     }
 
     public void startServer() throws Exception {
-        final ServerContext serverContext = HttpServers.forAddress(localAddress(0))
-                .secure().commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
-                .listenAndAwait((ctx, request, responseFactory) -> succeeded(responseFactory.ok()
-                        .payloadBody("host: " + request.headers().get(HOST), textSerializer())));
-        serverPort = serverHostAndPort(serverContext).port();
+        serverContext = HttpServers.forAddress(localAddress(0))
+                .ioExecutor(serverIoExecutor = createIoExecutor(new IoThreadFactory("server-io-executor")))
+                .secure()
+                .provider(SecurityConfigurator.SslProvider.JDK)
+                .commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                .listenBlockingStreamingAndAwait((ctx, request, response) -> {
+                    final String content = "host: " + request.headers().get(HOST);
+                    response.addHeader(CONTENT_LENGTH, valueOf(content.length()));
+                    if ("/close".equals(request.path())) {
+                        response.addHeader(CONNECTION, CLOSE);
+                    }
+
+                    try (HttpPayloadWriter<String> writer = response.sendMetaData(textSerializer())) {
+                        if ("/close".equals(request.path())) {
+                            // Defer payload body to see how client processes "Connection: close" header
+                            request.payloadBody().forEach(chunk -> requestPayloadSize.addAndGet(chunk.readableBytes()));
+                            responseReceived.await();
+                        }
+                        writer.write(content);
+                    }
+                });
+        serverAddress = serverHostAndPort(serverContext);
     }
 
     public void createClient() {
-        client = HttpClients.forSingleAddressViaProxy("localhost", serverPort, "localhost", proxyPort)
-                .secure().disableHostnameVerification().trustManager(DefaultTestCerts::loadMutualAuthCaPem).commit()
-                .build();
+        assert serverAddress != null && proxyAddress != null;
+        client = HttpClients
+                .forSingleAddressViaProxy(serverAddress, proxyAddress)
+                .secure().disableHostnameVerification().trustManager(DefaultTestCerts::loadMutualAuthCaPem)
+                .provider(SecurityConfigurator.SslProvider.JDK).commit()
+                .buildBlocking();
     }
 
     @Test
     public void testRequest() throws Exception {
-        final HttpResponse httpResponse = client.request(client.get("/path")).toFuture().get();
+        assert client != null;
+        final HttpResponse httpResponse = client.request(client.get("/path"));
         assertThat(httpResponse.status(), is(OK));
         assertThat(connectCount.get(), is(1));
-        assertThat(httpResponse.payloadBody().toString(US_ASCII), is("host: localhost:" + serverPort));
+        assertThat(httpResponse.payloadBody().toString(US_ASCII), is("host: " + serverAddress));
     }
 
     @Test
-    public void testBadProxyResponse() throws Exception {
+    public void testBadProxyResponse() {
         handler = (socket, in, initialLine) -> {
             socket.getOutputStream().write("HTTP/1.1 500 Internal Server Error\r\n\r\n".getBytes(UTF_8));
             socket.getOutputStream().flush();
         };
+        assert client != null;
+        assertThrows(ProxyResponseException.class, () -> client.request(client.get("/path")));
+    }
 
-        final Future<HttpResponse> httpResponseFuture = client.request(client.get("/path")).toFuture();
+    @Test
+    public void testResponseWithConnectionCloseHeaderAndDelayedResponsePayloadBody() throws Exception {
+        assert client != null;
+        StreamingHttpClient client = this.client.asStreamingClient();
+        final StreamingHttpRequest request = client.get("/close")
+                .addHeader(CONTENT_LENGTH, ZERO);
+        StreamingHttpResponse response = client.request(request).toFuture().get();
+        assertResponse(request, response);
+    }
 
-        expected.expect(ExecutionException.class);
-        expected.expectCause(Matchers.instanceOf(ProxyResponseException.class));
-        httpResponseFuture.get();
+    @Test
+    public void testResponseWithConnectionCloseHeaderAndDelayedRequestPayloadBody() throws Exception {
+        assert client != null;
+        StreamingHttpClient client = this.client.asStreamingClient();
+        String content = "hello";
+        final StreamingHttpRequest request = client.post("/close")
+                .addHeader(CONTENT_LENGTH, valueOf(content.length()))
+                .payloadBody(client.executionContext().executor().submit(() -> {
+                    try {
+                        responseReceived.await();
+                    } catch (InterruptedException e) {
+                        throwException(e);
+                    }
+                }).concat(from(content)), textSerializer());
+        StreamingHttpResponse response = client.request(request).toFuture().get();
+        assertResponse(request, response);
+    }
+
+    private void assertResponse(StreamingHttpRequest request, StreamingHttpResponse response) throws Exception {
+        assertThat(response.status(), is(OK));
+        assertThat(connectCount.get(), is(1));
+        assertThat(response.headers().get(CONNECTION), contentEqualTo(CLOSE));
+        responseReceived.countDown();
+
+        int actualContentLength = response.payloadBody().map(Buffer::readableBytes)
+                .collect(AtomicInteger::new, (total, current) -> {
+                    total.addAndGet(current);
+                    return total;
+                }).toFuture().get().get();
+        assertThat(response.headers().get(CONTENT_LENGTH), contentEqualTo(valueOf(actualContentLength)));
+        assertThat(request.headers().get(CONTENT_LENGTH), contentEqualTo(valueOf(requestPayloadSize.get())));
     }
 
     private static String readLine(final InputStream in) throws IOException {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
@@ -355,4 +355,15 @@ public abstract class CloseHandler {
             // No instances.
         }
     }
+
+    /**
+     * Netty UserEvent to indicate the output channel is closing.
+     */
+    static final class ChannelOutputClosingEvent {
+        static final ChannelOutputClosingEvent INSTANCE = new ChannelOutputClosingEvent();
+
+        private ChannelOutputClosingEvent() {
+            // No instances.
+        }
+    }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
@@ -357,12 +357,12 @@ public abstract class CloseHandler {
     }
 
     /**
-     * Netty UserEvent to indicate the output channel is closing.
+     * Netty UserEvent to indicate the output writes should be aborted because the channel is closing.
      */
-    static final class ChannelOutputClosingEvent {
-        static final ChannelOutputClosingEvent INSTANCE = new ChannelOutputClosingEvent();
+    static final class AbortWritesEvent {
+        static final AbortWritesEvent INSTANCE = new AbortWritesEvent();
 
-        private ChannelOutputClosingEvent() {
+        private AbortWritesEvent() {
             // No instances.
         }
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
@@ -240,13 +240,11 @@ class RequestResponseCloseHandler extends CloseHandler {
         if (idle(pending, state)) {
             // close when all pending requests drained
             closeChannel(channel, evt);
-        } else if (isClient && evt == PROTOCOL_CLOSING_OUTBOUND) {
-            // deferred half close after current request is done
-            clientHalfCloseOutbound(channel);
         } else if (!isClient && evt == PROTOCOL_CLOSING_INBOUND) {
             // deferred half close after current request is done
             serverHalfCloseInbound(channel);
         }
+        // do not perform half-closure on the client to prevent a server from premature connection closure
     }
 
     // Eagerly close on a closing event rather than deferring
@@ -255,15 +253,14 @@ class RequestResponseCloseHandler extends CloseHandler {
             closeChannel(channel, evt);
         } else if (isClient) {
             if (evt == PROTOCOL_CLOSING_INBOUND) {
-                if (pending != 0 || !has(state, WRITE)) {
-                    // eagerly close the outbound channel unless we are still writing the current request
+                if (pending != 0) {
+                    // Abort the current and all following pipelined requests
                     if (has(state, WRITE)) {
-                        setSocketResetOnClose(channel);
+                        channel.pipeline().fireUserEventTriggered(ChannelOutputClosingEvent.INSTANCE);
+                        state = unset(state, WRITE);
                     }
-                    clientHalfCloseOutbound(channel);
+                    pending = 0;
                 }
-                // discards extra pending requests when closing, ensures an eventual "idle" state
-                pending = 0;
             } else if (!has(state, WRITE)) { // only USER_CLOSING - Don't abort any request
                 clientHalfCloseOutbound(channel);
             }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandlerTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandlerTest.java
@@ -18,6 +18,7 @@ package io.servicetalk.transport.netty.internal;
 import io.servicetalk.concurrent.api.DefaultThreadFactory;
 import io.servicetalk.concurrent.api.Executors;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.transport.netty.internal.CloseHandler.ChannelOutputClosingEvent;
 import io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent;
 
 import io.netty.bootstrap.Bootstrap;
@@ -28,6 +29,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoop;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.epoll.Epoll;
@@ -82,6 +84,7 @@ import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.US
 import static io.servicetalk.transport.netty.internal.CloseHandler.forPipelinedRequestResponse;
 import static io.servicetalk.transport.netty.internal.EventLoopAwareNettyIoExecutors.toEventLoopAwareNettyIoExecutor;
 import static io.servicetalk.transport.netty.internal.NettyIoExecutors.createIoExecutor;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.CE;
 import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.FC;
 import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.IB;
 import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.IC;
@@ -91,7 +94,6 @@ import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandle
 import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.OB;
 import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.OC;
 import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.OE;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.OH;
 import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.OS;
 import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.SR;
 import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.UC;
@@ -153,6 +155,7 @@ public class RequestResponseCloseHandlerTest {
         private AtomicBoolean inputShutdown = new AtomicBoolean();
         private AtomicBoolean outputShutdown = new AtomicBoolean();
         private SocketChannelConfig scc;
+        private ChannelPipeline pipeline;
 
         public Scenarios(final Mode mode, final List<Events> events, final ExpectEvent expectEvent,
                          final String desc, final String location) {
@@ -175,6 +178,7 @@ public class RequestResponseCloseHandlerTest {
             SR,         // validate Socket TCP RST -> SO_LINGER=0
             UC,         // emit User Closing
             IH, OH, FC, // validate Input/Output Half-close, Full-Close
+            CE,         // emit ChannelOutputClosingEvent
         }
 
         protected enum ExpectEvent {
@@ -200,17 +204,17 @@ public class RequestResponseCloseHandlerTest {
                     // {Mode, Events, ExpectedEvent, Desc} - IGNORE disables test-case, keep contiguous on single line
                     {C, e(OB, OE, IB, IE), NIL, "sequential, no close"},
                     {C, e(OB, OE, IB, OB, OE, IE, IB, IE), NIL, "pipelined, no close"},
-                    {C, e(OB, OC, OE, OH, IB, IE, FC), PCO, "sequential, closing outbound"},
-                    {C, e(OB, OE, OB, OC, OE, OH, IB, IE, IB, IE, FC), PCO, "pipelined, closing outbound"},
-                    {C, e(OB, OE, OB, OC, IB, OE, OH, IE, IB, IE, FC), PCO, "pipelined, full dup, closing outbound"},
-                    {C, e(OB, IB, IC, OE, OH, IE, FC), PCI, "full dup, closing inbound"},
-                    {C, e(OB, OE, IB, OB, IC, SR, OH, IE, FC), PCI, "server closes 1st request, 2nd request discarded"},
-                    {C, e(OB, IB, OE, IC, OH, IE, FC), PCI, "pipelined, closing inbound"},
+                    {C, e(OB, OC, OE, IB, IE, FC), PCO, "sequential, closing outbound"},
+                    {C, e(OB, OE, OB, OC, OE, IB, IE, IB, IE, FC), PCO, "pipelined, closing outbound"},
+                    {C, e(OB, OE, OB, OC, IB, OE, IE, IB, IE, FC), PCO, "pipelined, full dup, closing outbound"},
+                    {C, e(OB, IB, IC, OE, IE, FC), PCI, "full dup, closing inbound"},
+                    {C, e(OB, OE, IB, OB, IC, CE, IE, FC), PCI, "server closes 1st request, 2nd request discarded"},
+                    {C, e(OB, IB, OE, IC, IE, FC), PCI, "pipelined, closing inbound"},
                     {C, e(OB, IB, IC, IE, OE, FC), PCI, "pipelined, full dup, closing inbound"},
-                    {C, e(OB, OE, IB, IC, OH, IE, FC), PCI, "sequential, closing inbound"},
-                    {C, e(OB, UC, OE, OH, IB, IE, FC), UCO, "sequential, user close"},
-                    {C, e(OB, IB, OE, OB, UC, OE, OH, IE, IB, IE, FC), UCO, "pipelined req graceful close"},
-                    {C, e(OB, IB, UC, OE, OH, IE, FC), UCO, "interleaved, user close"},
+                    {C, e(OB, OE, IB, IC, IE, FC), PCI, "sequential, closing inbound"},
+                    {C, e(OB, UC, OE, IB, IE, FC), UCO, "sequential, user close"},
+                    {C, e(OB, IB, OE, OB, UC, OE, IE, IB, IE, FC), UCO, "pipelined req graceful close"},
+                    {C, e(OB, IB, UC, OE, IE, FC), UCO, "interleaved, user close"},
                     {C, e(OB, OE, IB, IE, UC, FC), UCO, "sequential, idle, user close"},
                     {C, e(OB, IB, OE, IE, UC, FC), UCO, "interleaved, idle, user close"},
                     {C, e(OB, IB, IE, OE, UC, FC), UCO, "interleaved full dup, idle, user close"},
@@ -218,7 +222,7 @@ public class RequestResponseCloseHandlerTest {
                     {C, e(OB, OE, IS, FC), CCI, "abrupt input close after complete write, resp abort"},
                     {C, e(IS, FC), CCI, "idle, inbound closed"},
                     {C, e(OB, IS, SR, FC), CCI, "req abort, inbound closed"},
-                    {C, e(OB, IB, OE, OB, IC, SR, OH, IE, FC), PCI, "pipelined req abort after inbound close "},
+                    {C, e(OB, IB, OE, OB, IC, CE, IE, FC), PCI, "pipelined req abort after inbound close"},
                     {C, e(OB, IB, OE, IS, FC), CCI, "req complete, resp abort, inbound closed"},
                     {C, e(OB, IB, IE, IS, OE, FC), CCI, "continue write read completed, inbound closed"},
                     {C, e(OS, FC), CCO, "idle, outbound closed"},
@@ -308,6 +312,8 @@ public class RequestResponseCloseHandlerTest {
             when(channel.eventLoop()).thenReturn(loop);
             when(loop.inEventLoop()).thenReturn(true);
             when(scc.isAllowHalfClosure()).thenReturn(true);
+            pipeline = mock(ChannelPipeline.class);
+            when(channel.pipeline()).thenReturn(pipeline);
 
             when(channel.isOutputShutdown()).then(__ -> outputShutdown.get());
             when(channel.isInputShutdown()).then(__ -> inputShutdown.get());
@@ -337,7 +343,7 @@ public class RequestResponseCloseHandlerTest {
                 }
                 return scc;
             });
-            h = (RequestResponseCloseHandler) spy(mode == Mode.C ? forPipelinedRequestResponse(true, channel.config()) :
+            h = (RequestResponseCloseHandler) spy(mode == C ? forPipelinedRequestResponse(true, channel.config()) :
                     forPipelinedRequestResponse(false, channel.config()));
             h.registerEventHandler(channel, e -> {
                 if (observedEvent == null) {
@@ -359,7 +365,7 @@ public class RequestResponseCloseHandlerTest {
         public void simulate() {
             LOGGER.debug("Test.Params: ({})", location); // Intellij jump to parameter format, don't change!
             LOGGER.debug("[{}] {} - {} = {}", desc, mode, events, expectEvent);
-            InOrder order = inOrder(h, channel, scc);
+            InOrder order = inOrder(h, channel, scc, pipeline);
             verify(h).registerEventHandler(eq(channel), any());
             for (Events event : events) {
                 LOGGER.debug("{}", event);
@@ -418,6 +424,9 @@ public class RequestResponseCloseHandlerTest {
                     case FC:
                         order.verify(channel).close();
                         break;
+                    case CE:
+                        order.verify(pipeline).fireUserEventTriggered(ChannelOutputClosingEvent.INSTANCE);
+                        break;
                     default:
                         throw new IllegalArgumentException("Unknown: " + event);
                 }
@@ -427,7 +436,7 @@ public class RequestResponseCloseHandlerTest {
                 if (!events.contains(c)) {
                     switch (c) {
                         case IB:
-                           verify(h, never()).protocolPayloadBeginInbound(ctx);
+                            verify(h, never()).protocolPayloadBeginInbound(ctx);
                             break;
                         case IE:
                             verify(h, never()).protocolPayloadEndInbound(ctx);
@@ -462,6 +471,9 @@ public class RequestResponseCloseHandlerTest {
                             break;
                         case OH:
                             verify(channel, never()).shutdownOutput();
+                            break;
+                        case CE:
+                            verify(pipeline, never()).fireUserEventTriggered(ChannelOutputClosingEvent.INSTANCE);
                             break;
                         default:
                             throw new IllegalArgumentException("Unknown: " + c);


### PR DESCRIPTION
Motivation:

When client observes "Connection: close" header it shutdowns the output
channel as soon as request is written. Some servers interpret FIN from
the client as an indicator that it lost interest in their data and
therefore, server just closes the second half of the connection asap.
As the result, connection may be closed before client receives the full
response from the server.

Modifications:

- Reproduce this scenario using a simple proxy tunnel that is not aware
of HTTP protocol semantics;
- Defer connection closure on the client side until it completes the
full request-response iteration;
- Fail all subsequent or pipelined requests on the connection that moves
to the "closing" state;
- Adjust `RequestResponseCloseHandlerTest` to not expecting outbound
half-closure on the client side;
- Add more tests to verify that client handles "Connection: close" header
correctly;

Result:

Response is not aborted when client observes "Connection: close" header.