### PR TITLE
Fix assertEquals expected & actual order

### DIFF
--- a/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/partition/PowerSetPartitionMapTest.java
+++ b/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/partition/PowerSetPartitionMapTest.java
@@ -247,7 +247,7 @@ public class PowerSetPartitionMapTest {
         List<ListenableAsyncCloseable> added1 = map.add(partition);
         List<ListenableAsyncCloseable> added2 = map.add(partition);
         assertEquals("Added partitions are not equal.", added1, added2);
-        assertEquals("Same partition added twice.", map.size(), 1);
+        assertEquals("Same partition added twice.", 1, map.size());
 
         List<ListenableAsyncCloseable> removed = map.remove(partition);
         assertEquals("Unexpected size of removed partitions.", removed.size(), added1.size());


### PR DESCRIPTION
Method signature is `assertEquals(String message, long expected, long actual)` 