### PR TITLE
Simplify ServiceDiscoverer generics in client builders

### DIFF
--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/DefaultPartitionedClientGroup.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/DefaultPartitionedClientGroup.java
@@ -48,6 +48,7 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverCompleteFromSource;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
 
 /**
  * An implementation of {@link ClientGroup} that can be used for partitioned client use-cases where {@link
@@ -182,7 +183,7 @@ public final class DefaultPartitionedClientGroup<U, R, Client extends Listenable
                     }
                     return acceptEvent;
                 }
-            }).beforeFinally(partition::closeNow).map(psde -> psde);
+            }).beforeFinally(partition::closeNow).map(identity());
         }
 
         @Override

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/DefaultPartitionedClientGroup.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/DefaultPartitionedClientGroup.java
@@ -98,7 +98,7 @@ public final class DefaultPartitionedClientGroup<U, R, Client extends Listenable
                                          final Function<PartitionAttributes, Client> unknownPartitionClient,
                                          final PartitionedClientFactory<U, R, Client> clientFactory,
                                          final PartitionMapFactory partitionMapFactory,
-                                         final Publisher<? extends PartitionedServiceDiscovererEvent<R>> psdEvents,
+                                         final Publisher<PartitionedServiceDiscovererEvent<R>> psdEvents,
                                          final int psdMaxQueueSize) {
 
         this.unknownPartitionClient = unknownPartitionClient;

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -87,7 +87,7 @@ public abstract class GrpcClientBuilder<U, R>
 
     @Override
     public abstract GrpcClientBuilder<U, R> serviceDiscoverer(
-            ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer);
+            ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer);
 
     @Override
     public abstract GrpcClientBuilder<U, R> loadBalancerFactory(HttpLoadBalancerFactory<R> loadBalancerFactory);

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/SingleAddressGrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/SingleAddressGrpcClientBuilder.java
@@ -116,8 +116,7 @@ interface SingleAddressGrpcClientBuilder<U, R,
      * this {@link ServiceDiscoverer} is no longer needed.
      * @return {@code this}.
      */
-    SingleAddressGrpcClientBuilder<U, R, SDE> serviceDiscoverer(
-            ServiceDiscoverer<U, R, ? extends SDE> serviceDiscoverer);
+    SingleAddressGrpcClientBuilder<U, R, SDE> serviceDiscoverer(ServiceDiscoverer<U, R, SDE> serviceDiscoverer);
 
     /**
      * Set a {@link HttpLoadBalancerFactory} to create {@link LoadBalancer} instances.

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
@@ -119,7 +119,7 @@ final class DefaultGrpcClientBuilder<U, R> extends GrpcClientBuilder<U, R> {
 
     @Override
     public GrpcClientBuilder<U, R> serviceDiscoverer(
-            final ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer) {
+            final ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer) {
         httpClientBuilder.serviceDiscoverer(serviceDiscoverer);
         return this;
     }

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcClients.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcClients.java
@@ -115,8 +115,8 @@ public final class GrpcClients {
      * @return new builder with provided configuration
      */
     public static <U, R>
-    GrpcClientBuilder<U, R> forAddress(
-            final ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer, final U address) {
+    GrpcClientBuilder<U, R> forAddress(final ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer,
+                                       final U address) {
         return new DefaultGrpcClientBuilder<>(HttpClients.forSingleAddress(serviceDiscoverer, address));
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseSingleAddressHttpClientBuilder.java
@@ -81,7 +81,7 @@ abstract class BaseSingleAddressHttpClientBuilder<U, R, SDE extends ServiceDisco
 
     @Override
     public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> serviceDiscoverer(
-            ServiceDiscoverer<U, R, ? extends SDE> serviceDiscoverer);
+            ServiceDiscoverer<U, R, SDE> serviceDiscoverer);
 
     @Override
     public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> retryServiceDiscoveryErrors(

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategy.java
@@ -63,7 +63,7 @@ public final class DefaultServiceDiscoveryRetryStrategy<ResolvedAddress,
     }
 
     @Override
-    public Publisher<? extends E> apply(final Publisher<? extends E> sdEvents) {
+    public Publisher<E> apply(final Publisher<E> sdEvents) {
         return defer(() -> {
             EventsCache<ResolvedAddress, E> eventsCache =
                     new EventsCache<>(retainTillReceivePercentage, flipAvailability);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
@@ -181,7 +181,7 @@ abstract class HttpClientBuilder<U, R, SDE extends ServiceDiscovererEvent<R>> ex
      * @return {@code this}.
      */
     public abstract HttpClientBuilder<U, R, SDE> serviceDiscoverer(
-            ServiceDiscoverer<U, R, ? extends SDE> serviceDiscoverer);
+            ServiceDiscoverer<U, R, SDE> serviceDiscoverer);
 
     /**
      * Sets a retry strategy to retry errors emitted by {@link ServiceDiscoverer}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -95,7 +95,7 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
 
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> serviceDiscoverer(
-            ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer);
+            ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer);
 
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> retryServiceDiscoveryErrors(

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
@@ -86,7 +86,7 @@ public abstract class PartitionedHttpClientBuilder<U, R>
 
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> serviceDiscoverer(
-            ServiceDiscoverer<U, R, ? extends PartitionedServiceDiscovererEvent<R>> serviceDiscoverer);
+            ServiceDiscoverer<U, R, PartitionedServiceDiscovererEvent<R>> serviceDiscoverer);
 
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> retryServiceDiscoveryErrors(

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ServiceDiscoveryRetryStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ServiceDiscoveryRetryStrategy.java
@@ -34,5 +34,5 @@ public interface ServiceDiscoveryRetryStrategy<ResolvedAddress, E extends Servic
      * @param sdEvents {@link Publisher} of {@link ServiceDiscovererEvent} on which this strategy is to be applied.
      * @return {@link Publisher} after applying this retry strategy on the passed {@code sdEvents} {@link Publisher}.
      */
-    Publisher<? extends E> apply(Publisher<? extends E> sdEvents);
+    Publisher<E> apply(Publisher<E> sdEvents);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -80,7 +80,7 @@ public abstract class SingleAddressHttpClientBuilder<U, R>
 
     @Override
     public abstract SingleAddressHttpClientBuilder<U, R> serviceDiscoverer(
-            ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer);
+            ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer);
 
     @Override
     public abstract SingleAddressHttpClientBuilder<U, R> retryServiceDiscoveryErrors(

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -440,8 +440,7 @@ final class DefaultMultiAddressUrlHttpClientBuilder
 
     @Override
     public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> serviceDiscoverer(
-            final ServiceDiscoverer<HostAndPort, InetSocketAddress,
-                    ? extends ServiceDiscovererEvent<InetSocketAddress>> sd) {
+            final ServiceDiscoverer<HostAndPort, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>> sd) {
         builderTemplate.serviceDiscoverer(sd);
         return this;
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -253,8 +253,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
         final CompositeCloseable closeOnException = newCompositeCloseable();
         try {
 
-            final Publisher<? extends ServiceDiscovererEvent<R>> sdEvents =
-                    ctx.serviceDiscoverer.discover(ctx.address());
+            final Publisher<ServiceDiscovererEvent<R>> sdEvents = ctx.serviceDiscoverer.discover(ctx.address());
 
             final StreamingHttpRequestResponseFactory reqRespFactory = ctx.reqRespFactory;
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PartitionedHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PartitionedHttpClientTest.java
@@ -81,8 +81,7 @@ public class PartitionedHttpClientTest {
     private static ServerContext srv1;
     private static ServerContext srv2;
     private TestPublisher<PartitionedServiceDiscovererEvent<ServerAddress>> sdPublisher;
-    private ServiceDiscoverer<String, InetSocketAddress,
-            ? extends PartitionedServiceDiscovererEvent<InetSocketAddress>> psd;
+    private ServiceDiscoverer<String, InetSocketAddress, PartitionedServiceDiscovererEvent<InetSocketAddress>> psd;
 
     @BeforeClass
     public static void setUpServers() throws Exception {


### PR DESCRIPTION
__Motivation__

`SingleAddressHttpClientBuilder` is used as a template for partitioned and multi-address builders for which SD event types is different. Although, users are not expected to use a ServiceDiscoverer with different event type, we accommodate this usage in our public APIs. Accomodating this usage further trickles down to builder implementation and the external facing `ServiceDiscoveryRetryStrategy`. It also complicates generic handling whenever we change `ServiceDiscoverer` APIs.
Further the partitioned builder uncheck casts the service discovery stream while using which hides type issues.

__Modification__

 - Remove the `? extends` in the `ServiceDiscoverer` event type while accepting a `ServiceDiscoverer` in the builders. When a different event type is required (partitioned builder), store the `ServiceDiscoverer` locally.
 - Simplify `ServiceDiscoveryRetryStrategy` generics.

 __Result__

 Less generics clutter in public APIs.