### PR TITLE
Retain addresses on service discovery failure

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DefaultServiceDiscovererEvent.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DefaultServiceDiscovererEvent.java
@@ -46,6 +46,30 @@ public final class DefaultServiceDiscovererEvent<T> implements ServiceDiscoverer
     }
 
     @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final DefaultServiceDiscovererEvent<?> that = (DefaultServiceDiscovererEvent<?>) o;
+
+        if (available != that.available) {
+            return false;
+        }
+        return address.equals(that.address);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = address.hashCode();
+        result = 31 * result + (available ? 1 : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "DefaultServiceDiscovererEvent{" +
                 "address=" + address +

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsClientTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsClientTest.java
@@ -465,7 +465,7 @@ public class DefaultDnsClientTest {
         recordStore.addResponse("apple.com", A, nextIp());
 
         final int expectedActiveCount = 1;
-        final int expectedInactiveCount = 1;
+        final int expectedInactiveCount = 0;
         final int expectedErrorCount = 1;
 
         CountDownLatch latch = new CountDownLatch(expectedActiveCount + expectedInactiveCount + expectedErrorCount);
@@ -486,7 +486,7 @@ public class DefaultDnsClientTest {
     public void repeatDiscoverNxDomainNoSendUnavailable() throws Exception {
         recordStore.addResponse("apple.com", A, nextIp());
 
-        DnsClient customClient = dnsClientBuilder().invalidateHostsOnDnsFailure(__ -> false).build();
+        DnsClient customClient = dnsClientBuilder().build();
         try {
             final int expectedActiveCount = 1;
             final int expectedInactiveCount = 0;
@@ -516,7 +516,7 @@ public class DefaultDnsClientTest {
         DnsClient customClient = clientBuilderWithRetry().build();
         try {
             final int expectedActiveCount = 1;
-            final int expectedInactiveCount = 1;
+            final int expectedInactiveCount = 0;
 
             CountDownLatch latch1 = new CountDownLatch(expectedActiveCount + expectedInactiveCount);
             CountDownLatch latch2 = new CountDownLatch(expectedActiveCount + expectedInactiveCount + 1);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseSingleAddressHttpClientBuilder.java
@@ -20,8 +20,6 @@ import io.servicetalk.client.api.AutoRetryStrategyProvider;
 import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
-import io.servicetalk.concurrent.api.BiIntFunction;
-import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.transport.api.IoExecutor;
 
 import java.net.SocketOption;
@@ -74,7 +72,7 @@ abstract class BaseSingleAddressHttpClientBuilder<U, R, SDE extends ServiceDisco
 
     @Override
     public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> retryServiceDiscoveryErrors(
-            BiIntFunction<Throwable, ? extends Completable> retryStrategy);
+            ServiceDiscoveryRetryStrategy<R, SDE> retryStrategy);
 
     @Override
     public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> loadBalancerFactory(

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategy.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.client.api.DefaultServiceDiscovererEvent;
+import io.servicetalk.client.api.ServiceDiscoverer;
+import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.client.api.partition.PartitionAttributes;
+import io.servicetalk.client.api.partition.PartitionedServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.BiIntFunction;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.Publisher;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.UnaryOperator;
+
+import static io.servicetalk.concurrent.api.Publisher.defer;
+import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponentialBackoffAndJitter;
+import static java.lang.Math.ceil;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Default implementation for {@link ServiceDiscoveryRetryStrategy}.
+ *
+ * @param <ResolvedAddress> The type of address after resolution.
+ * @param <E> Type of {@link ServiceDiscovererEvent}s published from {@link ServiceDiscoverer#discover(Object)}.
+ */
+public final class DefaultServiceDiscoveryRetryStrategy<ResolvedAddress,
+        E extends ServiceDiscovererEvent<ResolvedAddress>>
+        implements ServiceDiscoveryRetryStrategy<ResolvedAddress, E> {
+    private final int retainTillReceivePercentage;
+    private final UnaryOperator<E> flipAvailability;
+    private final BiIntFunction<Throwable, ? extends Completable> retryStrategy;
+
+    private DefaultServiceDiscoveryRetryStrategy(final int retainTillReceivePercentage,
+                                                 final UnaryOperator<E> flipAvailability,
+                                                 final BiIntFunction<Throwable, ? extends Completable> retryStrategy) {
+        this.retainTillReceivePercentage = retainTillReceivePercentage;
+        this.flipAvailability = requireNonNull(flipAvailability);
+        this.retryStrategy = requireNonNull(retryStrategy);
+    }
+
+    @Override
+    public Publisher<? extends E> apply(final Publisher<? extends E> sdEvents) {
+        return defer(() -> {
+            EventsCache<ResolvedAddress, E> eventsCache =
+                    new EventsCache<>(retainTillReceivePercentage, flipAvailability);
+            return sdEvents.flatMapConcatIterable(eventsCache::consume)
+                    .beforeOnError(__ -> eventsCache.errorSeen())
+                    .retryWhen(retryStrategy);
+        });
+    }
+
+    /**
+     * A builder to build instances of {@link DefaultServiceDiscoveryRetryStrategy}.
+     *
+     * @param <ResolvedAddress> The type of address after resolution.
+     * @param <E> Type of {@link ServiceDiscovererEvent}s published from {@link ServiceDiscoverer#discover(Object)}.
+     */
+    public static final class Builder<ResolvedAddress, E extends ServiceDiscovererEvent<ResolvedAddress>> {
+        // There is no reason for the choice of 75%, it is arbitrary and can be configured by users.
+        private int retainTillReceivePercentage = 75;
+        private BiIntFunction<Throwable, ? extends Completable> retryStrategy;
+        private final UnaryOperator<E> flipAvailability;
+
+        private Builder(final BiIntFunction<Throwable, ? extends Completable> retryStrategy,
+                        final UnaryOperator<E> flipAvailability) {
+            this.retryStrategy = retryStrategy;
+            this.flipAvailability = requireNonNull(flipAvailability);
+        }
+
+        /**
+         * A {@link Publisher} returned from {@link ServiceDiscoverer#discover(Object)} may fail transiently leaving the
+         * consumer of these events with an option of either disposing the addresses that were provided before the
+         * error or retain them till a retry succeeds. This option enables retention of addresses after an error is
+         * observed till the total number of received addresses after an error is {@code retainTillReceivePercentage}
+         * percent of the addresses that were available before the error was received.
+         *
+         * @param retainTillReceivePercentage A percentage of addresses that were received before an error that should
+         * be received after a success, after which unreceived addresses are removed by sending appropriate
+         * {@link ServiceDiscovererEvent}s. When set to {@code 0}, addresses are not retained.
+         * @return {@code this}.
+         */
+        public Builder<ResolvedAddress, E> retainAddressesTillSuccess(final int retainTillReceivePercentage) {
+            if (retainTillReceivePercentage < 0) {
+                throw new IllegalArgumentException("retainTillReceivePercentage: " + retainTillReceivePercentage +
+                        " (expected >= 0)");
+            }
+            this.retainTillReceivePercentage = retainTillReceivePercentage;
+            return this;
+        }
+
+        public Builder<ResolvedAddress, E> retryStrategy(
+                final BiIntFunction<Throwable, ? extends Completable> retryStrategy) {
+            this.retryStrategy = requireNonNull(retryStrategy);
+            return this;
+        }
+
+        /**
+         * Creates a new {@link ServiceDiscoveryRetryStrategy} using the passed {@link BiFunction} which is applied
+         * as-is using {@link Publisher#retryWhen(BiIntFunction)} on the {@link Publisher} passed to
+         * {@link DefaultServiceDiscoveryRetryStrategy#apply(Publisher)}.
+         *
+         * @return A new {@link ServiceDiscoveryRetryStrategy}.
+         */
+        public ServiceDiscoveryRetryStrategy<ResolvedAddress, E> build() {
+            return new DefaultServiceDiscoveryRetryStrategy<>(retainTillReceivePercentage, flipAvailability,
+                    retryStrategy);
+        }
+
+        /**
+         * Creates a new builder that uses default retries.
+         *
+         * @param executor {@link Executor} to use for retry backoffs.
+         * @param initialDelay {@link Duration} to use as initial delay for backoffs.
+         * @param <ResolvedAddress> The type of address after resolution.
+         * @return A new {@link Builder}.
+         */
+        public static <ResolvedAddress> Builder<ResolvedAddress, ServiceDiscovererEvent<ResolvedAddress>>
+        withDefaults(final Executor executor, final Duration initialDelay) {
+            return new Builder<>(new IndefiniteRetryStrategy(executor, initialDelay),
+                    evt -> new DefaultServiceDiscovererEvent<>(evt.address(), !evt.isAvailable()));
+        }
+
+        /**
+         * Creates a new builder that uses default retries.
+         *
+         * @param executor {@link Executor} to use for retry backoffs.
+         * @param initialDelay {@link Duration} to use as initial delay for backoffs.
+         * @param <ResolvedAddress> The type of address after resolution.
+         * @return A new {@link Builder}.
+         */
+        public static <ResolvedAddress> Builder<ResolvedAddress, PartitionedServiceDiscovererEvent<ResolvedAddress>>
+        withDefaultsForPartitions(final Executor executor, final Duration initialDelay) {
+            return new Builder<>(new IndefiniteRetryStrategy(executor, initialDelay),
+                    evt -> new PartitionedServiceDiscovererEvent<ResolvedAddress>() {
+                        @Override
+                        public PartitionAttributes partitionAddress() {
+                            return evt.partitionAddress();
+                        }
+
+                        @Override
+                        public ResolvedAddress address() {
+                            return evt.address();
+                        }
+
+                        @Override
+                        public boolean isAvailable() {
+                            return !evt.isAvailable();
+                        }
+                    });
+        }
+
+        /**
+         * Creates a new builder that uses default retries.
+         *
+         * @param executor {@link Executor} to use for retry backoffs.
+         * @param initialDelay {@link Duration} to use as initial delay for backoffs.
+         * @param flipAvailability {@link UnaryOperator} that returns a new {@link ServiceDiscovererEvent} that is the
+         * same as the passed {@link ServiceDiscovererEvent} but with {@link ServiceDiscovererEvent#isAvailable()} value
+         * flipped.
+         * @param <ResolvedAddress> The type of address after resolution.
+         * @param <E> Type of {@link ServiceDiscovererEvent}s published from {@link ServiceDiscoverer#discover(Object)}.
+         * @return A new {@link Builder}.
+         */
+        public static <ResolvedAddress, E extends ServiceDiscovererEvent<ResolvedAddress>> Builder<ResolvedAddress, E>
+        withDefaults(final Executor executor, final Duration initialDelay, final UnaryOperator<E> flipAvailability) {
+            return new Builder<>(new IndefiniteRetryStrategy(executor, initialDelay), flipAvailability);
+        }
+    }
+
+    private static final class EventsCache<R, E extends ServiceDiscovererEvent<R>> {
+        @SuppressWarnings("rawtypes")
+        private static final Map NONE_RETAINED = emptyMap();
+
+        private Map<R, E> retainedAddresses = noneRetained();
+        private int targetSize;
+        private final Map<R, E> activeAddresses = new HashMap<>();
+        private final int retainTillReceivePercentage;
+        private final UnaryOperator<E> flipAvailability;
+
+        EventsCache(final int retainTillReceivePercentage, final UnaryOperator<E> flipAvailability) {
+            this.retainTillReceivePercentage = retainTillReceivePercentage;
+            this.flipAvailability = flipAvailability;
+        }
+
+        void errorSeen() {
+            if (retainedAddresses == NONE_RETAINED) {
+                retainedAddresses = new HashMap<>(activeAddresses);
+            } else {
+                retainedAddresses.putAll(activeAddresses);
+            }
+            targetSize = (int) (ceil(retainTillReceivePercentage / 100d) * activeAddresses.size());
+            activeAddresses.clear();
+        }
+
+        Iterable<E> consume(final E event) {
+            final R address = event.address();
+            if (retainedAddresses == NONE_RETAINED) {
+                if (event.isAvailable()) {
+                    activeAddresses.put(address, event);
+                } else {
+                    activeAddresses.remove(address);
+                }
+                return singletonList(event);
+            }
+
+            // we have seen an error and have not fully drained the retained address list
+            if (event.isAvailable()) {
+                // new address after a retry
+                activeAddresses.put(address, event);
+                final boolean removed = retainedAddresses.remove(address) != null;
+                if (activeAddresses.size() == targetSize) {
+                    final List<E> allEvents = new ArrayList<>(retainedAddresses.size() + (removed ? 0 : 1));
+                    if (!removed) {
+                        allEvents.add(event);
+                    }
+                    for (E removalEvent : retainedAddresses.values()) {
+                        allEvents.add(flipAvailability.apply(removalEvent));
+                    }
+                    retainedAddresses = noneRetained();
+                    targetSize = 0;
+                    return allEvents;
+                }
+                // If we already had it in retained addresses, then the event can be ignored as the consumer of events
+                // already knows about the address
+                return removed ? emptyList() : singletonList(event);
+            }
+            // removal must be for a previously added address which would have already removed from the retained
+            // address list, so we do not need to touch the retainedAddresses
+            activeAddresses.remove(address);
+            return singletonList(event);
+        }
+
+        @SuppressWarnings("unchecked")
+        private static <R, E extends ServiceDiscovererEvent<R>> Map<R, E> noneRetained() {
+            return NONE_RETAINED;
+        }
+    }
+
+    private static final class IndefiniteRetryStrategy implements BiIntFunction<Throwable, Completable> {
+        private static final int MAX_RETRIES = 10;
+        private final BiIntFunction<Throwable, Completable> delegate;
+
+        IndefiniteRetryStrategy(final Executor executor, final Duration initialDelay) {
+            delegate = retryWithExponentialBackoffAndJitter(MAX_RETRIES, __ -> true, initialDelay, executor);
+        }
+
+        @Override
+        public Completable apply(final int count, final Throwable cause) {
+            // As we are retrying indefinitely (unless closed), cap the backoff on MAX_RETRIES retries to avoid
+            // impractical backoffs
+            return delegate.apply(count % (MAX_RETRIES - 1), cause);
+        }
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategy.java
@@ -36,7 +36,6 @@ import java.util.function.UnaryOperator;
 import static io.servicetalk.concurrent.api.Publisher.defer;
 import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponentialBackoffAndJitter;
 import static java.lang.Math.ceil;
-import static java.lang.Math.max;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -220,7 +219,7 @@ public final class DefaultServiceDiscoveryRetryStrategy<ResolvedAddress,
             } else {
                 retainedAddresses.putAll(activeAddresses);
             }
-            targetSize = (int) (ceil(retainTillReceivePercentage / 100d) * activeAddresses.size());
+            targetSize = (int) (ceil(retainTillReceivePercentage / 100d * activeAddresses.size()));
             activeAddresses.clear();
         }
 
@@ -273,7 +272,7 @@ public final class DefaultServiceDiscoveryRetryStrategy<ResolvedAddress,
         private final int maxRetries;
 
         IndefiniteRetryStrategy(final Executor executor, final Duration initialDelay) {
-            this(executor, initialDelay, 10);
+            this(executor, initialDelay, 8);
         }
 
         IndefiniteRetryStrategy(final Executor executor, final Duration initialDelay, final int maxRetries) {
@@ -285,7 +284,7 @@ public final class DefaultServiceDiscoveryRetryStrategy<ResolvedAddress,
         public Completable apply(final int count, final Throwable cause) {
             // As we are retrying indefinitely (unless closed), cap the backoff on MAX_RETRIES retries to avoid
             // impractical backoffs
-            return delegate.apply(max(1, count % (maxRetries)), cause);
+            return delegate.apply((count % (maxRetries)) + 1, cause);
         }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
@@ -22,9 +22,7 @@ import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
-import io.servicetalk.concurrent.api.BiIntFunction;
 import io.servicetalk.concurrent.api.BiIntPredicate;
-import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.IoExecutor;
@@ -191,7 +189,7 @@ abstract class HttpClientBuilder<U, R, SDE extends ServiceDiscovererEvent<R>> ex
      * @return {@code this}.
      */
     public abstract HttpClientBuilder<U, R, SDE> retryServiceDiscoveryErrors(
-            BiIntFunction<Throwable, ? extends Completable> retryStrategy);
+            ServiceDiscoveryRetryStrategy<R, SDE> retryStrategy);
 
     /**
      * Sets a {@link HttpLoadBalancerFactory} to create {@link LoadBalancer} instances.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -20,8 +20,6 @@ import io.servicetalk.client.api.AutoRetryStrategyProvider;
 import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
-import io.servicetalk.concurrent.api.BiIntFunction;
-import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.transport.api.ClientSecurityConfigurator;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
@@ -98,7 +96,7 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
 
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> retryServiceDiscoveryErrors(
-            BiIntFunction<Throwable, ? extends Completable> retryStrategy);
+            ServiceDiscoveryRetryStrategy<R, ServiceDiscovererEvent<R>> retryStrategy);
 
     @Override
     public abstract

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
@@ -24,8 +24,6 @@ import io.servicetalk.client.api.partition.PartitionAttributes;
 import io.servicetalk.client.api.partition.PartitionMapFactory;
 import io.servicetalk.client.api.partition.PartitionedServiceDiscovererEvent;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
-import io.servicetalk.concurrent.api.BiIntFunction;
-import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.transport.api.IoExecutor;
 
 import java.net.SocketOption;
@@ -92,7 +90,7 @@ public abstract class PartitionedHttpClientBuilder<U, R>
 
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> retryServiceDiscoveryErrors(
-            BiIntFunction<Throwable, ? extends Completable> retryStrategy);
+            ServiceDiscoveryRetryStrategy<R, PartitionedServiceDiscovererEvent<R>> retryStrategy);
 
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> loadBalancerFactory(

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ServiceDiscoveryRetryStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ServiceDiscoveryRetryStrategy.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.client.api.ServiceDiscoverer;
+import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.Publisher;
+
+/**
+ * A retry strategy for errors emitted from {@link ServiceDiscoverer#discover(Object)}.
+ *
+ * @param <ResolvedAddress> The type of address after resolution.
+ * @param <E> Type of {@link ServiceDiscovererEvent}s published from {@link ServiceDiscoverer#discover(Object)}.
+ */
+@FunctionalInterface
+public interface ServiceDiscoveryRetryStrategy<ResolvedAddress, E extends ServiceDiscovererEvent<ResolvedAddress>> {
+
+    /**
+     * Applies this strategy on the passed {@link Publisher}.
+     *
+     * @param sdEvents {@link Publisher} of {@link ServiceDiscovererEvent} on which this strategy is to be applied.
+     * @return {@link Publisher} after applying this retry strategy on the passed {@code sdEvents} {@link Publisher}.
+     */
+    Publisher<? extends E> apply(Publisher<? extends E> sdEvents);
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -20,8 +20,6 @@ import io.servicetalk.client.api.AutoRetryStrategyProvider;
 import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
-import io.servicetalk.concurrent.api.BiIntFunction;
-import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.transport.api.IoExecutor;
 
 import java.net.SocketOption;
@@ -86,7 +84,7 @@ public abstract class SingleAddressHttpClientBuilder<U, R>
 
     @Override
     public abstract SingleAddressHttpClientBuilder<U, R> retryServiceDiscoveryErrors(
-            BiIntFunction<Throwable, ? extends Completable> retryStrategy);
+            ServiceDiscoveryRetryStrategy<R, ServiceDiscovererEvent<R>> retryStrategy);
 
     @Override
     public abstract SingleAddressHttpClientBuilder<U, R> loadBalancerFactory(

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategyTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategyTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.client.api.DefaultServiceDiscovererEvent;
+import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.TestExecutor;
+import io.servicetalk.concurrent.api.TestPublisher;
+import io.servicetalk.concurrent.api.TestPublisherSubscriber;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.http.api.DefaultServiceDiscoveryRetryStrategy.Builder;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static io.servicetalk.concurrent.api.Publisher.defer;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static java.lang.Long.MAX_VALUE;
+import static java.time.Duration.ofSeconds;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+public class DefaultServiceDiscoveryRetryStrategyTest {
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+
+    private final TestExecutor executor;
+    private final LinkedBlockingQueue<TestPublisher<ServiceDiscovererEvent<String>>> pubs;
+    private final TestPublisherSubscriber<ServiceDiscovererEvent<String>> subscriber;
+
+    public DefaultServiceDiscoveryRetryStrategyTest() {
+        executor = new TestExecutor();
+        ServiceDiscoveryRetryStrategy<String, ServiceDiscovererEvent<String>> strategy =
+                Builder.<String>withDefaults(executor, ofSeconds(1)).retainAddressesTillSuccess(75).build();
+        pubs = new LinkedBlockingQueue<>();
+        subscriber = new TestPublisherSubscriber<>();
+        toSource(strategy.apply(defer(() -> {
+            final TestPublisher<ServiceDiscovererEvent<String>> pub = new TestPublisher<>();
+            pubs.add(pub);
+            return pub;
+        }))).subscribe(subscriber);
+        subscriber.request(MAX_VALUE);
+    }
+
+    @Test
+    public void errorWithNoAddresses() throws Exception {
+        TestPublisher<ServiceDiscovererEvent<String>> sdEvents = pubs.take();
+        sdEvents = triggerRetry(sdEvents);
+        verifyNoEventsReceived();
+        sendUpAndVerifyReceive("addr1", sdEvents);
+    }
+
+    @Test
+    public void newAddressPostRetry() throws Exception {
+        TestPublisher<ServiceDiscovererEvent<String>> sdEvents = pubs.take();
+
+        final DefaultServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive("addr1", sdEvents);
+
+        sdEvents = triggerRetry(sdEvents);
+
+        verifyNoEventsReceived();
+        final DefaultServiceDiscovererEvent<String> evt2 = new DefaultServiceDiscovererEvent<>("addr2", true);
+        sdEvents.onNext(evt2);
+
+        assertThat("Unexpected event received", subscriber.takeItems(),
+                containsInAnyOrder(flipAvailable(evt1), evt2));
+    }
+
+    @Test
+    public void overlapAddressPostRetry() throws Exception {
+        TestPublisher<ServiceDiscovererEvent<String>> sdEvents = pubs.take();
+
+        final DefaultServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive("addr1", sdEvents);
+        final DefaultServiceDiscovererEvent<String> evt2 = sendUpAndVerifyReceive("addr2", sdEvents);
+
+        sdEvents = triggerRetry(sdEvents);
+
+        verifyNoEventsReceived();
+
+        sdEvents.onNext(evt1); // previously existing, should not be emitted
+        verifyNoEventsReceived();
+
+        final DefaultServiceDiscovererEvent<String> evt3 = new DefaultServiceDiscovererEvent<>("addr3", true);
+        sdEvents.onNext(evt3); // threshold breach, should evict addr2
+
+        assertThat("Unexpected event received", subscriber.takeItems(),
+                containsInAnyOrder(flipAvailable(evt2), evt3));
+    }
+
+    @Test
+    public void errorWhileRetaining() throws Exception {
+        TestPublisher<ServiceDiscovererEvent<String>> sdEvents = pubs.take();
+
+        final DefaultServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive("addr1", sdEvents);
+        final DefaultServiceDiscovererEvent<String> evt2 = sendUpAndVerifyReceive("addr2", sdEvents);
+
+        sdEvents = triggerRetry(sdEvents);
+
+        verifyNoEventsReceived();
+
+        sdEvents.onNext(evt1); // previously existing, should not be emitted
+        verifyNoEventsReceived();
+
+        sdEvents = triggerRetry(sdEvents); // error while retaining
+
+        final DefaultServiceDiscovererEvent<String> evt3 = new DefaultServiceDiscovererEvent<>("addr3", true);
+        sdEvents.onNext(evt3); // threshold breach, should evict addr2
+
+        assertThat("Unexpected event received", subscriber.takeItems(),
+                containsInAnyOrder(flipAvailable(evt1), flipAvailable(evt2), evt3));
+    }
+
+    @Test
+    public void addRemoveBeforeRetry() throws Exception {
+        TestPublisher<ServiceDiscovererEvent<String>> sdEvents = pubs.take();
+        final DefaultServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive("addr1", sdEvents);
+        sdEvents.onNext(flipAvailable(evt1));
+        assertThat("Unexpected event received", subscriber.takeItems(), contains(flipAvailable(evt1)));
+
+        sdEvents = triggerRetry(sdEvents);
+        verifyNoEventsReceived();
+
+        sendUpAndVerifyReceive("addr1", sdEvents);
+    }
+
+    @Test
+    public void removeAfterRetry() throws Exception {
+        TestPublisher<ServiceDiscovererEvent<String>> sdEvents = pubs.take();
+        final DefaultServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive("addr1", sdEvents);
+
+        sdEvents = triggerRetry(sdEvents);
+        verifyNoEventsReceived();
+
+        sdEvents.onNext(evt1); // pre-existing, no new event
+        sdEvents.onNext(flipAvailable(evt1));
+
+        assertThat("Unexpected event received", subscriber.takeItems(),
+                contains(flipAvailable(evt1)));
+    }
+
+    @Test
+    public void removeAfterRetryWithRetain() throws Exception {
+        TestPublisher<ServiceDiscovererEvent<String>> sdEvents = pubs.take();
+        final DefaultServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive("addr1", sdEvents);
+        final DefaultServiceDiscovererEvent<String> evt2 = sendUpAndVerifyReceive("addr2", sdEvents);
+
+        sdEvents = triggerRetry(sdEvents);
+        verifyNoEventsReceived();
+
+        sdEvents.onNext(evt1); // pre-existing, no new event
+        sdEvents.onNext(flipAvailable(evt1));
+
+        assertThat("Unexpected event received", subscriber.takeItems(),
+                contains(flipAvailable(evt1)));
+
+        sdEvents.onNext(evt2);
+        verifyNoEventsReceived();
+    }
+
+    private void verifyNoEventsReceived() {
+        assertThat("Unexpected event received", subscriber.takeItems(), hasSize(0));
+    }
+
+    private TestPublisher<ServiceDiscovererEvent<String>> triggerRetry(
+            final TestPublisher<ServiceDiscovererEvent<String>> sdEvents) throws Exception {
+        sdEvents.onError(DELIBERATE_EXCEPTION);
+        executor.advanceTimeBy(1, MINUTES);
+        return pubs.take();
+    }
+
+    private DefaultServiceDiscovererEvent<String> sendUpAndVerifyReceive(final String addr,
+            final TestPublisher<ServiceDiscovererEvent<String>> sdEvents) {
+        final DefaultServiceDiscovererEvent<String> evt = new DefaultServiceDiscovererEvent<>(addr, true);
+        sdEvents.onNext(evt);
+        final List<ServiceDiscovererEvent<String>> received = subscriber.takeItems();
+        assertThat("Event not received.", received, hasSize(1));
+        assertThat("Unexpected event received.", received.get(0).address(), is(addr));
+        assertThat("Unexpected event received.", received.get(0).isAvailable(), is(true));
+        return evt;
+    }
+
+    private static ServiceDiscovererEvent<String> flipAvailable(final ServiceDiscovererEvent<String> evt) {
+        return new DefaultServiceDiscovererEvent<>(evt.address(), !evt.isAvailable());
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -22,7 +22,6 @@ import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.AsyncCloseable;
-import io.servicetalk.concurrent.api.BiIntFunction;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
@@ -39,6 +38,7 @@ import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.MultiAddressHttpClientBuilder;
 import io.servicetalk.http.api.MultiAddressHttpClientFilterFactory;
+import io.servicetalk.http.api.ServiceDiscoveryRetryStrategy;
 import io.servicetalk.http.api.SingleAddressHttpClientSecurityConfigurator;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
@@ -448,7 +448,8 @@ final class DefaultMultiAddressUrlHttpClientBuilder
 
     @Override
     public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> retryServiceDiscoveryErrors(
-            final BiIntFunction<Throwable, ? extends Completable> retryStrategy) {
+            final ServiceDiscoveryRetryStrategy<InetSocketAddress,
+                    ServiceDiscovererEvent<InetSocketAddress>> retryStrategy) {
         builderTemplate.retryServiceDiscoveryErrors(retryStrategy);
         return this;
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -29,7 +29,6 @@ import io.servicetalk.client.api.partition.PartitionAttributesBuilder;
 import io.servicetalk.client.api.partition.PartitionMapFactory;
 import io.servicetalk.client.api.partition.PartitionedServiceDiscovererEvent;
 import io.servicetalk.client.api.partition.UnknownPartitionException;
-import io.servicetalk.concurrent.api.BiIntFunction;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
@@ -47,6 +46,7 @@ import io.servicetalk.http.api.PartitionHttpClientBuilderConfigurator;
 import io.servicetalk.http.api.PartitionedHttpClientBuilder;
 import io.servicetalk.http.api.PartitionedHttpClientSecurityConfigurator;
 import io.servicetalk.http.api.ReservedStreamingHttpConnection;
+import io.servicetalk.http.api.ServiceDiscoveryRetryStrategy;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
@@ -293,10 +293,11 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
         return this;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public PartitionedHttpClientBuilder<U, R> retryServiceDiscoveryErrors(
-            final BiIntFunction<Throwable, ? extends Completable> retryStrategy) {
-        builderTemplate.retryServiceDiscoveryErrors(retryStrategy);
+            ServiceDiscoveryRetryStrategy<R, PartitionedServiceDiscovererEvent<R>> retryStrategy) {
+        builderTemplate.retryServiceDiscoveryErrors((ServiceDiscoveryRetryStrategy) retryStrategy);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -26,12 +26,12 @@ import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.CompletableSource.Subscriber;
-import io.servicetalk.concurrent.api.BiIntFunction;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.http.api.CharSequences;
+import io.servicetalk.http.api.DefaultServiceDiscoveryRetryStrategy;
 import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
@@ -41,6 +41,7 @@ import io.servicetalk.http.api.HttpExecutionStrategyInfluencer;
 import io.servicetalk.http.api.HttpLoadBalancerFactory;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.MultiAddressHttpClientFilterFactory;
+import io.servicetalk.http.api.ServiceDiscoveryRetryStrategy;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.SingleAddressHttpClientSecurityConfigurator;
 import io.servicetalk.http.api.StreamingHttpClient;
@@ -62,16 +63,13 @@ import static io.netty.util.NetUtil.toSocketAddressString;
 import static io.servicetalk.client.api.AutoRetryStrategyProvider.DISABLE_AUTO_RETRIES;
 import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
-import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.Processors.newCompletableProcessor;
 import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.concurrent.api.Publisher.never;
-import static io.servicetalk.concurrent.api.RetryStrategies.retryWithConstantBackoffAndJitter;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.globalDnsServiceDiscoverer;
 import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.globalSrvDnsServiceDiscoverer;
-import static java.lang.Integer.MAX_VALUE;
 import static java.time.Duration.ofSeconds;
 import static java.util.Objects.requireNonNull;
 
@@ -85,9 +83,6 @@ import static java.util.Objects.requireNonNull;
  * @param <R> the type of address after resolution (resolved address)
  */
 final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHttpClientBuilder<U, R> {
-    private static final BiIntFunction<Throwable, ? extends Completable> DEFAULT_SD_RETRY_STRATEGY =
-            retryWithConstantBackoffAndJitter(MAX_VALUE, t -> true, ofSeconds(60), immediate());
-
     @Nullable
     private final U address;
     @Nullable
@@ -97,8 +92,9 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
     private final ClientStrategyInfluencerChainBuilder influencerChainBuilder;
     private HttpLoadBalancerFactory<R> loadBalancerFactory;
     private ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer;
-    private BiIntFunction<Throwable, ? extends Completable> serviceDiscovererRetryStrategy = DEFAULT_SD_RETRY_STRATEGY;
     private Function<U, CharSequence> hostToCharSequenceFunction = this::toAuthorityForm;
+    @Nullable
+    private ServiceDiscoveryRetryStrategy<R, ? super ServiceDiscovererEvent<R>> serviceDiscovererRetryStrategy;
     @Nullable
     private Function<U, StreamingHttpClientFilterFactory> hostHeaderFilterFactoryFunction =
             address -> new HostHeaderHttpRequesterFilter(hostToCharSequenceFunction.apply(address));
@@ -213,33 +209,37 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
         final DefaultSingleAddressHttpClientBuilder<U, R> builder;
         final HttpExecutionContext executionContext;
         final StreamingHttpRequestResponseFactory reqRespFactory;
+        final ServiceDiscoveryRetryStrategy<R, ? super ServiceDiscovererEvent<R>> serviceDiscovererRetryStrategy;
         @Nullable
         final U proxyAddress;
 
-        HttpClientBuildContext(final DefaultSingleAddressHttpClientBuilder<U, R> builder,
-                               final HttpExecutionContext executionContext,
-                               final StreamingHttpRequestResponseFactory reqRespFactory,
-                               @Nullable final U proxyAddress) {
+        HttpClientBuildContext(
+                final DefaultSingleAddressHttpClientBuilder<U, R> builder, final HttpExecutionContext executionContext,
+                final StreamingHttpRequestResponseFactory reqRespFactory,
+                @Nullable final ServiceDiscoveryRetryStrategy<R, ? super ServiceDiscovererEvent<R>> sdRetryStrategy,
+                @Nullable final U proxyAddress) {
             this.builder = builder;
             this.executionContext = executionContext;
             this.reqRespFactory = reqRespFactory;
+            this.serviceDiscovererRetryStrategy = sdRetryStrategy == null ?
+                    DefaultServiceDiscoveryRetryStrategy.Builder.<R>withDefaults(executionContext.executor(),
+                            ofSeconds(60)).build() : sdRetryStrategy;
             this.proxyAddress = proxyAddress;
         }
 
         Publisher<? extends ServiceDiscovererEvent<R>> discover() {
             assert builder.address != null : "Attempted to buildStreaming with an unknown address";
-            return builder.serviceDiscoverer.discover(
-                    proxyAddress != null ? proxyAddress : builder.address);
+            final Publisher<? extends ServiceDiscovererEvent<R>> sdEvents =
+                    builder.serviceDiscoverer.discover(proxyAddress != null ? proxyAddress : builder.address);
+            return serviceDiscovererRetryStrategy.apply(sdEvents);
         }
 
         Publisher<? extends ServiceDiscovererEvent<R>> discover(final SdStatusCompletable sdStatus) {
             assert builder.address != null : "Attempted to buildStreaming with an unknown address";
-            final BiIntFunction<Throwable, ? extends Completable> retryWhen = builder.serviceDiscovererRetryStrategy;
-            return builder.serviceDiscoverer.discover(proxyAddress != null ? proxyAddress : builder.address)
-                    .retryWhen((i, t) -> {
-                        sdStatus.nextError(t);
-                        return retryWhen.apply(i, t);
-                    }).whenOnNext(__ -> sdStatus.resetError());
+            final Publisher<? extends ServiceDiscovererEvent<R>> sdEvents =
+                    builder.serviceDiscoverer.discover(proxyAddress != null ? proxyAddress : builder.address);
+            return serviceDiscovererRetryStrategy.apply(sdEvents.beforeOnError(sdStatus::nextError))
+                    .whenOnNext(__ -> sdStatus.resetError());
             // We do not complete sdStatus to let LB decide when to retry if SD completes.
         }
 
@@ -368,7 +368,8 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
                     clonedBuilder.config.protocolConfigs().h1Config().headersFactory(), HTTP_1_1);
         }
 
-        return new HttpClientBuildContext<>(clonedBuilder, exec, reqRespFactory, proxyAddress);
+        return new HttpClientBuildContext<>(clonedBuilder, exec, reqRespFactory, serviceDiscovererRetryStrategy,
+                proxyAddress);
     }
 
     private AbsoluteAddressHttpRequesterFilter proxyAbsoluteAddressFilterFactory() {
@@ -468,7 +469,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
 
     @Override
     public DefaultSingleAddressHttpClientBuilder<U, R> retryServiceDiscoveryErrors(
-            final BiIntFunction<Throwable, ? extends Completable> retryStrategy) {
+            final ServiceDiscoveryRetryStrategy<R, ServiceDiscovererEvent<R>> retryStrategy) {
         this.serviceDiscovererRetryStrategy = requireNonNull(retryStrategy);
         return this;
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -239,7 +239,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
             final Publisher<? extends ServiceDiscovererEvent<R>> sdEvents =
                     builder.serviceDiscoverer.discover(proxyAddress != null ? proxyAddress : builder.address);
             return serviceDiscovererRetryStrategy.apply(sdEvents.beforeOnError(sdStatus::nextError))
-                    .whenOnNext(__ -> sdStatus.resetError());
+                    .beforeOnNext(__ -> sdStatus.resetError());
             // We do not complete sdStatus to let LB decide when to retry if SD completes.
         }
 


### PR DESCRIPTION
__Motivation__

Service discovery errors are retried by clients to avoid transient failures cause request errors. DNS service discoverer eagerly clears addresses for errors of type `UnknownHostException` but such errors can also be transient. This DNS discoverer behavior effectively defeats the retries done by the client as it results in request errors.
We should avoid service discovery implementations to react pessimistically to service discovery errors as service discovery results are just a hint and do not effectively represent the current state of the servers. Server availability may change asynchronously and may not accurately be reflected in service discovery result due to delays at multiple levels. Instead, we should assume that all service discovery errors are transient and retain the addresses till a subsequent success from service discovery.

__Modification__

Introduced a new contract for `ServiceDiscoveryRetryStrategy` and added a default implementation that retains addresses between an SD error and success. Old addresses are retained till a configured percentage of new addresses are removed post retry. This is done because service discovery events are emitted one at a time and hence does not provide a natural boundary which indicates completion of a successful resolution. Users can tune this percentage; the default is 75%.

Removed DNS service discoverer behavior of clearing addresses on certain errors.

__Result__

Clients better tolerate transient service discoverer errors irrespective of individual service discoverer implementation.