### PR TITLE
Add comments to clarify Client duplex behavior

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyPipelinedConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyPipelinedConnection.java
@@ -230,6 +230,11 @@ final class NettyPipelinedConnection<Req, Resp> implements NettyConnectionContex
                             if (nextWriteTask != null) {
                                 nextWriteTask.run();
                             }
+                        // The write and read operation are coupled via a merge operator. This is because if an error
+                        // occurs on write or read we want to propagate the error back to the user. On the client side
+                        // the most straightforward way to propagate an error through the APIs is through the read async
+                        // source. This has a side effect that the read async source isn't strictly full-duplex (data
+                        // will be full-duplex, but completion will be delayed until the write completes).
                         }).merge(new Publisher<Resp>() {
                             @Override
                             protected void handleSubscribe(final Subscriber<? super Resp> rSubscriber) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyPipelinedConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyPipelinedConnection.java
@@ -230,12 +230,13 @@ final class NettyPipelinedConnection<Req, Resp> implements NettyConnectionContex
                             if (nextWriteTask != null) {
                                 nextWriteTask.run();
                             }
+                        })
                         // The write and read operation are coupled via a merge operator. This is because if an error
                         // occurs on write or read we want to propagate the error back to the user. On the client side
                         // the most straightforward way to propagate an error through the APIs is through the read async
                         // source. This has a side effect that the read async source isn't strictly full-duplex (data
                         // will be full-duplex, but completion will be delayed until the write completes).
-                        }).merge(new Publisher<Resp>() {
+                        .merge(new Publisher<Resp>() {
                             @Override
                             protected void handleSubscribe(final Subscriber<? super Resp> rSubscriber) {
                                 final Subscriber<? super Resp> nextReadSubscriber;


### PR DESCRIPTION
Motivation:
NettyPipelinedConnection uses a merge operation to ensure errors are
propagated from the read and write operation. From a purely full-duplex
perspective it maybe unexpected that the response async source doesn't
complete until the write completes.

Modifications:
- Add comments in NettyPipelinedConnection to clarify rational for this
behavior
- Cleanup ConnectionCloseHeaderHandlingTest for tests which were ignored
to work around this behavior

Result:
NettyPipelinedConnection clarifies duplex rational in comments."