### PR TITLE
Add tests for HTTP request smuggling in headers

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -735,7 +735,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
             final int lfIndex = findLF(buffer, startIndex, toIndex);
             if (lfIndex == -1) {
                 if (toIndex - startIndex == maxLineSize) {
-                    throw new IllegalStateException("Could not find CRLF within " + maxLineSize + " bytes");
+                    throw new IllegalArgumentException("Could not find CRLF within " + maxLineSize + " bytes");
                 }
                 return -2;
             } else if (lfIndex == buffer.readerIndex()) {


### PR DESCRIPTION
Motivation:
HTTP uses a non-binary framing layer that is subject to request
smuggling. Our decoding relies upon the terminal newline characters to
frame requests and we should have tests to exercise behavior in cases
where a request is injected into a header value.

Modifications:
- Add HttpObjectDecoder tests which attempt to smuggle
requests/responses in headers

Result:
More tests verifying smuggling behavior.