### PR TITLE
Use `afterFinally` in examples

### DIFF
--- a/servicetalk-examples/grpc/helloworld/src/main/java/io/servicetalk/examples/grpc/helloworld/async/HelloWorldClient.java
+++ b/servicetalk-examples/grpc/helloworld/src/main/java/io/servicetalk/examples/grpc/helloworld/async/HelloWorldClient.java
@@ -32,7 +32,7 @@ public final class HelloWorldClient {
             // demonstration purposes.
             CountDownLatch responseProcessedLatch = new CountDownLatch(1);
             client.sayHello(HelloRequest.newBuilder().setName("Foo").build())
-                    .whenFinally(responseProcessedLatch::countDown)
+                    .afterFinally(responseProcessedLatch::countDown)
                     .subscribe(System.out::println);
 
             responseProcessedLatch.await();

--- a/servicetalk-examples/grpc/routeguide/src/main/java/io/servicetalk/examples/grpc/routeguide/async/RouteGuideClient.java
+++ b/servicetalk-examples/grpc/routeguide/src/main/java/io/servicetalk/examples/grpc/routeguide/async/RouteGuideClient.java
@@ -33,7 +33,7 @@ public final class RouteGuideClient {
             // demonstration purposes.
             CountDownLatch responseProcessedLatch = new CountDownLatch(1);
             client.getFeature(Point.newBuilder().setLatitude(123456).setLongitude(-123456).build())
-                    .whenFinally(responseProcessedLatch::countDown)
+                    .afterFinally(responseProcessedLatch::countDown)
                     .subscribe(System.out::println);
 
             responseProcessedLatch.await();

--- a/servicetalk-examples/grpc/routeguide/src/main/java/io/servicetalk/examples/grpc/routeguide/async/streaming/RouteGuideRequestStreamingClient.java
+++ b/servicetalk-examples/grpc/routeguide/src/main/java/io/servicetalk/examples/grpc/routeguide/async/streaming/RouteGuideRequestStreamingClient.java
@@ -36,7 +36,7 @@ public final class RouteGuideRequestStreamingClient {
             CountDownLatch responseProcessedLatch = new CountDownLatch(1);
             client.recordRoute(from(Point.newBuilder().setLatitude(123456).setLongitude(-123456).build(),
                             Point.newBuilder().setLatitude(789000).setLongitude(-789000).build()))
-                    .whenFinally(responseProcessedLatch::countDown)
+                    .afterFinally(responseProcessedLatch::countDown)
                     .subscribe(System.out::println);
 
             responseProcessedLatch.await();

--- a/servicetalk-examples/grpc/routeguide/src/main/java/io/servicetalk/examples/grpc/routeguide/async/streaming/RouteGuideResponseStreamingClient.java
+++ b/servicetalk-examples/grpc/routeguide/src/main/java/io/servicetalk/examples/grpc/routeguide/async/streaming/RouteGuideResponseStreamingClient.java
@@ -37,7 +37,7 @@ public final class RouteGuideResponseStreamingClient {
                     .setHi(Point.newBuilder().setLatitude(123456).setLongitude(-123456).build())
                     .setLo(Point.newBuilder().setLatitude(789000).setLongitude(-789000).build())
                     .build())
-                    .whenFinally(responseProcessedLatch::countDown)
+                    .afterFinally(responseProcessedLatch::countDown)
                     .forEach(System.out::println);
 
             responseProcessedLatch.await();

--- a/servicetalk-examples/grpc/routeguide/src/main/java/io/servicetalk/examples/grpc/routeguide/async/streaming/RouteGuideStreamingClient.java
+++ b/servicetalk-examples/grpc/routeguide/src/main/java/io/servicetalk/examples/grpc/routeguide/async/streaming/RouteGuideStreamingClient.java
@@ -43,7 +43,7 @@ public final class RouteGuideStreamingClient {
                     .setLocation(Point.newBuilder().setLatitude(123456).setLongitude(-123456).build())
                     .setMessage("Querying notes.")
                     .build()))
-                    .whenFinally(responseProcessedLatch::countDown)
+                    .afterFinally(responseProcessedLatch::countDown)
                     .forEach(System.out::println);
 
             responseProcessedLatch.await();

--- a/servicetalk-examples/http/helloworld/src/main/java/io/servicetalk/examples/http/helloworld/async/HelloWorldClient.java
+++ b/servicetalk-examples/http/helloworld/src/main/java/io/servicetalk/examples/http/helloworld/async/HelloWorldClient.java
@@ -31,7 +31,7 @@ public final class HelloWorldClient {
             // demonstration purposes.
             CountDownLatch responseProcessedLatch = new CountDownLatch(1);
             client.request(client.get("/sayHello"))
-                    .whenFinally(responseProcessedLatch::countDown)
+                    .afterFinally(responseProcessedLatch::countDown)
                     .subscribe(resp -> {
                         System.out.println(resp.toString((name, value) -> value));
                         System.out.println(resp.payloadBody(textDeserializer()));

--- a/servicetalk-examples/http/helloworld/src/main/java/io/servicetalk/examples/http/helloworld/async/HelloWorldUrlClient.java
+++ b/servicetalk-examples/http/helloworld/src/main/java/io/servicetalk/examples/http/helloworld/async/HelloWorldUrlClient.java
@@ -31,7 +31,7 @@ public final class HelloWorldUrlClient {
             // demonstration purposes.
             CountDownLatch responseProcessedLatch = new CountDownLatch(1);
             client.request(client.get("http://localhost:8080/sayHello"))
-                    .whenFinally(responseProcessedLatch::countDown)
+                    .afterFinally(responseProcessedLatch::countDown)
                     .subscribe(resp -> {
                         System.out.println(resp.toString((name, value) -> value));
                         System.out.println(resp.payloadBody(textDeserializer()));

--- a/servicetalk-examples/http/helloworld/src/main/java/io/servicetalk/examples/http/helloworld/async/streaming/HelloWorldStreamingClient.java
+++ b/servicetalk-examples/http/helloworld/src/main/java/io/servicetalk/examples/http/helloworld/async/streaming/HelloWorldStreamingClient.java
@@ -33,7 +33,7 @@ public final class HelloWorldStreamingClient {
             client.request(client.get("/sayHello"))
                     .beforeOnSuccess(response -> System.out.println(response.toString((name, value) -> value)))
                     .flatMapPublisher(resp -> resp.payloadBody(textDeserializer()))
-                    .whenFinally(responseProcessedLatch::countDown)
+                    .afterFinally(responseProcessedLatch::countDown)
                     .forEach(System.out::println);
 
             responseProcessedLatch.await();

--- a/servicetalk-examples/http/helloworld/src/main/java/io/servicetalk/examples/http/helloworld/async/streaming/HelloWorldStreamingUrlClient.java
+++ b/servicetalk-examples/http/helloworld/src/main/java/io/servicetalk/examples/http/helloworld/async/streaming/HelloWorldStreamingUrlClient.java
@@ -33,7 +33,7 @@ public final class HelloWorldStreamingUrlClient {
             client.request(client.get("http://localhost:8080/sayHello"))
                     .beforeOnSuccess(response -> System.out.println(response.toString((name, value) -> value)))
                     .flatMapPublisher(resp -> resp.payloadBody(textDeserializer()))
-                    .whenFinally(responseProcessedLatch::countDown)
+                    .afterFinally(responseProcessedLatch::countDown)
                     .forEach(System.out::println);
 
             responseProcessedLatch.await();

--- a/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/async/PojoClient.java
+++ b/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/async/PojoClient.java
@@ -38,7 +38,7 @@ public final class PojoClient {
 
             client.request(client.post("/pojos")
                     .payloadBody(new CreatePojoRequest("value"), serializer.serializerFor(CreatePojoRequest.class)))
-                    .whenFinally(responseProcessedLatch::countDown)
+                    .afterFinally(responseProcessedLatch::countDown)
                     .subscribe(resp -> {
                         System.out.println(resp.toString((name, value) -> value));
                         System.out.println(resp.payloadBody(serializer.deserializerFor(PojoResponse.class)));

--- a/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/async/PojoUrlClient.java
+++ b/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/async/PojoUrlClient.java
@@ -38,7 +38,7 @@ public final class PojoUrlClient {
 
             client.request(client.post("http://localhost:8080/pojos")
                     .payloadBody(new CreatePojoRequest("value"), serializer.serializerFor(CreatePojoRequest.class)))
-                    .whenFinally(responseProcessedLatch::countDown)
+                    .afterFinally(responseProcessedLatch::countDown)
                     .subscribe(resp -> {
                         System.out.println(resp.toString((name, value) -> value));
                         System.out.println(resp.payloadBody(serializer.deserializerFor(PojoResponse.class)));

--- a/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/async/streaming/PojoStreamingClient.java
+++ b/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/async/streaming/PojoStreamingClient.java
@@ -42,7 +42,7 @@ public final class PojoStreamingClient {
                             serializer.serializerFor(CreatePojoRequest.class)))
                     .beforeOnSuccess(response -> System.out.println(response.toString((name, value) -> value)))
                     .flatMapPublisher(resp -> resp.payloadBody(serializer.deserializerFor(PojoResponse.class)))
-                    .whenFinally(responseProcessedLatch::countDown)
+                    .afterFinally(responseProcessedLatch::countDown)
                     .forEach(System.out::println);
 
             responseProcessedLatch.await();

--- a/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/async/streaming/PojoStreamingUrlClient.java
+++ b/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/async/streaming/PojoStreamingUrlClient.java
@@ -42,7 +42,7 @@ public final class PojoStreamingUrlClient {
                             serializer.serializerFor(CreatePojoRequest.class)))
                     .beforeOnSuccess(response -> System.out.println(response.toString((name, value) -> value)))
                     .flatMapPublisher(resp -> resp.payloadBody(serializer.deserializerFor(PojoResponse.class)))
-                    .whenFinally(responseProcessedLatch::countDown)
+                    .afterFinally(responseProcessedLatch::countDown)
                     .forEach(System.out::println);
 
             responseProcessedLatch.await();


### PR DESCRIPTION
__Motivation__

We currently use `whenFinally` to decrement the countdown latch. As `whenFinally` uses `beforeFinally`, latch is decrementing before the output is printed.

__Modification__

Use `afterFinally` instead of `whenFinally`

__Result__

Examples print the output correctly.