### PR TITLE
Unix Domain Sockets HttpClientBuilder fixes

### DIFF
--- a/servicetalk-examples/http/uds/build.gradle
+++ b/servicetalk-examples/http/uds/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-examples/http/uds/build.gradle
+++ b/servicetalk-examples/http/uds/build.gradle
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: "java"
+apply from: "../../gradle/idea.gradle"
+
+dependencies {
+  implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-http-netty")
+
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+}

--- a/servicetalk-examples/http/uds/src/main/java/io/servicetalk/examples/http/uds/blocking/BlockingUdsClient.java
+++ b/servicetalk-examples/http/uds/src/main/java/io/servicetalk/examples/http/uds/blocking/BlockingUdsClient.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.uds.blocking;
+
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.netty.HttpClients;
+
+import static io.servicetalk.examples.http.uds.blocking.UdsUtils.udsAddress;
+import static io.servicetalk.http.api.HttpSerializationProviders.textDeserializer;
+
+/**
+ * <a href="http://man7.org/linux/man-pages/man7/unix.7.html">AF_UNIX socket</a> client example.
+ */
+public final class BlockingUdsClient {
+    public static void main(String[] args) throws Exception {
+        try (BlockingHttpClient client = HttpClients.forResolvedAddress(udsAddress()).buildBlocking()) {
+            HttpResponse response = client.request(client.get("/sayHello"));
+            System.out.println(response.toString((name, value) -> value));
+            System.out.println(response.payloadBody(textDeserializer()));
+        }
+    }
+}

--- a/servicetalk-examples/http/uds/src/main/java/io/servicetalk/examples/http/uds/blocking/BlockingUdsClient.java
+++ b/servicetalk-examples/http/uds/src/main/java/io/servicetalk/examples/http/uds/blocking/BlockingUdsClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-examples/http/uds/src/main/java/io/servicetalk/examples/http/uds/blocking/BlockingUdsServer.java
+++ b/servicetalk-examples/http/uds/src/main/java/io/servicetalk/examples/http/uds/blocking/BlockingUdsServer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.uds.blocking;
+
+import io.servicetalk.http.netty.HttpServers;
+import io.servicetalk.transport.api.DomainSocketAddress;
+
+import java.io.File;
+
+import static io.servicetalk.examples.http.uds.blocking.UdsUtils.udsAddress;
+import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
+
+/**
+ * <a href="http://man7.org/linux/man-pages/man7/unix.7.html">AF_UNIX socket</a> server example.
+ */
+public final class BlockingUdsServer {
+    public static void main(String[] args) throws Exception {
+        DomainSocketAddress udsAddress = udsAddress();
+        try {
+            HttpServers.forAddress(udsAddress)
+                    .listenBlockingAndAwait((ctx, request, responseFactory) ->
+                            responseFactory.ok().payloadBody("Hello World!", textSerializer()))
+                    .awaitShutdown();
+        } finally {
+            new File(udsAddress.getPath()).delete(); // After the server is done, clean up the file.
+        }
+    }
+}

--- a/servicetalk-examples/http/uds/src/main/java/io/servicetalk/examples/http/uds/blocking/UdsUtils.java
+++ b/servicetalk-examples/http/uds/src/main/java/io/servicetalk/examples/http/uds/blocking/UdsUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package io.servicetalk.examples.http.uds.blocking;
 import io.servicetalk.transport.api.DomainSocketAddress;
 
 import java.io.File;
-import java.io.IOException;
 
 public final class UdsUtils {
     /**

--- a/servicetalk-examples/http/uds/src/main/java/io/servicetalk/examples/http/uds/blocking/UdsUtils.java
+++ b/servicetalk-examples/http/uds/src/main/java/io/servicetalk/examples/http/uds/blocking/UdsUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.uds.blocking;
+
+import io.servicetalk.transport.api.DomainSocketAddress;
+
+import java.io.File;
+import java.io.IOException;
+
+public final class UdsUtils {
+    /**
+     * Create a {@link DomainSocketAddress} that is backed by a fixed file such that different JVMs
+     * can use it to communicate via UDS.
+     * @return a {@link DomainSocketAddress} that is backed by a fixed file such that different JVMs
+     * can use it to communicate via UDS.
+     */
+    public static DomainSocketAddress udsAddress() {
+        final String tempDirProp = "java.io.tmpdir";
+        final String tempDir = System.getProperty(tempDirProp);
+        if (tempDir == null) {
+            throw new IllegalStateException("unable to find " + tempDirProp + " in System properties");
+        }
+        return new DomainSocketAddress(new File(tempDir + "servicetalk.uds"));
+    }
+}

--- a/servicetalk-examples/http/uds/src/main/java/io/servicetalk/examples/http/uds/blocking/package-info.java
+++ b/servicetalk-examples/http/uds/src/main/java/io/servicetalk/examples/http/uds/blocking/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.http.uds.blocking;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-examples/http/uds/src/main/java/io/servicetalk/examples/http/uds/blocking/package-info.java
+++ b/servicetalk-examples/http/uds/src/main/java/io/servicetalk/examples/http/uds/blocking/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-examples/http/uds/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/uds/src/main/resources/log4j2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="info">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d %30t [%-5level] %-30logger{1} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <!-- Prints server start and shutdown -->
+    <Logger name="io.servicetalk.http.netty.NettyHttpServer" level="DEBUG"/>
+
+    <!-- Prints default subscriber errors-->
+    <Logger name="io.servicetalk.concurrent.api" level="DEBUG"/>
+
+    <!-- Use `-Dservicetalk.logger.level=DEBUG` to change the root logger level via command line  -->
+    <Root level="${sys:servicetalk.logger.level:-INFO}">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/servicetalk-examples/http/uds/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/uds/src/main/resources/log4j2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+  ~ Copyright © 2020 Apple Inc. and the ServiceTalk project authors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -55,6 +55,7 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.util.NetUtil;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.net.SocketOption;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -179,7 +180,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
                 globalDnsServiceDiscoverer());
     }
 
-    static <U, R> DefaultSingleAddressHttpClientBuilder<U, R> forResolvedAddress(
+    static <U, R extends SocketAddress> DefaultSingleAddressHttpClientBuilder<U, R> forResolvedAddress(
             final U u, final R address) {
         ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> sd =
                 new NoopServiceDiscoverer<>(u, address);
@@ -495,7 +496,6 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
         return influencerChainBuilder.buildForClient(strategy);
     }
 
-    @Nullable
     private CharSequence toAuthorityForm(final U address) {
         if (address instanceof CharSequence) {
             return (CharSequence) address;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -34,6 +34,7 @@ import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.transport.api.HostAndPort;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.function.Function;
 
 import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
@@ -237,10 +238,10 @@ public final class HttpClients {
      * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
      * if you want to override that value or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you
      * want to disable this behavior.
+     * @param <T> The type of {@link SocketAddress}.
      * @return new builder for the address
      */
-    public static SingleAddressHttpClientBuilder<InetSocketAddress, InetSocketAddress> forResolvedAddress(
-            final InetSocketAddress address) {
+    public static <T extends SocketAddress> SingleAddressHttpClientBuilder<T, T> forResolvedAddress(final T address) {
         return DefaultSingleAddressHttpClientBuilder.forResolvedAddress(address, address);
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpUdsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpUdsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.transport.api.DomainSocketAddress;
+import io.servicetalk.transport.api.IoExecutor;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.netty.internal.IoThreadFactory;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+public class HttpUdsTest {
+    private static IoExecutor ioExecutor;
+
+    @BeforeClass
+    public static void beforeClass() {
+        ioExecutor = createIoExecutor(new IoThreadFactory("io-executor"));
+    }
+
+    @AfterClass
+    public static void afterClass() throws ExecutionException, InterruptedException {
+        ioExecutor.closeAsync().toFuture().get();
+    }
+
+    @Test
+    public void udsRoundTrip() throws Exception {
+        assumeTrue(ioExecutor.isUnixDomainSocketSupported());
+        try (ServerContext serverContext = HttpServers.forAddress(newSocketAddress()).ioExecutor(ioExecutor)
+                             .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok())) {
+            try (BlockingHttpClient client = HttpClients.forResolvedAddress(serverContext.listenAddress())
+                    .ioExecutor(ioExecutor).buildBlocking()) {
+                assertEquals(HttpResponseStatus.OK, client.request(client.get("/")).status());
+            }
+        }
+    }
+
+    private static DomainSocketAddress newSocketAddress() throws IOException {
+        File file = File.createTempFile("STUDS", ".uds");
+        assertTrue(file.delete());
+        return new DomainSocketAddress(file);
+    }
+}

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
@@ -123,6 +123,7 @@ class RequestResponseCloseHandler extends CloseHandler {
 
     private static boolean isAllowHalfClosure(final Channel channel) {
         return (channel instanceof SocketChannel) ? ((SocketChannel) channel).config().isAllowHalfClosure() :
+                channel instanceof DuplexChannel ||
                 channel instanceof EmbeddedChannel; // Exceptionally used in unit tests
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -41,6 +41,7 @@ include "servicetalk-annotations",
         "servicetalk-examples:http:metadata",
         "servicetalk-examples:http:serialization",
         "servicetalk-examples:http:service-composition",
+        "servicetalk-examples:http:uds",
         "servicetalk-gradle-plugin-internal",
         "servicetalk-grpc-api",
         "servicetalk-grpc-netty",
@@ -82,3 +83,4 @@ project(":servicetalk-examples:http:jaxrs").name = "servicetalk-examples-http-ja
 project(":servicetalk-examples:http:metadata").name = "servicetalk-examples-http-metadata"
 project(":servicetalk-examples:http:serialization").name = "servicetalk-examples-http-serialization"
 project(":servicetalk-examples:http:service-composition").name = "servicetalk-examples-http-service-composition"
+project(":servicetalk-examples:http:uds").name = "servicetalk-examples-http-uds"


### PR DESCRIPTION
Motivation:
UDS is supported by ServicetTalk by passing in a DomainSocketAddress
address. However the HttpClientBuilder had some restrictions/assumptions
about the address type which prevented its use.

Modifications:
- Relax assumptions/restrictions in the HttpClientBuilder to allow for
DomainSocketAddress
- Add unit test to demonstrate UDS
- Add example for UDS

Result:
UDS client is now working and tested.