### PR TITLE
`ConnectionContext.toString()` prints Netty's channel id

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultNettyHttpConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultNettyHttpConnectionContext.java
@@ -75,9 +75,4 @@ final class DefaultNettyHttpConnectionContext extends DelegatingConnectionContex
     public Channel nettyChannel() {
         return nettyConnectionContext.nettyChannel();
     }
-
-    @Override
-    public String toString() {
-        return nettyConnectionContext.toString();
-    }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -382,6 +382,11 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
         }
 
         @Override
+        public String toString() {
+            return parentContext.toString();
+        }
+
+        @Override
         public StreamingHttpRequest newRequest(final HttpRequestMethod method, final String requestTarget) {
             return reqRespFactory.newRequest(method, requestTarget);
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -143,6 +143,11 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
     }
 
     @Override
+    public final String toString() {
+        return getClass().getSimpleName() + '(' + channel() + ')';
+    }
+
+    @Override
     protected final void doCloseAsyncGracefully() {
         keepAliveManager.initiateGracefulClose(onClosing::onComplete);
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -467,7 +467,7 @@ final class NettyHttpServer {
 
         @Override
         public String toString() {
-            return connection.toString();
+            return getClass().getSimpleName() + '(' + connection + ')';
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -247,11 +247,15 @@ public abstract class AbstractNettyHttpServerTest {
     }
 
     void assertResponse(final StreamingHttpResponse response, final HttpProtocolVersion version,
-                        final HttpResponseStatus status, final int expectedSize)
-            throws ExecutionException, InterruptedException {
+                        final HttpResponseStatus status) {
         assertEquals(status, response.status());
         assertEquals(version, response.version());
+    }
 
+    void assertResponse(final StreamingHttpResponse response, final HttpProtocolVersion version,
+                        final HttpResponseStatus status, final int expectedSize)
+            throws ExecutionException, InterruptedException {
+        assertResponse(response, version, status);
         final int size = awaitIndefinitelyNonNull(
                 response.payloadBody().collect(() -> 0, (is, c) -> is + c.readableBytes()));
         assertEquals(expectedSize, size);
@@ -260,8 +264,7 @@ public abstract class AbstractNettyHttpServerTest {
     void assertResponse(final StreamingHttpResponse response, final HttpProtocolVersion version,
                         final HttpResponseStatus status, final List<String> expectedPayloadChunksAsStrings)
             throws ExecutionException, InterruptedException {
-        assertEquals(status, response.status());
-        assertEquals(version, response.version());
+        assertResponse(response, version, status);
         final List<String> bodyAsListOfStrings = getBodyAsListOfStrings(response);
         if (expectedPayloadChunksAsStrings.isEmpty()) {
             assertTrue(bodyAsListOfStrings.isEmpty());

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionContextToStringTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionContextToStringTest.java
@@ -18,6 +18,7 @@ package io.servicetalk.http.netty;
 import io.servicetalk.http.api.BlockingHttpService;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpService;
+import io.servicetalk.http.netty.HttpTransportObserverTest.Protocol;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,17 +36,17 @@ import static org.hamcrest.Matchers.containsString;
 @RunWith(Parameterized.class)
 public class ConnectionContextToStringTest extends AbstractNettyHttpServerTest {
 
-    private final HttpProtocol protocol;
+    private final Protocol protocol;
 
-    public ConnectionContextToStringTest(HttpProtocol protocol) {
+    public ConnectionContextToStringTest(Protocol protocol) {
         super(CACHED, CACHED_SERVER);
         this.protocol = protocol;
         protocol(protocol.config);
     }
 
     @Parameterized.Parameters(name = "protocol={0}")
-    public static HttpProtocol[] data() {
-        return HttpProtocol.values();
+    public static Protocol[] data() {
+        return Protocol.values();
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionContextToStringTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionContextToStringTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.BlockingHttpService;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpService;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.api.HttpSerializationProviders.textDeserializer;
+import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
+import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED;
+import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED_SERVER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+@RunWith(Parameterized.class)
+public class ConnectionContextToStringTest extends AbstractNettyHttpServerTest {
+
+    private final HttpProtocol protocol;
+
+    public ConnectionContextToStringTest(HttpProtocol protocol) {
+        super(CACHED, CACHED_SERVER);
+        this.protocol = protocol;
+        protocol(protocol.config);
+    }
+
+    @Parameterized.Parameters(name = "protocol={0}")
+    public static HttpProtocol[] data() {
+        return HttpProtocol.values();
+    }
+
+    @Override
+    protected void service(final StreamingHttpService service) {
+        super.service((toStreamingHttpService((BlockingHttpService) (ctx, request, responseFactory) ->
+                        responseFactory.ok().payloadBody(ctx.toString(), textSerializer()),
+                strategy -> strategy)).adaptor());
+    }
+
+    @Test
+    public void test() throws Exception {
+        StreamingHttpResponse response = makeRequest(streamingHttpConnection().get("/"));
+        assertResponse(response, protocol.version, OK);
+        String serverContext = response.toResponse().toFuture().get().payloadBody(textDeserializer());
+
+        assertThat("Client's ConnectionContext does not contain netty channel id",
+                streamingHttpConnection().connectionContext().toString(), containsString("[id: "));
+        assertThat("Server's ConnectionContext does not contain netty channel id",
+                serverContext, containsString("[id: "));
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
@@ -82,12 +82,12 @@ import static org.mockito.Mockito.when;
 @RunWith(Parameterized.class)
 public class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
 
-    private enum Protocol {
+    enum Protocol {
         HTTP_1(h1Default(), HTTP_1_1),
         HTTP_2(h2Default(), HTTP_2_0);
 
-        private final HttpProtocolConfig config;
-        private final HttpProtocolVersion version;
+        final HttpProtocolConfig config;
+        final HttpProtocolVersion version;
 
         Protocol(HttpProtocolConfig config, HttpProtocolVersion version) {
             this.config = config;

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingConnectionContext.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingConnectionContext.java
@@ -95,4 +95,9 @@ public class DelegatingConnectionContext implements ConnectionContext {
     public Completable closeAsyncGracefully() {
         return delegate.closeAsyncGracefully();
     }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
 }


### PR DESCRIPTION
Motivation:

HTTP/1.1 `ConnectionContext.toString()` includes netty's `Channel` ID.
It helps to correlate the `ConnectionContext` with events in netty when
debug logging is enabled or with wire logging. HTTP/2 `ConnectionContext`
does not implement `toString()`.

Modifications:
- Implement `toString()` for all `ConnectionContext` implementations;
- Test that client's `ConnectionContext` and server's `ConnectionContext`
print netty's channel id for any HTTP protocol version;

Result:

All `ConnectionContext` implementations backed by netty print `Channel` id.