### PR TITLE
Report `streamEstablished` event, improve `streamClosed` handling

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/BiTransportObserver.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/BiTransportObserver.java
@@ -87,13 +87,14 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
-        public DataObserver established(final ConnectionInfo info) {
-            return new BiDataObserver(first.established(info), second.established(info));
+        public DataObserver connectionEstablished(final ConnectionInfo info) {
+            return new BiDataObserver(first.connectionEstablished(info), second.connectionEstablished(info));
         }
 
         @Override
-        public MultiplexedObserver establishedMultiplexed(final ConnectionInfo info) {
-            return new BiMultiplexedObserver(first.establishedMultiplexed(info), second.establishedMultiplexed(info));
+        public MultiplexedObserver multiplexedConnectionEstablished(final ConnectionInfo info) {
+            return new BiMultiplexedObserver(first.multiplexedConnectionEstablished(info),
+                    second.multiplexedConnectionEstablished(info));
         }
 
         @Override
@@ -133,23 +134,23 @@ final class BiTransportObserver implements TransportObserver {
         }
     }
 
-    private static class BiDataObserver implements DataObserver {
+    private static final class BiDataObserver implements DataObserver {
 
         private final DataObserver first;
         private final DataObserver second;
 
-        protected BiDataObserver(final DataObserver first, final DataObserver second) {
+        private BiDataObserver(final DataObserver first, final DataObserver second) {
             this.first = first;
             this.second = second;
         }
 
         @Override
-        public final ReadObserver onNewRead() {
+        public ReadObserver onNewRead() {
             return new BiReadObserver(first.onNewRead(), second.onNewRead());
         }
 
         @Override
-        public final WriteObserver onNewWrite() {
+        public WriteObserver onNewWrite() {
             return new BiWriteObserver(first.onNewWrite(), second.onNewWrite());
         }
     }
@@ -170,15 +171,19 @@ final class BiTransportObserver implements TransportObserver {
         }
     }
 
-    private static final class BiStreamObserver extends BiDataObserver implements StreamObserver {
+    private static final class BiStreamObserver implements StreamObserver {
 
         private final StreamObserver first;
         private final StreamObserver second;
 
         private BiStreamObserver(final StreamObserver first, final StreamObserver second) {
-            super(first, second);
             this.first = first;
             this.second = second;
+        }
+
+        @Override
+        public DataObserver streamEstablished() {
+            return new BiDataObserver(first.streamEstablished(), second.streamEstablished());
         }
 
         @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -23,6 +23,7 @@ import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
 import io.servicetalk.transport.netty.internal.CloseHandler;
 
 import io.netty.channel.ChannelHandlerContext;
@@ -57,8 +58,8 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
     private HttpRequestMethod method;
 
     H2ToStH1ClientDuplexHandler(boolean sslEnabled, BufferAllocator allocator, HttpHeadersFactory headersFactory,
-                                CloseHandler closeHandler) {
-        super(allocator, headersFactory, closeHandler);
+                                CloseHandler closeHandler, @Nullable StreamObserver observer) {
+        super(allocator, headersFactory, closeHandler, observer);
         this.scheme = sslEnabled ? HttpScheme.HTTPS : HttpScheme.HTTP;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
@@ -22,6 +22,7 @@ import io.servicetalk.http.api.HttpHeadersFactory;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
 import io.servicetalk.transport.netty.internal.CloseHandler;
 
 import io.netty.channel.ChannelHandlerContext;
@@ -53,8 +54,8 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
     private boolean readHeaders;
 
     H2ToStH1ServerDuplexHandler(BufferAllocator allocator, HttpHeadersFactory headersFactory,
-                                CloseHandler closeHandler) {
-        super(allocator, headersFactory, closeHandler);
+                                CloseHandler closeHandler, @Nullable StreamObserver observer) {
+        super(allocator, headersFactory, closeHandler, observer);
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.concurrent.internal.AutoClosableUtils.closeAndReThrowUnchecked;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
@@ -84,7 +83,11 @@ public class HttpsProxyTest {
 
     static void safeClose(@Nullable AutoCloseable closeable) {
         if (closeable != null) {
-            closeAndReThrowUnchecked(closeable);
+            try {
+                closeable.close();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.client.api.TransportObserverConnectionFactoryFilter;
+import io.servicetalk.concurrent.api.DefaultThreadFactory;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.HttpConnection;
+import io.servicetalk.transport.api.ConnectionInfo;
+import io.servicetalk.transport.api.ConnectionObserver;
+import io.servicetalk.transport.api.ConnectionObserver.DataObserver;
+import io.servicetalk.transport.api.ConnectionObserver.MultiplexedObserver;
+import io.servicetalk.transport.api.ConnectionObserver.ReadObserver;
+import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
+import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.TransportObserver;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http2.Http2Exception.StreamException;
+import io.netty.handler.codec.http2.Http2StreamChannel;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+
+import static io.servicetalk.http.netty.H2PriorKnowledgeFeatureParityTest.bindH2Server;
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h2Default;
+import static io.servicetalk.http.netty.HttpTransportObserverTest.await;
+import static io.servicetalk.http.netty.HttpsProxyTest.safeClose;
+import static io.servicetalk.transport.netty.internal.NettyIoExecutors.createEventLoopGroup;
+import static java.lang.Thread.NORM_PRIORITY;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class StreamObserverTest {
+
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+
+    private final TransportObserver clientTransportObserver;
+    private final ConnectionObserver clientConnectionObserver;
+    private final MultiplexedObserver clientMultiplexedObserver;
+    private final StreamObserver clientStreamObserver;
+    private final DataObserver clientDataObserver;
+    private final ReadObserver clientReadObserver;
+    private final WriteObserver clientWriteObserver;
+
+    private final EventLoopGroup serverEventLoopGroup;
+    private final Channel serverAcceptorChannel;
+    private final HttpClient client;
+    private final CountDownLatch requestReceived = new CountDownLatch(1);
+
+    public StreamObserverTest() {
+        clientTransportObserver = mock(TransportObserver.class, "clientTransportObserver");
+        clientConnectionObserver = mock(ConnectionObserver.class, "clientConnectionObserver");
+        clientMultiplexedObserver = mock(MultiplexedObserver.class, "clientMultiplexedObserver");
+        clientStreamObserver = mock(StreamObserver.class, "clientStreamObserver");
+        clientDataObserver = mock(DataObserver.class, "clientDataObserver");
+        clientReadObserver = mock(ReadObserver.class, "clientReadObserver");
+        clientWriteObserver = mock(WriteObserver.class, "clientWriteObserver");
+        when(clientTransportObserver.onNewConnection()).thenReturn(clientConnectionObserver);
+        when(clientConnectionObserver.multiplexedConnectionEstablished(any(ConnectionInfo.class)))
+                .thenReturn(clientMultiplexedObserver);
+        when(clientMultiplexedObserver.onNewStream()).thenReturn(clientStreamObserver);
+        when(clientStreamObserver.streamEstablished()).thenReturn(clientDataObserver);
+        when(clientDataObserver.onNewRead()).thenReturn(clientReadObserver);
+        when(clientDataObserver.onNewWrite()).thenReturn(clientWriteObserver);
+
+        serverEventLoopGroup = createEventLoopGroup(2, new DefaultThreadFactory("server-io", true, NORM_PRIORITY));
+        serverAcceptorChannel = bindH2Server(serverEventLoopGroup, new ChannelInitializer<Http2StreamChannel>() {
+            @Override
+            protected void initChannel(final Http2StreamChannel ch) {
+                ch.pipeline().addLast(new SimpleChannelInboundHandler<Object>() {
+                    @Override
+                    protected void channelRead0(final ChannelHandlerContext ctx, final Object msg) {
+                        requestReceived.countDown();
+                    }
+                });
+            }
+        }, parentPipeline -> { }, h2Builder -> {
+            h2Builder.initialSettings().maxConcurrentStreams(1L);
+            return h2Builder;
+        });
+        client = HttpClients.forSingleAddress(HostAndPort.of((InetSocketAddress) serverAcceptorChannel.localAddress()))
+                .protocols(h2Default())
+                .appendConnectionFactoryFilter(new TransportObserverConnectionFactoryFilter<>(clientTransportObserver))
+                .build();
+    }
+
+    @After
+    public void teardown() {
+        safeSync(() -> serverAcceptorChannel.close().syncUninterruptibly());
+        safeSync(() -> serverEventLoopGroup.shutdownGracefully(0, 0, MILLISECONDS).syncUninterruptibly());
+        safeClose(client);
+    }
+
+    private static void safeSync(Runnable runnable) {
+        try {
+            runnable.run();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void maxActiveStreamsViolationError() throws Exception {
+        try (HttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+            verify(clientTransportObserver).onNewConnection();
+            verify(clientConnectionObserver).multiplexedConnectionEstablished(any(ConnectionInfo.class));
+
+            connection.request(connection.get("/first")).subscribe(__ -> { /* no response expected */ });
+            requestReceived.await();
+            ExecutionException e = assertThrows(ExecutionException.class,
+                    () -> connection.request(connection.get("/second")).toFuture().get());
+            assertThat(e.getCause(), instanceOf(StreamException.class));
+
+            verify(clientMultiplexedObserver, times(2)).onNewStream();
+            verify(clientStreamObserver, times(2)).streamEstablished();
+            verify(clientDataObserver, times(2)).onNewRead();
+            verify(clientDataObserver, times(2)).onNewWrite();
+            verify(clientReadObserver).readCancelled();
+            verify(clientWriteObserver).writeFailed(e.getCause());
+            verify(clientStreamObserver).streamClosed(e.getCause());
+        }
+        verify(clientStreamObserver, await()).streamClosed();
+        verify(clientConnectionObserver).connectionClosed();
+
+        verifyNoMoreInteractions(clientTransportObserver, clientMultiplexedObserver, clientStreamObserver,
+                clientDataObserver);
+    }
+}

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
@@ -64,7 +64,7 @@ public class AbstractTransportObserverTest extends AbstractTcpServerTest {
         clientWriteObserver = mock(WriteObserver.class, "clientWriteObserver");
         when(clientTransportObserver.onNewConnection()).thenReturn(clientConnectionObserver);
         when(clientConnectionObserver.onSecurityHandshake()).thenReturn(clientSecurityHandshakeObserver);
-        when(clientConnectionObserver.established(any(ConnectionInfo.class))).thenReturn(clientDataObserver);
+        when(clientConnectionObserver.connectionEstablished(any(ConnectionInfo.class))).thenReturn(clientDataObserver);
         when(clientDataObserver.onNewRead()).thenReturn(clientReadObserver);
         when(clientDataObserver.onNewWrite()).thenReturn(clientWriteObserver);
 
@@ -76,7 +76,7 @@ public class AbstractTransportObserverTest extends AbstractTcpServerTest {
         serverWriteObserver = mock(WriteObserver.class, "serverWriteObserver");
         when(serverTransportObserver.onNewConnection()).thenReturn(serverConnectionObserver);
         when(serverConnectionObserver.onSecurityHandshake()).thenReturn(serverSecurityHandshakeObserver);
-        when(serverConnectionObserver.established(any(ConnectionInfo.class))).thenReturn(serverDataObserver);
+        when(serverConnectionObserver.connectionEstablished(any(ConnectionInfo.class))).thenReturn(serverDataObserver);
         when(serverDataObserver.onNewRead()).thenReturn(serverReadObserver);
         when(serverDataObserver.onNewWrite()).thenReturn(serverWriteObserver);
     }

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverTest.java
@@ -77,8 +77,8 @@ public class SecureTcpTransportObserverTest extends AbstractTransportObserverTes
         verify(clientTransportObserver).onNewConnection();
         verify(serverTransportObserver, await()).onNewConnection();
 
-        verify(clientConnectionObserver).established(any(ConnectionInfo.class));
-        verify(serverConnectionObserver, await()).established(any(ConnectionInfo.class));
+        verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
+        verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
 
         // handshake starts
         verify(clientConnectionObserver).onSecurityHandshake();

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverErrorsTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverErrorsTest.java
@@ -96,8 +96,8 @@ public final class TcpTransportObserverErrorsTest extends AbstractTransportObser
         NettyConnection<Buffer, Buffer> connection = client.connectBlocking(CLIENT_CTX, serverAddress);
         verify(clientTransportObserver).onNewConnection();
         verify(serverTransportObserver, await()).onNewConnection();
-        verify(clientConnectionObserver).established(any(ConnectionInfo.class));
-        verify(serverConnectionObserver, await()).established(any(ConnectionInfo.class));
+        verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
+        verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
         switch (errorSource) {
             case CONNECTION_ACCEPTOR:
                 break;

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverTest.java
@@ -40,8 +40,8 @@ public class TcpTransportObserverTest extends AbstractTransportObserverTest {
         NettyConnection<Buffer, Buffer> connection = client.connectBlocking(CLIENT_CTX, serverAddress);
         verify(clientTransportObserver).onNewConnection();
         verify(serverTransportObserver, await()).onNewConnection();
-        verify(clientConnectionObserver).established(any(ConnectionInfo.class));
-        verify(serverConnectionObserver, await()).established(any(ConnectionInfo.class));
+        verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
+        verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
 
         Buffer content = connection.executionContext().bufferAllocator().fromAscii("Hello");
         connection.write(from(content.duplicate())).toFuture().get();

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
@@ -87,14 +87,14 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
-        public DataObserver established(final ConnectionInfo info) {
-            return safeReport(() -> observer.established(info), observer, "connection established",
+        public DataObserver connectionEstablished(final ConnectionInfo info) {
+            return safeReport(() -> observer.connectionEstablished(info), observer, "connection established",
                     CatchAllDataObserver::new, NoopDataObserver.INSTANCE);
         }
 
         @Override
-        public MultiplexedObserver establishedMultiplexed(final ConnectionInfo info) {
-            return safeReport(() -> observer.establishedMultiplexed(info), observer,
+        public MultiplexedObserver multiplexedConnectionEstablished(final ConnectionInfo info) {
+            return safeReport(() -> observer.multiplexedConnectionEstablished(info), observer,
                     "multiplexed connection established",
                     CatchAllMultiplexedObserver::new, NoopMultiplexedObserver.INSTANCE);
         }
@@ -129,22 +129,22 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
     }
 
-    private static class CatchAllDataObserver implements DataObserver {
+    private static final class CatchAllDataObserver implements DataObserver {
 
         private final DataObserver observer;
 
-        protected CatchAllDataObserver(final DataObserver observer) {
+        private CatchAllDataObserver(final DataObserver observer) {
             this.observer = observer;
         }
 
         @Override
-        public final ReadObserver onNewRead() {
+        public ReadObserver onNewRead() {
             return safeReport(observer::onNewRead, observer, "new read",
                     CatchAllReadObserver::new, NoopReadObserver.INSTANCE);
         }
 
         @Override
-        public final WriteObserver onNewWrite() {
+        public WriteObserver onNewWrite() {
             return safeReport(observer::onNewWrite, observer, "new read",
                     CatchAllWriteObserver::new, NoopWriteObserver.INSTANCE);
         }
@@ -165,13 +165,18 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
     }
 
-    private static final class CatchAllStreamObserver extends CatchAllDataObserver implements StreamObserver {
+    private static final class CatchAllStreamObserver implements StreamObserver {
 
         private final StreamObserver observer;
 
         private CatchAllStreamObserver(final StreamObserver observer) {
-            super(observer);
             this.observer = observer;
+        }
+
+        @Override
+        public DataObserver streamEstablished() {
+            return safeReport(observer::streamEstablished, observer, "stream established",
+                    CatchAllDataObserver::new, NoopDataObserver.INSTANCE);
         }
 
         @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -57,7 +57,7 @@ public interface ConnectionObserver {
      * @param info {@link ConnectionInfo} for the established connection
      * @return a new {@link DataObserver} that provides visibility into read and write events
      */
-    DataObserver established(ConnectionInfo info);
+    DataObserver connectionEstablished(ConnectionInfo info);
 
     /**
      * Callback when a multiplexed connection is established and ready.
@@ -65,7 +65,7 @@ public interface ConnectionObserver {
      * @param info {@link ConnectionInfo} for the established connection
      * @return a new {@link MultiplexedObserver} that provides visibility into new streams
      */
-    MultiplexedObserver establishedMultiplexed(ConnectionInfo info);
+    MultiplexedObserver multiplexedConnectionEstablished(ConnectionInfo info);
 
     /**
      * Callback when the connection is closed due to an {@link Throwable error}.
@@ -128,7 +128,7 @@ public interface ConnectionObserver {
     interface MultiplexedObserver {
 
         /**
-         * Callback when the connection creates a new stream.
+         * Callback when the connection requests a new stream.
          *
          * @return {@link StreamObserver} that provides visibility into stream events
          */
@@ -141,7 +141,14 @@ public interface ConnectionObserver {
      * Either {@link #streamClosed()} or {@link #streamClosed(Throwable)} will be invoked to signal when a stream is
      * closed.
      */
-    interface StreamObserver extends DataObserver {
+    interface StreamObserver {
+
+        /**
+         * Callback when the stream is established and ready.
+         *
+         * @return a new {@link DataObserver} that provides visibility into read and write events
+         */
+        DataObserver streamEstablished();
 
         /**
          * Callback when the stream is closed due to an {@link Throwable error}.

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
@@ -63,12 +63,12 @@ final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
-        public DataObserver established(final ConnectionInfo info) {
+        public DataObserver connectionEstablished(final ConnectionInfo info) {
             return NoopDataObserver.INSTANCE;
         }
 
         @Override
-        public MultiplexedObserver establishedMultiplexed(final ConnectionInfo info) {
+        public MultiplexedObserver multiplexedConnectionEstablished(final ConnectionInfo info) {
             return NoopMultiplexedObserver.INSTANCE;
         }
 
@@ -140,13 +140,8 @@ final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
-        public ReadObserver onNewRead() {
-            return NoopReadObserver.INSTANCE;
-        }
-
-        @Override
-        public WriteObserver onNewWrite() {
-            return NoopWriteObserver.INSTANCE;
+        public DataObserver streamEstablished() {
+            return NoopDataObserver.INSTANCE;
         }
 
         @Override


### PR DESCRIPTION
Motivation:

1. `StreamObserver` lacks `streamEstablished` event similar to
`connectionEstablished`.
2. `StreamException` during stream initialization are not visible for
`StreamObserver`.

Modifications:

- Add `StreamObserver#streamEstablished()` event;
- Rename `ConnectionObserver#established` ->
`ConnectionObserver#connectionEstablished`;
- Rename `ConnectionObserver#establishedMultiplexed` ->
`ConnectionObserver#multiplexedConnectionEstablished`;
- Update tests to account for a new event;
- Report `StreamObserver#streamClosed` from `channelInactive` event
instead of stream close future;
- Test that "Maximum active streams violated for this endpoint" exception
is reported using `StreamObserver#streamClosed(Throwable)` event;

Results:

1. `ConnectionObserver` and `StreamObserver` API are aligned.
2. `StreamObserver#streamClosed` correctly reports stream initialization
errors.