### PR TITLE
Set the correct log level for wire logging and h2 frame logging

### DIFF
--- a/servicetalk-examples/grpc/helloworld/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/grpc/helloworld/src/main/resources/log4j2.xml
@@ -21,14 +21,6 @@
     </Console>
   </Appenders>
   <Loggers>
-    <!--
-        This is an example of how to configure logging of wire events:
-          1. Add a Logger with `TRACE` level;
-          2. Use this new Logger name as an argument for `enableWireLogging(name)` method with desired builder/starter.
-    -->
-    <Logger name="servicetalk-client-wire-logger" level="TRACE"/>
-    <Logger name="servicetalk-server-wire-logger" level="TRACE"/>
-
     <!-- Prints server start and shutdown -->
     <Logger name="io.servicetalk.http.netty.H2ServerParentConnectionContext" level="DEBUG"/>
 

--- a/servicetalk-examples/grpc/routeguide/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/grpc/routeguide/src/main/resources/log4j2.xml
@@ -21,14 +21,6 @@
     </Console>
   </Appenders>
   <Loggers>
-    <!--
-        This is an example of how to configure logging of wire events:
-          1. Add a Logger with `TRACE` level;
-          2. Use this new Logger name as an argument for `enableWireLogging(name)` method with desired builder/starter.
-    -->
-    <Logger name="servicetalk-client-wire-logger" level="TRACE"/>
-    <Logger name="servicetalk-server-wire-logger" level="TRACE"/>
-
     <!-- Prints server start and shutdown -->
     <Logger name="io.servicetalk.http.netty.H2ServerParentConnectionContext" level="DEBUG"/>
 

--- a/servicetalk-examples/http/helloworld/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/helloworld/src/main/resources/log4j2.xml
@@ -21,14 +21,6 @@
     </Console>
   </Appenders>
   <Loggers>
-    <!--
-        This is an example of how to configure logging of wire events:
-          1. Add a Logger with `TRACE` level;
-          2. Use this new Logger name as an argument for `enableWireLogging(name)` method with desired builder/starter.
-    -->
-    <Logger name="servicetalk-client-wire-logger" level="TRACE"/>
-    <Logger name="servicetalk-server-wire-logger" level="TRACE"/>
-
     <!-- Prints server start and shutdown -->
     <Logger name="io.servicetalk.http.netty.NettyHttpServer" level="DEBUG"/>
 

--- a/servicetalk-examples/http/http2/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/http2/src/main/resources/log4j2.xml
@@ -21,14 +21,6 @@
     </Console>
   </Appenders>
   <Loggers>
-    <!--
-        This is an example of how to configure logging of wire events:
-          1. Add a Logger with `TRACE` level;
-          2. Use this new Logger name as an argument for `enableWireLogging(name)` method with desired builder/starter.
-    -->
-    <Logger name="servicetalk-client-wire-logger" level="TRACE"/>
-    <Logger name="servicetalk-server-wire-logger" level="TRACE"/>
-
     <!-- Prints server start and shutdown -->
     <Logger name="io.servicetalk.http.netty.AlpnServerContext" level="DEBUG"/>
     <Logger name="io.servicetalk.http.netty.H2ServerParentConnectionContext" level="DEBUG"/>

--- a/servicetalk-examples/http/jaxrs/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/jaxrs/src/main/resources/log4j2.xml
@@ -21,14 +21,6 @@
     </Console>
   </Appenders>
   <Loggers>
-    <!--
-        This is an example of how to configure logging of wire events:
-          1. Add a Logger with `TRACE` level;
-          2. Use this new Logger name as an argument for `enableWireLogging(name)` method with desired builder/starter.
-    -->
-    <Logger name="servicetalk-client-wire-logger" level="TRACE"/>
-    <Logger name="servicetalk-server-wire-logger" level="TRACE"/>
-
     <!-- Prints server start and shutdown -->
     <Logger name="io.servicetalk.http.netty.NettyHttpServer" level="DEBUG"/>
 

--- a/servicetalk-examples/http/metadata/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/metadata/src/main/resources/log4j2.xml
@@ -21,14 +21,6 @@
     </Console>
   </Appenders>
   <Loggers>
-    <!--
-        This is an example of how to configure logging of wire events:
-          1. Add a Logger with `TRACE` level;
-          2. Use this new Logger name as an argument for `enableWireLogging(name)` method with desired builder/starter.
-    -->
-    <Logger name="servicetalk-client-wire-logger" level="TRACE"/>
-    <Logger name="servicetalk-server-wire-logger" level="TRACE"/>
-
     <!-- Prints server start and shutdown -->
     <Logger name="io.servicetalk.http.netty.NettyHttpServer" level="DEBUG"/>
 

--- a/servicetalk-examples/http/serialization/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/serialization/src/main/resources/log4j2.xml
@@ -21,14 +21,6 @@
     </Console>
   </Appenders>
   <Loggers>
-    <!--
-        This is an example of how to configure logging of wire events:
-          1. Add a Logger with `TRACE` level;
-          2. Use this new Logger name as an argument for `enableWireLogging(name)` method with desired builder/starter.
-    -->
-    <Logger name="servicetalk-client-wire-logger" level="TRACE"/>
-    <Logger name="servicetalk-server-wire-logger" level="TRACE"/>
-
     <!-- Prints server start and shutdown -->
     <Logger name="io.servicetalk.http.netty.NettyHttpServer" level="DEBUG"/>
 

--- a/servicetalk-examples/http/service-composition/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/service-composition/src/main/resources/log4j2.xml
@@ -21,14 +21,6 @@
     </Console>
   </Appenders>
   <Loggers>
-    <!--
-        This is an example of how to configure logging of wire events:
-          1. Add a Logger with `TRACE` level;
-          2. Use this new Logger name as an argument for `enableWireLogging(name)` method with desired builder/starter.
-    -->
-    <Logger name="servicetalk-client-wire-logger" level="TRACE"/>
-    <Logger name="servicetalk-server-wire-logger" level="TRACE"/>
-
     <!-- Prints server start and shutdown -->
     <Logger name="io.servicetalk.http.netty.NettyHttpServer" level="DEBUG"/>
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
@@ -30,7 +30,7 @@ import java.util.function.BiPredicate;
 
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2FrameCodecBuilder.forClient;
-import static io.netty.handler.logging.LogLevel.TRACE;
+import static io.servicetalk.transport.netty.internal.NettyLoggerUtils.getNettyLogLevel;
 
 final class H2ClientParentChannelInitializer implements ChannelInitializer {
 
@@ -62,7 +62,7 @@ final class H2ClientParentChannelInitializer implements ChannelInitializer {
 
         final String frameLoggerName = config.frameLoggerName();
         if (frameLoggerName != null) {
-            multiplexCodecBuilder.frameLogger(new Http2FrameLogger(TRACE, frameLoggerName));
+            multiplexCodecBuilder.frameLogger(new Http2FrameLogger(getNettyLogLevel(frameLoggerName), frameLoggerName));
         }
 
         // TODO(scott): more configuration. header validation, settings stream, etc...

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
@@ -25,6 +25,7 @@ import io.netty.handler.codec.http2.DefaultHttp2GoAwayFrame;
 import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
 import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.codec.http2.Http2MultiplexHandler;
+import io.netty.handler.logging.LogLevel;
 
 import java.util.function.BiPredicate;
 
@@ -62,7 +63,10 @@ final class H2ClientParentChannelInitializer implements ChannelInitializer {
 
         final String frameLoggerName = config.frameLoggerName();
         if (frameLoggerName != null) {
-            multiplexCodecBuilder.frameLogger(new Http2FrameLogger(getNettyLogLevel(frameLoggerName), frameLoggerName));
+            LogLevel logLevel = getNettyLogLevel(frameLoggerName);
+            if (logLevel != null) {
+                multiplexCodecBuilder.frameLogger(new Http2FrameLogger(logLevel, frameLoggerName));
+            }
         }
 
         // TODO(scott): more configuration. header validation, settings stream, etc...

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
 import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.codec.http2.Http2MultiplexHandler;
 import io.netty.handler.codec.http2.Http2StreamChannel;
+import io.netty.handler.logging.LogLevel;
 
 import java.util.function.BiPredicate;
 
@@ -55,7 +56,10 @@ final class H2ServerParentChannelInitializer implements ChannelInitializer {
 
         final String frameLoggerName = config.frameLoggerName();
         if (frameLoggerName != null) {
-            multiplexCodecBuilder.frameLogger(new Http2FrameLogger(getNettyLogLevel(frameLoggerName), frameLoggerName));
+            LogLevel logLevel = getNettyLogLevel(frameLoggerName);
+            if (logLevel != null) {
+                multiplexCodecBuilder.frameLogger(new Http2FrameLogger(logLevel, frameLoggerName));
+            }
         }
 
         // TODO(scott): more configuration. header validation, settings stream, etc...

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
@@ -26,7 +26,7 @@ import io.netty.handler.codec.http2.Http2StreamChannel;
 import java.util.function.BiPredicate;
 
 import static io.netty.handler.codec.http2.Http2FrameCodecBuilder.forServer;
-import static io.netty.handler.logging.LogLevel.TRACE;
+import static io.servicetalk.transport.netty.internal.NettyLoggerUtils.getNettyLogLevel;
 
 final class H2ServerParentChannelInitializer implements ChannelInitializer {
     private final H2ProtocolConfig config;
@@ -55,7 +55,7 @@ final class H2ServerParentChannelInitializer implements ChannelInitializer {
 
         final String frameLoggerName = config.frameLoggerName();
         if (frameLoggerName != null) {
-            multiplexCodecBuilder.frameLogger(new Http2FrameLogger(TRACE, frameLoggerName));
+            multiplexCodecBuilder.frameLogger(new Http2FrameLogger(getNettyLogLevel(frameLoggerName), frameLoggerName));
         }
 
         // TODO(scott): more configuration. header validation, settings stream, etc...

--- a/servicetalk-test-resources/src/main/resources/log4j2.xml
+++ b/servicetalk-test-resources/src/main/resources/log4j2.xml
@@ -17,17 +17,16 @@
 <Configuration status="info">
   <Properties>
     <Property name="rootLevel">${sys:servicetalk.logger.rootLevel:-INFO}</Property>
-    <Property name="thresholdLevel">${sys:servicetalk.logger.thresholdLevel:-INFO}</Property>
+    <Property name="wireLogLevel">${sys:servicetalk.logger.wireLogLevel:-OFF}</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout pattern="%d %30t [%-5level] %-30logger{1} - %msg%n"/>
-      <ThresholdFilter level="${thresholdLevel}"/>
     </Console>
   </Appenders>
   <Loggers>
-    <Logger name="servicetalk-tests-client-wire-logger" level="TRACE"/>
-    <Logger name="servicetalk-tests-server-wire-logger" level="TRACE"/>
+    <Logger name="servicetalk-tests-client-wire-logger" level="${wireLogLevel}"/>
+    <Logger name="servicetalk-tests-server-wire-logger" level="${wireLogLevel}"/>
     <Root level="${rootLevel}">
       <AppenderRef ref="Console"/>
     </Root>

--- a/servicetalk-test-resources/src/main/resources/log4j2.xml
+++ b/servicetalk-test-resources/src/main/resources/log4j2.xml
@@ -16,17 +16,19 @@
   -->
 <Configuration status="info">
   <Properties>
-    <Property name="level">${sys:servicetalk.logger.level:-INFO}</Property>
+    <Property name="rootLevel">${sys:servicetalk.logger.rootLevel:-INFO}</Property>
+    <Property name="thresholdLevel">${sys:servicetalk.logger.thresholdLevel:-INFO}</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout pattern="%d %30t [%-5level] %-30logger{1} - %msg%n"/>
+      <ThresholdFilter level="${thresholdLevel}"/>
     </Console>
   </Appenders>
   <Loggers>
     <Logger name="servicetalk-tests-client-wire-logger" level="TRACE"/>
     <Logger name="servicetalk-tests-server-wire-logger" level="TRACE"/>
-    <Root level="${level}">
+    <Root level="${rootLevel}">
       <AppenderRef ref="Console"/>
     </Root>
   </Loggers>

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyLoggerUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyLoggerUtils.java
@@ -20,6 +20,8 @@ import io.netty.util.internal.logging.InternalLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import static io.netty.handler.logging.LogLevel.DEBUG;
 import static io.netty.handler.logging.LogLevel.ERROR;
 import static io.netty.handler.logging.LogLevel.INFO;
@@ -36,8 +38,10 @@ public final class NettyLoggerUtils {
     /**
      * Translate the log level as determined by SL4J for the {@code loggerName} to Netty's {@link LogLevel} type.
      * @param loggerName The logger name to lookup.
-     * @return Netty's {@link LogLevel} corresponding to the SL4J log level for {@code loggerName}.
+     * @return Netty's {@link LogLevel} corresponding to the SL4J log level for {@code loggerName}, or {@code null} if
+     * the log level cannot be mapped to a {@link LogLevel}.
      */
+    @Nullable
     public static LogLevel getNettyLogLevel(String loggerName) {
         final Logger logger = LoggerFactory.getLogger(loggerName);
         if (logger.isTraceEnabled()) {
@@ -51,6 +55,6 @@ public final class NettyLoggerUtils {
         } else if (logger.isErrorEnabled()) {
             return ERROR;
         }
-        throw new IllegalArgumentException("unknown log level: " + logger);
+        return null;
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyLoggerUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyLoggerUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.netty.handler.logging.LogLevel;
+import io.netty.util.internal.logging.InternalLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.netty.handler.logging.LogLevel.DEBUG;
+import static io.netty.handler.logging.LogLevel.ERROR;
+import static io.netty.handler.logging.LogLevel.INFO;
+import static io.netty.handler.logging.LogLevel.TRACE;
+import static io.netty.handler.logging.LogLevel.WARN;
+
+/**
+ * Utility methods for {@link InternalLogger} related types.
+ */
+public final class NettyLoggerUtils {
+    private NettyLoggerUtils() {
+    }
+
+    /**
+     * Translate the log level as determined by SL4J for the {@code loggerName} to Netty's {@link LogLevel} type.
+     * @param loggerName The logger name to lookup.
+     * @return Netty's {@link LogLevel} corresponding to the SL4J log level for {@code loggerName}.
+     */
+    public static LogLevel getNettyLogLevel(String loggerName) {
+        final Logger logger = LoggerFactory.getLogger(loggerName);
+        if (logger.isTraceEnabled()) {
+            return TRACE;
+        } else if (logger.isDebugEnabled()) {
+            return DEBUG;
+        } else if (logger.isInfoEnabled()) {
+            return INFO;
+        } else if (logger.isWarnEnabled()) {
+            return WARN;
+        } else if (logger.isErrorEnabled()) {
+            return ERROR;
+        }
+        throw new IllegalArgumentException("unknown log level: " + logger);
+    }
+}

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WireLoggingInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WireLoggingInitializer.java
@@ -16,7 +16,10 @@
 package io.servicetalk.transport.netty.internal;
 
 import io.netty.channel.Channel;
+import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
+
+import javax.annotation.Nullable;
 
 import static io.servicetalk.transport.netty.internal.NettyLoggerUtils.getNettyLogLevel;
 
@@ -25,7 +28,7 @@ import static io.servicetalk.transport.netty.internal.NettyLoggerUtils.getNettyL
  * All wire events will be logged at trace level.
  */
 public class WireLoggingInitializer implements ChannelInitializer {
-
+    @Nullable
     private final LoggingHandler loggingHandler;
 
     /**
@@ -34,11 +37,14 @@ public class WireLoggingInitializer implements ChannelInitializer {
      * @param loggerName The name of the logger to log wire events.
      */
     public WireLoggingInitializer(final String loggerName) {
-        loggingHandler = new LoggingHandler(loggerName, getNettyLogLevel(loggerName));
+        LogLevel logLevel = getNettyLogLevel(loggerName);
+        loggingHandler = logLevel != null ? new LoggingHandler(loggerName, logLevel) : null;
     }
 
     @Override
     public void init(Channel channel) {
-        channel.pipeline().addLast(loggingHandler);
+        if (loggingHandler != null) {
+            channel.pipeline().addLast(loggingHandler);
+        }
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WireLoggingInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WireLoggingInitializer.java
@@ -18,7 +18,7 @@ package io.servicetalk.transport.netty.internal;
 import io.netty.channel.Channel;
 import io.netty.handler.logging.LoggingHandler;
 
-import static io.netty.handler.logging.LogLevel.TRACE;
+import static io.servicetalk.transport.netty.internal.NettyLoggerUtils.getNettyLogLevel;
 
 /**
  * A {@link ChannelInitializer} that enables wire-logging for all channels.
@@ -34,7 +34,7 @@ public class WireLoggingInitializer implements ChannelInitializer {
      * @param loggerName The name of the logger to log wire events.
      */
     public WireLoggingInitializer(final String loggerName) {
-        loggingHandler = new LoggingHandler(loggerName, TRACE);
+        loggingHandler = new LoggingHandler(loggerName, getNettyLogLevel(loggerName));
     }
 
     @Override


### PR DESCRIPTION
Motivation:
When enableWireLogging and h2 frameLogger are set on the builder we
always log at TRACE level regardless of what level the logging
configuration specifies. The h2 frameLogger has conditional logic which
limits the amount of data logged for levels less than TRACE, and it is
generally unexpected to log at a different level than configured by the
user.

Modifications:
- When Http2FrameLogger and LoggingHandler are created we should get the
log level from SL4J and pass the translated Netty LogLevel upon
construction

Result:
Debug logging uses the same log level as configured by the user.