### PR TITLE
Provide a public factory for `BiTransportObserver`

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/TransportObserverConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/TransportObserverConnectionFactoryFilter.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Single.failed;
+import static io.servicetalk.transport.api.TransportObservers.biTransportObserver;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -71,7 +72,7 @@ public final class TransportObserverConnectionFactoryFilter<ResolvedAddress, C e
                     return failed(t);
                 }
                 return delegate().newConnection(resolvedAddress, originalObserver == null ? newObserver :
-                       newObserver == null ? originalObserver : new BiTransportObserver(originalObserver, newObserver));
+                       newObserver == null ? originalObserver : biTransportObserver(originalObserver, newObserver));
             }
         };
     }

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/TransportObserverConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/TransportObserverConnectionFactoryFilter.java
@@ -23,7 +23,7 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Single.failed;
-import static io.servicetalk.transport.api.TransportObservers.biTransportObserver;
+import static io.servicetalk.transport.api.TransportObservers.combine;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -72,7 +72,7 @@ public final class TransportObserverConnectionFactoryFilter<ResolvedAddress, C e
                     return failed(t);
                 }
                 return delegate().newConnection(resolvedAddress, originalObserver == null ? newObserver :
-                       newObserver == null ? originalObserver : biTransportObserver(originalObserver, newObserver));
+                       newObserver == null ? originalObserver : combine(originalObserver, newObserver));
             }
         };
     }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
@@ -13,39 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.client.api;
+package io.servicetalk.transport.api;
 
-import io.servicetalk.transport.api.ConnectionInfo;
-import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ConnectionObserver.DataObserver;
 import io.servicetalk.transport.api.ConnectionObserver.MultiplexedObserver;
 import io.servicetalk.transport.api.ConnectionObserver.ReadObserver;
 import io.servicetalk.transport.api.ConnectionObserver.SecurityHandshakeObserver;
 import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
 import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
-import io.servicetalk.transport.api.TransportObserver;
 
 import javax.net.ssl.SSLSession;
 
-import static java.util.Objects.requireNonNull;
+import static io.servicetalk.transport.api.TransportObservers.asSafeObserver;
 
-/**
- * Combines two {@link TransportObserver}s into a single {@link TransportObserver}.
- */
 final class BiTransportObserver implements TransportObserver {
 
     private final TransportObserver first;
     private final TransportObserver second;
 
-    /**
-     * Creates a new instance.
-     *
-     * @param first the {@link TransportObserver} that will receive events first
-     * @param second the {@link TransportObserver} that will receive events second
-     */
     BiTransportObserver(final TransportObserver first, final TransportObserver second) {
-        this.first = requireNonNull(first);
-        this.second = requireNonNull(second);
+        this.first = asSafeObserver(first);
+        this.second = asSafeObserver(second);
     }
 
     @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportObservers.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportObservers.java
@@ -38,4 +38,16 @@ public final class TransportObservers {
         }
         return new CatchAllTransportObserver(observer);
     }
+
+    /**
+     * Combines two {@link TransportObserver}s into a single {@link TransportObserver}.
+     *
+     * @param first the {@link TransportObserver} that will receive events first
+     * @param second the {@link TransportObserver} that will receive events second
+     * @return a {@link TransportObserver} that delegates all invocations to the {@code first} and {@code second}
+     * {@link TransportObserver}s
+     */
+    public static TransportObserver biTransportObserver(final TransportObserver first, final TransportObserver second) {
+        return new BiTransportObserver(first, second);
+    }
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportObservers.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportObservers.java
@@ -36,18 +36,27 @@ public final class TransportObservers {
         if (observer instanceof CatchAllTransportObserver) {
             return observer;
         }
+        if (observer instanceof BiTransportObserver) {
+            // BiTransportObserver is always safe
+            return observer;
+        }
         return new CatchAllTransportObserver(observer);
     }
 
     /**
-     * Combines two {@link TransportObserver}s into a single {@link TransportObserver}.
+     * Combines multiple {@link TransportObserver}s into a single {@link TransportObserver}.
      *
      * @param first the {@link TransportObserver} that will receive events first
      * @param second the {@link TransportObserver} that will receive events second
-     * @return a {@link TransportObserver} that delegates all invocations to the {@code first} and {@code second}
-     * {@link TransportObserver}s
+     * @param others additional {@link TransportObserver}s that will receive events
+     * @return a {@link TransportObserver} that delegates all invocations to the provided {@link TransportObserver}s
      */
-    public static TransportObserver biTransportObserver(final TransportObserver first, final TransportObserver second) {
-        return new BiTransportObserver(first, second);
+    public static TransportObserver combine(final TransportObserver first, final TransportObserver second,
+                                            final TransportObserver... others) {
+        BiTransportObserver bi = new BiTransportObserver(first, second);
+        for (TransportObserver other : others) {
+            bi = new BiTransportObserver(bi, other);
+        }
+        return bi;
     }
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportObservers.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportObservers.java
@@ -15,6 +15,8 @@
  */
 package io.servicetalk.transport.api;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * A factory to create different {@link TransportObserver}s.
  */
@@ -46,17 +48,21 @@ public final class TransportObservers {
     /**
      * Combines multiple {@link TransportObserver}s into a single {@link TransportObserver}.
      *
-     * @param first the {@link TransportObserver} that will receive events first
-     * @param second the {@link TransportObserver} that will receive events second
-     * @param others additional {@link TransportObserver}s that will receive events
+     * @param other {@link TransportObserver}s to combine
      * @return a {@link TransportObserver} that delegates all invocations to the provided {@link TransportObserver}s
      */
-    public static TransportObserver combine(final TransportObserver first, final TransportObserver second,
-                                            final TransportObserver... others) {
-        BiTransportObserver bi = new BiTransportObserver(first, second);
-        for (TransportObserver other : others) {
-            bi = new BiTransportObserver(bi, other);
+    public static TransportObserver combine(final TransportObserver... other) {
+        switch (other.length) {
+            case 0:
+                throw new IllegalArgumentException("At least one TransportObserver is required to combine");
+            case 1:
+                return requireNonNull(other[0]);
+            default:
+                BiTransportObserver bi = new BiTransportObserver(other[0], other[1]);
+                for (int i = 2; i < other.length; i++) {
+                    bi = new BiTransportObserver(bi, other[i]);
+                }
+                return bi;
         }
-        return bi;
     }
 }


### PR DESCRIPTION
Motivation:

Users who need to report events to two `TransportObserver`s simultaneously
on the server-side or who need their own variant of
`TransportObserverConnectionFactoryFilter` will find it useful.

Modifications:

- Move `BiTransportObserver` from `client-api` to `transport-api`;
- Convert passes first and second observers into safe observers;
- Add public `TransportObservers.biTransportObserver` factory;

Result:

Users can easily report events to two `TransportObserver`s.