### PR TITLE
Do not abort server write if PROTOCOL_CLOSING_INBOUND was already observed

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -284,7 +284,8 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                                     HTTP_2_0,
                                     parentContext.sslSession(),
                                     parentContext.nettyChannel().config(),
-                                    streamObserver);
+                                    streamObserver,
+                                    true);
 
                     // In h2 a stream is 1 to 1 with a request/response life cycle. This means there is no concept of
                     // pipelining on a stream so we can use the non-pipelined connection which is more light weight.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -171,7 +171,8 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                                                 HTTP_2_0,
                                                 connection.sslSession(),
                                                 channel.config(),
-                                                streamObserver);
+                                                streamObserver,
+                                                false);
 
                                 // ServiceTalk HTTP service handler
                                 new NettyHttpServerConnection(streamConnection, service,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -163,7 +163,7 @@ final class NettyHttpServer {
                 httpExecutionContext.bufferAllocator(), httpExecutionContext.executor(), LAST_CHUNK_PREDICATE,
                 closeHandler, config.tcpConfig().flushStrategy(), config.tcpConfig().idleTimeoutMs(),
                 initializer.andThen(getChannelInitializer(getByteBufAllocator(httpExecutionContext.bufferAllocator()),
-                        h1Config, closeHandler)), httpExecutionContext.executionStrategy(), HTTP_1_1, observer)
+                        h1Config, closeHandler)), httpExecutionContext.executionStrategy(), HTTP_1_1, observer, false)
                 .map(conn -> new NettyHttpServerConnection(conn, service, httpExecutionContext.executionStrategy(),
                         h1Config.headersFactory(), drainRequestPayloadBody)), HTTP_1_1, channel);
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -60,6 +60,6 @@ final class StreamingConnectionFactory {
                 executionContext.executor(), LAST_CHUNK_PREDICATE, closeHandler, config.tcpConfig().flushStrategy(),
                 config.tcpConfig().idleTimeoutMs(), initializer.andThen(new HttpClientChannelInitializer(
                         getByteBufAllocator(executionContext.bufferAllocator()), config.h1Config(), closeHandler)),
-                executionContext.executionStrategy(), HTTP_1_1, connectionObserver), HTTP_1_1, channel);
+                executionContext.executionStrategy(), HTTP_1_1, connectionObserver, true), HTTP_1_1, channel);
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -429,7 +429,7 @@ public class HttpRequestEncoderTest {
                                                 channel2 -> {
                                                     serverChannelRef.compareAndSet(null, channel2);
                                                     serverChannelLatch.countDown();
-                                                }), defaultStrategy(), mock(Protocol.class), observer);
+                                                }), defaultStrategy(), mock(Protocol.class), observer, false);
                             },
                             connection -> { }).toFuture().get());
             ReadOnlyHttpClientConfig cConfig = new HttpClientConfig().asReadOnly();
@@ -460,7 +460,7 @@ public class HttpRequestEncoderTest {
                                                                 }
                                                             }
                                                         })), defaultStrategy(), HTTP_1_1,
-                                                            NoopConnectionObserver.INSTANCE);
+                                                            NoopConnectionObserver.INSTANCE, true);
                             }
                     ).toFuture().get());
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyPipelinedConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyPipelinedConnectionTest.java
@@ -104,7 +104,7 @@ public class NettyPipelinedConnectionTest {
         final DefaultNettyConnection<Integer, Integer> connection =
                 DefaultNettyConnection.<Integer, Integer>initChannel(channel, DEFAULT_ALLOCATOR,
                 immediate(), obj -> true, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, defaultFlushStrategy(), null,
-                channel2 -> { }, defaultStrategy(), mock(Protocol.class), NoopConnectionObserver.INSTANCE)
+                channel2 -> { }, defaultStrategy(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, true)
                         .toFuture().get();
         requester = new NettyPipelinedConnection<>(connection);
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnProtocolClosingInboundTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnProtocolClosingInboundTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.ExecutorRule;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.http.api.DefaultHttpExecutionContext;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.StreamingHttpService;
+import io.servicetalk.http.netty.FlushStrategyOnServerTest.OutboundWriteEventsInterceptor;
+import io.servicetalk.http.netty.NettyHttpServer.NettyHttpServerConnection;
+import io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer;
+import io.servicetalk.transport.api.ConnectionObserver;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
+
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import static io.netty.buffer.ByteBufUtil.writeAscii;
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.concurrent.api.ExecutorRule.newRule;
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
+import static io.servicetalk.http.netty.NettyHttpServer.initChannel;
+import static io.servicetalk.transport.netty.internal.NettyIoExecutors.fromNettyEventLoop;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+public class ServerRespondsOnProtocolClosingInboundTest {
+
+    @ClassRule
+    public static final ExecutorRule<Executor> EXECUTOR_RULE = newRule();
+
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+
+    private final OutboundWriteEventsInterceptor interceptor;
+    private final EmbeddedChannel channel;
+    private final NettyHttpServerConnection serverConnection;
+
+    public ServerRespondsOnProtocolClosingInboundTest() throws Exception {
+        interceptor = new OutboundWriteEventsInterceptor();
+        channel = new EmbeddedChannel(interceptor);
+
+        DefaultHttpExecutionContext httpExecutionContext = new DefaultHttpExecutionContext(DEFAULT_ALLOCATOR,
+                fromNettyEventLoop(channel.eventLoop()), EXECUTOR_RULE.executor(), defaultStrategy());
+        ReadOnlyHttpServerConfig config = new HttpServerConfig().asReadOnly();
+        ConnectionObserver connectionObserver = NoopConnectionObserver.INSTANCE;
+        StreamingHttpService service = (ctx, request, responseFactory) -> responseFactory.ok()
+                .payloadBody(from("Hello World"), textSerializer()).toResponse().map(HttpResponse::toStreamingResponse);
+        serverConnection = initChannel(channel, httpExecutionContext, config, new TcpServerChannelInitializer(
+                config.tcpConfig(), connectionObserver), service, true, connectionObserver).toFuture().get();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        try {
+            serverConnection.closeAsyncGracefully().toFuture().get();
+        } finally {
+            channel.close().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    public void requestReceivedBeforeProcessingStarts() throws Exception {
+        channel.writeInbound(writeAscii(PooledByteBufAllocator.DEFAULT, "GET / HTTP/1.1\r\n" +
+                "Host: localhost\r\n" +
+                "Content-length: 0\r\n" +
+                "Connection: close\r\n" + "\r\n"));
+        // Start request processing (read and write) after request was received:
+        serverConnection.process(true);
+        // Verify that the server responded:
+        assertThat("Unexpected writes", interceptor.takeWritesTillFlush(), hasSize(3));
+        assertThat("Unexpected writes", interceptor.pendingEvents(), is(0));
+    }
+}

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpConnectorTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpConnectorTest.java
@@ -111,7 +111,7 @@ public final class TcpConnectorTest extends AbstractTcpServerTest {
                                     ctx.fireChannelActive();
                                 }
                             });
-                        }, CLIENT_CTX.executionStrategy(), mock(Protocol.class), NoopConnectionObserver.INSTANCE))
+                        }, CLIENT_CTX.executionStrategy(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, true))
                 .toFuture().get();
         connection.closeAsync().toFuture().get();
 

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
@@ -100,7 +100,7 @@ public final class TcpClient {
                             UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, config.flushStrategy(), config.idleTimeoutMs(),
                             new TcpClientChannelInitializer(config, connectionObserver).andThen(
                                     channel2 -> channel2.pipeline().addLast(BufferHandler.INSTANCE)),
-                            executionContext.executionStrategy(), TCP, connectionObserver);
+                            executionContext.executionStrategy(), TCP, connectionObserver, true);
                 });
     }
 

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
@@ -92,7 +92,7 @@ public class TcpServer {
                             UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, config.flushStrategy(), config.idleTimeoutMs(),
                             new TcpServerChannelInitializer(config, connectionObserver)
                                     .andThen(getChannelInitializer(service, executionContext)), executionStrategy, TCP,
-                            connectionObserver);
+                            connectionObserver, false);
                 },
                 serverConnection -> service.apply(serverConnection)
                         .beforeOnError(throwable -> LOGGER.error("Error handling a connection.", throwable))

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
@@ -116,7 +116,7 @@ public class DefaultNettyConnectionTest {
                     return true;
                 },
                 closeHandler, defaultFlushStrategy(), null, trailerProtocolEndEventEmitter(), OFFLOAD_ALL_STRATEGY,
-                mock(Protocol.class), NoopConnectionObserver.INSTANCE).toFuture().get();
+                mock(Protocol.class), NoopConnectionObserver.INSTANCE, true).toFuture().get();
         publisher = new TestPublisher<>();
     }
 

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherRefCountTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherRefCountTest.java
@@ -56,7 +56,8 @@ public class NettyChannelPublisherRefCountTest {
         channel = new EmbeddedChannel();
         publisher = DefaultNettyConnection.initChannel(channel, DEFAULT_ALLOCATOR, immediate(), x -> false,
                 UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, defaultFlushStrategy(), null, channel2 -> { },
-                OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE).toFuture().get().read();
+                OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE, true).toFuture().get()
+                .read();
     }
 
     @After

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherTest.java
@@ -103,7 +103,7 @@ public class NettyChannelPublisherTest {
                     readRequested = true;
                     super.read(ctx);
                 }
-            }), OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE).toFuture().get();
+            }), OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE, true).toFuture().get();
         publisher = connection.read();
         channel.config().setAutoRead(false);
     }
@@ -151,7 +151,7 @@ public class NettyChannelPublisherTest {
                             super.read(ctx);
                         }
                     });
-                }, OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE).toFuture().get();
+                }, OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE, true).toFuture().get();
         publisher = connection.read();
         channel.config().setAutoRead(false);
     }


### PR DESCRIPTION
Motivation:

If a server receives a request with `Connection: close` header, it registers
`PROTOCOL_CLOSING_INBOUND` event and transitions to the `CLOSING` state.
This event can be observed before the server connection started processing
requests. As the result, server's write stream fails and does not let the server
respond.
This use-case happens frequently when `TLSv1.3` is used, because a client
starts sending data before the server completes TLS handshake. Therefore,
the first request can be pending before the server connection is established.
A similar scenario (request received before processing starts, closing state
waits for the response) may occur with graceful closure or
`CHANNEL_CLOSED_INBOUND` event (client half-closes the connection
after a request is sent).

Modifications:

- Abort new writes only on the client side in `DefaultNettyConnection`;
- Add tests that reproduce described behavior;
- Improve `FlushStrategyOnServerTest` to let other tests reuse its code;

Result:

Server initializes request-response processing and responds to the already
received request.