### PR TITLE
Unignore temporarily disabled tests that require full discard of inbound data

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
@@ -34,7 +34,6 @@ import io.servicetalk.transport.netty.internal.ExecutionContextRule;
 
 import org.junit.After;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
@@ -335,7 +334,6 @@ public class ConnectionCloseHeaderHandlingTest {
         }
 
         @Test
-        @Ignore("Temporary disable until https://github.com/apple/servicetalk/pull/1141 is merged")
         public void serverCloseTwoPipelinedRequestsSentBeforeFirstResponse() throws Exception {
             AtomicReference<Throwable> secondRequestError = new AtomicReference<>();
             CountDownLatch secondResponseReceived = new CountDownLatch(1);
@@ -365,7 +363,6 @@ public class ConnectionCloseHeaderHandlingTest {
         }
 
         @Test
-        @Ignore("Temporary disable until https://github.com/apple/servicetalk/pull/1141 is merged")
         public void serverCloseSecondPipelinedRequestWriteAborted() throws Exception {
             AtomicReference<Throwable> secondRequestError = new AtomicReference<>();
             CountDownLatch secondResponseReceived = new CountDownLatch(1);


### PR DESCRIPTION
Motivation:

These tests were temporarily disabled until #1141 implements a proper discard
of further inbound data that were read from the network but were pending in
previous handlers.

Modifications:

- Unignore temporary disabled tests in `ConnectionCloseHeaderHandlingTest`;

Result:

Better test coverage.