### PR TITLE
Support half-closure for UnixDomainSockets

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
@@ -68,6 +68,7 @@ import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
 import static io.servicetalk.http.api.Matchers.contentEqualTo;
 import static io.servicetalk.http.netty.HttpsProxyTest.safeClose;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.newSocketAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static io.servicetalk.transport.netty.internal.ExecutionContextRule.cached;
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
@@ -78,6 +79,8 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 @RunWith(Enclosed.class)
 public class ConnectionCloseHeaderHandlingTest {
@@ -112,8 +115,17 @@ public class ConnectionCloseHeaderHandlingTest {
         protected final CountDownLatch requestPayloadReceived = new CountDownLatch(1);
         protected final AtomicInteger requestPayloadSize = new AtomicInteger();
 
-        protected ConnectionSetup(boolean viaProxy, boolean awaitRequestPayload) throws Exception {
-            HttpServerBuilder serverBuilder = HttpServers.forAddress(localAddress(0))
+        protected ConnectionSetup(boolean useUds, boolean viaProxy, boolean awaitRequestPayload) throws Exception {
+            if (useUds) {
+                assumeTrue("Server's IoExecutor does not support UnixDomainSocket",
+                        SERVER_CTX.ioExecutor().isUnixDomainSocketSupported());
+                assumeTrue("Client's IoExecutor does not support UnixDomainSocket",
+                        CLIENT_CTX.ioExecutor().isUnixDomainSocketSupported());
+                assumeFalse("UDS cannot be used via proxy", viaProxy);
+            }
+            HttpServerBuilder serverBuilder = (useUds ?
+                    HttpServers.forAddress(newSocketAddress()) :
+                    HttpServers.forAddress(localAddress(0)))
                     .ioExecutor(SERVER_CTX.ioExecutor())
                     .executionStrategy(defaultStrategy(SERVER_CTX.executor()))
                     .enableWireLogging("servicetalk-tests-server-wire-logger")
@@ -173,13 +185,12 @@ public class ConnectionCloseHeaderHandlingTest {
                         }
                     });
 
-            HostAndPort serverAddress = serverHostAndPort(serverContext);
-            client = (viaProxy ? HttpClients.forSingleAddressViaProxy(serverAddress, proxyAddress)
+            client = (viaProxy ? HttpClients.forSingleAddressViaProxy(serverHostAndPort(serverContext), proxyAddress)
                     .secure().disableHostnameVerification()
                     .protocols("TLSv1.2")   // FIXME: remove after https://github.com/apple/servicetalk/pull/1156
                     .trustManager(DefaultTestCerts::loadMutualAuthCaPem)
                     .commit() :
-                    HttpClients.forSingleAddress(serverAddress))
+                    HttpClients.forResolvedAddress(serverContext.listenAddress()))
                     .ioExecutor(CLIENT_CTX.ioExecutor())
                     .executionStrategy(defaultStrategy(CLIENT_CTX.executor()))
                     .enableWireLogging("servicetalk-tests-client-wire-logger")
@@ -233,26 +244,32 @@ public class ConnectionCloseHeaderHandlingTest {
         private final boolean noRequestContent;
         private final boolean noResponseContent;
 
-        public NonPipelinedRequestsTest(boolean viaProxy, boolean awaitRequestPayload,
+        public NonPipelinedRequestsTest(boolean useUds, boolean viaProxy, boolean awaitRequestPayload,
                                         boolean requestInitiatesClosure,
                                         boolean noRequestContent, boolean noResponseContent) throws Exception {
-            super(viaProxy, awaitRequestPayload);
+            super(useUds, viaProxy, awaitRequestPayload);
             this.requestInitiatesClosure = requestInitiatesClosure;
             this.noRequestContent = noRequestContent;
             this.noResponseContent = noResponseContent;
         }
 
-        @Parameters(name = "{index}: viaProxy={0}, awaitRequestPayload={1}, " +
-                "requestInitiatesClosure={2}, noRequestContent={3}, noResponseContent={4}")
+        @Parameters(name = "{index}: useUds={0}, viaProxy={1}, awaitRequestPayload={2}, " +
+                "requestInitiatesClosure={3}, noRequestContent={4}, noResponseContent={5}")
         public static Collection<Boolean[]> data() {
             Collection<Boolean[]> data = new ArrayList<>();
-            for (boolean viaProxy : TRUE_FALSE) {
-                for (boolean awaitRequestPayload : TRUE_FALSE) {
-                    for (boolean requestInitiatesClosure : TRUE_FALSE) {
-                        for (boolean noRequestContent : TRUE_FALSE) {
-                            for (boolean noResponseContent : TRUE_FALSE) {
-                                data.add(new Boolean[] {viaProxy, awaitRequestPayload,
-                                        requestInitiatesClosure, noRequestContent, noResponseContent});
+            for (boolean useUds : TRUE_FALSE) {
+                for (boolean viaProxy : TRUE_FALSE) {
+                    if (useUds && viaProxy) {
+                        // UDS cannot be used via proxy
+                        continue;
+                    }
+                    for (boolean awaitRequestPayload : TRUE_FALSE) {
+                        for (boolean requestInitiatesClosure : TRUE_FALSE) {
+                            for (boolean noRequestContent : TRUE_FALSE) {
+                                for (boolean noResponseContent : TRUE_FALSE) {
+                                    data.add(new Boolean[] {useUds, viaProxy, awaitRequestPayload,
+                                            requestInitiatesClosure, noRequestContent, noResponseContent});
+                                }
                             }
                         }
                     }
@@ -300,17 +317,19 @@ public class ConnectionCloseHeaderHandlingTest {
     @RunWith(Parameterized.class)
     public static class PipelinedRequestsTest extends ConnectionSetup {
 
-        public PipelinedRequestsTest(boolean viaProxy, boolean awaitRequestPayload) throws Exception {
-            super(viaProxy, awaitRequestPayload);
+        public PipelinedRequestsTest(boolean useUds, boolean viaProxy, boolean awaitRequestPayload) throws Exception {
+            super(useUds, viaProxy, awaitRequestPayload);
         }
 
-        @Parameters(name = "{index}: viaProxy={0}, awaitRequestPayload={1}")
+        @Parameters(name = "{index}: useUds={0} viaProxy={1}, awaitRequestPayload={2}")
         public static Collection<Boolean[]> data() {
             return asList(
-                    new Boolean[] {false, false},
-                    new Boolean[] {false, true},
-                    new Boolean[] {true, false},
-                    new Boolean[] {true, true}
+                    new Boolean[] {false, false, false},
+                    new Boolean[] {false, false, true},
+                    new Boolean[] {false, true, false},
+                    new Boolean[] {false, true, true},
+                    new Boolean[] {true, false, false},
+                    new Boolean[] {true, false, true}
             );
         }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
@@ -34,6 +34,7 @@ import io.servicetalk.transport.netty.internal.ExecutionContextRule;
 
 import org.junit.After;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
@@ -321,7 +322,7 @@ public class ConnectionCloseHeaderHandlingTest {
             super(useUds, viaProxy, awaitRequestPayload);
         }
 
-        @Parameters(name = "{index}: useUds={0} viaProxy={1}, awaitRequestPayload={2}")
+        @Parameters(name = "{index}: useUds={0}, viaProxy={1}, awaitRequestPayload={2}")
         public static Collection<Boolean[]> data() {
             return asList(
                     new Boolean[] {false, false, false},
@@ -334,6 +335,7 @@ public class ConnectionCloseHeaderHandlingTest {
         }
 
         @Test
+        @Ignore("Temporary disable until https://github.com/apple/servicetalk/pull/1141 is merged")
         public void serverCloseTwoPipelinedRequestsSentBeforeFirstResponse() throws Exception {
             AtomicReference<Throwable> secondRequestError = new AtomicReference<>();
             CountDownLatch secondResponseReceived = new CountDownLatch(1);
@@ -357,14 +359,13 @@ public class ConnectionCloseHeaderHandlingTest {
             assertResponsePayloadBody(response);
 
             awaitConnectionClosed();
-            // FIXME: temporary disable check for /second until https://github.com/apple/servicetalk/pull/1141
-            // For more information, see https://github.com/apple/servicetalk/issues/1154
-            // secondResponseReceived.await();
-            // assertThat(secondRequestError.get(), instanceOf(ClosedChannelException.class));
+            secondResponseReceived.await();
+            assertThat(secondRequestError.get(), instanceOf(ClosedChannelException.class));
             assertClosedChannelException("/third");
         }
 
         @Test
+        @Ignore("Temporary disable until https://github.com/apple/servicetalk/pull/1141 is merged")
         public void serverCloseSecondPipelinedRequestWriteAborted() throws Exception {
             AtomicReference<Throwable> secondRequestError = new AtomicReference<>();
             CountDownLatch secondResponseReceived = new CountDownLatch(1);
@@ -390,10 +391,8 @@ public class ConnectionCloseHeaderHandlingTest {
             assertResponsePayloadBody(response);
 
             awaitConnectionClosed();
-            // FIXME: temporary disable check for /second until https://github.com/apple/servicetalk/pull/1141
-            // For more information, see https://github.com/apple/servicetalk/issues/1154
-            // secondResponseReceived.await();
-            // assertThat(secondRequestError.get(), instanceOf(ClosedChannelException.class));
+            secondResponseReceived.await();
+            assertThat(secondRequestError.get(), instanceOf(ClosedChannelException.class));
             assertClosedChannelException("/third");
         }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpUdsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpUdsTest.java
@@ -17,7 +17,6 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.HttpResponseStatus;
-import io.servicetalk.transport.api.DomainSocketAddress;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.IoThreadFactory;
@@ -26,13 +25,11 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
+import static io.servicetalk.transport.netty.internal.AddressUtils.newSocketAddress;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 public class HttpUdsTest {
@@ -58,11 +55,5 @@ public class HttpUdsTest {
                 assertEquals(HttpResponseStatus.OK, client.request(client.get("/")).status());
             }
         }
-    }
-
-    private static DomainSocketAddress newSocketAddress() throws IOException {
-        File file = File.createTempFile("STUDS", ".uds");
-        assertTrue(file.delete());
-        return new DomainSocketAddress(file);
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
@@ -20,11 +20,13 @@ import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoop;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.SocketChannelConfig;
 
 import java.nio.channels.ClosedChannelException;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
+
+import static io.netty.channel.ChannelOption.ALLOW_HALF_CLOSURE;
+import static java.lang.Boolean.TRUE;
 
 /**
  * Contract between protocol codecs and a close handler.
@@ -43,9 +45,7 @@ public abstract class CloseHandler {
      * @return a new connection close handler with behavior for a pipelined request/response client or server
      */
     public static CloseHandler forPipelinedRequestResponse(boolean client, ChannelConfig config) {
-        if (config instanceof SocketChannelConfig) {
-            ((SocketChannelConfig) config).setAllowHalfClosure(true);
-        }
+        config.setOption(ALLOW_HALF_CLOSURE, TRUE);
         config.setAutoClose(false);
         return new RequestResponseCloseHandler(client);
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
@@ -128,7 +128,7 @@ class RequestResponseCloseHandler extends CloseHandler {
                 || channel instanceof EmbeddedChannel   // Exceptionally used in unit tests
                 : "Channel does not implement DuplexChannel";
         if (channel instanceof DuplexChannel) {
-            assert channel.config().getOption(ALLOW_HALF_CLOSURE) == TRUE :
+            assert TRUE.equals(channel.config().getOption(ALLOW_HALF_CLOSURE)) :
                     "Half-Closure DISABLED, this may violate some protocols";
         }
     }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandlerTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandlerTest.java
@@ -104,6 +104,7 @@ import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandle
 import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.ExpectEvent.UCO;
 import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Mode.C;
 import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Mode.S;
+import static java.lang.Boolean.TRUE;
 import static java.lang.Integer.toHexString;
 import static java.lang.Thread.NORM_PRIORITY;
 import static java.util.Arrays.asList;
@@ -308,7 +309,7 @@ public class RequestResponseCloseHandlerTest {
             EventLoop loop = mock(EventLoop.class);
             when(channel.eventLoop()).thenReturn(loop);
             when(loop.inEventLoop()).thenReturn(true);
-            when(scc.isAllowHalfClosure()).thenReturn(true);
+            when(scc.getOption(ALLOW_HALF_CLOSURE)).thenReturn(TRUE);
             ChannelPipeline pipeline = mock(ChannelPipeline.class);
             when(channel.pipeline()).thenReturn(pipeline);
 

--- a/servicetalk-transport-netty-internal/src/testFixtures/java/io/servicetalk/transport/netty/internal/AddressUtils.java
+++ b/servicetalk-transport-netty-internal/src/testFixtures/java/io/servicetalk/transport/netty/internal/AddressUtils.java
@@ -15,14 +15,18 @@
  */
 package io.servicetalk.transport.netty.internal;
 
+import io.servicetalk.transport.api.DomainSocketAddress;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
 
+import java.io.File;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
 import static io.netty.util.NetUtil.isValidIpV6Address;
 import static java.net.InetAddress.getLoopbackAddress;
+import static org.junit.Assert.assertTrue;
 
 /**
  * A utility class to work with addresses.
@@ -64,5 +68,17 @@ public final class AddressUtils {
     public static String hostHeader(final HostAndPort hostAndPort) {
         return isValidIpV6Address(hostAndPort.hostName()) ?
                 "[" + hostAndPort.hostName() + "]:" + hostAndPort.port() : hostAndPort.toString();
+    }
+
+    /**
+     * Creates a new {@link DomainSocketAddress}.
+     *
+     * @return a new {@link DomainSocketAddress}
+     * @throws IOException if a temporary file cannot be created for {@link DomainSocketAddress}
+     */
+    public static DomainSocketAddress newSocketAddress() throws IOException {
+        File file = File.createTempFile("STUDS", ".uds");
+        assertTrue(file.delete());
+        return new DomainSocketAddress(file);
     }
 }


### PR DESCRIPTION
Motivation:

`CloseHandler.forPipelinedRequestResponse` enables half-closure only for
`SocketChannelConfig`. `DomainSocketChannel` does not use this config.
As the result, half-closure does not work for UnixDomainSockets.

Modifications:

- Use `ALLOW_HALF_CLOSURE` socket option to enable half-closure for the
`Channel`;
- Assert in `RequestResponseCloseHandler` that `Channel` implements
`DuplexChannel` and also has `ALLOW_HALF_CLOSURE` socket option enabled;
- Enhance `ConnectionCloseHeaderHandlingTest` to test the same scenarios
for `DomainSocketAddress`;
- Move `newSocketAddress()` utility to `AddressUtils`;

Result:

Half-closure is enabled for `DomainSocketChannel`.