### PR TITLE
Add more test scenarios for `HeaderUtils#hasContentType`

### DIFF
--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
@@ -75,6 +75,9 @@ public class HeaderUtilsTest {
         assertTrue(HeaderUtils.hasContentType(
                 headersWithContentType(TEXT_PLAIN), TEXT_PLAIN, null));
 
+        assertTrue(HeaderUtils.hasContentType(
+                headersWithContentType(TEXT_PLAIN_UTF_8), TEXT_PLAIN, null));
+
         assertFalse(HeaderUtils.hasContentType(
                 headersWithContentType(TEXT_PLAIN), APPLICATION_JSON, null));
 
@@ -111,6 +114,12 @@ public class HeaderUtilsTest {
 
         assertTrue(HeaderUtils.hasContentType(
                 headersWithContentType(of("Text/Plain")), TEXT_PLAIN, null));
+
+        assertTrue(HeaderUtils.hasContentType(
+                headersWithContentType(of("text/plain; charset=UTF-8")), TEXT_PLAIN, null));
+
+        assertTrue(HeaderUtils.hasContentType(
+                headersWithContentType(of("text/plain;charset=UTF-8")), TEXT_PLAIN, null));
 
         assertTrue(HeaderUtils.hasContentType(
                 headersWithContentType(of("Text/Plain")), TEXT_PLAIN, UTF_8));


### PR DESCRIPTION
Motivation:

Verify that when `expectedCharset` is `null` it can recognize the `content-type`
header value that contains `charset=UTF-8` with and without space after `;`.

Modifications:
- Add more test scenarios at `HeaderUtilsTest.java.hasContentType()`;

Result:

Better test coverage for `HeaderUtils#hasContentType`.