### PR TITLE
Enhance `connection: close` tests to cover more use-cases on the server-side

### DIFF
--- a/servicetalk-http-netty/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-http-netty/gradle/spotbugs/test-exclusions.xml
@@ -34,7 +34,8 @@
     <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
   </Match>
   <Match>
-    <Class name="io.servicetalk.http.netty.HttpsProxyTest"/>
+    <Class name="io.servicetalk.http.netty.ProxyTunnel"/>
+    <Method name="startProxy"/>
     <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
   </Match>
   <!-- false positive in Java 11, see https://github.com/spotbugs/spotbugs/issues/756 -->

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
@@ -16,12 +16,16 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.concurrent.BlockingIterator;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.http.api.HttpPayloadWriter;
+import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.ReservedStreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.test.resources.DefaultTestCerts;
+import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.IoThreadFactory;
@@ -29,12 +33,19 @@ import io.servicetalk.transport.netty.internal.IoThreadFactory;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 import java.nio.channels.ClosedChannelException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.concurrent.api.Completable.never;
@@ -43,214 +54,336 @@ import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
+import static io.servicetalk.http.api.HttpRequestMethod.GET;
+import static io.servicetalk.http.api.HttpRequestMethod.POST;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
 import static io.servicetalk.http.api.Matchers.contentEqualTo;
+import static io.servicetalk.http.netty.HttpsProxyTest.safeClose;
 import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.lang.String.valueOf;
+import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assume.assumeFalse;
 
+@RunWith(Enclosed.class)
 public class ConnectionCloseHeaderHandlingTest {
 
-    @Rule
-    public final ServiceTalkTestTimeout timeout = new ServiceTalkTestTimeout();
+    private static final Collection<Boolean> TRUE_FALSE = asList(true, false);
 
-    private final IoExecutor serverIoExecutor;
-    private final ServerContext serverContext;
-    private final StreamingHttpClient client;
-    private final ReservedStreamingHttpConnection connection;
+    private abstract static class ConnectionSetup {
 
-    private final CountDownLatch sendResponse = new CountDownLatch(1);
-    private final CountDownLatch responseReceived = new CountDownLatch(1);
-    private final CountDownLatch requestReceived = new CountDownLatch(1);
-    private final CountDownLatch connectionClosed = new CountDownLatch(1);
-    private final AtomicInteger requestPayloadSize = new AtomicInteger();
+        @Rule
+        public final ServiceTalkTestTimeout timeout = new ServiceTalkTestTimeout();
 
-    public ConnectionCloseHeaderHandlingTest() throws Exception {
-        serverIoExecutor = createIoExecutor(new IoThreadFactory("server-io-executor"));
-        serverContext = HttpServers.forAddress(localAddress(0))
-                .ioExecutor(serverIoExecutor)
-                .listenBlockingStreamingAndAwait((ctx, request, response) -> {
-                    requestReceived.countDown();
-                    String content = "server_content";
-                    response.addHeader(CONTENT_LENGTH, valueOf(content.length()))
-                            .addHeader(CONNECTION, CLOSE);
+        @Nullable
+        private final ProxyTunnel proxyTunnel;
+        private final IoExecutor serverIoExecutor;
+        private final ServerContext serverContext;
+        private final StreamingHttpClient client;
+        protected final ReservedStreamingHttpConnection connection;
 
-                    sendResponse.await();
-                    try (HttpPayloadWriter<String> writer = response.sendMetaData(textSerializer())) {
-                        // Defer payload body to see how client processes "Connection: close" header
-                        request.payloadBody().forEach(chunk -> requestPayloadSize.addAndGet(chunk.readableBytes()));
-                        responseReceived.await();
-                        writer.write(content);
+        protected final CountDownLatch connectionClosed = new CountDownLatch(1);
+        protected final CountDownLatch sendResponse = new CountDownLatch(1);
+        protected final CountDownLatch responseReceived = new CountDownLatch(1);
+        protected final CountDownLatch requestReceived = new CountDownLatch(1);
+        protected final CountDownLatch requestPayloadReceived = new CountDownLatch(1);
+        protected final AtomicInteger requestPayloadSize = new AtomicInteger();
+
+        protected ConnectionSetup(boolean viaProxy, boolean awaitRequestPayload) throws Exception {
+            serverIoExecutor = createIoExecutor(new IoThreadFactory("server-io-executor"));
+            HttpServerBuilder serverBuilder = HttpServers.forAddress(localAddress(0))
+                    .ioExecutor(serverIoExecutor);
+
+            HostAndPort proxyAddress = null;
+            if (viaProxy) {
+                // Dummy proxy helps to emulate old intermediate systems that do not support half-closed TCP connections
+                proxyTunnel = new ProxyTunnel();
+                proxyAddress = proxyTunnel.startProxy();
+                serverBuilder.secure().commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey);
+            } else {
+                proxyTunnel = null;
+            }
+
+            serverContext = serverBuilder
+                    .listenBlockingStreamingAndAwait((ctx, request, response) -> {
+                        requestReceived.countDown();
+                        boolean noResponseContent = request.hasQueryParameter("noResponseContent", "true");
+                        String content = noResponseContent ? "" : "server_content";
+                        response.addHeader(CONTENT_LENGTH, noResponseContent ? ZERO : valueOf(content.length()))
+                                .addHeader(CONNECTION, CLOSE);
+
+                        sendResponse.await();
+                        try (HttpPayloadWriter<String> writer = response.sendMetaData(textSerializer())) {
+                            // Subscribe to the request payload body before response writer closes
+                            BlockingIterator<Buffer> iterator = request.payloadBody().iterator();
+                            // Consume request payload body asynchronously:
+                            ctx.executionContext().executor().execute(() -> {
+                                while (iterator.hasNext()) {
+                                    Buffer chunk = iterator.next();
+                                    assert chunk != null;
+                                    requestPayloadSize.addAndGet(chunk.readableBytes());
+                                }
+                                requestPayloadReceived.countDown();
+                            });
+                            if (awaitRequestPayload) {
+                                requestPayloadReceived.await();
+                            }
+                            if (!noResponseContent) {
+                                // Defer payload body to see how client-side processes "Connection: close" header
+                                responseReceived.await();
+                            }
+                            writer.write(content);
+                        }
+                    });
+
+            HostAndPort serverAddress = serverHostAndPort(serverContext);
+            client = (viaProxy ? HttpClients.forSingleAddressViaProxy(serverAddress, proxyAddress)
+                    .secure().disableHostnameVerification()
+                    .trustManager(DefaultTestCerts::loadMutualAuthCaPem)
+                    .commit() :
+                    HttpClients.forSingleAddress(serverAddress))
+                    .buildStreaming();
+            connection = client.reserveConnection(client.get("/")).toFuture().get();
+            connection.onClose().whenFinally(connectionClosed::countDown).subscribe();
+        }
+
+        @After
+        public void tearDown() throws Exception {
+            try {
+                newCompositeCloseable().appendAll(connection, client, serverContext, serverIoExecutor).close();
+            } finally {
+                if (proxyTunnel != null) {
+                    safeClose(proxyTunnel);
+                }
+            }
+        }
+
+        protected void assertClosedChannelException(String path) {
+            Exception e = assertThrows(ExecutionException.class,
+                    () -> connection.request(connection.get(path).addHeader(CONTENT_LENGTH, ZERO)).toFuture().get());
+            assertThat(e.getCause(), instanceOf(ClosedChannelException.class));
+        }
+
+        protected static void assertResponse(StreamingHttpResponse response) {
+            assertThat(response.status(), is(OK));
+            assertThat(response.headers().get(CONNECTION), contentEqualTo(CLOSE));
+        }
+
+        protected static void assertResponsePayloadBody(StreamingHttpResponse response) throws Exception {
+            int actualContentLength = response.payloadBody().map(Buffer::readableBytes)
+                    .collect(AtomicInteger::new, (total, current) -> {
+                        total.addAndGet(current);
+                        return total;
+                    }).toFuture().get().get();
+            assertThat(response.headers().get(CONTENT_LENGTH), contentEqualTo(valueOf(actualContentLength)));
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class NonPipelinedRequestsTest extends ConnectionSetup {
+
+        private final CountDownLatch responsePayloadReceived = new CountDownLatch(1);
+
+        private final boolean awaitRequestPayload;
+        private final boolean awaitResponsePayload;
+        private final boolean requestInitiatesClosure;
+        private final boolean noRequestContent;
+        private final boolean noResponseContent;
+
+        public NonPipelinedRequestsTest(boolean viaProxy, boolean awaitRequestPayload, boolean awaitResponsePayload,
+                                        boolean requestInitiatesClosure,
+                                        boolean noRequestContent, boolean noResponseContent) throws Exception {
+            super(viaProxy, awaitRequestPayload);
+            this.awaitRequestPayload = awaitRequestPayload;
+            this.awaitResponsePayload = awaitResponsePayload;
+            this.requestInitiatesClosure = requestInitiatesClosure;
+            this.noRequestContent = noRequestContent;
+            this.noResponseContent = noResponseContent;
+        }
+
+        @Parameters(name = "viaProxy={0}, awaitRequestPayload={1}, awaitResponsePayload={2}, " +
+                "requestInitiatesClosure={3}, noRequestContent={4}, noResponseContent={5}")
+        public static Collection<Boolean[]> data() {
+            Collection<Boolean[]> data = new ArrayList<>();
+            for (boolean viaProxy : TRUE_FALSE) {
+                for (boolean awaitRequestPayload : TRUE_FALSE) {
+                    for (boolean awaitResponsePayload : TRUE_FALSE) {
+                        for (boolean requestInitiatesClosure : TRUE_FALSE) {
+                            for (boolean noRequestContent : TRUE_FALSE) {
+                                for (boolean noResponseContent : TRUE_FALSE) {
+                                    data.add(new Boolean[] {viaProxy, awaitRequestPayload, awaitResponsePayload,
+                                            requestInitiatesClosure, noRequestContent, noResponseContent});
+                                }
+                            }
+                        }
                     }
-                });
+                }
+            }
+            return data;
+        }
 
-        client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
-                .buildStreaming();
-        connection = client.reserveConnection(client.get("/")).toFuture().get();
-        connection.onClose().whenFinally(connectionClosed::countDown).subscribe();
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        newCompositeCloseable().appendAll(client, serverContext, serverIoExecutor).close();
-    }
-
-    @Test
-    public void serverCloseNoRequestPayloadBody() throws Exception {
-        sendRequestAndAssertResponse(connection.get("/first")
-                .addHeader(CONTENT_LENGTH, ZERO));
-    }
-
-    @Test
-    public void serverCloseRequestWithPayloadBody() throws Exception {
-        String content = "request_content";
-        sendRequestAndAssertResponse(connection.post("/first")
-                .addHeader(CONTENT_LENGTH, valueOf(content.length()))
-                .payloadBody(client.executionContext().executor().submit(() -> {
+        @Test
+        public void testConnectionClosure() throws Exception {
+            assumeFalse("Skip states that will cause deadlock", awaitRequestPayload && awaitResponsePayload);
+            // FIXME: remove the following assume when the NettyPipelinedConnection bug is fixed:
+            assumeFalse("Temporarily skip states that unexpectedly cause deadlock",
+                    !awaitRequestPayload && awaitResponsePayload && !noRequestContent);
+            String content = "request_content";
+            StreamingHttpRequest request = connection.newRequest(noRequestContent ? GET : POST, "/first")
+                    .setQueryParameter("noResponseContent", valueOf(noResponseContent))
+                    .addHeader(CONTENT_LENGTH, noRequestContent ? ZERO : valueOf(content.length()));
+            if (!noRequestContent) {
+                request.payloadBody(connection.connectionContext().executionContext().executor().submit(() -> {
                     try {
                         responseReceived.await();
+                        if (awaitResponsePayload) {
+                            responsePayloadReceived.await();
+                        }
                     } catch (InterruptedException e) {
                         throwException(e);
                     }
-                }).concat(from(content)), textSerializer()));
-    }
+                }).concat(from(content)), textSerializer());
+            }
+            if (requestInitiatesClosure) {
+                request.addHeader(CONNECTION, CLOSE);
+            }
 
-    private void sendRequestAndAssertResponse(StreamingHttpRequest request) throws Exception {
-        sendResponse.countDown();
-        StreamingHttpResponse response = connection.request(request).toFuture().get();
-        assertResponse(response);
-        responseReceived.countDown();
-
-        assertResponsePayloadBody(response);
-        assertThat(request.headers().get(CONTENT_LENGTH), contentEqualTo(valueOf(requestPayloadSize.get())));
-
-        connectionClosed.await();
-        assertClosedChannelException("/second");
-    }
-
-    @Test
-    public void serverCloseTwoPipelinedRequestsSentBeforeFirstResponse() throws Exception {
-        AtomicReference<StreamingHttpResponse> firstResponse = new AtomicReference<>();
-        AtomicReference<Throwable> secondRequestError = new AtomicReference<>();
-        CountDownLatch secondResponseReceived = new CountDownLatch(1);
-
-        connection.request(connection.get("/first")
-                .addHeader(CONTENT_LENGTH, ZERO)).subscribe(first -> {
-            firstResponse.set(first);
+            sendResponse.countDown();
+            StreamingHttpResponse response = connection.request(request).toFuture().get();
+            assertResponse(response);
             responseReceived.countDown();
-        });
-        connection.request(connection.get("/second")
-                .addHeader(CONTENT_LENGTH, ZERO))
-                .whenOnError(secondRequestError::set)
-                .whenFinally(secondResponseReceived::countDown)
-                .subscribe(second -> { });
-        requestReceived.await();
-        sendResponse.countDown();
-        responseReceived.await();
 
-        StreamingHttpResponse response = firstResponse.get();
-        assertResponse(response);
-        assertResponsePayloadBody(response);
+            assertResponsePayloadBody(response);
+            responsePayloadReceived.countDown();
+            requestPayloadReceived.await();
+            assertThat(request.headers().get(CONTENT_LENGTH), contentEqualTo(valueOf(requestPayloadSize.get())));
 
-        connectionClosed.await();
-        secondResponseReceived.await();
-        assertThat(secondRequestError.get(), instanceOf(ClosedChannelException.class));
-        assertClosedChannelException("/third");
+            connectionClosed.await();
+            assertClosedChannelException("/second");
+        }
     }
 
-    @Test
-    public void serverCloseSecondPipelinedRequestWriteAborted() throws Exception {
-        AtomicReference<StreamingHttpResponse> firstResponse = new AtomicReference<>();
-        AtomicReference<Throwable> secondRequestError = new AtomicReference<>();
-        CountDownLatch secondResponseReceived = new CountDownLatch(1);
+    @RunWith(Parameterized.class)
+    public static class PipelinedRequestsTest extends ConnectionSetup {
 
-        connection.request(connection.get("/first")
-                .addHeader(CONTENT_LENGTH, ZERO)).subscribe(first -> {
-            firstResponse.set(first);
+        public PipelinedRequestsTest(boolean viaProxy, boolean awaitRequestPayload) throws Exception {
+            super(viaProxy, awaitRequestPayload);
+        }
+
+        @Parameters(name = "viaProxy={0}, awaitRequestPayload={1}")
+        public static Collection<Boolean[]> data() {
+            return asList(
+                    new Boolean[] {false, false},
+                    new Boolean[] {false, true},
+                    new Boolean[] {true, false},
+                    new Boolean[] {true, true}
+            );
+        }
+
+        @Test
+        public void serverCloseTwoPipelinedRequestsSentBeforeFirstResponse() throws Exception {
+            AtomicReference<StreamingHttpResponse> firstResponse = new AtomicReference<>();
+            AtomicReference<Throwable> secondRequestError = new AtomicReference<>();
+            CountDownLatch secondResponseReceived = new CountDownLatch(1);
+
+            connection.request(connection.get("/first")
+                    .addHeader(CONTENT_LENGTH, ZERO)).subscribe(first -> {
+                firstResponse.set(first);
+                responseReceived.countDown();
+            });
+            connection.request(connection.get("/second")
+                    .addHeader(CONTENT_LENGTH, ZERO))
+                    .whenOnError(secondRequestError::set)
+                    .whenFinally(secondResponseReceived::countDown)
+                    .subscribe(second -> { });
+            requestReceived.await();
+            sendResponse.countDown();
+            responseReceived.await();
+
+            StreamingHttpResponse response = firstResponse.get();
+            assertResponse(response);
+            assertResponsePayloadBody(response);
+
+            connectionClosed.await();
+            secondResponseReceived.await();
+            assertThat(secondRequestError.get(), instanceOf(ClosedChannelException.class));
+            assertClosedChannelException("/third");
+        }
+
+        @Test
+        public void serverCloseSecondPipelinedRequestWriteAborted() throws Exception {
+            AtomicReference<StreamingHttpResponse> firstResponse = new AtomicReference<>();
+            AtomicReference<Throwable> secondRequestError = new AtomicReference<>();
+            CountDownLatch secondResponseReceived = new CountDownLatch(1);
+
+            connection.request(connection.get("/first")
+                    .addHeader(CONTENT_LENGTH, ZERO)).subscribe(first -> {
+                firstResponse.set(first);
+                responseReceived.countDown();
+            });
+            String content = "request_content";
+            connection.request(connection.get("/second")
+                    .addHeader(CONTENT_LENGTH, valueOf(content.length()))
+                    .payloadBody(from(content).concat(never()), textSerializer()))
+                    .whenOnError(secondRequestError::set)
+                    .whenFinally(secondResponseReceived::countDown)
+                    .subscribe(second -> { });
+            requestReceived.await();
+            sendResponse.countDown();
+            responseReceived.await();
+
+            StreamingHttpResponse response = firstResponse.get();
+            assertResponse(response);
+            assertResponsePayloadBody(response);
+
+            connectionClosed.await();
+            secondResponseReceived.await();
+            assertThat(secondRequestError.get(), instanceOf(ClosedChannelException.class));
+            assertClosedChannelException("/third");
+        }
+
+        @Test
+        public void serverCloseTwoPipelinedRequestsInSequence() throws Exception {
+            sendResponse.countDown();
+            StreamingHttpResponse response = connection.request(connection.get("/first")
+                    .addHeader(CONTENT_LENGTH, ZERO)).toFuture().get();
+            assertResponse(response);
+
+            // Send another request before connection reads payload body of the first request:
+            assertClosedChannelException("/second");
+
             responseReceived.countDown();
-        });
-        String content = "request_content";
-        connection.request(connection.get("/second")
-                .addHeader(CONTENT_LENGTH, valueOf(content.length()))
-                .payloadBody(from(content).concat(never()), textSerializer()))
-                .whenOnError(secondRequestError::set)
-                .whenFinally(secondResponseReceived::countDown)
-                .subscribe(second -> { });
-        requestReceived.await();
-        sendResponse.countDown();
-        responseReceived.await();
+            assertResponsePayloadBody(response);
+            connectionClosed.await();
+        }
 
-        StreamingHttpResponse response = firstResponse.get();
-        assertResponse(response);
-        assertResponsePayloadBody(response);
+        @Test
+        public void clientCloseTwoPipelinedRequestsSentBeforeFirstResponse() throws Exception {
+            AtomicReference<StreamingHttpResponse> firstResponse = new AtomicReference<>();
 
-        connectionClosed.await();
-        secondResponseReceived.await();
-        assertThat(secondRequestError.get(), instanceOf(ClosedChannelException.class));
-        assertClosedChannelException("/third");
-    }
+            connection.request(connection.get("/first")
+                    .addHeader(CONTENT_LENGTH, ZERO)
+                    // Request connection closure:
+                    .addHeader(CONNECTION, CLOSE)).subscribe(first -> {
+                firstResponse.set(first);
+                responseReceived.countDown();
+            });
+            // Send another request before connection receives a response for the first request:
+            assertClosedChannelException("/second");
+            sendResponse.countDown();
+            responseReceived.await();
 
-    @Test
-    public void serverCloseTwoPipelinedRequestsInSequence() throws Exception {
-        sendResponse.countDown();
-        StreamingHttpResponse response = connection.request(connection.get("/first")
-                .addHeader(CONTENT_LENGTH, ZERO)).toFuture().get();
-        assertResponse(response);
-
-        // Send another request before client reads payload body of the first request:
-        assertClosedChannelException("/second");
-
-        responseReceived.countDown();
-        assertResponsePayloadBody(response);
-        connectionClosed.await();
-    }
-
-    @Test
-    public void clientCloseTwoPipelinedRequestsSentBeforeFirstResponse() throws Exception {
-        AtomicReference<StreamingHttpResponse> firstResponse = new AtomicReference<>();
-
-        connection.request(connection.get("/first")
-                .addHeader(CONTENT_LENGTH, ZERO)
-                // Request connection closure:
-                .addHeader(CONNECTION, CLOSE)).subscribe(first -> {
-            firstResponse.set(first);
-            responseReceived.countDown();
-        });
-        // Send another request before client receives a response for the first request:
-        assertClosedChannelException("/second");
-        sendResponse.countDown();
-        responseReceived.await();
-
-        StreamingHttpResponse response = firstResponse.get();
-        assertResponse(response);
-        assertResponsePayloadBody(response);
-        connectionClosed.await();
-    }
-
-    private static void assertResponse(StreamingHttpResponse response) {
-        assertThat(response.status(), is(OK));
-        assertThat(response.headers().get(CONNECTION), contentEqualTo(CLOSE));
-    }
-
-    private static void assertResponsePayloadBody(StreamingHttpResponse response) throws Exception {
-        int actualContentLength = response.payloadBody().map(Buffer::readableBytes)
-                .collect(AtomicInteger::new, (total, current) -> {
-                    total.addAndGet(current);
-                    return total;
-                }).toFuture().get().get();
-        assertThat(response.headers().get(CONTENT_LENGTH), contentEqualTo(valueOf(actualContentLength)));
-    }
-
-    private void assertClosedChannelException(String path) {
-        Exception e = assertThrows(ExecutionException.class,
-                () -> connection.request(connection.get(path).addHeader(CONTENT_LENGTH, ZERO)).toFuture().get());
-        assertThat(e.getCause(), instanceOf(ClosedChannelException.class));
+            StreamingHttpResponse response = firstResponse.get();
+            assertResponse(response);
+            assertResponsePayloadBody(response);
+            connectionClosed.await();
+        }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
@@ -208,13 +208,17 @@ public class ConnectionCloseHeaderHandlingTest {
             this.noResponseContent = noResponseContent;
         }
 
-        @Parameters(name = "viaProxy={0}, awaitRequestPayload={1}, awaitResponsePayload={2}, " +
+        @Parameters(name = "{index}: viaProxy={0}, awaitRequestPayload={1}, awaitResponsePayload={2}, " +
                 "requestInitiatesClosure={3}, noRequestContent={4}, noResponseContent={5}")
         public static Collection<Boolean[]> data() {
             Collection<Boolean[]> data = new ArrayList<>();
             for (boolean viaProxy : TRUE_FALSE) {
                 for (boolean awaitRequestPayload : TRUE_FALSE) {
                     for (boolean awaitResponsePayload : TRUE_FALSE) {
+                        if (awaitRequestPayload && awaitResponsePayload) {
+                            // Skip configuration that will cause a deadlock.
+                            continue;
+                        }
                         for (boolean requestInitiatesClosure : TRUE_FALSE) {
                             for (boolean noRequestContent : TRUE_FALSE) {
                                 for (boolean noResponseContent : TRUE_FALSE) {
@@ -231,7 +235,6 @@ public class ConnectionCloseHeaderHandlingTest {
 
         @Test
         public void testConnectionClosure() throws Exception {
-            assumeFalse("Skip states that will cause deadlock", awaitRequestPayload && awaitResponsePayload);
             // FIXME: remove the following assume when the NettyPipelinedConnection bug is fixed:
             assumeFalse("Temporarily skip states that unexpectedly cause deadlock",
                     !awaitRequestPayload && awaitResponsePayload && !noRequestContent);
@@ -277,7 +280,7 @@ public class ConnectionCloseHeaderHandlingTest {
             super(viaProxy, awaitRequestPayload);
         }
 
-        @Parameters(name = "viaProxy={0}, awaitRequestPayload={1}")
+        @Parameters(name = "{index}: viaProxy={0}, awaitRequestPayload={1}")
         public static Collection<Boolean[]> data() {
             return asList(
                     new Boolean[] {false, false},

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
@@ -15,18 +15,12 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.http.api.BlockingHttpClient;
-import io.servicetalk.http.api.HttpPayloadWriter;
 import io.servicetalk.http.api.HttpResponse;
-import io.servicetalk.http.api.StreamingHttpClient;
-import io.servicetalk.http.api.StreamingHttpRequest;
-import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.test.resources.DefaultTestCerts;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
-import io.servicetalk.transport.api.SecurityConfigurator;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.IoThreadFactory;
 
@@ -34,56 +28,29 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
-import java.net.ServerSocket;
-import java.net.Socket;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.internal.AutoClosableUtils.closeAndReThrowUnchecked;
-import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
-import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
-import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
-import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
-import static io.servicetalk.http.api.Matchers.contentEqualTo;
 import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
-import static java.lang.String.valueOf;
-import static java.net.InetAddress.getLoopbackAddress;
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 
 public class HttpsProxyTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(HttpsProxyTest.class);
-
     @Rule
     public final ServiceTalkTestTimeout timeout = new ServiceTalkTestTimeout();
 
-    private static final String CONNECT_PREFIX = "CONNECT ";
-    @Nullable
-    private ServerSocket serverSocket;
-    @Nullable
-    private ExecutorService executor;
+    private final ProxyTunnel proxyTunnel = new ProxyTunnel();
+
     @Nullable
     private HostAndPort proxyAddress;
     @Nullable
@@ -94,28 +61,20 @@ public class HttpsProxyTest {
     private HostAndPort serverAddress;
     @Nullable
     private BlockingHttpClient client;
-    private final AtomicInteger connectCount = new AtomicInteger();
-    private ProxyRequestHandler handler = this::handleRequest;
-    private final CountDownLatch responseReceived = new CountDownLatch(1);
-    private final AtomicInteger requestPayloadSize = new AtomicInteger();
 
     @Before
     public void setUp() throws Exception {
-        startProxy();
+        proxyAddress = proxyTunnel.startProxy();
         startServer();
         createClient();
     }
 
     @After
     public void tearDown() throws Exception {
-        safeClose(client);
-        safeClose(serverContext);
-        safeClose(serverSocket);
         try {
-            if (executor != null) {
-                executor.shutdown();
-                executor.awaitTermination(100, MILLISECONDS);
-            }
+            safeClose(client);
+            safeClose(serverContext);
+            safeClose(proxyTunnel);
         } finally {
             if (serverIoExecutor != null) {
                 serverIoExecutor.closeAsync().toFuture().get();
@@ -129,89 +88,12 @@ public class HttpsProxyTest {
         }
     }
 
-    public void startProxy() throws Exception {
-        serverSocket = new ServerSocket(0, 50, getLoopbackAddress());
-        proxyAddress = HostAndPort.of((InetSocketAddress) serverSocket.getLocalSocketAddress());
-        executor = Executors.newCachedThreadPool();
-
-        executor.submit(() -> {
-            while (!executor.isShutdown()) {
-                final Socket socket = serverSocket.accept();
-                executor.submit(() -> {
-                    try {
-                        final InputStream in = socket.getInputStream();
-                        final String initialLine = readLine(in);
-                        while (readLine(in).length() > 0) {
-                            // ignore headers
-                        }
-
-                        handler.handle(socket, in, initialLine);
-                    } catch (Exception e) {
-                        LOGGER.error("Error from proxy", e);
-                    } finally {
-                        try {
-                            socket.close();
-                        } catch (IOException e) {
-                            e.printStackTrace();
-                        }
-                    }
-                });
-            }
-            return null;
-        });
-    }
-
-    @FunctionalInterface
-    private interface ProxyRequestHandler {
-        void handle(Socket socket, InputStream in, String initialLine) throws IOException;
-    }
-
-    private void handleRequest(final Socket socket, final InputStream in, final String initialLine) throws IOException {
-        if (initialLine.startsWith(CONNECT_PREFIX)) {
-            final int end = initialLine.indexOf(' ', CONNECT_PREFIX.length());
-            final String authority = initialLine.substring(CONNECT_PREFIX.length(), end);
-            final String protocol = initialLine.substring(end + 1);
-            final int colon = authority.indexOf(':');
-            final String host = authority.substring(0, colon);
-            final int port = Integer.parseInt(authority.substring(colon + 1));
-
-            final Socket clientSocket = new Socket(host, port);
-            connectCount.incrementAndGet();
-            final OutputStream out = socket.getOutputStream();
-            out.write((protocol + " 200 Connection established\r\n\r\n").getBytes(UTF_8));
-            out.flush();
-
-            final InputStream cin = clientSocket.getInputStream();
-            assert executor != null;
-            executor.submit(() -> copyStream(out, cin));
-            copyStream(clientSocket.getOutputStream(), in);
-        } else {
-            throw new RuntimeException("Unrecognized initial line: " + initialLine);
-        }
-    }
-
     public void startServer() throws Exception {
         serverContext = HttpServers.forAddress(localAddress(0))
                 .ioExecutor(serverIoExecutor = createIoExecutor(new IoThreadFactory("server-io-executor")))
-                .secure()
-                .provider(SecurityConfigurator.SslProvider.JDK)
-                .commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
-                .listenBlockingStreamingAndAwait((ctx, request, response) -> {
-                    final String content = "host: " + request.headers().get(HOST);
-                    response.addHeader(CONTENT_LENGTH, valueOf(content.length()));
-                    if ("/close".equals(request.path())) {
-                        response.addHeader(CONNECTION, CLOSE);
-                    }
-
-                    try (HttpPayloadWriter<String> writer = response.sendMetaData(textSerializer())) {
-                        if ("/close".equals(request.path())) {
-                            // Defer payload body to see how client processes "Connection: close" header
-                            request.payloadBody().forEach(chunk -> requestPayloadSize.addAndGet(chunk.readableBytes()));
-                            responseReceived.await();
-                        }
-                        writer.write(content);
-                    }
-                });
+                .secure().commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                .listenAndAwait((ctx, request, responseFactory) -> succeeded(responseFactory.ok()
+                        .payloadBody("host: " + request.headers().get(HOST), textSerializer())));
         serverAddress = serverHostAndPort(serverContext);
     }
 
@@ -219,8 +101,7 @@ public class HttpsProxyTest {
         assert serverAddress != null && proxyAddress != null;
         client = HttpClients
                 .forSingleAddressViaProxy(serverAddress, proxyAddress)
-                .secure().disableHostnameVerification().trustManager(DefaultTestCerts::loadMutualAuthCaPem)
-                .provider(SecurityConfigurator.SslProvider.JDK).commit()
+                .secure().disableHostnameVerification().trustManager(DefaultTestCerts::loadMutualAuthCaPem).commit()
                 .buildBlocking();
     }
 
@@ -229,86 +110,14 @@ public class HttpsProxyTest {
         assert client != null;
         final HttpResponse httpResponse = client.request(client.get("/path"));
         assertThat(httpResponse.status(), is(OK));
-        assertThat(connectCount.get(), is(1));
+        assertThat(proxyTunnel.connectCount(), is(1));
         assertThat(httpResponse.payloadBody().toString(US_ASCII), is("host: " + serverAddress));
     }
 
     @Test
     public void testBadProxyResponse() {
-        handler = (socket, in, initialLine) -> {
-            socket.getOutputStream().write("HTTP/1.1 500 Internal Server Error\r\n\r\n".getBytes(UTF_8));
-            socket.getOutputStream().flush();
-        };
+        proxyTunnel.badResponseProxy();
         assert client != null;
         assertThrows(ProxyResponseException.class, () -> client.request(client.get("/path")));
-    }
-
-    @Test
-    public void testResponseWithConnectionCloseHeaderAndDelayedResponsePayloadBody() throws Exception {
-        assert client != null;
-        StreamingHttpClient client = this.client.asStreamingClient();
-        final StreamingHttpRequest request = client.get("/close")
-                .addHeader(CONTENT_LENGTH, ZERO);
-        StreamingHttpResponse response = client.request(request).toFuture().get();
-        assertResponse(request, response);
-    }
-
-    @Test
-    public void testResponseWithConnectionCloseHeaderAndDelayedRequestPayloadBody() throws Exception {
-        assert client != null;
-        StreamingHttpClient client = this.client.asStreamingClient();
-        String content = "hello";
-        final StreamingHttpRequest request = client.post("/close")
-                .addHeader(CONTENT_LENGTH, valueOf(content.length()))
-                .payloadBody(client.executionContext().executor().submit(() -> {
-                    try {
-                        responseReceived.await();
-                    } catch (InterruptedException e) {
-                        throwException(e);
-                    }
-                }).concat(from(content)), textSerializer());
-        StreamingHttpResponse response = client.request(request).toFuture().get();
-        assertResponse(request, response);
-    }
-
-    private void assertResponse(StreamingHttpRequest request, StreamingHttpResponse response) throws Exception {
-        assertThat(response.status(), is(OK));
-        assertThat(connectCount.get(), is(1));
-        assertThat(response.headers().get(CONNECTION), contentEqualTo(CLOSE));
-        responseReceived.countDown();
-
-        int actualContentLength = response.payloadBody().map(Buffer::readableBytes)
-                .collect(AtomicInteger::new, (total, current) -> {
-                    total.addAndGet(current);
-                    return total;
-                }).toFuture().get().get();
-        assertThat(response.headers().get(CONTENT_LENGTH), contentEqualTo(valueOf(actualContentLength)));
-        assertThat(request.headers().get(CONTENT_LENGTH), contentEqualTo(valueOf(requestPayloadSize.get())));
-    }
-
-    private static String readLine(final InputStream in) throws IOException {
-        byte[] bytes = new byte[1024];
-        int i = 0;
-        int b;
-        while ((b = in.read()) >= 0) {
-            if (b == '\n') {
-                break;
-            }
-            if (b != '\r') {
-                bytes[i++] = (byte) b;
-            }
-        }
-        return new String(bytes, 0, i, UTF_8);
-    }
-
-    private static void copyStream(final OutputStream out, final InputStream cin) {
-        try {
-            int b;
-            while ((b = cin.read()) >= 0) {
-                out.write(b);
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.api.DefaultThreadFactory;
+import io.servicetalk.transport.api.HostAndPort;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.http.netty.HttpsProxyTest.safeClose;
+import static java.net.InetAddress.getLoopbackAddress;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+final class ProxyTunnel implements AutoCloseable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProxyTunnel.class);
+    private static final String CONNECT_PREFIX = "CONNECT ";
+
+    private final ExecutorService executor = newCachedThreadPool(new DefaultThreadFactory("proxy-tunnel"));
+    private final AtomicInteger connectCount = new AtomicInteger();
+
+    @Nullable
+    private ServerSocket serverSocket;
+    private ProxyRequestHandler handler = this::handleRequest;
+
+    @Override
+    public void close() throws Exception {
+        try {
+            safeClose(serverSocket);
+        } finally {
+            executor.shutdown();
+            executor.awaitTermination(100, MILLISECONDS);
+        }
+    }
+
+    HostAndPort startProxy() throws IOException {
+        serverSocket = new ServerSocket(0, 50, getLoopbackAddress());
+        executor.submit(() -> {
+            while (!executor.isShutdown()) {
+                final Socket socket = serverSocket.accept();
+                executor.submit(() -> {
+                    try {
+                        final InputStream in = socket.getInputStream();
+                        final String initialLine = readLine(in);
+                        while (readLine(in).length() > 0) {
+                            // ignore headers
+                        }
+
+                        handler.handle(socket, in, initialLine);
+                    } catch (Exception e) {
+                        LOGGER.error("Error from proxy", e);
+                    } finally {
+                        try {
+                            socket.close();
+                        } catch (IOException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                });
+            }
+            return null;
+        });
+        return HostAndPort.of((InetSocketAddress) serverSocket.getLocalSocketAddress());
+    }
+
+    void badResponseProxy() {
+        handler = (socket, in, initialLine) -> {
+            socket.getOutputStream().write("HTTP/1.1 500 Internal Server Error\r\n\r\n".getBytes(UTF_8));
+            socket.getOutputStream().flush();
+        };
+    }
+
+    int connectCount() {
+        return connectCount.get();
+    }
+
+    private static String readLine(final InputStream in) throws IOException {
+        byte[] bytes = new byte[1024];
+        int i = 0;
+        int b;
+        while ((b = in.read()) >= 0) {
+            if (b == '\n') {
+                break;
+            }
+            if (b != '\r') {
+                bytes[i++] = (byte) b;
+            }
+        }
+        return new String(bytes, 0, i, UTF_8);
+    }
+
+    private void handleRequest(final Socket socket, final InputStream in, final String initialLine) throws IOException {
+        if (initialLine.startsWith(CONNECT_PREFIX)) {
+            final int end = initialLine.indexOf(' ', CONNECT_PREFIX.length());
+            final String authority = initialLine.substring(CONNECT_PREFIX.length(), end);
+            final String protocol = initialLine.substring(end + 1);
+            final int colon = authority.indexOf(':');
+            final String host = authority.substring(0, colon);
+            final int port = Integer.parseInt(authority.substring(colon + 1));
+
+            final Socket clientSocket = new Socket(host, port);
+            connectCount.incrementAndGet();
+            final OutputStream out = socket.getOutputStream();
+            out.write((protocol + " 200 Connection established\r\n\r\n").getBytes(UTF_8));
+            out.flush();
+
+            final InputStream cin = clientSocket.getInputStream();
+            executor.submit(() -> copyStream(out, cin));
+            copyStream(clientSocket.getOutputStream(), in);
+        } else {
+            throw new RuntimeException("Unrecognized initial line: " + initialLine);
+        }
+    }
+
+    private static void copyStream(final OutputStream out, final InputStream cin) {
+        try {
+            int b;
+            while ((b = cin.read()) >= 0) {
+                out.write(b);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ProxyRequestHandler {
+        void handle(Socket socket, InputStream in, String initialLine) throws IOException;
+    }
+}


### PR DESCRIPTION
Motivation:

Current tests for handling of `connection: close` header focused on the client
side, missing some of the interesting server-side use-cases when request or
response payload is delayed.

Modifications:

- Summarize all tests related to `connection: close` header in one class:
`ConnectionCloseHeaderHandlingTest`;
- Share secure proxy tunnel related code between `ConnectionCloseHeaderHandlingTest`
and `HttpsProxyTest`;
- Parametrize tests in `ConnectionCloseHeaderHandlingTest` to cover all
combinations of request-response ordering;

Result:

Enhanced test coverage for `connection: close` handling logic.
