### PR TITLE
Add missed overrides for the client builders

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseSingleAddressHttpClientBuilder.java
@@ -35,6 +35,9 @@ abstract class BaseSingleAddressHttpClientBuilder<U, R, SDE extends ServiceDisco
     public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> ioExecutor(IoExecutor ioExecutor);
 
     @Override
+    public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> executionStrategy(HttpExecutionStrategy strategy);
+
+    @Override
     public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> bufferAllocator(BufferAllocator allocator);
 
     @Override
@@ -60,6 +63,16 @@ abstract class BaseSingleAddressHttpClientBuilder<U, R, SDE extends ServiceDisco
     @Override
     public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> appendConnectionFactoryFilter(
             ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> factory);
+
+    @Override
+    public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> appendClientFilter(
+            StreamingHttpClientFilterFactory factory);
+
+    @Override
+    public BaseSingleAddressHttpClientBuilder<U, R, SDE> appendClientFilter(Predicate<StreamingHttpRequest> predicate,
+                                                                            StreamingHttpClientFilterFactory factory) {
+        return (BaseSingleAddressHttpClientBuilder<U, R, SDE>) super.appendClientFilter(predicate, factory);
+    }
 
     @Override
     public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> disableHostHeaderFallback();

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -63,6 +63,9 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
     public abstract MultiAddressHttpClientBuilder<U, R> enableWireLogging(String loggerName);
 
     @Override
+    public abstract MultiAddressHttpClientBuilder<U, R> protocols(HttpProtocolConfig... protocols);
+
+    @Override
     public abstract MultiAddressHttpClientBuilder<U, R> disableHostHeaderFallback();
 
     /**
@@ -114,8 +117,7 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
     @Override
     public MultiAddressHttpClientBuilder<U, R> appendClientFilter(final Predicate<StreamingHttpRequest> predicate,
                                                                   final StreamingHttpClientFilterFactory factory) {
-        super.appendClientFilter(predicate, factory);
-        return this;
+        return (MultiAddressHttpClientBuilder<U, R>) super.appendClientFilter(predicate, factory);
     }
 
     /**
@@ -166,7 +168,6 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
                                                                   MultiAddressHttpClientFilterFactory<U> factory) {
         requireNonNull(predicate);
         requireNonNull(factory);
-
         return appendClientFilter(toMultiAddressConditionalFilterFactory(predicate, factory));
     }
 


### PR DESCRIPTION
Motivation:

Some methods are not overridden in `BaseSingleAddressHttpClientBuilder`
and `MultiAddressHttpClientBuilder`. Users have to cast if they use
those missed methods on this builders.

Modifications:

- Add overrides for `BaseSingleAddressHttpClientBuilder`: `executionStrategy`
and `appendClientFilter`;
- Add overrides for `MultiAddressHttpClientBuilder.java`: `protocols`;

Result:

Users can use fluent builder API without need to cast builder types.