### PR TITLE
Avoid using nullable fields for observers

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractH2DuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractH2DuplexHandler.java
@@ -50,11 +50,10 @@ abstract class AbstractH2DuplexHandler extends ChannelDuplexHandler {
     final BufferAllocator allocator;
     final HttpHeadersFactory headersFactory;
     final CloseHandler closeHandler;
-    @Nullable
     private final StreamObserver observer;
 
     AbstractH2DuplexHandler(BufferAllocator allocator, HttpHeadersFactory headersFactory, CloseHandler closeHandler,
-                            @Nullable StreamObserver observer) {
+                            StreamObserver observer) {
         this.allocator = allocator;
         this.headersFactory = headersFactory;
         this.closeHandler = closeHandler;
@@ -131,13 +130,11 @@ abstract class AbstractH2DuplexHandler extends ChannelDuplexHandler {
 
     @Override
     public void channelInactive(final ChannelHandlerContext ctx) {
-        if (observer != null) {
-            final Throwable t = channelError(ctx.channel());
-            if (t == null) {
-                observer.streamClosed();
-            } else {
-                observer.streamClosed(t);
-            }
+        final Throwable t = channelError(ctx.channel());
+        if (t == null) {
+            observer.streamClosed();
+        } else {
+            observer.streamClosed(t);
         }
         ctx.fireChannelInactive();
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLBHttpConnectionFactory.java
@@ -30,6 +30,7 @@ import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver;
 
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -69,7 +70,8 @@ abstract class AbstractLBHttpConnectionFactory<ResolvedAddress>
                     @Override
                     public Single<FilterableStreamingHttpConnection> newConnection(
                             final ResolvedAddress ra, @Nullable final TransportObserver observer) {
-                        return newFilterableConnection(ra, observer == null ? null : asSafeObserver(observer));
+                        return newFilterableConnection(ra, observer == null ? NoopTransportObserver.INSTANCE :
+                                asSafeObserver(observer));
                     }
 
                     @Override
@@ -111,7 +113,7 @@ abstract class AbstractLBHttpConnectionFactory<ResolvedAddress>
     }
 
     abstract Single<FilterableStreamingHttpConnection> newFilterableConnection(
-            ResolvedAddress resolvedAddress, @Nullable TransportObserver observer);
+            ResolvedAddress resolvedAddress, TransportObserver observer);
 
     abstract ReservableRequestConcurrencyController newConcurrencyController(
             FilterableStreamingHttpConnection connection, Completable onClosing);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnChannelSingle.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnChannelSingle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
@@ -60,7 +60,7 @@ final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpC
 
     @Override
     Single<FilterableStreamingHttpConnection> newFilterableConnection(
-            final ResolvedAddress resolvedAddress, @Nullable final TransportObserver observer) {
+            final ResolvedAddress resolvedAddress, final TransportObserver observer) {
         // This state is read only, so safe to keep a copy across Subscribers
         final ReadOnlyTcpClientConfig roTcpClientConfig = config.tcpConfig();
         // We disable auto read by default so we can handle stuff in the ConnectionFilter before we accept any content.
@@ -70,9 +70,9 @@ final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpC
     }
 
     private Single<FilterableStreamingHttpConnection> createConnection(
-            final Channel channel, @Nullable final TransportObserver observer) {
+            final Channel channel, final TransportObserver observer) {
         final ReadOnlyTcpClientConfig tcpConfig = this.config.tcpConfig();
-        final ConnectionObserver connectionObserver = observer == null ? null : observer.onNewConnection();
+        final ConnectionObserver connectionObserver = observer.onNewConnection();
         return new AlpnChannelSingle(channel,
                 new TcpClientChannelInitializer(tcpConfig, connectionObserver), false).flatMap(protocol -> {
             switch (protocol) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnServerContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnServerContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer;
 import io.servicetalk.transport.api.ConnectionAcceptor;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ServerContext;
-import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;
 
 import io.netty.channel.Channel;
@@ -62,8 +61,7 @@ final class AlpnServerContext {
         // In case ALPN negotiates h2, h2 connection MUST enable auto read for its Channel.
         return TcpServerBinder.bind(listenAddress, tcpConfig, false, executionContext, connectionAcceptor,
                 channel -> {
-                    final TransportObserver observer = tcpConfig.transportObserver();
-                    final ConnectionObserver connectionObserver = observer == null ? null : observer.onNewConnection();
+                    final ConnectionObserver connectionObserver = tcpConfig.transportObserver().onNewConnection();
                     return initChannel(listenAddress, channel, config, executionContext, service,
                             drainRequestPayloadBody, connectionObserver);
                 },
@@ -87,7 +85,7 @@ final class AlpnServerContext {
                                                               final HttpExecutionContext httpExecutionContext,
                                                               final StreamingHttpService service,
                                                               final boolean drainRequestPayloadBody,
-                                                              @Nullable final ConnectionObserver observer) {
+                                                              final ConnectionObserver observer) {
         return new AlpnChannelSingle(channel,
                 new TcpServerChannelInitializer(config.tcpConfig(), observer), true).flatMap(protocol -> {
             switch (protocol) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
@@ -53,14 +53,14 @@ final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpCon
 
     @Override
     Single<FilterableStreamingHttpConnection> newFilterableConnection(
-            final ResolvedAddress resolvedAddress, @Nullable final TransportObserver observer) {
+            final ResolvedAddress resolvedAddress, final TransportObserver observer) {
         assert config.h2Config() != null;
         // This state is read only, so safe to keep a copy across Subscribers
         final ReadOnlyTcpClientConfig roTcpClientConfig = config.tcpConfig();
         // Auto read is required for h2
         return TcpConnector.connect(null, resolvedAddress, roTcpClientConfig, true, executionContext,
                 channel -> {
-                    final ConnectionObserver connectionObserver = observer == null ? null : observer.onNewConnection();
+                    final ConnectionObserver connectionObserver = observer.onNewConnection();
                     return H2ClientParentConnectionContext.initChannel(channel,
                             executionContext.bufferAllocator(), executionContext.executor(),
                             config.h2Config(), reqRespFactory, roTcpClientConfig.flushStrategy(),

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -225,7 +225,8 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
             try {
                 if (evt instanceof SslHandshakeCompletionEvent) {
                     parentContext.sslSession = extractSslSessionAndReport(ctx.pipeline(),
-                            (SslHandshakeCompletionEvent) evt, this::tryFailSubscriber);
+                            (SslHandshakeCompletionEvent) evt, this::tryFailSubscriber,
+                            observer != NoopConnectionObserver.INSTANCE);
                     tryCompleteSubscriber();
                 }
             } finally {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -225,8 +225,7 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
             try {
                 if (evt instanceof SslHandshakeCompletionEvent) {
                     parentContext.sslSession = extractSslSessionAndReport(ctx.pipeline(),
-                            (SslHandshakeCompletionEvent) evt, this::tryFailSubscriber,
-                            observer != NoopConnectionObserver.INSTANCE);
+                            (SslHandshakeCompletionEvent) evt, this::tryFailSubscriber);
                     tryCompleteSubscriber();
                 }
             } finally {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -58,7 +58,7 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
     private HttpRequestMethod method;
 
     H2ToStH1ClientDuplexHandler(boolean sslEnabled, BufferAllocator allocator, HttpHeadersFactory headersFactory,
-                                CloseHandler closeHandler, @Nullable StreamObserver observer) {
+                                CloseHandler closeHandler, StreamObserver observer) {
         super(allocator, headersFactory, closeHandler, observer);
         this.scheme = sslEnabled ? HttpScheme.HTTPS : HttpScheme.HTTP;
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
@@ -54,7 +54,7 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
     private boolean readHeaders;
 
     H2ToStH1ServerDuplexHandler(BufferAllocator allocator, HttpHeadersFactory headersFactory,
-                                CloseHandler closeHandler, @Nullable StreamObserver observer) {
+                                CloseHandler closeHandler, StreamObserver observer) {
         super(allocator, headersFactory, closeHandler, observer);
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -51,7 +51,6 @@ import io.servicetalk.transport.api.ConnectionAcceptor;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.ServerContext;
-import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
 import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.servicetalk.transport.netty.internal.CloseHandler.CloseEventObservedException;
@@ -126,8 +125,7 @@ final class NettyHttpServer {
         // We disable auto read so we can handle stuff in the ConnectionFilter before we accept any content.
         return TcpServerBinder.bind(address, tcpServerConfig, false, executionContext, connectionAcceptor,
                 channel -> {
-                    final TransportObserver observer = tcpServerConfig.transportObserver();
-                    final ConnectionObserver connectionObserver = observer == null ? null : observer.onNewConnection();
+                    final ConnectionObserver connectionObserver = tcpServerConfig.transportObserver().onNewConnection();
                     return initChannel(channel, executionContext, config,
                             new TcpServerChannelInitializer(tcpServerConfig, connectionObserver), service,
                             drainRequestPayloadBody, connectionObserver);
@@ -146,7 +144,7 @@ final class NettyHttpServer {
                                                          final ChannelInitializer initializer,
                                                          final StreamingHttpService service,
                                                          final boolean drainRequestPayloadBody,
-                                                         @Nullable final ConnectionObserver observer) {
+                                                         final ConnectionObserver observer) {
         return initChannel(channel, httpExecutionContext, config, initializer, service, drainRequestPayloadBody,
                 observer, forPipelinedRequestResponse(false, channel.config()));
     }
@@ -157,7 +155,7 @@ final class NettyHttpServer {
                                                          final ChannelInitializer initializer,
                                                          final StreamingHttpService service,
                                                          final boolean drainRequestPayloadBody,
-                                                         @Nullable final ConnectionObserver observer,
+                                                         final ConnectionObserver observer,
                                                          final CloseHandler closeHandler) {
         final H1ProtocolConfig h1Config = config.h1Config();
         assert h1Config != null;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
@@ -49,7 +49,7 @@ final class PipelinedLBHttpConnectionFactory<ResolvedAddress> extends AbstractLB
 
     @Override
     Single<FilterableStreamingHttpConnection> newFilterableConnection(final ResolvedAddress resolvedAddress,
-                                                                      @Nullable final TransportObserver observer) {
+                                                                      final TransportObserver observer) {
         assert config.h1Config() != null;
         return buildStreaming(executionContext, resolvedAddress, config, observer)
                 .map(conn -> new PipelinedStreamingHttpConnection(conn, config.h1Config(), executionContext,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -28,8 +28,6 @@ import io.servicetalk.transport.netty.internal.NettyConnection;
 
 import io.netty.channel.Channel;
 
-import javax.annotation.Nullable;
-
 import static io.servicetalk.buffer.netty.BufferUtils.getByteBufAllocator;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.netty.HeaderUtils.LAST_CHUNK_PREDICATE;
@@ -43,11 +41,11 @@ final class StreamingConnectionFactory {
 
     static <ResolvedAddress> Single<? extends NettyConnection<Object, Object>> buildStreaming(
             final HttpExecutionContext executionContext, final ResolvedAddress resolvedAddress,
-            final ReadOnlyHttpClientConfig roConfig, @Nullable final TransportObserver observer) {
+            final ReadOnlyHttpClientConfig roConfig, final TransportObserver observer) {
         // We disable auto read so we can handle stuff in the ConnectionFilter before we accept any content.
         return TcpConnector.connect(null, resolvedAddress, roConfig.tcpConfig(), false, executionContext,
                 channel -> {
-                    final ConnectionObserver connectionObserver = observer == null ? null : observer.onNewConnection();
+                    final ConnectionObserver connectionObserver = observer.onNewConnection();
                     return createConnection(channel, executionContext, roConfig, new TcpClientChannelInitializer(
                             roConfig.tcpConfig(), connectionObserver, roConfig.hasProxy()), connectionObserver);
                 });
@@ -55,7 +53,7 @@ final class StreamingConnectionFactory {
 
     static Single<? extends DefaultNettyConnection<Object, Object>> createConnection(final Channel channel,
             final HttpExecutionContext executionContext, final ReadOnlyHttpClientConfig config,
-            final ChannelInitializer initializer, @Nullable final ConnectionObserver connectionObserver) {
+            final ChannelInitializer initializer, final ConnectionObserver connectionObserver) {
         final CloseHandler closeHandler = forPipelinedRequestResponse(true, channel.config());
         assert config.h1Config() != null;
         return showPipeline(DefaultNettyConnection.initChannel(channel, executionContext.bufferAllocator(),

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.netty.NettyHttpServer.NettyHttpServerConnection;
 import io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer;
+import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.IoExecutor;
 
 import io.netty.channel.ChannelHandlerContext;
@@ -125,9 +126,10 @@ public class FlushStrategyOnServerTest {
                 new DefaultHttpExecutionContext(DEFAULT_ALLOCATOR, ioExecutor, executor, param.executionStrategy);
 
         final ReadOnlyHttpServerConfig config = new HttpServerConfig().asReadOnly();
+        final ConnectionObserver connectionObserver = config.tcpConfig().transportObserver().onNewConnection();
         serverConnection = initChannel(channel, httpExecutionContext, config,
-                new TcpServerChannelInitializer(config.tcpConfig(), null), service, true, null,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER)
+                new TcpServerChannelInitializer(config.tcpConfig(), connectionObserver), service, true,
+                connectionObserver, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER)
                 .toFuture().get();
         serverConnection.process(true);
         headersFactory = DefaultHttpHeadersFactory.INSTANCE;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
@@ -257,13 +257,9 @@ public class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         verify(clientReadObserver).readComplete();
 
         if (protocol == Protocol.HTTP_2) {
-            verify(clientStreamObserver).streamClosed();
+            verify(clientStreamObserver, await()).streamClosed();
             verify(serverStreamObserver, await()).streamClosed();
         }
-
-        verifyNoMoreInteractions(
-                clientDataObserver, clientMultiplexedObserver, clientReadObserver, clientWriteObserver,
-                serverDataObserver, serverMultiplexedObserver, serverReadObserver, serverWriteObserver);
     }
 
     @Test

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyPipelinedConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyPipelinedConnectionTest.java
@@ -31,6 +31,7 @@ import io.servicetalk.transport.api.ConnectionInfo.Protocol;
 import io.servicetalk.transport.netty.internal.DefaultNettyConnection;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.NettyConnection;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
 import io.servicetalk.transport.netty.internal.WriteDemandEstimator;
 import io.servicetalk.transport.netty.internal.WriteDemandEstimators;
 
@@ -103,7 +104,8 @@ public class NettyPipelinedConnectionTest {
         final DefaultNettyConnection<Integer, Integer> connection =
                 DefaultNettyConnection.<Integer, Integer>initChannel(channel, DEFAULT_ALLOCATOR,
                 immediate(), obj -> true, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, defaultFlushStrategy(), null,
-                channel2 -> { }, defaultStrategy(), mock(Protocol.class), null).toFuture().get();
+                channel2 -> { }, defaultStrategy(), mock(Protocol.class), NoopConnectionObserver.INSTANCE)
+                        .toFuture().get();
         requester = new NettyPipelinedConnection<>(connection);
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TestServiceStreaming.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TestServiceStreaming.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-tcp-netty-internal/build.gradle
+++ b/servicetalk-tcp-netty-internal/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-tcp-netty-internal/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-tcp-netty-internal/gradle/spotbugs/test-exclusions.xml
@@ -20,4 +20,9 @@
     <Source name="~.*Test\.java"/>
     <Bug pattern="NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
   </Match>
+  <!-- False positive, verify() on mock  -->
+  <Match>
+    <Source name="~.*Test\.java"/>
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
@@ -35,7 +35,6 @@ import static io.servicetalk.transport.netty.internal.SslContextFactory.forServe
 public final class ReadOnlyTcpServerConfig
         extends AbstractReadOnlyTcpConfig<ReadOnlyServerSecurityConfig, ReadOnlyTcpServerConfig> {
 
-    @Nullable
     private final TransportObserver transportObserver;
     @Nullable
     private final SslContext sslContext;
@@ -50,7 +49,7 @@ public final class ReadOnlyTcpServerConfig
      */
     ReadOnlyTcpServerConfig(final TcpServerConfig from, final List<String> supportedAlpnProtocols) {
         super(from, !supportedAlpnProtocols.isEmpty());
-        transportObserver = from.transportObserver() == null ? null : asSafeObserver(from.transportObserver());
+        transportObserver = asSafeObserver(from.transportObserver());
         final ReadOnlyServerSecurityConfig securityConfig = from.securityConfig();
         if (from.sniConfigs() != null) {
             if (securityConfig == null) {
@@ -78,7 +77,6 @@ public final class ReadOnlyTcpServerConfig
      *
      * @return the {@link TransportObserver} if any
      */
-    @Nullable
     public TransportObserver transportObserver() {
         return transportObserver;
     }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
@@ -20,14 +20,13 @@ import io.servicetalk.transport.netty.internal.ChannelInitializer;
 import io.servicetalk.transport.netty.internal.ConnectionObserverInitializer;
 import io.servicetalk.transport.netty.internal.DeferSslHandler;
 import io.servicetalk.transport.netty.internal.IdleTimeoutInitializer;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
 import io.servicetalk.transport.netty.internal.SslClientChannelInitializer;
 import io.servicetalk.transport.netty.internal.WireLoggingInitializer;
 
 import io.netty.channel.Channel;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
-
-import javax.annotation.Nullable;
 
 /**
  * {@link ChannelInitializer} for TCP client.
@@ -43,7 +42,7 @@ public class TcpClientChannelInitializer implements ChannelInitializer {
      * @param observer {@link ConnectionObserver} to report network events.
      */
     public TcpClientChannelInitializer(final ReadOnlyTcpClientConfig config,
-                                       @Nullable final ConnectionObserver observer) {
+                                       final ConnectionObserver observer) {
         this(config, observer, false);
     }
 
@@ -55,12 +54,12 @@ public class TcpClientChannelInitializer implements ChannelInitializer {
      * @param deferSslHandler {@code true} to wrap the {@link SslHandler} in a {@link DeferSslHandler}.
      */
     public TcpClientChannelInitializer(final ReadOnlyTcpClientConfig config,
-                                       @Nullable final ConnectionObserver observer,
+                                       final ConnectionObserver observer,
                                        final boolean deferSslHandler) {
         ChannelInitializer delegate = ChannelInitializer.defaultInitializer();
 
         final SslContext sslContext = config.sslContext();
-        if (observer != null) {
+        if (observer != NoopConnectionObserver.INSTANCE) {
             delegate = delegate.andThen(new ConnectionObserverInitializer(observer,
                     sslContext != null && !deferSslHandler));
         }
@@ -72,7 +71,7 @@ public class TcpClientChannelInitializer implements ChannelInitializer {
         if (sslContext != null) {
             delegate = delegate.andThen(new SslClientChannelInitializer(sslContext,
                     config.sslHostnameVerificationAlgorithm(), config.sslHostnameVerificationHost(),
-                    config.sslHostnameVerificationPort(), deferSslHandler, observer != null));
+                    config.sslHostnameVerificationPort(), deferSslHandler));
         }
 
         final WireLoggingInitializer wireLoggingInitializer = config.wireLoggingInitializer();

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
@@ -19,12 +19,11 @@ import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
 import io.servicetalk.transport.netty.internal.ConnectionObserverInitializer;
 import io.servicetalk.transport.netty.internal.IdleTimeoutInitializer;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
 import io.servicetalk.transport.netty.internal.SslServerChannelInitializer;
 import io.servicetalk.transport.netty.internal.WireLoggingInitializer;
 
 import io.netty.channel.Channel;
-
-import javax.annotation.Nullable;
 
 /**
  * {@link ChannelInitializer} for TCP.
@@ -40,10 +39,10 @@ public class TcpServerChannelInitializer implements ChannelInitializer {
      * @param observer {@link ConnectionObserver} to report network events.
      */
     public TcpServerChannelInitializer(final ReadOnlyTcpServerConfig config,
-                                       @Nullable final ConnectionObserver observer) {
+                                       final ConnectionObserver observer) {
         ChannelInitializer delegate = ChannelInitializer.defaultInitializer();
 
-        if (observer != null) {
+        if (observer != NoopConnectionObserver.INSTANCE) {
             delegate = delegate.andThen(new ConnectionObserverInitializer(observer,
                     config.sslContext() != null || config.domainNameMapping() != null));
         }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
@@ -16,6 +16,7 @@
 package io.servicetalk.tcp.netty.internal;
 
 import io.servicetalk.transport.api.TransportObserver;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver;
 import io.servicetalk.transport.netty.internal.ReadOnlyServerSecurityConfig;
 
 import io.netty.util.NetUtil;
@@ -32,13 +33,11 @@ import static java.util.Objects.requireNonNull;
  */
 public final class TcpServerConfig extends AbstractTcpConfig<ReadOnlyServerSecurityConfig, ReadOnlyTcpServerConfig> {
 
-    @Nullable
-    private TransportObserver transportObserver;
+    private TransportObserver transportObserver = NoopTransportObserver.INSTANCE;
     @Nullable
     private Map<String, ReadOnlyServerSecurityConfig> sniConfigs;
     private int backlog = NetUtil.SOMAXCONN;
 
-    @Nullable
     TransportObserver transportObserver() {
         return transportObserver;
     }

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
@@ -29,6 +29,7 @@ import io.servicetalk.transport.netty.internal.ClientSecurityConfig;
 import io.servicetalk.transport.netty.internal.ExecutionContextRule;
 import io.servicetalk.transport.netty.internal.IoThreadFactory;
 import io.servicetalk.transport.netty.internal.NettyConnection;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver;
 import io.servicetalk.transport.netty.internal.ServerSecurityConfig;
 
 import org.junit.After;
@@ -39,7 +40,6 @@ import org.junit.rules.Timeout;
 
 import java.net.InetSocketAddress;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.transport.api.ConnectionAcceptor.ACCEPT_ALL;
@@ -113,9 +113,8 @@ public abstract class AbstractTcpServerTest {
     }
 
     // Visible for overriding.
-    @Nullable
     TransportObserver getClientTransportObserver() {
-        return null;
+        return NoopTransportObserver.INSTANCE;
     }
 
     // Visible for overriding.

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
@@ -30,8 +30,6 @@ import io.servicetalk.transport.netty.internal.ServerSecurityConfig;
 import org.mockito.Mockito;
 import org.mockito.verification.VerificationWithTimeout;
 
-import javax.annotation.Nullable;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
@@ -81,7 +79,6 @@ public class AbstractTransportObserverTest extends AbstractTcpServerTest {
         when(serverDataObserver.onNewWrite()).thenReturn(serverWriteObserver);
     }
 
-    @Nullable
     @Override
     TransportObserver getClientTransportObserver() {
         return clientTransportObserver;

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpConnectorTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpConnectorTest.java
@@ -21,6 +21,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.transport.api.ConnectionInfo.Protocol;
 import io.servicetalk.transport.netty.internal.DefaultNettyConnection;
 import io.servicetalk.transport.netty.internal.NettyConnection;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -110,7 +111,8 @@ public final class TcpConnectorTest extends AbstractTcpServerTest {
                                     ctx.fireChannelActive();
                                 }
                             });
-                        }, CLIENT_CTX.executionStrategy(), mock(Protocol.class), null)).toFuture().get();
+                        }, CLIENT_CTX.executionStrategy(), mock(Protocol.class), NoopConnectionObserver.INSTANCE))
+                .toFuture().get();
         connection.closeAsync().toFuture().get();
 
         registeredLatch.await();

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
@@ -41,12 +41,12 @@ import java.net.SocketAddress;
 import java.net.StandardSocketOptions;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import javax.annotation.Nullable;
 
 import static io.servicetalk.tcp.netty.internal.TcpProtocol.TCP;
 import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
 import static io.servicetalk.transport.netty.internal.DefaultNettyConnection.initChannel;
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assume.assumeTrue;
@@ -57,7 +57,6 @@ import static org.junit.Assume.assumeTrue;
 public final class TcpClient {
 
     private final ReadOnlyTcpClientConfig config;
-    @Nullable
     private final TransportObserver observer;
 
     /**
@@ -66,9 +65,9 @@ public final class TcpClient {
      * @param config for the client.
      * @param observer {@link TransportObserver} for the newly created connection.
      */
-    public TcpClient(TcpClientConfig config, @Nullable TransportObserver observer) {
+    public TcpClient(TcpClientConfig config, TransportObserver observer) {
         this.config = config.asReadOnly(emptyList());
-        this.observer = observer;
+        this.observer = requireNonNull(observer);
     }
 
     /**
@@ -95,7 +94,7 @@ public final class TcpClient {
     public Single<NettyConnection<Buffer, Buffer>> connect(ExecutionContext executionContext, SocketAddress address) {
         return TcpConnector.connect(null, address, config, false, executionContext,
                 channel -> {
-                    final ConnectionObserver connectionObserver = observer == null ? null : observer.onNewConnection();
+                    final ConnectionObserver connectionObserver = observer.onNewConnection();
                     return initChannel(channel,
                             executionContext.bufferAllocator(), executionContext.executor(), buffer -> false,
                             UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, config.flushStrategy(), config.idleTimeoutMs(),

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.ServerContext;
-import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.BufferHandler;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
 import io.servicetalk.transport.netty.internal.DefaultNettyConnection;
@@ -85,11 +84,9 @@ public class TcpServer {
                               Function<NettyConnection<Buffer, Buffer>, Completable> service,
                               ExecutionStrategy executionStrategy)
             throws ExecutionException, InterruptedException {
-        return TcpServerBinder.bind(localAddress(port), config, false,
-                executionContext, connectionAcceptor,
+        return TcpServerBinder.bind(localAddress(port), config, false, executionContext, connectionAcceptor,
                 channel -> {
-                    final TransportObserver observer = config.transportObserver();
-                    final ConnectionObserver connectionObserver = observer == null ? null : observer.onNewConnection();
+                    final ConnectionObserver connectionObserver = config.transportObserver().onNewConnection();
                     return DefaultNettyConnection.<Buffer, Buffer>initChannel(channel,
                             executionContext.bufferAllocator(), executionContext.executor(), buffer -> false,
                             UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, config.flushStrategy(), config.idleTimeoutMs(),

--- a/servicetalk-transport-api/build.gradle
+++ b/servicetalk-transport-api/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -640,7 +640,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
                 connection.nettyChannelPublisher.channelInboundClosed();
             } else if (evt instanceof SslHandshakeCompletionEvent) {
                 connection.sslSession = extractSslSessionAndReport(ctx.pipeline(), (SslHandshakeCompletionEvent) evt,
-                        this::tryFailSubscriber);
+                        this::tryFailSubscriber, observer != NoopConnectionObserver.INSTANCE);
                 if (subscriber != null) {
                     assert waitForSslHandshake;
                     completeSubscriber();

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -640,7 +640,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
                 connection.nettyChannelPublisher.channelInboundClosed();
             } else if (evt instanceof SslHandshakeCompletionEvent) {
                 connection.sslSession = extractSslSessionAndReport(ctx.pipeline(), (SslHandshakeCompletionEvent) evt,
-                        this::tryFailSubscriber, observer != NoopConnectionObserver.INSTANCE);
+                        this::tryFailSubscriber);
                 if (subscriber != null) {
                     assert waitForSslHandshake;
                     completeSubscriber();

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DeferSslHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DeferSslHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,12 +29,10 @@ import io.netty.handler.ssl.SslHandler;
 public class DeferSslHandler extends ChannelDuplexHandler {
     private final Channel channel;
     private final SslHandler handler;
-    private final boolean shouldReport;
 
-    DeferSslHandler(final Channel channel, final SslHandler handler, boolean shouldReport) {
+    DeferSslHandler(final Channel channel, final SslHandler handler) {
         this.channel = channel;
         this.handler = handler;
-        this.shouldReport = shouldReport;
     }
 
     /**
@@ -42,11 +40,9 @@ public class DeferSslHandler extends ChannelDuplexHandler {
      */
     public void ready() {
         final ChannelPipeline pipeline = channel.pipeline();
-        if (shouldReport) {
-            final ConnectionObserverHandler handler = pipeline.get(ConnectionObserverHandler.class);
-            if (handler != null) {
-                handler.reportSecurityHandshakeStarting();
-            }
+        final ConnectionObserverHandler observerHandler = pipeline.get(ConnectionObserverHandler.class);
+        if (observerHandler != null) {
+            observerHandler.reportSecurityHandshakeStarting();
         }
         pipeline.replace(this, null, handler);
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyPipelineSslUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyPipelineSslUtils.java
@@ -52,29 +52,13 @@ public final class NettyPipelineSslUtils {
      * @param pipeline the {@link ChannelPipeline} which contains handler containing the {@link SSLSession}.
      * @param sslEvent the event indicating a SSL/TLS handshake completed.
      * @param failureConsumer invoked if a failure is encountered.
-     * @param shouldReport {@code true} if the handshake status should be reported to {@link SecurityHandshakeObserver}.
      * @return The {@link SSLSession} or {@code null} if none can be found.
      */
     @Nullable
     public static SSLSession extractSslSessionAndReport(ChannelPipeline pipeline,
                                                         SslHandshakeCompletionEvent sslEvent,
-                                                        Consumer<Throwable> failureConsumer,
-                                                        boolean shouldReport) {
-        final SecurityHandshakeObserver observer;
-        if (shouldReport) {
-            try {
-                observer = handshakeObserver(pipeline);
-            } catch (Exception e) {
-                if (!sslEvent.isSuccess()) {
-                    e.addSuppressed(sslEvent.cause());
-                }
-                deliverFailureCause(failureConsumer, e, null);
-                return null;
-            }
-        } else {
-            observer = null;
-        }
-
+                                                        Consumer<Throwable> failureConsumer) {
+        final SecurityHandshakeObserver observer = handshakeObserver(pipeline);
         if (sslEvent.isSuccess()) {
             final SslHandler sslHandler = pipeline.get(SslHandler.class);
             if (sslHandler != null) {
@@ -101,15 +85,12 @@ public final class NettyPipelineSslUtils {
         failureConsumer.accept(cause);
     }
 
+    @Nullable
     private static SecurityHandshakeObserver handshakeObserver(final ChannelPipeline pipeline) {
         final ConnectionObserverHandler handler = pipeline.get(ConnectionObserverHandler.class);
         if (handler == null) {
-            throw new IllegalStateException("Unable to find " + ConnectionObserverHandler.class + " in the pipeline.");
+            return null;
         }
-        final SecurityHandshakeObserver handshakeObserver = handler.handshakeObserver();
-        if (handshakeObserver == null) {
-            throw new IllegalStateException("Unable to find " + SecurityHandshakeObserver.class);
-        }
-        return handshakeObserver;
+        return handler.handshakeObserver();
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.servicetalk.transport.api.ConnectionInfo;
+import io.servicetalk.transport.api.ConnectionObserver;
+import io.servicetalk.transport.api.ConnectionObserver.DataObserver;
+import io.servicetalk.transport.api.ConnectionObserver.MultiplexedObserver;
+import io.servicetalk.transport.api.ConnectionObserver.ReadObserver;
+import io.servicetalk.transport.api.ConnectionObserver.SecurityHandshakeObserver;
+import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
+import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
+import io.servicetalk.transport.api.TransportObserver;
+
+import javax.net.ssl.SSLSession;
+
+/**
+ * Noop version of {@link TransportObserver}.
+ */
+public final class NoopTransportObserver implements TransportObserver {
+
+    public static final TransportObserver INSTANCE = new NoopTransportObserver();
+
+    private NoopTransportObserver() {
+        // Singleton
+    }
+
+    @Override
+    public ConnectionObserver onNewConnection() {
+        return NoopConnectionObserver.INSTANCE;
+    }
+
+    /**
+     * Noop version of {@link ConnectionObserver}.
+     */
+    public static final class NoopConnectionObserver implements ConnectionObserver {
+
+        public static final ConnectionObserver INSTANCE = new NoopConnectionObserver();
+
+        private NoopConnectionObserver() {
+            // Singleton
+        }
+
+        @Override
+        public void onDataRead(final int size) {
+        }
+
+        @Override
+        public void onDataWrite(final int size) {
+        }
+
+        @Override
+        public void onFlush() {
+        }
+
+        @Override
+        public SecurityHandshakeObserver onSecurityHandshake() {
+            return NoopSecurityHandshakeObserver.INSTANCE;
+        }
+
+        @Override
+        public DataObserver connectionEstablished(final ConnectionInfo info) {
+            return NoopDataObserver.INSTANCE;
+        }
+
+        @Override
+        public MultiplexedObserver multiplexedConnectionEstablished(final ConnectionInfo info) {
+            return NoopMultiplexedObserver.INSTANCE;
+        }
+
+        @Override
+        public void connectionClosed(final Throwable error) {
+        }
+
+        @Override
+        public void connectionClosed() {
+        }
+    }
+
+    /**
+     * Noop version of {@link SecurityHandshakeObserver}.
+     */
+    public static final class NoopSecurityHandshakeObserver implements SecurityHandshakeObserver {
+
+        public static final SecurityHandshakeObserver INSTANCE = new NoopSecurityHandshakeObserver();
+
+        private NoopSecurityHandshakeObserver() {
+            // Singleton
+        }
+
+        @Override
+        public void handshakeFailed(final Throwable cause) {
+        }
+
+        @Override
+        public void handshakeComplete(final SSLSession sslSession) {
+        }
+    }
+
+    /**
+     * Noop version of {@link DataObserver}.
+     */
+    public static final class NoopDataObserver implements DataObserver {
+
+        public static final DataObserver INSTANCE = new NoopDataObserver();
+
+        private NoopDataObserver() {
+            // Singleton
+        }
+
+        @Override
+        public ReadObserver onNewRead() {
+            return NoopReadObserver.INSTANCE;
+        }
+
+        @Override
+        public WriteObserver onNewWrite() {
+            return NoopWriteObserver.INSTANCE;
+        }
+    }
+
+    /**
+     * Noop version of {@link MultiplexedObserver}.
+     */
+    public static final class NoopMultiplexedObserver implements MultiplexedObserver {
+
+        public static final MultiplexedObserver INSTANCE = new NoopMultiplexedObserver();
+
+        private NoopMultiplexedObserver() {
+            // Singleton
+        }
+
+        @Override
+        public StreamObserver onNewStream() {
+            return NoopStreamObserver.INSTANCE;
+        }
+    }
+
+    /**
+     * Noop version of {@link StreamObserver}.
+     */
+    public static final class NoopStreamObserver implements StreamObserver {
+
+        public static final StreamObserver INSTANCE = new NoopStreamObserver();
+
+        private NoopStreamObserver() {
+            // Singleton
+        }
+
+        @Override
+        public DataObserver streamEstablished() {
+            return NoopDataObserver.INSTANCE;
+        }
+
+        @Override
+        public void streamClosed(final Throwable error) {
+        }
+
+        @Override
+        public void streamClosed() {
+        }
+    }
+
+    /**
+     * Noop version of {@link ReadObserver}.
+     */
+    public static final class NoopReadObserver implements ReadObserver {
+
+        public static final ReadObserver INSTANCE = new NoopReadObserver();
+
+        private NoopReadObserver() {
+            // Singleton
+        }
+
+        @Override
+        public void requestedToRead(final long n) {
+        }
+
+        @Override
+        public void itemRead() {
+        }
+
+        @Override
+        public void readFailed(final Throwable cause) {
+        }
+
+        @Override
+        public void readComplete() {
+        }
+
+        @Override
+        public void readCancelled() {
+        }
+    }
+
+    /**
+     * Noop version of {@link WriteObserver}.
+     */
+    public static final class NoopWriteObserver implements WriteObserver {
+
+        public static final WriteObserver INSTANCE = new NoopWriteObserver();
+
+        private NoopWriteObserver() {
+            // Singleton
+        }
+
+        @Override
+        public void requestedToWrite(final long n) {
+        }
+
+        @Override
+        public void itemReceived() {
+        }
+
+        @Override
+        public void onFlushRequest() {
+        }
+
+        @Override
+        public void itemWritten() {
+        }
+
+        @Override
+        public void writeFailed(final Throwable cause) {
+        }
+
+        @Override
+        public void writeComplete() {
+        }
+
+        @Override
+        public void writeCancelled() {
+        }
+    }
+}

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslClientChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslClientChannelInitializer.java
@@ -37,7 +37,6 @@ public class SslClientChannelInitializer implements ChannelInitializer {
     private final int hostnameVerificationPort;
     private final SslContext sslContext;
     private final boolean deferSslHandler;
-    private final boolean shouldReport;
 
     /**
      * New instance.
@@ -46,24 +45,21 @@ public class SslClientChannelInitializer implements ChannelInitializer {
      * @param hostnameVerificationHost the non-authoritative name of the host.
      * @param hostnameVerificationPort the non-authoritative port.
      * @param deferSslHandler {@code true} to wrap the {@link SslHandler} in a {@link DeferSslHandler}.
-     * @param shouldReport {@code true} to report security handshake start when {@link DeferSslHandler} is ready.
      */
     public SslClientChannelInitializer(SslContext sslContext, @Nullable String hostnameVerificationAlgorithm,
                                        @Nullable String hostnameVerificationHost, int hostnameVerificationPort,
-                                       final boolean deferSslHandler, final boolean shouldReport) {
+                                       final boolean deferSslHandler) {
         this.sslContext = requireNonNull(sslContext);
         this.hostnameVerificationAlgorithm = hostnameVerificationAlgorithm;
         this.hostnameVerificationHost = hostnameVerificationHost;
         this.hostnameVerificationPort = hostnameVerificationPort;
         this.deferSslHandler = deferSslHandler;
-        this.shouldReport = shouldReport;
     }
 
     @Override
     public void init(Channel channel) {
         final SslHandler sslHandler = newHandler(sslContext, POOLED_ALLOCATOR,
                 hostnameVerificationAlgorithm, hostnameVerificationHost, hostnameVerificationPort);
-        channel.pipeline().addLast(deferSslHandler ? new DeferSslHandler(channel, sslHandler, shouldReport) :
-                sslHandler);
+        channel.pipeline().addLast(deferSslHandler ? new DeferSslHandler(channel, sslHandler) : sslHandler);
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -109,7 +109,7 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
     private final CloseHandler closeHandler;
 
     WriteStreamSubscriber(Channel channel, WriteDemandEstimator demandEstimator, Subscriber subscriber,
-                          CloseHandler closeHandler, @Nullable WriteObserver observer) {
+                          CloseHandler closeHandler, WriteObserver observer) {
         this.eventLoop = requireNonNull(channel.eventLoop());
         this.subscriber = subscriber;
         this.channel = channel;
@@ -276,10 +276,9 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
          * We assume that no listener for a write is added after that write is completed (a.k.a late listeners).
          */
         private final Deque<GenericFutureListener<?>> listenersOnWriteBoundaries = new ArrayDeque<>();
-        @Nullable
         private final WriteObserver observer;
 
-        AllWritesPromise(final Channel channel, @Nullable WriteObserver observer) {
+        AllWritesPromise(final Channel channel, WriteObserver observer) {
             super(channel);
             this.observer = observer;
         }
@@ -415,9 +414,7 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
             if (hasFlag(SUBSCRIBER_TERMINATED)) {
                 return nettySharedPromiseTryStatus();
             }
-            if (observer != null) {
-                observer.itemWritten();
-            }
+            observer.itemWritten();
             if (--activeWrites == 0 && hasFlag(SOURCE_TERMINATED)) {
                 setFlag(SUBSCRIBER_TERMINATED);
                 try {
@@ -469,9 +466,7 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
             notifyAllListeners(cause);
             if (cause == null) {
                 try {
-                    if (observer != null) {
-                        observer.writeComplete();
-                    }
+                    observer.writeComplete();
                     subscriber.onComplete();
                 } catch (Throwable t) {
                     tryFailureOrLog(t);
@@ -481,9 +476,7 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
                 }
             } else {
                 try {
-                    if (observer != null) {
-                        observer.writeFailed(cause);
-                    }
+                    observer.writeFailed(cause);
                     assignConnectionError(channel, cause);
                     subscriber.onError(cause);
                 } catch (Throwable t) {

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractFlushTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractFlushTest.java
@@ -16,6 +16,7 @@
 package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopWriteObserver;
 
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
@@ -37,7 +38,7 @@ abstract class AbstractFlushTest {
         EventLoop eventLoop = mock(EventLoop.class);
         when(eventLoop.inEventLoop()).thenReturn(true);
         when(channel.eventLoop()).thenReturn(eventLoop);
-        Publisher<String> flushedStream = composeFlushes(channel, source, strategy, null)
+        Publisher<String> flushedStream = composeFlushes(channel, source, strategy, NoopWriteObserver.INSTANCE)
                 .beforeOnNext(s -> channel.write(s));
         verifier = inOrder(channel);
         return flushedStream;

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
@@ -25,6 +25,7 @@ import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestPublisherSubscriber;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.transport.api.ConnectionInfo.Protocol;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundBuffer;
@@ -115,7 +116,7 @@ public class DefaultNettyConnectionTest {
                     return true;
                 },
                 closeHandler, defaultFlushStrategy(), null, trailerProtocolEndEventEmitter(), OFFLOAD_ALL_STRATEGY,
-                mock(Protocol.class), null).toFuture().get();
+                mock(Protocol.class), NoopConnectionObserver.INSTANCE).toFuture().get();
         publisher = new TestPublisher<>();
     }
 

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/FlushOutsideEventloopTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/FlushOutsideEventloopTest.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestPublisherSubscriber;
 import io.servicetalk.transport.netty.internal.FlushStrategy.FlushSender;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopWriteObserver;
 
 import io.netty.channel.EventLoop;
 import org.junit.Test;
@@ -40,7 +41,7 @@ public class FlushOutsideEventloopTest extends AbstractOutOfEventloopTest {
     public void setup0() {
         src = new TestPublisher<>();
         strategy = new MockFlushStrategy();
-        Publisher<Integer> composedFlush = composeFlushes(channel, src, strategy, null)
+        Publisher<Integer> composedFlush = composeFlushes(channel, src, strategy, NoopWriteObserver.INSTANCE)
                 .beforeOnNext(integer -> channel.write(integer));
         toSource(composedFlush).subscribe(subscriber);
         subscriber.request(Long.MAX_VALUE);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherRefCountTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherRefCountTest.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TestPublisherSubscriber;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.transport.api.ConnectionInfo.Protocol;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -55,7 +56,7 @@ public class NettyChannelPublisherRefCountTest {
         channel = new EmbeddedChannel();
         publisher = DefaultNettyConnection.initChannel(channel, DEFAULT_ALLOCATOR, immediate(), x -> false,
                 UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, defaultFlushStrategy(), null, channel2 -> { },
-                OFFLOAD_ALL_STRATEGY, mock(Protocol.class), null).toFuture().get().read();
+                OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE).toFuture().get().read();
     }
 
     @After

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherTest.java
@@ -25,6 +25,7 @@ import io.servicetalk.concurrent.api.TestPublisherSubscriber;
 import io.servicetalk.concurrent.internal.DuplicateSubscribeException;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.transport.api.ConnectionInfo.Protocol;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
 
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -102,7 +103,7 @@ public class NettyChannelPublisherTest {
                     readRequested = true;
                     super.read(ctx);
                 }
-            }), OFFLOAD_ALL_STRATEGY, mock(Protocol.class), null).toFuture().get();
+            }), OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE).toFuture().get();
         publisher = connection.read();
         channel.config().setAutoRead(false);
     }
@@ -150,7 +151,7 @@ public class NettyChannelPublisherTest {
                             super.read(ctx);
                         }
                     });
-                }, OFFLOAD_ALL_STRATEGY, mock(Protocol.class), null).toFuture().get();
+                }, OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE).toFuture().get();
         publisher = connection.read();
         channel.config().setAutoRead(false);
     }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberFutureListenersTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberFutureListenersTest.java
@@ -18,6 +18,7 @@ package io.servicetalk.transport.netty.internal;
 import io.servicetalk.concurrent.api.TestCompletableSubscriber;
 import io.servicetalk.concurrent.api.TestSubscription;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopWriteObserver;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -73,7 +74,7 @@ public class WriteStreamSubscriberFutureListenersTest {
         WriteDemandEstimator estimator = WriteDemandEstimators.newDefaultEstimator();
         TestCompletableSubscriber completableSubscriber = new TestCompletableSubscriber();
         subscriber = new WriteStreamSubscriber(channel, estimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, null);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE);
         TestSubscription subscription = new TestSubscription();
         subscriber.onSubscribe(subscription);
         assertThat("No items requested.", subscription.requested(), greaterThan(0L));
@@ -177,7 +178,7 @@ public class WriteStreamSubscriberFutureListenersTest {
         WriteDemandEstimator estimator = WriteDemandEstimators.newDefaultEstimator();
         TestCompletableSubscriber completableSubscriber = new TestCompletableSubscriber();
         WriteStreamSubscriber subscriber = new WriteStreamSubscriber(mockChannel, estimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, null);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE);
         subscriber.onNext(1);
         verifyListenerInvokedWithSuccess(listeners.take());
         subscriber.onNext(2);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberOutOfEventloopTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberOutOfEventloopTest.java
@@ -18,6 +18,7 @@ package io.servicetalk.transport.netty.internal;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.CompletableSource.Processor;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopWriteObserver;
 
 import io.netty.channel.EventLoop;
 import org.junit.Test;
@@ -44,7 +45,7 @@ public class WriteStreamSubscriberOutOfEventloopTest extends AbstractOutOfEventl
         CompletableSource.Subscriber completableSubscriber = mock(CompletableSource.Subscriber.class);
         WriteDemandEstimator demandEstimator = mock(WriteDemandEstimator.class);
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, null);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE);
     }
 
     @Test
@@ -102,7 +103,7 @@ public class WriteStreamSubscriberOutOfEventloopTest extends AbstractOutOfEventl
         };
         WriteDemandEstimator demandEstimator = mock(WriteDemandEstimator.class);
         this.subscriber = new WriteStreamSubscriber(channel, demandEstimator, subscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, null);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE);
 
         this.subscriber.onNext(1);
         this.subscriber.onError(DELIBERATE_EXCEPTION);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberTest.java
@@ -16,6 +16,7 @@
 package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.PublisherSource.Subscription;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopWriteObserver;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -48,7 +49,8 @@ public class WriteStreamSubscriberTest extends AbstractWriteTest {
     public void setUp() throws Exception {
         super.setUp();
         closeHandler = mock(CloseHandler.class);
-        subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber, closeHandler, null);
+        subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber, closeHandler,
+                NoopWriteObserver.INSTANCE);
         subscription = mock(Subscription.class);
         when(demandEstimator.estimateRequestN(anyLong())).thenReturn(1L);
         subscriber.onSubscribe(subscription);
@@ -103,7 +105,7 @@ public class WriteStreamSubscriberTest extends AbstractWriteTest {
     @Test
     public void testCancelBeforeOnSubscribe() {
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, null);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE);
         subscription = mock(Subscription.class);
         subscriber.cancel();
         subscriber.onSubscribe(subscription);
@@ -122,7 +124,7 @@ public class WriteStreamSubscriberTest extends AbstractWriteTest {
     public void testRequestMoreBeforeOnSubscribe() {
         reset(completableSubscriber);
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, null);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE);
         subscriber.channelWritable();
         subscription = mock(Subscription.class);
         subscriber.onSubscribe(subscription);


### PR DESCRIPTION
Motivation:

`@Nullable` fields make the internal control flow more complex,
as we always have to checks for `null` before using the field.

Modifications:

- Use NOOP implementation of observers instead of handling `null`
everywhere;

Result:

Simplified internal control flow.