### PR TITLE
Improve tests for ALPN

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
@@ -20,6 +20,8 @@ import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.ReservedBlockingHttpConnection;
 import io.servicetalk.test.resources.DefaultTestCerts;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
@@ -28,7 +30,6 @@ import io.netty.handler.codec.DecoderException;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -37,6 +38,7 @@ import org.junit.runners.Parameterized.Parameters;
 import java.nio.channels.ClosedChannelException;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
@@ -51,10 +53,10 @@ import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.rules.ExpectedException.none;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(Parameterized.class)
 public class AlpnClientAndServerTest {
@@ -64,15 +66,15 @@ public class AlpnClientAndServerTest {
     @Rule
     public final Timeout timeout = new ServiceTalkTestTimeout();
 
-    @Rule
-    public final ExpectedException expectedException = none();
-
     private final ServerContext serverContext;
     private final BlockingHttpClient client;
     @Nullable
     private final HttpProtocolVersion expectedProtocol;
     @Nullable
     private final Class<? extends Throwable> expectedExceptionType;
+
+    private final AtomicReference<HttpServiceContext> serviceContext = new AtomicReference<>();
+    private final AtomicReference<HttpProtocolVersion> requestVersion = new AtomicReference<>();
 
     public AlpnClientAndServerTest(List<String> serverSideProtocols,
                                    List<String> clientSideProtocols,
@@ -110,19 +112,16 @@ public class AlpnClientAndServerTest {
         });
     }
 
-    private static ServerContext startServer(List<String> supportedProtocols,
-                                             @Nullable HttpProtocolVersion expectedProtocol) throws Exception {
+    private ServerContext startServer(List<String> supportedProtocols,
+                                      @Nullable HttpProtocolVersion expectedProtocol) throws Exception {
         return HttpServers.forAddress(localAddress(0))
                 .protocols(toProtocolConfigs(supportedProtocols))
                 .secure()
                 .provider(OPENSSL)
                 .commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
                 .listenBlocking((ctx, request, responseFactory) -> {
-                    if ("PRI".equals(request.method().name()) && expectedProtocol == null) {
-                        return responseFactory.badRequest();
-                    }
-                    assertThat(request.version(), is(expectedProtocol));
-                    assertThat(ctx.sslSession(), is(notNullValue()));
+                    serviceContext.set(ctx);
+                    requestVersion.set(request.version());
                     return responseFactory.ok().payloadBody(PAYLOAD_BODY, textSerializer());
                 })
                 .toFuture().get();
@@ -166,13 +165,22 @@ public class AlpnClientAndServerTest {
     @Test
     public void testAlpn() throws Exception {
         if (expectedExceptionType != null) {
-            expectedException.expect(expectedExceptionType);
+            assertThrows(expectedExceptionType, () -> client.request(client.get("/")));
+            return;
         }
-        HttpResponse response = client.request(client.get("/"));
-        if (expectedExceptionType == null) {
+
+        try (ReservedBlockingHttpConnection connection = client.reserveConnection(client.get("/"))) {
+            assertThat(connection.connectionContext().protocol(), is(expectedProtocol));
+            assertThat(connection.connectionContext().sslSession(), is(notNullValue()));
+
+            HttpResponse response = connection.request(client.get("/"));
             assertThat(response.version(), is(expectedProtocol));
             assertThat(response.status(), is(OK));
             assertThat(response.payloadBody(textDeserializer()), is(PAYLOAD_BODY));
+
+            assertThat(serviceContext.get().protocol(), is(expectedProtocol));
+            assertThat(serviceContext.get().sslSession(), is(notNullValue()));
+            assertThat(requestVersion.get(), is(expectedProtocol));
         }
     }
 }


### PR DESCRIPTION
Motivation:

Assertions from non-main thread (e.g. inside the service handle method)
do not fail the test.
Also, existing tests do not verify that `SSLSession` is set on the client
side.

Modifications:

- Assert server-side state in the main thread;
- Assert that `ConnectionContext` is set correctly on the client-side;
- Avoid using deprecated jUnit API;

Result:

Better test coverage for ALPN use cases.