### PR TITLE
Improve `servicetalk-test-resources/log4j2.xml`

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
@@ -128,7 +128,7 @@ public class ConnectionCloseHeaderHandlingTest {
                     HttpServers.forAddress(localAddress(0)))
                     .ioExecutor(SERVER_CTX.ioExecutor())
                     .executionStrategy(defaultStrategy(SERVER_CTX.executor()))
-                    .enableWireLogging("servicetalk-tests-server-wire-logger")
+                    .enableWireLogging("servicetalk-tests-wire-logger")
                     .appendConnectionAcceptorFilter(original -> new DelegatingConnectionAcceptor(original) {
                         @Override
                         public Completable accept(final ConnectionContext context) {
@@ -193,7 +193,7 @@ public class ConnectionCloseHeaderHandlingTest {
                     HttpClients.forResolvedAddress(serverContext.listenAddress()))
                     .ioExecutor(CLIENT_CTX.ioExecutor())
                     .executionStrategy(defaultStrategy(CLIENT_CTX.executor()))
-                    .enableWireLogging("servicetalk-tests-client-wire-logger")
+                    .enableWireLogging("servicetalk-tests-wire-logger")
                     .buildStreaming();
             connection = client.reserveConnection(client.get("/")).toFuture().get();
             connection.onClose().whenFinally(clientConnectionClosed::countDown).subscribe();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
@@ -142,7 +142,7 @@ public class GracefulConnectionClosureHandlingTest {
                 HttpServers.forAddress(localAddress(0)))
                 .ioExecutor(SERVER_CTX.ioExecutor())
                 .executionStrategy(defaultStrategy(SERVER_CTX.executor()))
-                .enableWireLogging("servicetalk-tests-server-wire-logger")
+                .enableWireLogging("servicetalk-tests-wire-logger")
                 .appendConnectionAcceptorFilter(original -> new DelegatingConnectionAcceptor(original) {
                     @Override
                     public Completable accept(final ConnectionContext context) {
@@ -199,7 +199,7 @@ public class GracefulConnectionClosureHandlingTest {
                 HttpClients.forResolvedAddress(serverContext.listenAddress()))
                 .ioExecutor(CLIENT_CTX.ioExecutor())
                 .executionStrategy(defaultStrategy(CLIENT_CTX.executor()))
-                .enableWireLogging("servicetalk-tests-client-wire-logger")
+                .enableWireLogging("servicetalk-tests-wire-logger")
                 .appendConnectionFactoryFilter(cf -> initiateClosureFromClient ?
                         new OnClosingConnectionFactoryFilter<>(cf, onClosing) : cf)
                 .buildStreaming();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProtocol.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProtocol.java
@@ -21,11 +21,11 @@ import io.servicetalk.http.api.HttpProtocolVersion;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
-import static io.servicetalk.http.netty.HttpProtocolConfigs.h2Default;
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h2;
 
 enum HttpProtocol {
     HTTP_1(h1Default(), HTTP_1_1),
-    HTTP_2(h2Default(), HTTP_2_0);
+    HTTP_2(h2().enableFrameLogging("servicetalk-tests-h2-frame-logger").build(), HTTP_2_0);
 
     final HttpProtocolConfig config;
     final HttpProtocolVersion version;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
@@ -77,7 +77,7 @@ public class ServerRespondsOnClosingTest {
         DefaultHttpExecutionContext httpExecutionContext = new DefaultHttpExecutionContext(DEFAULT_ALLOCATOR,
                 fromNettyEventLoop(channel.eventLoop()), immediate(), noOffloadsStrategy());
         final HttpServerConfig httpServerConfig = new HttpServerConfig();
-        httpServerConfig.tcpConfig().enableWireLogging("servicetalk-tests-server-wire-logger");
+        httpServerConfig.tcpConfig().enableWireLogging("servicetalk-tests-wire-logger");
         ReadOnlyHttpServerConfig config = httpServerConfig.asReadOnly();
         ConnectionObserver connectionObserver = NoopConnectionObserver.INSTANCE;
         HttpService service = (ctx, request, responseFactory) -> {

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
@@ -102,6 +102,7 @@ public abstract class AbstractTcpServerTest {
             securityConfig.disableHostnameVerification();
             tcpClientConfig.secure(securityConfig.asReadOnly());
         }
+        tcpClientConfig.enableWireLogging("servicetalk-tests-wire-logger");
         return tcpClientConfig;
     }
 
@@ -123,6 +124,7 @@ public abstract class AbstractTcpServerTest {
             securityConfig.keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey);
             tcpServerConfig.secure(securityConfig.asReadOnly());
         }
+        tcpServerConfig.enableWireLogging("servicetalk-tests-wire-logger");
         return tcpServerConfig;
     }
 

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverErrorsTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverErrorsTest.java
@@ -76,8 +76,6 @@ public final class SecureTcpTransportObserverErrorsTest extends AbstractTranspor
         this.errorReason = errorReason;
         this.clientProvider = clientProvider;
         this.serverProvider = serverProvider;
-        // clientConfig.enableWireLogging("servicetalk-tests-client-wire-logger");
-        // serverConfig.enableWireLogging("servicetalk-tests-server-wire-logger");
         ClientSecurityConfig clientSecurityConfig = defaultClientSecurityConfig(clientProvider);
         ServerSecurityConfig serverSecurityConfig = defaultServerSecurityConfig(serverProvider);
         switch (errorReason) {

--- a/servicetalk-test-resources/src/main/resources/log4j2.xml
+++ b/servicetalk-test-resources/src/main/resources/log4j2.xml
@@ -18,6 +18,7 @@
   <Properties>
     <Property name="rootLevel">${sys:servicetalk.logger.rootLevel:-INFO}</Property>
     <Property name="wireLogLevel">${sys:servicetalk.logger.wireLogLevel:-OFF}</Property>
+    <Property name="h2FrameLogLevel">${sys:servicetalk.logger.h2FrameLogLevel:-OFF}</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
@@ -25,8 +26,8 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Logger name="servicetalk-tests-client-wire-logger" level="${wireLogLevel}"/>
-    <Logger name="servicetalk-tests-server-wire-logger" level="${wireLogLevel}"/>
+    <Logger name="servicetalk-tests-wire-logger" level="${wireLogLevel}"/>
+    <Logger name="servicetalk-tests-h2-frame-logger" level="${h2FrameLogLevel}"/>
     <Root level="${rootLevel}">
       <AppenderRef ref="Console"/>
     </Root>


### PR DESCRIPTION
Motivation:

Wire logger and h2 frame logger are controlled by the logger configuration
after #1123. It allows us to use these logger names in tests and enabled them
via system property when required for local debugging.
Having 2 different logger names for client and server controlled by a single
system property does not help much. We can use a thread name to understand
if a logger statement belongs to a client or to a server. A single logger name
simplifies usage in tests.

Modifications:

- Keep only a single `servicetalk-tests-wire-logger` logger name;
- Add `servicetalk-tests-h2-frame-logger` logger name and
`servicetalk.logger.h2FrameLogLevel` system property to control visibility
for h2 frames;
- Update all tests to use new names;

Result:

Separate system properties to control wire logger and h2 frame logger.