### PR TITLE
DynamicCompositeCancellable queue full return value fix

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/QueueDynamicCompositeCancellable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/QueueDynamicCompositeCancellable.java
@@ -43,6 +43,7 @@ final class QueueDynamicCompositeCancellable implements DynamicCompositeCancella
     public boolean add(Cancellable toAdd) {
         if (!cancellables.offer(toAdd)) {
             toAdd.cancel();
+            return false;
         } else if (isCancelled()) {
             cancelAll();
             return false;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SetDynamicCompositeCancellable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SetDynamicCompositeCancellable.java
@@ -72,6 +72,7 @@ final class SetDynamicCompositeCancellable implements DynamicCompositeCancellabl
     public boolean add(Cancellable toAdd) {
         if (!cancellables.add(toAdd)) {
             toAdd.cancel(); // out of memory, or user has implemented equals/hashCode so there is overlap.
+            return false;
         } else if (isCancelled()) {
             cancelAll(); // avoid concurrency on toAdd if another thread invokes cancel(), just cancel all.
             return false;


### PR DESCRIPTION
Motivation:
The DynamicCompositeCancellable may return true even if they failed to
add the Cancellable to the collection and invoked cancel(). The javadoc
says the method should return false in this scenario.

Modifications:
- Return false if the internal queue/set is full and the underlying add
fails

Result:
SetDynamicCompositeCancellable and QueueDynamicCompositeCancellable more
correctly implement the DynamicCompositeCancellable#add(..) API.