### PR TITLE
HTTP server does not complete the response if handler method throws

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -343,7 +343,7 @@ final class NettyHttpServer {
                                             return handleResponse(requestMethod, response);
                                         }),
                                 (cause, executor) -> from(newErrorResponse(cause, executor,
-                                        request.version(), keepAlive)));
+                                        request.version(), keepAlive), EmptyHttpHeaders.INSTANCE));
 
                 if (drainRequestPayloadBody) {
                     responsePublisher = responsePublisher.concat(defer(() -> payloadSubscribed.get() ?


### PR DESCRIPTION
Motivation:

If service handle method throws an exception, server does not add an empty
trailers as a marker of response end. Therefore, client can not drain the
response payload body when HTTP/2 is used.

Modifications:

- Add `EmptyHttpHeaders.INSTANCE` as the last item for rrror handler in
`NettyHttpServer`;

Result:

Client sees `endStream=true` and completes payload body publisher for HTTP/2.