### PR TITLE
Exclude netty.io from validateHtmlLinks task

### DIFF
--- a/docs/generation/gradle/validateSite.gradle
+++ b/docs/generation/gradle/validateSite.gradle
@@ -27,6 +27,7 @@ def httpLinks = [
 
 // links to exclude from validation (for example because they require authentication or use untrusted cert)
 def excludedLinks = [
+    "https://netty.io", // started to return 520 status code frequently
     "https://reactivex.io", // untrusted cert
     "https://jemalloc.net" // untrusted cert
 ]


### PR DESCRIPTION
Motivation:

`https://netty.io/wiki/forked-tomcat-native.html` started return 520 status
code, resulting in frequent PRB failures.

---

Example: https://ci.servicetalk.io/job/servicetalk-quality-prb/1120/console