### PR TITLE
Clear AsyncContext before invoking HttpService

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContext.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContext.java
@@ -280,6 +280,15 @@ public final class AsyncContext {
     }
 
     /**
+     * Determine if {@link #disable()} has been previously called.
+     *
+     * @return {@code true} if {@link #disable()} has been previously called.
+     */
+    public static boolean isDisabled() {
+        return ENABLED_STATE.get() == STATE_DISABLED;
+    }
+
+    /**
      * This method is currently internal only! If it is exposed publicly, and {@link #STATE_DISABLED} is no longer a
      * terminal state the racy {@link #ENABLED_STATE} should be re-evaluated. We currently don't try to account for an
      * application calling this method and {@link #disable()} concurrently, and this may result in inconsistent

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AsyncContextAwareHttpServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AsyncContextAwareHttpServiceFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.concurrent.api.AsyncContext;
+import io.servicetalk.concurrent.api.Single;
+
+final class AsyncContextAwareHttpServiceFilter implements
+                                               StreamingHttpServiceFilterFactory, HttpExecutionStrategyInfluencer {
+    @Override
+    public StreamingHttpServiceFilter create(final StreamingHttpService service) {
+        return new StreamingHttpServiceFilter(service) {
+            @Override
+            public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
+                                                        final StreamingHttpRequest request,
+                                                        final StreamingHttpResponseFactory responseFactory) {
+                AsyncContext.clear();
+                return delegate().handle(ctx, request, responseFactory);
+            }
+        };
+    }
+
+    @Override
+    public HttpExecutionStrategy influenceStrategy(final HttpExecutionStrategy strategy) {
+        // No influence since we do not block.
+        return strategy;
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
@@ -88,6 +88,12 @@ public abstract class AbstractHttpServiceAsyncContextTest {
         final ExecutorService executorService = Executors.newCachedThreadPool();
         final int concurrency = 10;
         final int numRequests = 10;
+        final String k1Value = "value";
+        // The service should get an empty AsyncContext regardless of what is done outside the service.
+        // There are utilities that may be accessed in a static context or before service initialization that
+        // shouldn't pollute the service's AsyncContext.
+        AsyncContext.current().put(K1, k1Value);
+
         try (ServerContext ctx = serverWithEmptyAsyncContextService(HttpServers.forAddress(localAddress(0)),
                 useImmediate)) {
 
@@ -118,6 +124,7 @@ public abstract class AbstractHttpServiceAsyncContextTest {
             }
             latch.await();
             assertNull(causeRef.get());
+            assertEquals(k1Value, AsyncContext.get(K1));
         } finally {
             executorService.shutdown();
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingHttpServiceAsyncContextTest.java
@@ -87,20 +87,12 @@ public class StreamingHttpServiceAsyncContextTest extends AbstractHttpServiceAsy
     }
 
     private static StreamingHttpService newEmptyAsyncContextService() {
-        // The service should get an empty AsyncContext regardless of what is done outside the service.
-        // There are utilities that may be accessed in a static context or before service initialization that
-        // shouldn't pollute the service's AsyncContext.
-        AsyncContext.current().put(K1, "value");
-
         return (ctx, request, factory) -> {
             request.payloadBodyAndTrailers().ignoreElements().subscribe();
 
             AsyncContextMap current = AsyncContext.current();
             if (!current.isEmpty()) {
-                StreamingHttpResponse response = factory.internalServerError();
-                return succeeded(response.payloadBody(textSerializer()
-                        .serialize(response.headers(), from(current.toString()),
-                                ctx.executionContext().bufferAllocator())));
+                return succeeded(factory.internalServerError().payloadBody(from(current.toString()), textSerializer()));
             }
             CharSequence requestId = request.headers().getAndRemove(REQUEST_ID_HEADER);
             if (requestId != null) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingHttpServiceAsyncContextTest.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.concurrent.api.AsyncContext;
+import io.servicetalk.concurrent.api.AsyncContextMap;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.HttpServiceContext;
@@ -27,9 +28,11 @@ import io.servicetalk.transport.api.ServerContext;
 
 import org.junit.Test;
 
+import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
 import static java.lang.Thread.currentThread;
 
 public class StreamingHttpServiceAsyncContextTest extends AbstractHttpServiceAsyncContextTest {
@@ -84,15 +87,24 @@ public class StreamingHttpServiceAsyncContextTest extends AbstractHttpServiceAsy
     }
 
     private static StreamingHttpService newEmptyAsyncContextService() {
+        // The service should get an empty AsyncContext regardless of what is done outside the service.
+        // There are utilities that may be accessed in a static context or before service initialization that
+        // shouldn't pollute the service's AsyncContext.
+        AsyncContext.current().put(K1, "value");
+
         return (ctx, request, factory) -> {
             request.payloadBodyAndTrailers().ignoreElements().subscribe();
 
-            if (!AsyncContext.isEmpty()) {
-                return succeeded(factory.internalServerError());
+            AsyncContextMap current = AsyncContext.current();
+            if (!current.isEmpty()) {
+                StreamingHttpResponse response = factory.internalServerError();
+                return succeeded(response.payloadBody(textSerializer()
+                        .serialize(response.headers(), from(current.toString()),
+                                ctx.executionContext().bufferAllocator())));
             }
             CharSequence requestId = request.headers().getAndRemove(REQUEST_ID_HEADER);
             if (requestId != null) {
-                AsyncContext.put(K1, requestId);
+                current.put(K1, requestId);
                 return succeeded(factory.ok()
                         .setHeader(REQUEST_ID_HEADER, requestId));
             } else {


### PR DESCRIPTION
Motivation:
Each HttpService should get an empty AsyncContext. This will happen if
the AsyncContext at the root level is empty, which it typically is.
However it is possible that the AsyncContext maybe modified before this
time (e.g. MDC) and if this happens that may result in shared state
between requests (if values are modifiable).

Modification:
- Wrap each service in a filter that explicitly clears the AsyncContext
before executing the user's service filter chain

Result:
AsyncContext is empty when the user service/filter chain is invoked.