### PR TITLE
Cancel Subscription when channel outbound has closed

### DIFF
--- a/servicetalk-test-resources/src/main/resources/log4j2.xml
+++ b/servicetalk-test-resources/src/main/resources/log4j2.xml
@@ -16,8 +16,8 @@
   -->
 <Configuration status="info">
   <Properties>
-    <Property name="rootLevel">${sys:servicetalk.logger.rootLevel:-INFO}</Property>
-    <Property name="wireLogLevel">${sys:servicetalk.logger.wireLogLevel:-OFF}</Property>
+    <Property name="rootLevel">${sys:servicetalk.logger.rootLevel:-DEBUG}</Property>
+    <Property name="wireLogLevel">${sys:servicetalk.logger.wireLogLevel:-TRACE}</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -200,6 +200,10 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
     @Override
     public void channelOutboundClosed() {
         assert eventLoop.inEventLoop();
+        Subscription oldVal = subscriptionUpdater.getAndSet(this, CANCELLED);
+        if (oldVal != null) {
+            oldVal.cancel();
+        }
         promise.sourceTerminated(null);
     }
 


### PR DESCRIPTION
Motivation:

`DefaultNettyConnection` may signal its `ChannelOutboundListener` that the
outbound has closed. `WriteStreamSubscriber` implements
`ChannelOutboundListener`. It terminates the `Subscriber` but does not
cancel `Subscription`.

Modifications:

- Cancel current `Subscription` on
`WriteStreamSubscriber#channelOutboundClosed()`;
- Add tests to verify the behavior;

Result:

`Subscription` receives cancel signal when channel outbound is closed.