### PR TITLE
Fix flaky `StreamObserverTest.maxActiveStreamsViolationError()`

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
@@ -182,7 +182,7 @@ public class StreamObserverTest {
 
         private final Publisher<? extends ConsumableEvent<Integer>> maxConcurrent;
 
-        public MulticastTransportEventsStreamingHttpConnectionFilter(final FilterableStreamingHttpConnection delegate) {
+        MulticastTransportEventsStreamingHttpConnectionFilter(final FilterableStreamingHttpConnection delegate) {
             super(delegate);
             maxConcurrent = delegate.transportEventStream(MAX_CONCURRENCY).multicastToExactly(2);
         }


### PR DESCRIPTION
Motivation:

`StreamObserverTest.maxActiveStreamsViolationError()` test expects that
client already received a new value of `MAX_CONCURRENT_STREAMS` from the
server when the connection is established. But actually, the server
sends settings frame after the first request.

Modifications:

- Await until the client receives `MAX_CONCURRENT_STREAMS` value from
the server before starting the second request;

Result:

`StreamObserverTest.maxActiveStreamsViolationError()` test is not flaky.

Fixes #1148.