### PR TITLE
Propagate `SecurityHandshakeObserver` without channel attribute

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -28,8 +28,6 @@ import io.servicetalk.http.api.HttpConnectionContext;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.transport.api.ConnectionObserver;
-import io.servicetalk.transport.api.ConnectionObserver.SecurityHandshakeObserver;
-import io.servicetalk.transport.netty.internal.ConnectionObserverInitializer.WaitingForHandshakeCompletionEvent;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.FlushStrategyHolder;
 import io.servicetalk.transport.netty.internal.NettyChannelListenableAsyncCloseable;
@@ -158,9 +156,6 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
         private final DelayedCancellable delayedCancellable;
         @Nullable
         final ConnectionObserver observer;
-        @Nullable
-        private SecurityHandshakeObserver handshakeObserver;
-        private boolean active;
 
         AbstractH2ParentConnection(H2ParentConnectionContext parentContext,
                                    DelayedCancellable delayedCancellable,
@@ -228,13 +223,9 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
         @Override
         public final void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
             try {
-                if (evt instanceof SecurityHandshakeObserver) {
-                    assert this.handshakeObserver == null;
-                    this.handshakeObserver = (SecurityHandshakeObserver) evt;
-                }
                 if (evt instanceof SslHandshakeCompletionEvent) {
                     parentContext.sslSession = extractSslSessionAndReport(ctx.pipeline(),
-                            (SslHandshakeCompletionEvent) evt, this::tryFailSubscriber, handshakeObserver);
+                            (SslHandshakeCompletionEvent) evt, this::tryFailSubscriber, observer != null);
                     tryCompleteSubscriber();
                 }
             } finally {
@@ -265,16 +256,7 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
         }
 
         private void doChannelActive(ChannelHandlerContext ctx) {
-            if (active) {
-                return;
-            }
-            active = true;
-
             if (waitForSslHandshake) {
-                if (observer != null) {
-                    // Notify ConnectionObserverHandler that we are ready to receive SecurityHandshakeObserver instance
-                    ctx.pipeline().fireUserEventTriggered(WaitingForHandshakeCompletionEvent.INSTANCE);
-                }
                 // Force a read to get the SSL handshake started, any application data that makes it past the SslHandler
                 // will be queued in the NettyChannelPublisher.
                 ctx.read();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
@@ -81,7 +81,7 @@ public class SecurityHandshakeObserverTest {
     private final ConnectionObserver serverConnectionObserver;
     private final SecurityHandshakeObserver serverSecurityHandshakeObserver;
 
-    public SecurityHandshakeObserverTest() throws Exception {
+    public SecurityHandshakeObserverTest() {
         clientTransportObserver = mock(TransportObserver.class, "clientTransportObserver");
         clientConnectionObserver = mock(ConnectionObserver.class, "clientConnectionObserver");
         clientSecurityHandshakeObserver = mock(SecurityHandshakeObserver.class, "clientSecurityHandshakeObserver");
@@ -92,14 +92,13 @@ public class SecurityHandshakeObserverTest {
         WriteObserver clientWriteObserver = mock(WriteObserver.class, "clientWriteObserver");
         when(clientTransportObserver.onNewConnection()).thenReturn(clientConnectionObserver);
         when(clientConnectionObserver.onSecurityHandshake()).thenReturn(clientSecurityHandshakeObserver);
-        when(clientConnectionObserver.established(any(ConnectionInfo.class))).thenReturn(clientDataObserver);
-        when(clientConnectionObserver.establishedMultiplexed(any(ConnectionInfo.class)))
+        when(clientConnectionObserver.connectionEstablished(any(ConnectionInfo.class))).thenReturn(clientDataObserver);
+        when(clientConnectionObserver.multiplexedConnectionEstablished(any(ConnectionInfo.class)))
                 .thenReturn(clientMultiplexedObserver);
         when(clientMultiplexedObserver.onNewStream()).thenReturn(clientStreamObserver);
+        when(clientStreamObserver.streamEstablished()).thenReturn(clientDataObserver);
         when(clientDataObserver.onNewRead()).thenReturn(clientReadObserver);
         when(clientDataObserver.onNewWrite()).thenReturn(clientWriteObserver);
-        when(clientStreamObserver.onNewRead()).thenReturn(clientReadObserver);
-        when(clientStreamObserver.onNewWrite()).thenReturn(clientWriteObserver);
 
         serverTransportObserver = mock(TransportObserver.class, "serverTransportObserver");
         serverConnectionObserver = mock(ConnectionObserver.class, "serverConnectionObserver");
@@ -111,14 +110,13 @@ public class SecurityHandshakeObserverTest {
         WriteObserver serverWriteObserver = mock(WriteObserver.class, "serverWriteObserver");
         when(serverTransportObserver.onNewConnection()).thenReturn(serverConnectionObserver);
         when(serverConnectionObserver.onSecurityHandshake()).thenReturn(serverSecurityHandshakeObserver);
-        when(serverConnectionObserver.established(any(ConnectionInfo.class))).thenReturn(serverDataObserver);
-        when(serverConnectionObserver.establishedMultiplexed(any(ConnectionInfo.class)))
+        when(serverConnectionObserver.connectionEstablished(any(ConnectionInfo.class))).thenReturn(serverDataObserver);
+        when(serverConnectionObserver.multiplexedConnectionEstablished(any(ConnectionInfo.class)))
                 .thenReturn(serverMultiplexedObserver);
         when(serverMultiplexedObserver.onNewStream()).thenReturn(serverStreamObserver);
+        when(serverStreamObserver.streamEstablished()).thenReturn(serverDataObserver);
         when(serverDataObserver.onNewRead()).thenReturn(serverReadObserver);
         when(serverDataObserver.onNewWrite()).thenReturn(serverWriteObserver);
-        when(serverStreamObserver.onNewRead()).thenReturn(serverReadObserver);
-        when(serverStreamObserver.onNewWrite()).thenReturn(serverWriteObserver);
     }
 
     @Test

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.client.api.TransportObserverConnectionFactoryFilter;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.test.resources.DefaultTestCerts;
+import io.servicetalk.transport.api.ConnectionInfo;
+import io.servicetalk.transport.api.ConnectionObserver;
+import io.servicetalk.transport.api.ConnectionObserver.DataObserver;
+import io.servicetalk.transport.api.ConnectionObserver.MultiplexedObserver;
+import io.servicetalk.transport.api.ConnectionObserver.ReadObserver;
+import io.servicetalk.transport.api.ConnectionObserver.SecurityHandshakeObserver;
+import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
+import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.TransportObserver;
+import io.servicetalk.transport.netty.internal.ExecutionContextRule;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.function.Function;
+import javax.net.ssl.SSLSession;
+
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.api.HttpSerializationProviders.textDeserializer;
+import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h2Default;
+import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ECHO;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static io.servicetalk.transport.netty.internal.ExecutionContextRule.cached;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SecurityHandshakeObserverTest {
+
+    @ClassRule
+    public static final ExecutionContextRule SERVER_CTX = cached("server-io", "server-executor");
+    @ClassRule
+    public static final ExecutionContextRule CLIENT_CTX = cached("client-io", "client-executor");
+
+    // @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+
+    private final TransportObserver clientTransportObserver;
+    private final ConnectionObserver clientConnectionObserver;
+    private final SecurityHandshakeObserver clientSecurityHandshakeObserver;
+
+    private final TransportObserver serverTransportObserver;
+    private final ConnectionObserver serverConnectionObserver;
+    private final SecurityHandshakeObserver serverSecurityHandshakeObserver;
+
+    public SecurityHandshakeObserverTest() throws Exception {
+        clientTransportObserver = mock(TransportObserver.class, "clientTransportObserver");
+        clientConnectionObserver = mock(ConnectionObserver.class, "clientConnectionObserver");
+        clientSecurityHandshakeObserver = mock(SecurityHandshakeObserver.class, "clientSecurityHandshakeObserver");
+        DataObserver clientDataObserver = mock(DataObserver.class, "clientDataObserver");
+        MultiplexedObserver clientMultiplexedObserver = mock(MultiplexedObserver.class, "clientMultiplexedObserver");
+        StreamObserver clientStreamObserver = mock(StreamObserver.class, "clientStreamObserver");
+        ReadObserver clientReadObserver = mock(ReadObserver.class, "clientReadObserver");
+        WriteObserver clientWriteObserver = mock(WriteObserver.class, "clientWriteObserver");
+        when(clientTransportObserver.onNewConnection()).thenReturn(clientConnectionObserver);
+        when(clientConnectionObserver.onSecurityHandshake()).thenReturn(clientSecurityHandshakeObserver);
+        when(clientConnectionObserver.established(any(ConnectionInfo.class))).thenReturn(clientDataObserver);
+        when(clientConnectionObserver.establishedMultiplexed(any(ConnectionInfo.class)))
+                .thenReturn(clientMultiplexedObserver);
+        when(clientMultiplexedObserver.onNewStream()).thenReturn(clientStreamObserver);
+        when(clientDataObserver.onNewRead()).thenReturn(clientReadObserver);
+        when(clientDataObserver.onNewWrite()).thenReturn(clientWriteObserver);
+        when(clientStreamObserver.onNewRead()).thenReturn(clientReadObserver);
+        when(clientStreamObserver.onNewWrite()).thenReturn(clientWriteObserver);
+
+        serverTransportObserver = mock(TransportObserver.class, "serverTransportObserver");
+        serverConnectionObserver = mock(ConnectionObserver.class, "serverConnectionObserver");
+        serverSecurityHandshakeObserver = mock(SecurityHandshakeObserver.class, "serverSecurityHandshakeObserver");
+        DataObserver serverDataObserver = mock(DataObserver.class, "serverDataObserver");
+        MultiplexedObserver serverMultiplexedObserver = mock(MultiplexedObserver.class, "serverMultiplexedObserver");
+        StreamObserver serverStreamObserver = mock(StreamObserver.class, "serverStreamObserver");
+        ReadObserver serverReadObserver = mock(ReadObserver.class, "serverReadObserver");
+        WriteObserver serverWriteObserver = mock(WriteObserver.class, "serverWriteObserver");
+        when(serverTransportObserver.onNewConnection()).thenReturn(serverConnectionObserver);
+        when(serverConnectionObserver.onSecurityHandshake()).thenReturn(serverSecurityHandshakeObserver);
+        when(serverConnectionObserver.established(any(ConnectionInfo.class))).thenReturn(serverDataObserver);
+        when(serverConnectionObserver.establishedMultiplexed(any(ConnectionInfo.class)))
+                .thenReturn(serverMultiplexedObserver);
+        when(serverMultiplexedObserver.onNewStream()).thenReturn(serverStreamObserver);
+        when(serverDataObserver.onNewRead()).thenReturn(serverReadObserver);
+        when(serverDataObserver.onNewWrite()).thenReturn(serverWriteObserver);
+        when(serverStreamObserver.onNewRead()).thenReturn(serverReadObserver);
+        when(serverStreamObserver.onNewWrite()).thenReturn(serverWriteObserver);
+    }
+
+    @Test
+    public void withH1() throws Exception {
+        verifyHandshakeObserved(address -> HttpServers.forAddress(address).protocols(h1Default()),
+                address -> HttpClients.forSingleAddress(address).protocols(h1Default()));
+    }
+
+    @Test
+    public void withH2() throws Exception {
+        verifyHandshakeObserved(address -> HttpServers.forAddress(address).protocols(h2Default()),
+                address -> HttpClients.forSingleAddress(address).protocols(h2Default()));
+    }
+
+    @Test
+    public void withAlpnPreferH1() throws Exception {
+        verifyHandshakeObserved(address -> HttpServers.forAddress(address).protocols(h1Default(), h2Default()),
+                address -> HttpClients.forSingleAddress(address).protocols(h1Default(), h2Default()));
+    }
+
+    @Test
+    public void withAlpnPreferH2() throws Exception {
+        verifyHandshakeObserved(address -> HttpServers.forAddress(address).protocols(h2Default(), h1Default()),
+                address -> HttpClients.forSingleAddress(address).protocols(h2Default(), h1Default()));
+    }
+
+    @Test
+    public void withProxyTunnel() throws Exception {
+        try (ProxyTunnel proxyTunnel = new ProxyTunnel()) {
+            HostAndPort proxyAddress = proxyTunnel.startProxy();
+            verifyHandshakeObserved(HttpServers::forAddress,
+                    address -> HttpClients.forSingleAddressViaProxy(address, proxyAddress));
+        }
+    }
+
+    private void verifyHandshakeObserved(Function<SocketAddress, HttpServerBuilder> serverBuilderFactory,
+                                         Function<HostAndPort, SingleAddressHttpClientBuilder<HostAndPort,
+                                                 InetSocketAddress>> clientBuilderFactory) throws Exception {
+
+        try (ServerContext serverContext = serverBuilderFactory.apply(localAddress(0))
+                .ioExecutor(SERVER_CTX.ioExecutor())
+                .executionStrategy(defaultStrategy(SERVER_CTX.executor()))
+                .secure()
+                .commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                .transportObserver(serverTransportObserver)
+                .listenStreamingAndAwait(new TestServiceStreaming());
+
+             BlockingHttpClient client = clientBuilderFactory.apply(serverHostAndPort(serverContext))
+                     .ioExecutor(CLIENT_CTX.ioExecutor())
+                     .executionStrategy(defaultStrategy(CLIENT_CTX.executor()))
+                     .secure()
+                     .disableHostnameVerification()
+                     .trustManager(DefaultTestCerts::loadMutualAuthCaPem)
+                     .commit()
+                     .appendConnectionFactoryFilter(
+                             new TransportObserverConnectionFactoryFilter<>(clientTransportObserver))
+                     .buildBlocking()) {
+
+            String content = "payload_body";
+            HttpResponse response = client.request(client.post(SVC_ECHO).payloadBody(content, textSerializer()));
+            assertThat(response.status(), is(OK));
+            assertThat(response.payloadBody(textDeserializer()), equalTo(content));
+
+            verify(clientConnectionObserver).onSecurityHandshake();
+            verify(clientSecurityHandshakeObserver).handshakeComplete(any(SSLSession.class));
+
+            verify(serverConnectionObserver).onSecurityHandshake();
+            verify(serverSecurityHandshakeObserver).handshakeComplete(any(SSLSession.class));
+        }
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
@@ -36,6 +36,7 @@ import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.ExecutionContextRule;
 
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
@@ -69,7 +70,7 @@ public class SecurityHandshakeObserverTest {
     @ClassRule
     public static final ExecutionContextRule CLIENT_CTX = cached("client-io", "client-executor");
 
-    // @Rule
+    @Rule
     public final Timeout timeout = new ServiceTalkTestTimeout();
 
     private final TransportObserver clientTransportObserver;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TestServiceStreaming.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TestServiceStreaming.java
@@ -32,9 +32,11 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 
+import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
+import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
 import static io.servicetalk.http.api.HttpResponseStatus.NOT_FOUND;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 
@@ -56,6 +58,10 @@ final class TestServiceStreaming implements StreamingHttpService {
     private final Function<StreamingHttpRequest, Publisher<Buffer>> publisherSupplier;
 
     private int counter;
+
+    TestServiceStreaming() {
+        this(__ -> empty());
+    }
 
     TestServiceStreaming(final Function<StreamingHttpRequest, Publisher<Buffer>> publisherSupplier) {
         this.publisherSupplier = publisherSupplier;
@@ -113,6 +119,10 @@ final class TestServiceStreaming implements StreamingHttpService {
         final CharSequence contentLength = req.headers().get(CONTENT_LENGTH);
         if (contentLength != null) {
             response.headers().set(CONTENT_LENGTH, contentLength);
+        }
+        final CharSequence contentType = req.headers().get(CONTENT_TYPE);
+        if (contentType != null) {
+            response.headers().set(CONTENT_TYPE, contentType);
         }
         return response;
     }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
@@ -72,7 +72,7 @@ public class TcpClientChannelInitializer implements ChannelInitializer {
         if (sslContext != null) {
             delegate = delegate.andThen(new SslClientChannelInitializer(sslContext,
                     config.sslHostnameVerificationAlgorithm(), config.sslHostnameVerificationHost(),
-                    config.sslHostnameVerificationPort(), deferSslHandler, observer));
+                    config.sslHostnameVerificationPort(), deferSslHandler, observer != null));
         }
 
         final WireLoggingInitializer wireLoggingInitializer = config.wireLoggingInitializer();

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
@@ -25,9 +25,10 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.util.AttributeKey;
+import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 
-import static io.netty.util.AttributeKey.newInstance;
+import javax.annotation.Nullable;
+
 import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.channelError;
 import static java.util.Objects.requireNonNull;
 
@@ -35,9 +36,6 @@ import static java.util.Objects.requireNonNull;
  * A {@link ChannelInitializer} that registers a {@link ConnectionObserver} for all channels.
  */
 public final class ConnectionObserverInitializer implements ChannelInitializer {
-
-    public static final AttributeKey<SecurityHandshakeObserver> SECURITY_HANDSHAKE_OBSERVER =
-            newInstance("SecurityHandshakeObserver");
 
     private final ConnectionObserver observer;
     private final boolean secure;
@@ -70,7 +68,8 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
 
         private final ConnectionObserver observer;
         private final boolean secure;
-        private boolean handshakeStartNotified;
+        @Nullable
+        private SecurityHandshakeObserver handshakeObserver;
 
         ConnectionObserverHandler(final ConnectionObserver observer, final boolean secure) {
             this.observer = observer;
@@ -80,22 +79,32 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
         @Override
         public void handlerAdded(final ChannelHandlerContext ctx) {
             if (secure && ctx.channel().isActive()) {
-                reportSecurityHandshakeStarting(ctx.channel());
+                reportSecurityHandshakeStarting();
             }
         }
 
         @Override
         public void channelActive(final ChannelHandlerContext ctx) {
             if (secure) {
-                reportSecurityHandshakeStarting(ctx.channel());
+                reportSecurityHandshakeStarting();
             }
             ctx.fireChannelActive();
         }
 
-        void reportSecurityHandshakeStarting(final Channel channel) {
-            if (!handshakeStartNotified) {
-                handshakeStartNotified = true;
-                channel.attr(SECURITY_HANDSHAKE_OBSERVER).set(observer.onSecurityHandshake());
+        void reportSecurityHandshakeStarting() {
+            if (handshakeObserver == null) {
+                handshakeObserver = observer.onSecurityHandshake();
+            }
+        }
+
+        @Override
+        public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) {
+            if (evt instanceof WaitingForHandshakeCompletionEvent) {
+                final SecurityHandshakeObserver handshakeObserver = this.handshakeObserver;
+                assert handshakeObserver != null;
+                ctx.fireUserEventTriggered(handshakeObserver);
+            } else {
+                ctx.fireUserEventTriggered(evt);
             }
         }
 
@@ -123,6 +132,20 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
         public void flush(final ChannelHandlerContext ctx) {
             observer.onFlush();
             ctx.flush();
+        }
+    }
+
+    /**
+     * Event that is fired once the handler is awaiting {@link SslHandshakeCompletionEvent}.
+     */
+    public static final class WaitingForHandshakeCompletionEvent {
+        /**
+         * {@link WaitingForHandshakeCompletionEvent} instance to use.
+         */
+        public static final WaitingForHandshakeCompletionEvent INSTANCE = new WaitingForHandshakeCompletionEvent();
+
+        private WaitingForHandshakeCompletionEvent() {
+            // Singleton
         }
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
@@ -25,7 +25,6 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 
 import javax.annotation.Nullable;
 
@@ -64,7 +63,7 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
         channel.pipeline().addLast(new ConnectionObserverHandler(observer, secure));
     }
 
-    private static final class ConnectionObserverHandler extends ChannelDuplexHandler {
+    static final class ConnectionObserverHandler extends ChannelDuplexHandler {
 
         private final ConnectionObserver observer;
         private final boolean secure;
@@ -97,15 +96,9 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
             }
         }
 
-        @Override
-        public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) {
-            if (evt instanceof WaitingForHandshakeCompletionEvent) {
-                final SecurityHandshakeObserver handshakeObserver = this.handshakeObserver;
-                assert handshakeObserver != null;
-                ctx.fireUserEventTriggered(handshakeObserver);
-            } else {
-                ctx.fireUserEventTriggered(evt);
-            }
+        @Nullable
+        SecurityHandshakeObserver handshakeObserver() {
+            return handshakeObserver;
         }
 
         @Override
@@ -132,20 +125,6 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
         public void flush(final ChannelHandlerContext ctx) {
             observer.onFlush();
             ctx.flush();
-        }
-    }
-
-    /**
-     * Event that is fired once the handler is awaiting {@link SslHandshakeCompletionEvent}.
-     */
-    public static final class WaitingForHandshakeCompletionEvent {
-        /**
-         * {@link WaitingForHandshakeCompletionEvent} instance to use.
-         */
-        public static final WaitingForHandshakeCompletionEvent INSTANCE = new WaitingForHandshakeCompletionEvent();
-
-        private WaitingForHandshakeCompletionEvent() {
-            // Singleton
         }
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -32,6 +32,7 @@ import io.servicetalk.concurrent.internal.DelayedCancellable;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ConnectionObserver.DataObserver;
 import io.servicetalk.transport.api.ConnectionObserver.ReadObserver;
+import io.servicetalk.transport.api.ConnectionObserver.SecurityHandshakeObserver;
 import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
 import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
 import io.servicetalk.transport.api.DefaultExecutionContext;
@@ -41,6 +42,7 @@ import io.servicetalk.transport.api.ServiceTalkSocketOptions;
 import io.servicetalk.transport.netty.internal.CloseHandler.AbortWritesEvent;
 import io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent;
 import io.servicetalk.transport.netty.internal.CloseHandler.CloseEventObservedException;
+import io.servicetalk.transport.netty.internal.ConnectionObserverInitializer.WaitingForHandshakeCompletionEvent;
 import io.servicetalk.transport.netty.internal.WriteStreamSubscriber.AbortedFirstWrite;
 
 import io.netty.channel.Channel;
@@ -548,6 +550,9 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
         private SingleSource.Subscriber<? super DefaultNettyConnection<Read, Write>> subscriber;
         @Nullable
         private final ConnectionObserver observer;
+        @Nullable
+        private SecurityHandshakeObserver handshakeObserver;
+        private boolean active;
 
         NettyToStChannelInboundHandler(DefaultNettyConnection<Read, Write> connection,
                                        @Nullable
@@ -639,9 +644,12 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
                 // all the available data. ChannelInputShutdownReadComplete is the one that seems to (at least in
                 // the current netty version) gets triggered reliably at the appropriate time.
                 connection.nettyChannelPublisher.channelInboundClosed();
+            } else if (evt instanceof SecurityHandshakeObserver) {
+                assert this.handshakeObserver == null;
+                this.handshakeObserver = (SecurityHandshakeObserver) evt;
             } else if (evt instanceof SslHandshakeCompletionEvent) {
                 connection.sslSession = extractSslSessionAndReport(ctx.pipeline(), (SslHandshakeCompletionEvent) evt,
-                        this::tryFailSubscriber);
+                        this::tryFailSubscriber, handshakeObserver);
                 if (subscriber != null) {
                     assert waitForSslHandshake;
                     completeSubscriber();
@@ -673,7 +681,16 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
         }
 
         private void doChannelActive(ChannelHandlerContext ctx) {
+            if (active) {
+                return;
+            }
+            active = true;
+
             if (waitForSslHandshake) {
+                if (observer != null) {
+                    // Notify ConnectionObserverHandler that we are ready to receive SecurityHandshakeObserver instance
+                    ctx.pipeline().fireUserEventTriggered(WaitingForHandshakeCompletionEvent.INSTANCE);
+                }
                 // Force a read to get the SSL handshake started, any application data that makes it past the SslHandler
                 // will be queued in the NettyChannelPublisher.
                 ctx.read();

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DeferSslHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DeferSslHandler.java
@@ -24,8 +24,6 @@ import io.netty.handler.ssl.SslHandler;
 
 import javax.annotation.Nullable;
 
-import static io.servicetalk.transport.netty.internal.ConnectionObserverInitializer.SECURITY_HANDSHAKE_OBSERVER;
-
 /**
  * A {@link ChannelHandler} that holds a place in a pipeline, allowing us to defer adding the {@link SslHandler}.
  */
@@ -46,7 +44,7 @@ public class DeferSslHandler extends ChannelDuplexHandler {
      */
     public void ready() {
         if (observer != null) {
-            channel.attr(SECURITY_HANDSHAKE_OBSERVER).set(observer.onSecurityHandshake());
+            channel.pipeline().fireUserEventTriggered(observer.onSecurityHandshake());
         }
         channel.pipeline().replace(this, null, handler);
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslClientChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslClientChannelInitializer.java
@@ -15,8 +15,6 @@
  */
 package io.servicetalk.transport.netty.internal;
 
-import io.servicetalk.transport.api.ConnectionObserver;
-
 import io.netty.channel.Channel;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
@@ -39,8 +37,7 @@ public class SslClientChannelInitializer implements ChannelInitializer {
     private final int hostnameVerificationPort;
     private final SslContext sslContext;
     private final boolean deferSslHandler;
-    @Nullable
-    private final ConnectionObserver observer;
+    private final boolean shouldReport;
 
     /**
      * New instance.
@@ -49,23 +46,24 @@ public class SslClientChannelInitializer implements ChannelInitializer {
      * @param hostnameVerificationHost the non-authoritative name of the host.
      * @param hostnameVerificationPort the non-authoritative port.
      * @param deferSslHandler {@code true} to wrap the {@link SslHandler} in a {@link DeferSslHandler}.
-     * @param observer {@link ConnectionObserver} to report network events.
+     * @param shouldReport {@link true} to report security handshake start when {@link DeferSslHandler} is ready.
      */
     public SslClientChannelInitializer(SslContext sslContext, @Nullable String hostnameVerificationAlgorithm,
                                        @Nullable String hostnameVerificationHost, int hostnameVerificationPort,
-                                       final boolean deferSslHandler, @Nullable final ConnectionObserver observer) {
+                                       final boolean deferSslHandler, final boolean shouldReport) {
         this.sslContext = requireNonNull(sslContext);
         this.hostnameVerificationAlgorithm = hostnameVerificationAlgorithm;
         this.hostnameVerificationHost = hostnameVerificationHost;
         this.hostnameVerificationPort = hostnameVerificationPort;
         this.deferSslHandler = deferSslHandler;
-        this.observer = observer;
+        this.shouldReport = shouldReport;
     }
 
     @Override
     public void init(Channel channel) {
         final SslHandler sslHandler = newHandler(sslContext, POOLED_ALLOCATOR,
                 hostnameVerificationAlgorithm, hostnameVerificationHost, hostnameVerificationPort);
-        channel.pipeline().addLast(deferSslHandler ? new DeferSslHandler(channel, sslHandler, observer) : sslHandler);
+        channel.pipeline().addLast(deferSslHandler ? new DeferSslHandler(channel, sslHandler, shouldReport) :
+                sslHandler);
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslClientChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslClientChannelInitializer.java
@@ -46,7 +46,7 @@ public class SslClientChannelInitializer implements ChannelInitializer {
      * @param hostnameVerificationHost the non-authoritative name of the host.
      * @param hostnameVerificationPort the non-authoritative port.
      * @param deferSslHandler {@code true} to wrap the {@link SslHandler} in a {@link DeferSslHandler}.
-     * @param shouldReport {@link true} to report security handshake start when {@link DeferSslHandler} is ready.
+     * @param shouldReport {@code true} to report security handshake start when {@link DeferSslHandler} is ready.
      */
     public SslClientChannelInitializer(SslContext sslContext, @Nullable String hostnameVerificationAlgorithm,
                                        @Nullable String hostnameVerificationHost, int hostnameVerificationPort,


### PR DESCRIPTION
Motivation:

Usage of Channel's attributes increase a shared state of the `Channel`.
`SecurityHandshakeObserver` can be propagated without using it.

Modifications:

- When `SslHandshakeCompletionEvent` arrives, look up for
`ConnectionObserverHandler` to access previously initialized
`SecurityHandshakeObserver`;
- Add `SecurityHandshakeObserverTest` to verify that
`SecurityHandshakeObserver` is working with different configurations:
HTTP/1.1, HTTP/2, ALPN, secure proxy tunnel;
- Improve `TestServiceStreaming` to echo content-type header;

Result:

Less state on the `Channel` instance.