### PR TITLE
DefaultDnsClientTest.repeatDiscoverNxDomain test failure

### DIFF
--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsClientTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsClientTest.java
@@ -466,8 +466,9 @@ public class DefaultDnsClientTest {
 
         final int expectedActiveCount = 1;
         final int expectedInactiveCount = 1;
+        final int expectedErrorCount = 1;
 
-        CountDownLatch latch = new CountDownLatch(expectedActiveCount + expectedInactiveCount);
+        CountDownLatch latch = new CountDownLatch(expectedActiveCount + expectedInactiveCount + expectedErrorCount);
         AtomicReference<Throwable> throwableRef = new AtomicReference<>();
         Publisher<ServiceDiscovererEvent<InetAddress>> publisher = client.dnsQuery("apple.com");
         ServiceDiscovererTestSubscriber<InetAddress> subscriber =
@@ -489,8 +490,9 @@ public class DefaultDnsClientTest {
         try {
             final int expectedActiveCount = 1;
             final int expectedInactiveCount = 0;
+            final int expectedErrorCount = 1;
 
-            CountDownLatch latch = new CountDownLatch(expectedActiveCount + expectedInactiveCount + 1);
+            CountDownLatch latch = new CountDownLatch(expectedActiveCount + expectedInactiveCount + expectedErrorCount);
             AtomicReference<Throwable> throwableRef = new AtomicReference<>();
             Publisher<ServiceDiscovererEvent<InetAddress>> publisher = customClient.dnsQuery("apple.com");
             ServiceDiscovererTestSubscriber<InetAddress> subscriber =


### PR DESCRIPTION
Motivation:
DefaultDnsClientTest.repeatDiscoverNxDomain attempts to assert that an
UnknownHostException is eventually received. However the test initial
state has the address available, and the test harness eventually removes
the address in the background. The test doesn't wait for the error event
to happen before asserting the error condition.

Modifications:
- Increase the test latch countdown to wait for the error to be received

Result:
Fixes https://github.com/apple/servicetalk/issues/1102