### PR TITLE
Fix flaky test in `HttpTransportObserverTest`

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
@@ -305,8 +305,8 @@ public class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         if (serverReadCompletes) {
             verify(serverReadObserver).readComplete();
         } else {
-            // FIXME: because nobody subscribes to the request payload publisher, the cancel signal is not delivered
-            // verify(serverReadObserver).readCancelled();
+            verify(serverReadObserver, atMostOnce()).readCancelled();
+            verify(serverReadObserver, atMostOnce()).readFailed(any(Throwable.class));
         }
 
         verify(serverWriteObserver, atLeastOnce()).requestedToWrite(anyLong());


### PR DESCRIPTION
Motivation:

`HttpTransportObserverTest.serverFailsResponsePayloadBodyBeforeRead[protocol=HTTP_2]]`
may fail because `serverReadObserver` may emit `readFailed` event.

Modification:

- Verify that either `readCancelled` or `readFailed` events are expected on
`serverReadObserver`;

Result:

Test is not flaky anymore.

---

Seen:
1. https://ci.servicetalk.io/job/servicetalk-java11-prb/1499/testReport/io.servicetalk.http.netty/HttpTransportObserverTest/serverFailsResponsePayloadBodyBeforeRead_protocol_HTTP_2_/
2. https://ci.servicetalk.io/job/servicetalk-java11-prb/1498/testReport/junit/io.servicetalk.http.netty/HttpTransportObserverTest/serverFailsResponsePayloadBodyBeforeRead_protocol_HTTP_2_/