### PR TITLE
BlockingStreamingHttp[Response|Response] to support InputStream setter

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
@@ -57,12 +57,12 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     /**
      * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload set to {@code payloadBody}.
      * <p>
-     * A best effort will be made to apply back pressure to the existing {@link Iterable} payload body. If this
+     * A best effort will be made to apply back pressure to the existing payload body which is being replaced. If this
      * default policy is not sufficient you can use {@link #transformPayloadBody(UnaryOperator)} for more fine grain
      * control.
      * <p>
      * This method reserves the right to delay completion/consumption of {@code payloadBody}. This may occur due to the
-     * combination with the existing {@link Iterable} payload body.
+     * combination with the existing payload body that is being replaced.
      * @param payloadBody The new payload body.
      * @return {@code this}
      */
@@ -71,26 +71,40 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     /**
      * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload set to {@code payloadBody}.
      * <p>
-     * A best effort will be made to apply back pressure to the existing {@link CloseableIterable} payload body. If this
+     * A best effort will be made to apply back pressure to the existing payload body which is being replaced. If this
      * default policy is not sufficient you can use {@link #transformPayloadBody(UnaryOperator)} for more fine grain
      * control.
      * <p>
      * This method reserves the right to delay completion/consumption of {@code payloadBody}. This may occur due to the
-     * combination with the existing {@link CloseableIterable} payload body.
+     * combination with the existing payload body that is being replaced.
      * @param payloadBody The new payload body.
      * @return {@code this}
      */
     BlockingStreamingHttpRequest payloadBody(CloseableIterable<Buffer> payloadBody);
 
     /**
+     * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload set to {@code payloadBody}.
+     * <p>
+     * A best effort will be made to apply back pressure to the existing payload body which is being replaced. If this
+     * default policy is not sufficient you can use {@link #transformPayloadBody(UnaryOperator)} for more fine grain
+     * control.
+     * <p>
+     * This method reserves the right to delay completion/consumption of {@code payloadBody}. This may occur due to the
+     * combination with the existing payload body that is being replaced.
+     * @param payloadBody The new payload body.
+     * @return {@code this}
+     */
+    BlockingStreamingHttpRequest payloadBody(InputStream payloadBody);
+
+    /**
      * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload set to the result of serialization.
      * <p>
-     * A best effort will be made to apply back pressure to the existing {@link Iterable} payload body. If this
+     * A best effort will be made to apply back pressure to the existing payload body which is being replaced. If this
      * default policy is not sufficient you can use {@link #transformPayloadBody(Function, HttpSerializer)} for more
      * fine grain control.
      * <p>
      * This method reserves the right to delay completion/consumption of {@code payloadBody}. This may occur due to the
-     * combination with the existing {@link Iterable} payload body.
+     * combination with the existing payload body that is being replaced.
      * @param payloadBody The new payload body, prior to serialization.
      * @param serializer Used to serialize the payload body.
      * @param <T> The type of objects to serialize.
@@ -101,12 +115,12 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     /**
      * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload set to the result of serialization.
      * <p>
-     * A best effort will be made to apply back pressure to the existing {@link CloseableIterable} payload body. If this
+     * A best effort will be made to apply back pressure to the existing payload body which is being replaced. If this
      * default policy is not sufficient you can use {@link #transformPayloadBody(Function, HttpSerializer)} for more
      * fine grain control.
      * <p>
      * This method reserves the right to delay completion/consumption of {@code payloadBody}. This may occur due to the
-     * combination with the existing {@link CloseableIterable} payload body.
+     * combination with the existing payload body that is being replaced.
      * @param payloadBody The new payload body, prior to serialization.
      * @param serializer Used to serialize the payload body.
      * @param <T> The type of objects to serialize.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
@@ -57,12 +57,12 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
     /**
      * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload set to {@code payloadBody}.
      * <p>
-     * A best effort will be made to apply back pressure to the existing {@link Iterable} payload body. If this
+     * A best effort will be made to apply back pressure to the existing payload body which is being replaced. If this
      * default policy is not sufficient you can use {@link #transformPayloadBody(UnaryOperator)} for more fine grain
      * control.
      * <p>
      * This method reserves the right to delay completion/consumption of {@code payloadBody}. This may occur due to the
-     * combination with the existing {@link Iterable} payload body.
+     * combination with the existing payload body that is being replaced.
      * @param payloadBody The new payload body.
      * @return {@code this}
      */
@@ -71,26 +71,40 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
     /**
      * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload set to {@code payloadBody}.
      * <p>
-     * A best effort will be made to apply back pressure to the existing {@link CloseableIterable} payload body. If this
+     * A best effort will be made to apply back pressure to the existing payload body which is being replaced. If this
      * default policy is not sufficient you can use {@link #transformPayloadBody(UnaryOperator)} for more fine grain
      * control.
      * <p>
      * This method reserves the right to delay completion/consumption of {@code payloadBody}. This may occur due to the
-     * combination with the existing {@link CloseableIterable} payload body.
+     * combination with the existing payload body that is being replaced.
      * @param payloadBody The new payload body.
      * @return {@code this}
      */
     BlockingStreamingHttpResponse payloadBody(CloseableIterable<Buffer> payloadBody);
 
     /**
+     * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload set to {@code payloadBody}.
+     * <p>
+     * A best effort will be made to apply back pressure to the existing payload body which is being replaced. If this
+     * default policy is not sufficient you can use {@link #transformPayloadBody(UnaryOperator)} for more fine grain
+     * control.
+     * <p>
+     * This method reserves the right to delay completion/consumption of {@code payloadBody}. This may occur due to the
+     * combination with the existing payload body that is being replaced.
+     * @param payloadBody The new payload body.
+     * @return {@code this}
+     */
+    BlockingStreamingHttpResponse payloadBody(InputStream payloadBody);
+
+    /**
      * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload set to the result of serialization.
      * <p>
-     * A best effort will be made to apply back pressure to the existing {@link Iterable} payload body. If this
+     * A best effort will be made to apply back pressure to the existing payload body which is being replaced. If this
      * default policy is not sufficient you can use {@link #transformPayloadBody(Function, HttpSerializer)} for more
      * fine grain control.
      * <p>
      * This method reserves the right to delay completion/consumption of {@code payloadBody}. This may occur due to the
-     * combination with the existing {@link Iterable} payload body.
+     * combination with the existing payload body that is being replaced.
      * @param payloadBody The new payload body, prior to serialization.
      * @param serializer Used to serialize the payload body.
      * @param <T> The type of objects to serialize.
@@ -101,12 +115,12 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
     /**
      * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload set to the result of serialization.
      * <p>
-     * A best effort will be made to apply back pressure to the existing {@link CloseableIterable} payload body. If this
+     * A best effort will be made to apply back pressure to the existing payload body which is being replaced. If this
      * default policy is not sufficient you can use {@link #transformPayloadBody(Function, HttpSerializer)} for more
      * fine grain control.
      * <p>
      * This method reserves the right to delay completion/consumption of {@code payloadBody}. This may occur due to the
-     * combination with the existing {@link CloseableIterable} payload body.
+     * combination with the existing payload body that is being replaced.
      * @param payloadBody The new payload body, prior to serialization.
      * @param serializer Used to serialize the payload body.
      * @param <T> The type of objects to serialize.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
@@ -20,9 +20,11 @@ import io.servicetalk.concurrent.BlockingIterable;
 import io.servicetalk.concurrent.CloseableIterable;
 import io.servicetalk.concurrent.api.Single;
 
+import java.io.InputStream;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import static io.servicetalk.concurrent.api.Publisher.fromInputStream;
 import static io.servicetalk.concurrent.api.Publisher.fromIterable;
 
 final class DefaultBlockingStreamingHttpRequest extends AbstractDelegatingHttpRequest
@@ -124,6 +126,13 @@ final class DefaultBlockingStreamingHttpRequest extends AbstractDelegatingHttpRe
     @Override
     public BlockingStreamingHttpRequest payloadBody(final CloseableIterable<Buffer> payloadBody) {
         original.payloadBody(fromIterable(payloadBody));
+        return this;
+    }
+
+    @Override
+    public BlockingStreamingHttpRequest payloadBody(final InputStream payloadBody) {
+        original.payloadBody(fromInputStream(payloadBody)
+                .map(bytes -> original.payloadHolder().allocator().wrap(bytes)));
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpResponse.java
@@ -20,9 +20,11 @@ import io.servicetalk.concurrent.BlockingIterable;
 import io.servicetalk.concurrent.CloseableIterable;
 import io.servicetalk.concurrent.api.Single;
 
+import java.io.InputStream;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import static io.servicetalk.concurrent.api.Publisher.fromInputStream;
 import static io.servicetalk.concurrent.api.Publisher.fromIterable;
 
 final class DefaultBlockingStreamingHttpResponse extends AbstractDelegatingHttpResponse
@@ -46,6 +48,13 @@ final class DefaultBlockingStreamingHttpResponse extends AbstractDelegatingHttpR
     @Override
     public BlockingStreamingHttpResponse payloadBody(final CloseableIterable<Buffer> payloadBody) {
         original.payloadBody(fromIterable(payloadBody));
+        return this;
+    }
+
+    @Override
+    public BlockingStreamingHttpResponse payloadBody(final InputStream payloadBody) {
+        original.payloadBody(fromInputStream(payloadBody)
+                .map(bytes -> original.payloadHolder().allocator().wrap(bytes)));
         return this;
     }
 


### PR DESCRIPTION
Motivation:
BlockingStreamingHttp[Response|Response] allow a user to get the payload
body as an InputStream. However the user is not able to set the payload
body as an InputStream. This requires manual conversion from the user
perspective and raises the bar to entry.

Modifications:
- BlockingStreamingHttp[Response|Response] supports an additional method
to set the payloadBody as an InputStream

Result:
BlockingStreamingHttp[Response|Response] APIs are more InputStream
friendly.