### PR TITLE
Configure `TransportObserver` via `ConnectionFactory` on the client-side

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/loadbalancer/RoundRobinLoadBalancerSDEventsBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/loadbalancer/RoundRobinLoadBalancerSDEventsBenchmark.java
@@ -22,6 +22,7 @@ import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.loadbalancer.RoundRobinLoadBalancer;
+import io.servicetalk.transport.api.TransportObserver;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
@@ -36,6 +37,7 @@ import org.openjdk.jmh.annotations.Warmup;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Publisher.fromIterable;
@@ -87,7 +89,8 @@ public class RoundRobinLoadBalancerSDEventsBenchmark {
         }
 
         @Override
-        public Single<LoadBalancedConnection> newConnection(final InetSocketAddress inetSocketAddress) {
+        public Single<LoadBalancedConnection> newConnection(final InetSocketAddress inetSocketAddress,
+                                                            @Nullable final TransportObserver observer) {
             return succeeded(new LoadBalancedConnection() {
                 @Override
                 public int score() {

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/BiTransportObserver.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/BiTransportObserver.java
@@ -63,29 +63,20 @@ final class BiTransportObserver implements TransportObserver {
 
         @Override
         public void onDataRead(final int size) {
-            try {
-                first.onDataRead(size);
-            } finally {
-                second.onDataRead(size);
-            }
+            first.onDataRead(size);
+            second.onDataRead(size);
         }
 
         @Override
         public void onDataWrite(final int size) {
-            try {
-                first.onDataWrite(size);
-            } finally {
-                second.onDataWrite(size);
-            }
+            first.onDataWrite(size);
+            second.onDataWrite(size);
         }
 
         @Override
         public void onFlush() {
-            try {
-                first.onFlush();
-            } finally {
-                second.onFlush();
-            }
+            first.onFlush();
+            second.onFlush();
         }
 
         @Override
@@ -105,20 +96,14 @@ final class BiTransportObserver implements TransportObserver {
 
         @Override
         public void connectionClosed(final Throwable error) {
-            try {
-                first.connectionClosed(error);
-            } finally {
-                second.connectionClosed(error);
-            }
+            first.connectionClosed(error);
+            second.connectionClosed(error);
         }
 
         @Override
         public void connectionClosed() {
-            try {
-                first.connectionClosed();
-            } finally {
-                second.connectionClosed();
-            }
+            first.connectionClosed();
+            second.connectionClosed();
         }
     }
 
@@ -135,20 +120,14 @@ final class BiTransportObserver implements TransportObserver {
 
         @Override
         public void handshakeFailed(final Throwable cause) {
-            try {
-                first.handshakeFailed(cause);
-            } finally {
-                second.handshakeFailed(cause);
-            }
+            first.handshakeFailed(cause);
+            second.handshakeFailed(cause);
         }
 
         @Override
         public void handshakeComplete(final SSLSession sslSession) {
-            try {
-                first.handshakeComplete(sslSession);
-            } finally {
-                second.handshakeComplete(sslSession);
-            }
+            first.handshakeComplete(sslSession);
+            second.handshakeComplete(sslSession);
         }
     }
 
@@ -202,20 +181,14 @@ final class BiTransportObserver implements TransportObserver {
 
         @Override
         public void streamClosed(final Throwable error) {
-            try {
-                first.streamClosed(error);
-            } finally {
-                second.streamClosed(error);
-            }
+            first.streamClosed(error);
+            second.streamClosed(error);
         }
 
         @Override
         public void streamClosed() {
-            try {
-                first.streamClosed();
-            } finally {
-                second.streamClosed();
-            }
+            first.streamClosed();
+            second.streamClosed();
         }
     }
 
@@ -231,47 +204,32 @@ final class BiTransportObserver implements TransportObserver {
 
         @Override
         public void requestedToRead(final long n) {
-            try {
-                first.requestedToRead(n);
-            } finally {
-                second.requestedToRead(n);
-            }
+            first.requestedToRead(n);
+            second.requestedToRead(n);
         }
 
         @Override
         public void itemRead() {
-            try {
-                first.itemRead();
-            } finally {
-                second.itemRead();
-            }
+            first.itemRead();
+            second.itemRead();
         }
 
         @Override
         public void readFailed(final Throwable cause) {
-            try {
-                first.readFailed(cause);
-            } finally {
-                second.readFailed(cause);
-            }
+            first.readFailed(cause);
+            second.readFailed(cause);
         }
 
         @Override
         public void readComplete() {
-            try {
-                first.readComplete();
-            } finally {
-                second.readComplete();
-            }
+            first.readComplete();
+            second.readComplete();
         }
 
         @Override
         public void readCancelled() {
-            try {
-                first.readCancelled();
-            } finally {
-                second.readCancelled();
-            }
+            first.readCancelled();
+            second.readCancelled();
         }
     }
 
@@ -287,65 +245,44 @@ final class BiTransportObserver implements TransportObserver {
 
         @Override
         public void requestedToWrite(final long n) {
-            try {
-                first.requestedToWrite(n);
-            } finally {
-                second.requestedToWrite(n);
-            }
+            first.requestedToWrite(n);
+            second.requestedToWrite(n);
         }
 
         @Override
         public void itemReceived() {
-            try {
-                first.itemReceived();
-            } finally {
-                second.itemReceived();
-            }
+            first.itemReceived();
+            second.itemReceived();
         }
 
         @Override
         public void onFlushRequest() {
-            try {
-                first.onFlushRequest();
-            } finally {
-                second.onFlushRequest();
-            }
+            first.onFlushRequest();
+            second.onFlushRequest();
         }
 
         @Override
         public void itemWritten() {
-            try {
-                first.itemWritten();
-            } finally {
-                second.itemWritten();
-            }
+            first.itemWritten();
+            second.itemWritten();
         }
 
         @Override
         public void writeFailed(final Throwable cause) {
-            try {
-                first.writeFailed(cause);
-            } finally {
-                second.writeFailed(cause);
-            }
+            first.writeFailed(cause);
+            second.writeFailed(cause);
         }
 
         @Override
         public void writeComplete() {
-            try {
-                first.writeComplete();
-            } finally {
-                second.writeComplete();
-            }
+            first.writeComplete();
+            second.writeComplete();
         }
 
         @Override
         public void writeCancelled() {
-            try {
-                first.writeCancelled();
-            } finally {
-                second.writeCancelled();
-            }
+            first.writeCancelled();
+            second.writeCancelled();
         }
     }
 }

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/BiTransportObserver.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/BiTransportObserver.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.client.api;
+
+import io.servicetalk.transport.api.ConnectionInfo;
+import io.servicetalk.transport.api.ConnectionObserver;
+import io.servicetalk.transport.api.ConnectionObserver.DataObserver;
+import io.servicetalk.transport.api.ConnectionObserver.MultiplexedObserver;
+import io.servicetalk.transport.api.ConnectionObserver.ReadObserver;
+import io.servicetalk.transport.api.ConnectionObserver.SecurityHandshakeObserver;
+import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
+import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
+import io.servicetalk.transport.api.TransportObserver;
+
+import javax.net.ssl.SSLSession;
+
+/**
+ * Combines two {@link TransportObserver}s into a single {@link TransportObserver}.
+ */
+final class BiTransportObserver implements TransportObserver {
+
+    private final TransportObserver first;
+    private final TransportObserver second;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param first the {@link TransportObserver} that will receive events first
+     * @param second the {@link TransportObserver} that will receive events second
+     */
+    BiTransportObserver(final TransportObserver first, final TransportObserver second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    @Override
+    public ConnectionObserver onNewConnection() {
+        return new BiConnectionObserver(first.onNewConnection(), second.onNewConnection());
+    }
+
+    private static final class BiConnectionObserver implements ConnectionObserver {
+
+        private final ConnectionObserver first;
+        private final ConnectionObserver second;
+
+        private BiConnectionObserver(final ConnectionObserver first, final ConnectionObserver second) {
+            this.first = first;
+            this.second = second;
+        }
+
+        @Override
+        public void onDataRead(final int size) {
+            try {
+                first.onDataRead(size);
+            } finally {
+                second.onDataRead(size);
+            }
+        }
+
+        @Override
+        public void onDataWrite(final int size) {
+            try {
+                first.onDataWrite(size);
+            } finally {
+                second.onDataWrite(size);
+            }
+        }
+
+        @Override
+        public void onFlush() {
+            try {
+                first.onFlush();
+            } finally {
+                second.onFlush();
+            }
+        }
+
+        @Override
+        public SecurityHandshakeObserver onSecurityHandshake() {
+            return new BiSecurityHandshakeObserver(first.onSecurityHandshake(), second.onSecurityHandshake());
+        }
+
+        @Override
+        public DataObserver established(final ConnectionInfo info) {
+            return new BiDataObserver(first.established(info), second.established(info));
+        }
+
+        @Override
+        public MultiplexedObserver establishedMultiplexed(final ConnectionInfo info) {
+            return new BiMultiplexedObserver(first.establishedMultiplexed(info), second.establishedMultiplexed(info));
+        }
+
+        @Override
+        public void connectionClosed(final Throwable error) {
+            try {
+                first.connectionClosed(error);
+            } finally {
+                second.connectionClosed(error);
+            }
+        }
+
+        @Override
+        public void connectionClosed() {
+            try {
+                first.connectionClosed();
+            } finally {
+                second.connectionClosed();
+            }
+        }
+    }
+
+    private static final class BiSecurityHandshakeObserver implements SecurityHandshakeObserver {
+
+        private final SecurityHandshakeObserver first;
+        private final SecurityHandshakeObserver second;
+
+        private BiSecurityHandshakeObserver(final SecurityHandshakeObserver first,
+                                            final SecurityHandshakeObserver second) {
+            this.first = first;
+            this.second = second;
+        }
+
+        @Override
+        public void handshakeFailed(final Throwable cause) {
+            try {
+                first.handshakeFailed(cause);
+            } finally {
+                second.handshakeFailed(cause);
+            }
+        }
+
+        @Override
+        public void handshakeComplete(final SSLSession sslSession) {
+            try {
+                first.handshakeComplete(sslSession);
+            } finally {
+                second.handshakeComplete(sslSession);
+            }
+        }
+    }
+
+    private static class BiDataObserver implements DataObserver {
+
+        private final DataObserver first;
+        private final DataObserver second;
+
+        protected BiDataObserver(final DataObserver first, final DataObserver second) {
+            this.first = first;
+            this.second = second;
+        }
+
+        @Override
+        public ReadObserver onNewRead() {
+            return new BiReadObserver(first.onNewRead(), second.onNewRead());
+        }
+
+        @Override
+        public WriteObserver onNewWrite() {
+            return new BiWriteObserver(first.onNewWrite(), second.onNewWrite());
+        }
+    }
+
+    private static final class BiMultiplexedObserver implements MultiplexedObserver {
+
+        private final MultiplexedObserver first;
+        private final MultiplexedObserver second;
+
+        private BiMultiplexedObserver(final MultiplexedObserver first, final MultiplexedObserver second) {
+            this.first = first;
+            this.second = second;
+        }
+
+        @Override
+        public StreamObserver onNewStream() {
+            return new BiStreamObserver(first.onNewStream(), second.onNewStream());
+        }
+    }
+
+    private static final class BiStreamObserver extends BiDataObserver implements StreamObserver {
+
+        private final StreamObserver first;
+        private final StreamObserver second;
+
+        private BiStreamObserver(final StreamObserver first, final StreamObserver second) {
+            super(first, second);
+            this.first = first;
+            this.second = second;
+        }
+
+        @Override
+        public void streamClosed(final Throwable error) {
+            try {
+                first.streamClosed(error);
+            } finally {
+                second.streamClosed(error);
+            }
+        }
+
+        @Override
+        public void streamClosed() {
+            try {
+                first.streamClosed();
+            } finally {
+                second.streamClosed();
+            }
+        }
+    }
+
+    private static final class BiReadObserver implements ReadObserver {
+
+        private final ReadObserver first;
+        private final ReadObserver second;
+
+        private BiReadObserver(final ReadObserver first, final ReadObserver second) {
+            this.first = first;
+            this.second = second;
+        }
+
+        @Override
+        public void requestedToRead(final long n) {
+            try {
+                first.requestedToRead(n);
+            } finally {
+                second.requestedToRead(n);
+            }
+        }
+
+        @Override
+        public void itemRead() {
+            try {
+                first.itemRead();
+            } finally {
+                second.itemRead();
+            }
+        }
+
+        @Override
+        public void readFailed(final Throwable cause) {
+            try {
+                first.readFailed(cause);
+            } finally {
+                second.readFailed(cause);
+            }
+        }
+
+        @Override
+        public void readComplete() {
+            try {
+                first.readComplete();
+            } finally {
+                second.readComplete();
+            }
+        }
+
+        @Override
+        public void readCancelled() {
+            try {
+                first.readCancelled();
+            } finally {
+                second.readCancelled();
+            }
+        }
+    }
+
+    private static final class BiWriteObserver implements WriteObserver {
+
+        private final WriteObserver first;
+        private final WriteObserver second;
+
+        private BiWriteObserver(final WriteObserver first, final WriteObserver second) {
+            this.first = first;
+            this.second = second;
+        }
+
+        @Override
+        public void requestedToWrite(final long n) {
+            try {
+                first.requestedToWrite(n);
+            } finally {
+                second.requestedToWrite(n);
+            }
+        }
+
+        @Override
+        public void itemReceived() {
+            try {
+                first.itemReceived();
+            } finally {
+                second.itemReceived();
+            }
+        }
+
+        @Override
+        public void onFlushRequest() {
+            try {
+                first.onFlushRequest();
+            } finally {
+                second.onFlushRequest();
+            }
+        }
+
+        @Override
+        public void itemWritten() {
+            try {
+                first.itemWritten();
+            } finally {
+                second.itemWritten();
+            }
+        }
+
+        @Override
+        public void writeFailed(final Throwable cause) {
+            try {
+                first.writeFailed(cause);
+            } finally {
+                second.writeFailed(cause);
+            }
+        }
+
+        @Override
+        public void writeComplete() {
+            try {
+                first.writeComplete();
+            } finally {
+                second.writeComplete();
+            }
+        }
+
+        @Override
+        public void writeCancelled() {
+            try {
+                first.writeCancelled();
+            } finally {
+                second.writeCancelled();
+            }
+        }
+    }
+}

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/BiTransportObserver.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/BiTransportObserver.java
@@ -27,6 +27,8 @@ import io.servicetalk.transport.api.TransportObserver;
 
 import javax.net.ssl.SSLSession;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Combines two {@link TransportObserver}s into a single {@link TransportObserver}.
  */
@@ -42,8 +44,8 @@ final class BiTransportObserver implements TransportObserver {
      * @param second the {@link TransportObserver} that will receive events second
      */
     BiTransportObserver(final TransportObserver first, final TransportObserver second) {
-        this.first = first;
-        this.second = second;
+        this.first = requireNonNull(first);
+        this.second = requireNonNull(second);
     }
 
     @Override

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionFactory.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionFactory.java
@@ -17,6 +17,9 @@ package io.servicetalk.client.api;
 
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.transport.api.TransportObserver;
+
+import javax.annotation.Nullable;
 
 /**
  * A factory for creating new connections.
@@ -31,7 +34,9 @@ public interface ConnectionFactory<ResolvedAddress, C extends ListenableAsyncClo
      * Creates and asynchronously returns a connection.
      *
      * @param address to connect.
+     * @param observer {@link TransportObserver} that provides visibility into transport events associated with a new
+     * connection.
      * @return {@link Single} that emits the created connection.
      */
-    Single<C> newConnection(ResolvedAddress address);
+    Single<C> newConnection(ResolvedAddress address, @Nullable TransportObserver observer);
 }

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionFactory.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionFactory.java
@@ -34,8 +34,7 @@ public interface ConnectionFactory<ResolvedAddress, C extends ListenableAsyncClo
      * Creates and asynchronously returns a connection.
      *
      * @param address to connect.
-     * @param observer {@link TransportObserver} that provides visibility into transport events associated with a new
-     * connection.
+     * @param observer {@link TransportObserver} for the newly created connection.
      * @return {@link Single} that emits the created connection.
      */
     Single<C> newConnection(ResolvedAddress address, @Nullable TransportObserver observer);

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionFactory.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DelegatingConnectionFactory.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DelegatingConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DelegatingConnectionFactory.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DelegatingConnectionFactory.java
@@ -18,6 +18,9 @@ package io.servicetalk.client.api;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.transport.api.TransportObserver;
+
+import javax.annotation.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -41,8 +44,8 @@ public class DelegatingConnectionFactory<ResolvedAddress, C extends ListenableAs
     }
 
     @Override
-    public Single<C> newConnection(final ResolvedAddress resolvedAddress) {
-        return delegate.newConnection(resolvedAddress);
+    public Single<C> newConnection(final ResolvedAddress resolvedAddress, @Nullable final TransportObserver observer) {
+        return delegate.newConnection(resolvedAddress, observer);
     }
 
     @Override

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LimitingConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LimitingConnectionFactoryFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/NoopTransportObserver.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/NoopTransportObserver.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.client.api;
+
+import io.servicetalk.transport.api.ConnectionInfo;
+import io.servicetalk.transport.api.ConnectionObserver;
+import io.servicetalk.transport.api.ConnectionObserver.DataObserver;
+import io.servicetalk.transport.api.ConnectionObserver.MultiplexedObserver;
+import io.servicetalk.transport.api.ConnectionObserver.ReadObserver;
+import io.servicetalk.transport.api.ConnectionObserver.SecurityHandshakeObserver;
+import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
+import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
+import io.servicetalk.transport.api.TransportObserver;
+
+import javax.net.ssl.SSLSession;
+
+final class NoopTransportObserver implements TransportObserver {
+
+    static final TransportObserver INSTANCE = new NoopTransportObserver();
+
+    private NoopTransportObserver() {
+        // Singleton
+    }
+
+    @Override
+    public ConnectionObserver onNewConnection() {
+        return NoopConnectionObserver.INSTANCE;
+    }
+
+    static final class NoopConnectionObserver implements ConnectionObserver {
+
+        static final ConnectionObserver INSTANCE = new NoopConnectionObserver();
+
+        private NoopConnectionObserver() {
+            // Singleton
+        }
+
+        @Override
+        public void onDataRead(final int size) {
+        }
+
+        @Override
+        public void onDataWrite(final int size) {
+        }
+
+        @Override
+        public void onFlush() {
+        }
+
+        @Override
+        public SecurityHandshakeObserver onSecurityHandshake() {
+            return NoopSecurityHandshakeObserver.INSTANCE;
+        }
+
+        @Override
+        public DataObserver established(final ConnectionInfo info) {
+            return NoopDataObserver.INSTANCE;
+        }
+
+        @Override
+        public MultiplexedObserver establishedMultiplexed(final ConnectionInfo info) {
+            return NoopMultiplexedObserver.INSTANCE;
+        }
+
+        @Override
+        public void connectionClosed(final Throwable error) {
+        }
+
+        @Override
+        public void connectionClosed() {
+        }
+    }
+
+    static final class NoopSecurityHandshakeObserver implements SecurityHandshakeObserver {
+
+        static final SecurityHandshakeObserver INSTANCE = new NoopSecurityHandshakeObserver();
+
+        private NoopSecurityHandshakeObserver() {
+            // Singleton
+        }
+
+        @Override
+        public void handshakeFailed(final Throwable cause) {
+        }
+
+        @Override
+        public void handshakeComplete(final SSLSession sslSession) {
+        }
+    }
+
+    static final class NoopDataObserver implements DataObserver {
+
+        static final DataObserver INSTANCE = new NoopDataObserver();
+
+        private NoopDataObserver() {
+            // Singleton
+        }
+
+        @Override
+        public ReadObserver onNewRead() {
+            return NoopReadObserver.INSTANCE;
+        }
+
+        @Override
+        public WriteObserver onNewWrite() {
+            return NoopWriteObserver.INSTANCE;
+        }
+    }
+
+    static final class NoopMultiplexedObserver implements MultiplexedObserver {
+
+        static final MultiplexedObserver INSTANCE = new NoopMultiplexedObserver();
+
+        private NoopMultiplexedObserver() {
+            // Singleton
+        }
+
+        @Override
+        public StreamObserver onNewStream() {
+            return NoopStreamObserver.INSTANCE;
+        }
+    }
+
+    static final class NoopStreamObserver implements StreamObserver {
+
+        static final StreamObserver INSTANCE = new NoopStreamObserver();
+
+        private NoopStreamObserver() {
+            // Singleton
+        }
+
+        @Override
+        public ReadObserver onNewRead() {
+            return NoopReadObserver.INSTANCE;
+        }
+
+        @Override
+        public WriteObserver onNewWrite() {
+            return NoopWriteObserver.INSTANCE;
+        }
+
+        @Override
+        public void streamClosed(final Throwable error) {
+        }
+
+        @Override
+        public void streamClosed() {
+        }
+    }
+
+    static final class NoopReadObserver implements ReadObserver {
+
+        static final ReadObserver INSTANCE = new NoopReadObserver();
+
+        private NoopReadObserver() {
+            // Singleton
+        }
+
+        @Override
+        public void requestedToRead(final long n) {
+        }
+
+        @Override
+        public void itemRead() {
+        }
+
+        @Override
+        public void readFailed(final Throwable cause) {
+        }
+
+        @Override
+        public void readComplete() {
+        }
+
+        @Override
+        public void readCancelled() {
+        }
+    }
+
+    static final class NoopWriteObserver implements WriteObserver {
+
+        static final WriteObserver INSTANCE = new NoopWriteObserver();
+
+        private NoopWriteObserver() {
+            // Singleton
+        }
+
+        @Override
+        public void requestedToWrite(final long n) {
+        }
+
+        @Override
+        public void itemReceived() {
+        }
+
+        @Override
+        public void onFlushRequest() {
+        }
+
+        @Override
+        public void itemWritten() {
+        }
+
+        @Override
+        public void writeFailed(final Throwable cause) {
+        }
+
+        @Override
+        public void writeComplete() {
+        }
+
+        @Override
+        public void writeCancelled() {
+        }
+    }
+}

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/TransportObserverConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/TransportObserverConnectionFactoryFilter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.client.api;
+
+import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.transport.api.TransportObserver;
+
+import java.util.function.Function;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.Single.defer;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A {@link ConnectionFactoryFilter} that configures a {@link TransportObserver} for new connections.
+ *
+ * @param <ResolvedAddress> The type of a resolved address that can be used for connecting.
+ * @param <C> The type of connections created by the {@link ConnectionFactory} decorated by this filter.
+ */
+public final class TransportObserverConnectionFactoryFilter<ResolvedAddress, C extends ListenableAsyncCloseable>
+        implements ConnectionFactoryFilter<ResolvedAddress, C> {
+
+    private final Function<ResolvedAddress, TransportObserver> observerFactory;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param observer {@link TransportObserver} to use for new connections
+     */
+    public TransportObserverConnectionFactoryFilter(final TransportObserver observer) {
+        requireNonNull(observer);
+        observerFactory = __ -> observer;
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param observerFactory a factory to create a {@link TransportObserver} for new connections
+     */
+    public TransportObserverConnectionFactoryFilter(
+            final Function<ResolvedAddress, TransportObserver> observerFactory) {
+        this.observerFactory = requireNonNull(observerFactory);
+    }
+
+    @Override
+    public ConnectionFactory<ResolvedAddress, C> create(final ConnectionFactory<ResolvedAddress, C> original) {
+        return new DelegatingConnectionFactory<ResolvedAddress, C>(original) {
+            @Override
+            public Single<C> newConnection(final ResolvedAddress resolvedAddress,
+                                           @Nullable final TransportObserver originalObserver) {
+                return defer(() -> {
+                    final TransportObserver newObserver = requireNonNull(observerFactory.apply(resolvedAddress));
+                    return delegate().newConnection(resolvedAddress, originalObserver == null ? newObserver :
+                            new BiTransportObserver(originalObserver, newObserver));
+                }).subscribeShareContext();
+            }
+        };
+    }
+}

--- a/servicetalk-client-api/src/test/java/io/servicetalk/client/api/LimitingConnectionFactoryFilterTest.java
+++ b/servicetalk-client-api/src/test/java/io/servicetalk/client/api/LimitingConnectionFactoryFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-client-api/src/test/java/io/servicetalk/client/api/LimitingConnectionFactoryFilterTest.java
+++ b/servicetalk-client-api/src/test/java/io/servicetalk/client/api/LimitingConnectionFactoryFilterTest.java
@@ -58,7 +58,7 @@ public class LimitingConnectionFactoryFilterTest {
     public void setUp() {
         original = newMockConnectionFactory();
         connectionOnClose = new LinkedBlockingQueue<>();
-        when(original.newConnection(any())).thenAnswer(invocation -> {
+        when(original.newConnection(any(), any())).thenAnswer(invocation -> {
             ListenableAsyncCloseable conn = mock(ListenableAsyncCloseable.class);
             Processor onClose = newCompletableProcessor();
             connectionOnClose.add(onClose);
@@ -77,42 +77,42 @@ public class LimitingConnectionFactoryFilterTest {
     public void enforceMaxConnections() throws Exception {
         ConnectionFactory<String, ? extends ListenableAsyncCloseable> cf =
                 makeCF(LimitingConnectionFactoryFilter.withMax(1), original);
-        cf.newConnection("c1").toFuture().get();
+        cf.newConnection("c1", null).toFuture().get();
         expectedException.expect(ExecutionException.class);
         expectedException.expectCause(instanceOf(ConnectException.class));
-        cf.newConnection("c2").toFuture().get();
+        cf.newConnection("c2", null).toFuture().get();
     }
 
     @Test
     public void onCloseReleasesPermit() throws Exception {
         ConnectionFactory<String, ? extends ListenableAsyncCloseable> cf =
                 makeCF(LimitingConnectionFactoryFilter.withMax(1), original);
-        cf.newConnection("c1").toFuture().get();
+        cf.newConnection("c1", null).toFuture().get();
         connectAndVerifyFailed(cf);
         connectionOnClose.take().onComplete();
-        cf.newConnection("c3").toFuture().get();
+        cf.newConnection("c3", null).toFuture().get();
     }
 
     @Test
     public void cancelReleasesPermit() throws Exception {
         ConnectionFactory<String, ListenableAsyncCloseable> o = newMockConnectionFactory();
-        when(o.newConnection(any())).thenReturn(never());
+        when(o.newConnection(any(), any())).thenReturn(never());
         ConnectionFactory<String, ? extends ListenableAsyncCloseable> cf =
                 makeCF(LimitingConnectionFactoryFilter.withMax(1), o);
-        connectlistener.listen(cf.newConnection("c1")).verifyNoEmissions();
+        connectlistener.listen(cf.newConnection("c1", null)).verifyNoEmissions();
         connectAndVerifyFailed(cf);
         connectlistener.cancel();
 
         ListenableAsyncCloseable c = mock(ListenableAsyncCloseable.class);
         when(c.onClose()).thenReturn(Completable.never());
-        when(o.newConnection(any())).thenReturn(succeeded(c));
-        cf.newConnection("c2").toFuture().get();
+        when(o.newConnection(any(), any())).thenReturn(succeeded(c));
+        cf.newConnection("c2", null).toFuture().get();
     }
 
     private static void connectAndVerifyFailed(final ConnectionFactory<String, ? extends ListenableAsyncCloseable> cf)
             throws Exception {
         try {
-            cf.newConnection("c-fail").toFuture().get();
+            cf.newConnection("c-fail", null).toFuture().get();
             fail("Connect expected to fail.");
         } catch (ExecutionException e) {
             assertThat("Unexpected exception.", e.getCause(), instanceOf(ConnectException.class));

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/BaseGrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/BaseGrpcClientBuilder.java
@@ -22,7 +22,6 @@ import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServiceTalkSocketOptions;
-import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketOption;
 import java.net.StandardSocketOptions;
@@ -73,14 +72,6 @@ interface BaseGrpcClientBuilder<U, R> {
      * @return {@code this}.
      */
     BaseGrpcClientBuilder<U, R> enableWireLogging(String loggerName);
-
-    /**
-     * Sets a {@link TransportObserver} that provides visibility into transport events.
-     *
-     * @param transportObserver A {@link TransportObserver} that provides visibility into transport events.
-     * @return {@code this}.
-     */
-    BaseGrpcClientBuilder<U, R> transportObserver(TransportObserver transportObserver);
 
     /**
      * Configurations of various underlying protocol versions.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -32,7 +32,6 @@ import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequester;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.transport.api.IoExecutor;
-import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketOption;
 import java.util.function.Predicate;
@@ -64,9 +63,6 @@ public abstract class GrpcClientBuilder<U, R>
 
     @Override
     public abstract GrpcClientBuilder<U, R> enableWireLogging(String loggerName);
-
-    @Override
-    public abstract GrpcClientBuilder<U, R> transportObserver(TransportObserver transportObserver);
 
     @Override
     public abstract GrpcClientBuilder<U, R> protocols(HttpProtocolConfig... protocols);

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/SingleAddressGrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/SingleAddressGrpcClientBuilder.java
@@ -30,6 +30,7 @@ import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.transport.api.IoExecutor;
+import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketOption;
 import java.util.function.Predicate;
@@ -60,7 +61,7 @@ interface SingleAddressGrpcClientBuilder<U, R,
      * builder.
      * <p>
      * Filtering allows you to wrap a {@link ConnectionFactory} and modify behavior of
-     * {@link ConnectionFactory#newConnection(Object)}.
+     * {@link ConnectionFactory#newConnection(Object, TransportObserver)}.
      * Some potential candidates for filtering include logging and metrics.
      * <p>
      * The order of execution of these filters are in order of append. If 3 filters are added as follows:

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/SingleAddressGrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/SingleAddressGrpcClientBuilder.java
@@ -30,7 +30,6 @@ import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.transport.api.IoExecutor;
-import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketOption;
 import java.util.function.Predicate;
@@ -52,9 +51,6 @@ interface SingleAddressGrpcClientBuilder<U, R,
 
     @Override
     SingleAddressGrpcClientBuilder<U, R, SDE> enableWireLogging(String loggerName);
-
-    @Override
-    SingleAddressGrpcClientBuilder<U, R, SDE> transportObserver(TransportObserver transportObserver);
 
     @Override
     SingleAddressGrpcClientBuilder<U, R, SDE> protocols(HttpProtocolConfig... protocols);

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
@@ -33,7 +33,6 @@ import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.transport.api.IoExecutor;
-import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketOption;
 import java.util.function.Predicate;
@@ -75,12 +74,6 @@ final class DefaultGrpcClientBuilder<U, R> extends GrpcClientBuilder<U, R> {
     @Override
     public GrpcClientBuilder<U, R> enableWireLogging(final String loggerName) {
         httpClientBuilder.enableWireLogging(loggerName);
-        return this;
-    }
-
-    @Override
-    public GrpcClientBuilder<U, R> transportObserver(final TransportObserver transportObserver) {
-        httpClientBuilder.transportObserver(transportObserver);
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseSingleAddressHttpClientBuilder.java
@@ -23,7 +23,6 @@ import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.BiIntFunction;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.transport.api.IoExecutor;
-import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketOption;
 import java.util.function.Function;
@@ -43,15 +42,6 @@ abstract class BaseSingleAddressHttpClientBuilder<U, R, SDE extends ServiceDisco
 
     @Override
     public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> enableWireLogging(String loggerName);
-
-    /**
-     * Sets a {@link TransportObserver} that provides visibility into transport events.
-     *
-     * @param transportObserver A {@link TransportObserver} that provides visibility into transport events.
-     * @return {@code this}.
-     */
-    public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> transportObserver(
-            TransportObserver transportObserver);
 
     @Override
     public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> protocols(HttpProtocolConfig... protocols);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/EmptyCloseConnectionFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/EmptyCloseConnectionFactory.java
@@ -19,8 +19,10 @@ import io.servicetalk.client.api.ConnectionFactory;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.transport.api.TransportObserver;
 
 import java.util.function.Function;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
 
@@ -35,7 +37,7 @@ final class EmptyCloseConnectionFactory<ResolvedAddress, C extends ListenableAsy
     }
 
     @Override
-    public Single<C> newConnection(ResolvedAddress resolvedAddress) {
+    public Single<C> newConnection(final ResolvedAddress resolvedAddress, @Nullable final TransportObserver observer) {
         return factory.apply(resolvedAddress);
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
@@ -28,6 +28,7 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.IoExecutor;
+import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketOption;
 import java.util.function.Function;
@@ -77,7 +78,7 @@ abstract class HttpClientBuilder<U, R, SDE extends ServiceDiscovererEvent<R>> ex
      * builder.
      * <p>
      * Filtering allows you to wrap a {@link ConnectionFactory} and modify behavior of
-     * {@link ConnectionFactory#newConnection(Object)}.
+     * {@link ConnectionFactory#newConnection(Object, TransportObserver)}.
      * Some potential candidates for filtering include logging and metrics.
      * <p>
      * The order of execution of these filters are in order of append. If 3 filters are added as follows:

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -25,7 +25,6 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.transport.api.ClientSecurityConfigurator;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
-import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketOption;
 import java.util.function.BiConsumer;
@@ -65,15 +64,6 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
 
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> disableHostHeaderFallback();
-
-    /**
-     * Sets a factory for {@link TransportObserver} that provides visibility into transport events.
-     *
-     * @param transportObserverFactory A factory that creates a {@link TransportObserver} per {@link HostAndPort}.
-     * @return {@code this}.
-     */
-    public abstract MultiAddressHttpClientBuilder<U, R> transportObserver(
-            Function<HostAndPort, TransportObserver> transportObserverFactory);
 
     /**
      * Sets a function that is used for configuring SSL/TLS for https requests.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
@@ -27,7 +27,6 @@ import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.api.BiIntFunction;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.transport.api.IoExecutor;
-import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketOption;
 import java.util.function.BiFunction;
@@ -61,9 +60,6 @@ public abstract class PartitionedHttpClientBuilder<U, R>
 
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> enableWireLogging(String loggerName);
-
-    @Override
-    public abstract PartitionedHttpClientBuilder<U, R> transportObserver(TransportObserver transportObserver);
 
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> protocols(HttpProtocolConfig... protocols);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -23,7 +23,6 @@ import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.BiIntFunction;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.transport.api.IoExecutor;
-import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketOption;
 import java.util.function.Function;
@@ -55,9 +54,6 @@ public abstract class SingleAddressHttpClientBuilder<U, R>
 
     @Override
     public abstract SingleAddressHttpClientBuilder<U, R> enableWireLogging(String loggerName);
-
-    @Override
-    public abstract SingleAddressHttpClientBuilder<U, R> transportObserver(TransportObserver transportObserver);
 
     @Override
     public abstract SingleAddressHttpClientBuilder<U, R> protocols(HttpProtocolConfig... protocols);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLBHttpConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -56,7 +56,6 @@ import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.HttpClientBuildContext;
 import io.servicetalk.transport.api.IoExecutor;
-import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketOption;
 import java.util.function.Function;
@@ -251,12 +250,6 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
     @Override
     public PartitionedHttpClientBuilder<U, R> enableWireLogging(final String loggerName) {
         builderTemplate.enableWireLogging(loggerName);
-        return this;
-    }
-
-    @Override
-    public PartitionedHttpClientBuilder<U, R> transportObserver(final TransportObserver transportObserver) {
-        builderTemplate.transportObserver(transportObserver);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -49,7 +49,6 @@ import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
-import io.servicetalk.transport.api.TransportObserver;
 
 import io.netty.handler.ssl.SslContext;
 import io.netty.util.NetUtil;
@@ -404,12 +403,6 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
     @Override
     public DefaultSingleAddressHttpClientBuilder<U, R> enableWireLogging(final String loggerName) {
         config.tcpConfig().enableWireLogging(loggerName);
-        return this;
-    }
-
-    @Override
-    public SingleAddressHttpClientBuilder<U, R> transportObserver(final TransportObserver transportObserver) {
-        config.tcpConfig().transportObserver(transportObserver);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
@@ -28,6 +28,7 @@ import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.tcp.netty.internal.ReadOnlyTcpClientConfig;
 import io.servicetalk.tcp.netty.internal.TcpClientChannelInitializer;
 import io.servicetalk.tcp.netty.internal.TcpConnector;
+import io.servicetalk.transport.api.TransportObserver;
 
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -50,7 +51,8 @@ final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpCon
     }
 
     @Override
-    Single<FilterableStreamingHttpConnection> newFilterableConnection(final ResolvedAddress resolvedAddress) {
+    Single<FilterableStreamingHttpConnection> newFilterableConnection(final ResolvedAddress resolvedAddress,
+                                                                      @Nullable final TransportObserver observer) {
         assert config.h2Config() != null;
         // This state is read only, so safe to keep a copy across Subscribers
         final ReadOnlyTcpClientConfig roTcpClientConfig = config.tcpConfig();
@@ -60,7 +62,7 @@ final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpCon
                         executionContext.bufferAllocator(), executionContext.executor(),
                         config.h2Config(), reqRespFactory, roTcpClientConfig.flushStrategy(),
                         roTcpClientConfig.idleTimeoutMs(), executionContext.executionStrategy(),
-                        new TcpClientChannelInitializer(roTcpClientConfig).andThen(
+                        new TcpClientChannelInitializer(roTcpClientConfig, observer).andThen(
                                 new H2ClientParentChannelInitializer(config.h2Config()))));
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
@@ -25,6 +25,7 @@ import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategyInfluencer;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
+import io.servicetalk.transport.api.TransportObserver;
 
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -47,9 +48,10 @@ final class PipelinedLBHttpConnectionFactory<ResolvedAddress> extends AbstractLB
     }
 
     @Override
-    Single<FilterableStreamingHttpConnection> newFilterableConnection(final ResolvedAddress resolvedAddress) {
+    Single<FilterableStreamingHttpConnection> newFilterableConnection(final ResolvedAddress resolvedAddress,
+                                                                      @Nullable final TransportObserver observer) {
         assert config.h1Config() != null;
-        return buildStreaming(executionContext, resolvedAddress, config)
+        return buildStreaming(executionContext, resolvedAddress, config, observer)
                 .map(conn -> new PipelinedStreamingHttpConnection(conn, config.h1Config(), executionContext,
                         reqRespFactory));
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
@@ -24,6 +24,7 @@ import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpExecutionStrategyInfluencer;
 import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.DeferSslHandler;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;
 
@@ -31,6 +32,8 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+
+import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Processors.newSingleProcessor;
 import static io.servicetalk.concurrent.api.Single.failed;
@@ -67,8 +70,9 @@ final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends Filte
         }
 
         @Override
-        public Single<C> newConnection(final ResolvedAddress resolvedAddress) {
-            return delegate().newConnection(resolvedAddress).flatMap(c -> {
+        public Single<C> newConnection(final ResolvedAddress resolvedAddress,
+                                       @Nullable final TransportObserver observer) {
+            return delegate().newConnection(resolvedAddress, observer).flatMap(c -> {
                 try {
                     // We currently only have access to a StreamingHttpRequester, which means we are forced to provide
                     // an HttpExecutionStrategy. Because we can't be sure if there is any blocking code in the

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -19,12 +19,15 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.tcp.netty.internal.TcpClientChannelInitializer;
 import io.servicetalk.tcp.netty.internal.TcpConnector;
+import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
 import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.servicetalk.transport.netty.internal.DefaultNettyConnection;
 import io.servicetalk.transport.netty.internal.NettyConnection;
 
 import io.netty.channel.Channel;
+
+import javax.annotation.Nullable;
 
 import static io.servicetalk.buffer.netty.BufferUtils.getByteBufAllocator;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
@@ -39,11 +42,11 @@ final class StreamingConnectionFactory {
 
     static <ResolvedAddress> Single<? extends NettyConnection<Object, Object>> buildStreaming(
             final HttpExecutionContext executionContext, final ResolvedAddress resolvedAddress,
-            final ReadOnlyHttpClientConfig roConfig) {
+            final ReadOnlyHttpClientConfig roConfig, @Nullable final TransportObserver observer) {
         // We disable auto read so we can handle stuff in the ConnectionFilter before we accept any content.
         return TcpConnector.connect(null, resolvedAddress, roConfig.tcpConfig(), false,
                 executionContext, channel -> createConnection(channel, executionContext, roConfig,
-                        new TcpClientChannelInitializer(roConfig.tcpConfig(), roConfig.hasProxy())));
+                        new TcpClientChannelInitializer(roConfig.tcpConfig(), observer, roConfig.hasProxy())));
     }
 
     static Single<? extends DefaultNettyConnection<Object, Object>> createConnection(final Channel channel,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -16,12 +16,15 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.client.api.ConnectionFactoryFilter;
+import io.servicetalk.client.api.DelegatingConnectionFactory;
 import io.servicetalk.concurrent.api.DefaultThreadFactory;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Executors;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpResponseStatus;
@@ -174,7 +177,7 @@ public abstract class AbstractNettyHttpServerTest {
                     .trustManager(DefaultTestCerts::loadMutualAuthCaPem).commit();
         }
         if (clientTransportObserver != null) {
-            clientBuilder.transportObserver(clientTransportObserver);
+            clientBuilder.appendConnectionFactoryFilter(observableConnectionFactoryFilter(clientTransportObserver));
         }
         httpClient = clientBuilder.ioExecutor(clientIoExecutor)
                 .executionStrategy(defaultStrategy(clientExecutor))
@@ -237,9 +240,21 @@ public abstract class AbstractNettyHttpServerTest {
         this.protocol = requireNonNull(protocol);
     }
 
-    void transportObserver(TransportObserver client, TransportObserver server) {
+    void transportObserver(@Nullable TransportObserver client, @Nullable TransportObserver server) {
         this.clientTransportObserver = client;
         this.serverTransportObserver = server;
+    }
+
+    private static ConnectionFactoryFilter<InetSocketAddress, FilterableStreamingHttpConnection>
+            observableConnectionFactoryFilter(TransportObserver clientTransportObserver) {
+        return original ->
+                new DelegatingConnectionFactory<InetSocketAddress, FilterableStreamingHttpConnection>(original) {
+                    @Override
+                    public Single<FilterableStreamingHttpConnection> newConnection(
+                            InetSocketAddress inetSocketAddress, @Nullable TransportObserver observer) {
+                        return delegate().newConnection(inetSocketAddress, clientTransportObserver);
+                    }
+                };
     }
 
     StreamingHttpResponse makeRequest(final StreamingHttpRequest request)

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AutoRetryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AutoRetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AutoRetryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AutoRetryTest.java
@@ -34,6 +34,7 @@ import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.RetryableException;
 import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.TransportObserver;
 
 import org.junit.After;
 import org.junit.Rule;
@@ -170,8 +171,9 @@ public class AutoRetryTest {
         }
 
         @Override
-        public Single<FilterableStreamingHttpConnection> newConnection(final InetSocketAddress inetSocketAddress) {
-            return delegate().newConnection(inetSocketAddress)
+        public Single<FilterableStreamingHttpConnection> newConnection(final InetSocketAddress inetSocketAddress,
+                                                                       @Nullable final TransportObserver observer) {
+            return delegate().newConnection(inetSocketAddress, observer)
                     .flatMap(c -> c.closeAsync().concat(succeeded(c)));
         }
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryFilterTest.java
@@ -39,6 +39,7 @@ import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;
 
@@ -160,8 +161,8 @@ public class ConnectionFactoryFilterTest {
                 new DelegatingConnectionFactory<InetSocketAddress, FilterableStreamingHttpConnection>(original) {
                     @Override
                     public Single<FilterableStreamingHttpConnection> newConnection(
-                            final InetSocketAddress inetSocketAddress) {
-                        return delegate().newConnection(inetSocketAddress).map(filter);
+                            final InetSocketAddress inetSocketAddress, @Nullable final TransportObserver observer) {
+                        return delegate().newConnection(inetSocketAddress, observer).map(filter);
                     }
                 };
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
@@ -26,6 +26,7 @@ import io.servicetalk.http.api.StreamingHttpRequestFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.ExecutionContextRule;
 
 import org.junit.After;
@@ -99,8 +100,8 @@ public class HttpAuthConnectionFactoryClientTest {
 
         @Override
         public Single<FilterableStreamingHttpConnection> newConnection(
-                final ResolvedAddress resolvedAddress) {
-            return delegate.newConnection(resolvedAddress).flatMap(cnx ->
+                final ResolvedAddress resolvedAddress, @Nullable final TransportObserver observer) {
+            return delegate.newConnection(resolvedAddress, observer).flatMap(cnx ->
                     cnx.request(defaultStrategy(), newTestRequest(cnx, "/auth"))
                             .recoverWith(cause -> {
                                 cnx.closeAsync().subscribe();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientBuilderTest.java
@@ -82,15 +82,16 @@ public class HttpClientBuilderTest extends AbstractEchoServerBasedHttpRequesterT
         makeRequestValidateResponseAndClose(requester);
 
         InOrder verifier = inOrder(factory1, factory2);
-        verifier.verify(factory1).newConnection(any());
-        verifier.verify(factory2).newConnection(any());
+        verifier.verify(factory1).newConnection(any(), any());
+        verifier.verify(factory2).newConnection(any(), any());
     }
 
     private static ConnectionFactoryFilter<InetSocketAddress, FilterableStreamingHttpConnection> factoryFilter(
             final ConnectionFactory<InetSocketAddress, FilterableStreamingHttpConnection> factory) {
         return orig -> {
-            when(factory.newConnection(any()))
-                    .thenAnswer(invocation -> orig.newConnection(invocation.getArgument(0)));
+            when(factory.newConnection(any(), any()))
+                    .thenAnswer(invocation -> orig.newConnection(invocation.getArgument(0),
+                            invocation.getArgument(1)));
             return factory;
         };
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -436,7 +436,7 @@ public class HttpRequestEncoderTest {
                                 closeHandlerRef.compareAndSet(null, closeHandler);
                                 return DefaultNettyConnection.initChannel(channel, CEC.bufferAllocator(),
                                         CEC.executor(), LAST_CHUNK_PREDICATE, closeHandler, defaultFlushStrategy(),
-                                        null, new TcpClientChannelInitializer(cConfig.tcpConfig())
+                                        null, new TcpClientChannelInitializer(cConfig.tcpConfig(), null)
                                                 .andThen(new HttpClientChannelInitializer(
                                                         getByteBufAllocator(CEC.bufferAllocator()),
                                                         cConfig.h1Config(), closeHandler))

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilterTest.java
@@ -139,9 +139,9 @@ public class ProxyConnectConnectionFactoryFilterTest {
     private void subscribeToProxyConnectionFactory() {
         @SuppressWarnings("unchecked")
         ConnectionFactory<String, FilterableStreamingHttpConnection> original = mock(ConnectionFactory.class);
-        when(original.newConnection(any())).thenReturn(succeeded(connection));
+        when(original.newConnection(any(), any())).thenReturn(succeeded(connection));
         toSource(new ProxyConnectConnectionFactoryFilter<String, FilterableStreamingHttpConnection>(CONNECT_ADDRESS)
-                .create(original).newConnection(RESOLVED_ADDRESS)).subscribe(subscriber);
+                .create(original).newConnection(RESOLVED_ADDRESS, null)).subscribe(subscriber);
     }
 
     @Test

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseCancelTest.java
@@ -30,6 +30,7 @@ import io.servicetalk.http.api.StreamingHttpConnectionFilter;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.TransportObserver;
 
 import org.hamcrest.Matcher;
 import org.junit.After;
@@ -179,10 +180,11 @@ public class ResponseCancelTest {
         }
 
         @Override
-        public Single<FilterableStreamingHttpConnection> newConnection(final InetSocketAddress inetSocketAddress) {
+        public Single<FilterableStreamingHttpConnection> newConnection(final InetSocketAddress inetSocketAddress,
+                                                                       @Nullable final TransportObserver observer) {
             return defer(() -> {
                 connectionCount.incrementAndGet();
-                return delegate().newConnection(inetSocketAddress);
+                return delegate().newConnection(inetSocketAddress, observer);
             });
         }
     }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -273,7 +273,7 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
         }
 
         // No connection was selected: create a new one
-        return connectionFactory.newConnection(host.address)
+        return connectionFactory.newConnection(host.address, null)
                 .flatMap(newCnx -> {
                     // Invoke the selector before adding the connection to the pool, otherwise, connection can be used
                     // concurrently and hence a new connection can be rejected by the selector.

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -272,7 +272,9 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
             }
         }
 
-        // No connection was selected: create a new one
+        // No connection was selected: create a new one.
+        // This LB implementation does not automatically provide TransportObserver. Therefore, we pass "null" here.
+        // Users can apply a ConnectionFactoryFilter if they need to override this "null" value with TransportObserver.
         return connectionFactory.newConnection(host.address, null)
                 .flatMap(newCnx -> {
                     // Invoke the selector before adding the connection to the pool, otherwise, connection can be used

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -34,6 +34,7 @@ import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
 import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.transport.api.TransportObserver;
 
 import org.junit.After;
 import org.junit.Before;
@@ -508,7 +509,7 @@ public class RoundRobinLoadBalancerTest {
         }
 
         @Override
-        public Single<TestLoadBalancedConnection> newConnection(String s) {
+        public Single<TestLoadBalancedConnection> newConnection(String s, TransportObserver observer) {
             return connectionFactory.apply(s);
         }
 

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractReadOnlyTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractReadOnlyTcpConfig.java
@@ -16,7 +16,6 @@
 package io.servicetalk.tcp.netty.internal;
 
 import io.servicetalk.transport.api.ServiceTalkSocketOptions;
-import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.WireLoggingInitializer;
 
@@ -45,8 +44,6 @@ abstract class AbstractReadOnlyTcpConfig<SecurityConfig, ReadOnlyView> {
     private final FlushStrategy flushStrategy;
     @Nullable
     private final WireLoggingInitializer wireLoggingInitializer;
-    @Nullable
-    private final TransportObserver transportObserver;
     private final boolean alpnConfigured;
 
     protected AbstractReadOnlyTcpConfig(final AbstractTcpConfig<SecurityConfig, ReadOnlyView> from,
@@ -56,7 +53,6 @@ abstract class AbstractReadOnlyTcpConfig<SecurityConfig, ReadOnlyView> {
         flushStrategy = from.flushStrategy();
         final String wireLoggerName = from.wireLoggerName();
         wireLoggingInitializer = wireLoggerName != null ? new WireLoggingInitializer(wireLoggerName) : null;
-        transportObserver = from.transportObserver();
         this.alpnConfigured = alpnConfigured;
     }
 
@@ -97,16 +93,6 @@ abstract class AbstractReadOnlyTcpConfig<SecurityConfig, ReadOnlyView> {
     @Nullable
     public final WireLoggingInitializer wireLoggingInitializer() {
         return wireLoggingInitializer;
-    }
-
-    /**
-     * Returns the {@link TransportObserver} if any for all channels.
-     *
-     * @return the {@link TransportObserver} if any
-     */
-    @Nullable
-    public final TransportObserver transportObserver() {
-        return transportObserver;
     }
 
     /**

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
@@ -16,7 +16,6 @@
 package io.servicetalk.tcp.netty.internal;
 
 import io.servicetalk.transport.api.ServiceTalkSocketOptions;
-import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.ReadOnlyServerSecurityConfig;
 
@@ -50,8 +49,6 @@ abstract class AbstractTcpConfig<SecurityConfig, ReadOnlyView> {
     @Nullable
     private String wireLoggerName;
     @Nullable
-    private TransportObserver transportObserver;
-    @Nullable
     private SecurityConfig securityConfig;
 
     protected AbstractTcpConfig() {
@@ -62,7 +59,6 @@ abstract class AbstractTcpConfig<SecurityConfig, ReadOnlyView> {
         idleTimeoutMs = from.idleTimeoutMs;
         flushStrategy = from.flushStrategy;
         wireLoggerName = from.wireLoggerName;
-        transportObserver = from.transportObserver;
         securityConfig = from.securityConfig;
     }
 
@@ -84,11 +80,6 @@ abstract class AbstractTcpConfig<SecurityConfig, ReadOnlyView> {
     @Nullable
     final String wireLoggerName() {
         return wireLoggerName;
-    }
-
-    @Nullable
-    final TransportObserver transportObserver() {
-        return transportObserver;
     }
 
     @Nullable
@@ -135,15 +126,6 @@ abstract class AbstractTcpConfig<SecurityConfig, ReadOnlyView> {
      */
     public final void enableWireLogging(final String loggerName) {
         wireLoggerName = requireNonNull(loggerName);
-    }
-
-    /**
-     * Sets a {@link TransportObserver} that provides visibility into transport events.
-     *
-     * @param transportObserver A {@link TransportObserver} that provides visibility into transport events.
-     */
-    public final void transportObserver(final TransportObserver transportObserver) {
-        this.transportObserver = requireNonNull(transportObserver);
     }
 
     /**

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.tcp.netty.internal;
 
+import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.ReadOnlyServerSecurityConfig;
 
 import io.netty.handler.ssl.SslContext;
@@ -34,6 +35,8 @@ public final class ReadOnlyTcpServerConfig
         extends AbstractReadOnlyTcpConfig<ReadOnlyServerSecurityConfig, ReadOnlyTcpServerConfig> {
 
     @Nullable
+    private final TransportObserver transportObserver;
+    @Nullable
     private final SslContext sslContext;
     @Nullable
     private final DomainNameMapping<SslContext> mappings;
@@ -46,6 +49,7 @@ public final class ReadOnlyTcpServerConfig
      */
     ReadOnlyTcpServerConfig(final TcpServerConfig from, final List<String> supportedAlpnProtocols) {
         super(from, !supportedAlpnProtocols.isEmpty());
+        transportObserver = from.transportObserver();
         final ReadOnlyServerSecurityConfig securityConfig = from.securityConfig();
         if (from.sniConfigs() != null) {
             if (securityConfig == null) {
@@ -66,6 +70,16 @@ public final class ReadOnlyTcpServerConfig
             mappings = null;
         }
         backlog = from.backlog();
+    }
+
+    /**
+     * Returns the {@link TransportObserver} if any for all channels.
+     *
+     * @return the {@link TransportObserver} if any
+     */
+    @Nullable
+    public TransportObserver transportObserver() {
+        return transportObserver;
     }
 
     @Nullable

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
@@ -27,6 +27,8 @@ import io.netty.channel.Channel;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 
+import javax.annotation.Nullable;
+
 /**
  * {@link ChannelInitializer} for TCP client.
  */
@@ -38,24 +40,30 @@ public class TcpClientChannelInitializer implements ChannelInitializer {
      * Creates a {@link ChannelInitializer} for the {@code config}.
      *
      * @param config to use for initialization.
+     * @param observer {@link TransportObserver} that provides visibility into transport events associated with a new
+     * TCP connection.
      */
-    public TcpClientChannelInitializer(final ReadOnlyTcpClientConfig config) {
-        this(config, false);
+    public TcpClientChannelInitializer(final ReadOnlyTcpClientConfig config,
+                                       @Nullable final TransportObserver observer) {
+        this(config, observer, false);
     }
 
     /**
      * Creates a {@link ChannelInitializer} for the {@code config}.
      *
      * @param config to use for initialization.
+     * @param observer {@link TransportObserver} that provides visibility into transport events associated with a new
+     * TCP connection.
      * @param deferSslHandler {@code true} to wrap the {@link SslHandler} in a {@link DeferSslHandler}.
      */
-    public TcpClientChannelInitializer(final ReadOnlyTcpClientConfig config, final boolean deferSslHandler) {
+    public TcpClientChannelInitializer(final ReadOnlyTcpClientConfig config,
+                                       @Nullable final TransportObserver observer,
+                                       final boolean deferSslHandler) {
         ChannelInitializer delegate = ChannelInitializer.defaultInitializer();
 
         final SslContext sslContext = config.sslContext();
-        final TransportObserver transportObserver = config.transportObserver();
-        if (transportObserver != null) {
-            delegate = delegate.andThen(new TransportObserverInitializer(transportObserver,
+        if (observer != null) {
+            delegate = delegate.andThen(new TransportObserverInitializer(observer,
                     sslContext != null && !deferSslHandler));
         }
 
@@ -66,7 +74,7 @@ public class TcpClientChannelInitializer implements ChannelInitializer {
         if (sslContext != null) {
             delegate = delegate.andThen(new SslClientChannelInitializer(sslContext,
                     config.sslHostnameVerificationAlgorithm(), config.sslHostnameVerificationHost(),
-                    config.sslHostnameVerificationPort(), deferSslHandler, transportObserver != null));
+                    config.sslHostnameVerificationPort(), deferSslHandler, observer != null));
         }
 
         final WireLoggingInitializer wireLoggingInitializer = config.wireLoggingInitializer();

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.tcp.netty.internal;
 
+import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.ReadOnlyServerSecurityConfig;
 
 import io.netty.util.NetUtil;
@@ -32,8 +33,15 @@ import static java.util.Objects.requireNonNull;
 public final class TcpServerConfig extends AbstractTcpConfig<ReadOnlyServerSecurityConfig, ReadOnlyTcpServerConfig> {
 
     @Nullable
+    private TransportObserver transportObserver;
+    @Nullable
     private Map<String, ReadOnlyServerSecurityConfig> sniConfigs;
     private int backlog = NetUtil.SOMAXCONN;
+
+    @Nullable
+    TransportObserver transportObserver() {
+        return transportObserver;
+    }
 
     @Nullable
     Map<String, ReadOnlyServerSecurityConfig> sniConfigs() {
@@ -42,6 +50,15 @@ public final class TcpServerConfig extends AbstractTcpConfig<ReadOnlyServerSecur
 
     int backlog() {
         return backlog;
+    }
+
+    /**
+     * Sets a {@link TransportObserver} that provides visibility into transport events.
+     *
+     * @param transportObserver A {@link TransportObserver} that provides visibility into transport events.
+     */
+    public void transportObserver(final TransportObserver transportObserver) {
+        this.transportObserver = requireNonNull(transportObserver);
     }
 
     /**

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
@@ -23,6 +23,7 @@ import io.servicetalk.test.resources.DefaultTestCerts;
 import io.servicetalk.transport.api.ConnectionAcceptor;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.AddressUtils;
 import io.servicetalk.transport.netty.internal.ClientSecurityConfig;
 import io.servicetalk.transport.netty.internal.ExecutionContextRule;
@@ -38,6 +39,7 @@ import org.junit.rules.Timeout;
 
 import java.net.InetSocketAddress;
 import java.util.function.Function;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.transport.api.ConnectionAcceptor.ACCEPT_ALL;
@@ -93,7 +95,7 @@ public abstract class AbstractTcpServerTest {
 
     // Visible for overriding.
     TcpClient createClient() {
-        return new TcpClient(getTcpClientConfig());
+        return new TcpClient(getTcpClientConfig(), getClientTransportObserver());
     }
 
     // Visible for overriding.
@@ -108,6 +110,12 @@ public abstract class AbstractTcpServerTest {
             tcpClientConfig.secure(securityConfig.asReadOnly());
         }
         return tcpClientConfig;
+    }
+
+    // Visible for overriding.
+    @Nullable
+    TransportObserver getClientTransportObserver() {
+        return null;
     }
 
     // Visible for overriding.

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
@@ -30,6 +30,8 @@ import io.servicetalk.transport.netty.internal.ServerSecurityConfig;
 import org.mockito.Mockito;
 import org.mockito.verification.VerificationWithTimeout;
 
+import javax.annotation.Nullable;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
@@ -79,11 +81,10 @@ public class AbstractTransportObserverTest extends AbstractTcpServerTest {
         when(serverDataObserver.onNewWrite()).thenReturn(serverWriteObserver);
     }
 
+    @Nullable
     @Override
-    TcpClientConfig getTcpClientConfig() {
-        final TcpClientConfig config = super.getTcpClientConfig();
-        config.transportObserver(clientTransportObserver);
-        return config;
+    TransportObserver getClientTransportObserver() {
+        return clientTransportObserver;
     }
 
     static ClientSecurityConfig defaultClientSecurityConfig(SslProvider provider) {

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
@@ -63,6 +63,7 @@ public final class TcpClient {
      * New instance.
      *
      * @param config for the client.
+     * @param observer {@link TransportObserver} for the newly created connection.
      */
     public TcpClient(TcpClientConfig config, @Nullable TransportObserver observer) {
         this.config = config.asReadOnly(emptyList());

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
@@ -19,6 +19,7 @@ import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.FileDescriptorSocketAddress;
+import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.BufferHandler;
 import io.servicetalk.transport.netty.internal.DefaultNettyConnection;
 import io.servicetalk.transport.netty.internal.NettyConnection;
@@ -40,6 +41,7 @@ import java.net.SocketAddress;
 import java.net.StandardSocketOptions;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.tcp.netty.internal.TcpProtocol.TCP;
 import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
@@ -54,21 +56,17 @@ import static org.junit.Assume.assumeTrue;
 public final class TcpClient {
 
     private final ReadOnlyTcpClientConfig config;
-
-    /**
-     * New instance with default configuration.
-     */
-    public TcpClient() {
-        this(defaultConfig());
-    }
+    @Nullable
+    private final TransportObserver observer;
 
     /**
      * New instance.
      *
      * @param config for the client.
      */
-    public TcpClient(TcpClientConfig config) {
+    public TcpClient(TcpClientConfig config, @Nullable TransportObserver observer) {
         this.config = config.asReadOnly(emptyList());
+        this.observer = observer;
     }
 
     /**
@@ -97,7 +95,7 @@ public final class TcpClient {
                 channel -> DefaultNettyConnection.initChannel(channel,
                         executionContext.bufferAllocator(), executionContext.executor(), buffer -> false,
                         UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, config.flushStrategy(), config.idleTimeoutMs(),
-                        new TcpClientChannelInitializer(config).andThen(
+                        new TcpClientChannelInitializer(config, observer).andThen(
                                 channel2 -> channel2.pipeline().addLast(BufferHandler.INSTANCE)),
                         executionContext.executionStrategy(), TCP));
     }

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Motivation:

Having `TransportObserver` on `ConnectionFactory#newConnection` method gives
users more flexibility when they need to correlate prior events and a state
with observability events of new connections. It also allows them to choose
for which `ResolvedAddress`es they need an observer.

Modification:

- Add `TransportObserver` as a second argument for
`ConnectionFactory#newConnection`;
- Remove `#transportObserver(...)` configuration method from all client builders;
- Introduce `TransportObserverConnectionFactoryFilter` to simplify `TransportObserver`
configuration for the client;
- Update code to use new `ConnectionFactory` API;

Results:

More flexible approach for users to configure `TransportObserver` on the
client-side.