### PR TITLE
Add grpc protoc options example

### DIFF
--- a/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
@@ -9,3 +9,4 @@
 * xref:{page-version}@servicetalk-examples::grpc/index.adoc[gRPC]
 ** xref:{page-version}@servicetalk-examples::grpc/index.adoc#HelloWorld[Hello World]
 ** xref:{page-version}@servicetalk-examples::grpc/index.adoc#route-guide[Route Guide]
+** xref:{page-version}@servicetalk-examples::grpc/index.adoc#protoc-options[Protoc Options]

--- a/servicetalk-examples/docs/modules/ROOT/pages/grpc/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/grpc/index.adoc
@@ -74,3 +74,10 @@ xref:{page-version}@servicetalk::programming-paradigms.adoc#asynchronous-and-str
 * link:{source-root}/servicetalk-examples/grpc/routeguide/src/main/java/io/servicetalk/examples/grpc/routeguide/blocking/streaming/BlockingRouteGuideStreamingClient.java[BlockingRouteGuideStreamingClient] -
 `recordRoute` API that uses the
 xref:{page-version}@servicetalk::programming-paradigms.adoc#asynchronous-and-streaming[bi-directional streaming programming paradigm].
+
+[#protoc-options]
+== Protoc Options
+
+This example demonstrates how options for the servicetalk-grpc-protoc plugin can be used. See
+* link:{source-root}/servicetalk-examples/grpc/routeguide/src/main/java/io/servicetalk/examples/grpc/protoc-options[protoc-options]
+for more details.

--- a/servicetalk-examples/grpc/protoc-options/README.adoc
+++ b/servicetalk-examples/grpc/protoc-options/README.adoc
@@ -2,6 +2,8 @@
 
 Using the same interface as the "Hello World" examples, demonstrate servicetalk-grpc-protoc plugin options.
 
+See link:{source-root}/servicetalk-grpc-protoc[servicetalk-grpc-protoc] for detailed description of options.
+
 For example here is one of the options demonstrated:
 
 [source,gradle]

--- a/servicetalk-examples/grpc/protoc-options/README.adoc
+++ b/servicetalk-examples/grpc/protoc-options/README.adoc
@@ -1,0 +1,14 @@
+== ServiceTalk gRPC protoc options
+
+Using the same interface as the "Hello World" examples, demonstrate servicetalk-grpc-protoc plugin options.
+
+For example here is one of the options demonstrated:
+
+[source,gradle]
+----
+task.plugins {
+  servicetalk_grpc {
+    option 'typeNameSuffix=St'
+  }
+}
+----

--- a/servicetalk-examples/grpc/protoc-options/build.gradle
+++ b/servicetalk-examples/grpc/protoc-options/build.gradle
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+buildscript {
+  dependencies {
+    classpath "com.google.protobuf:protobuf-gradle-plugin:$protobufGradlePluginVersion"
+  }
+}
+
+apply plugin: "java"
+apply plugin: "com.google.protobuf"
+apply from: "../../gradle/idea.gradle"
+
+dependencies {
+  implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-grpc-netty")
+  implementation project(":servicetalk-grpc-protoc")
+  implementation project(":servicetalk-grpc-protobuf")
+
+  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+}
+
+protobuf {
+  protoc {
+    artifact = "com.google.protobuf:protoc:$protobufVersion"
+  }
+  plugins {
+    servicetalk_grpc {
+      //// Users are expected to use "artifact" instead of "path". we use "path"
+      //// only because we want to use the gradle project local version of the plugin
+      // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
+      path = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
+                  "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+    }
+  }
+  generateProtoTasks {
+    all().each { task ->
+      task.plugins {
+        servicetalk_grpc {
+          // Need to tell protobuf-gradle-plugin to output in the correct directory if all generated
+          // code for a single proto goes to a single file (e.g. "java_multiple_files = false" in the .proto).
+          outputSubDir = "java"
+          // Option to append a suffix to type names to avoid naming collisions with other code generation.
+          option 'typeNameSuffix=St'
+        }
+      }
+    }
+  }
+  generatedFilesBaseDir = "$buildDir/generated/sources/proto"
+}
+
+// The following setting must be omitted in users projects and is necessary here
+// only because we want to use the locally built version of the plugin
+afterEvaluate {
+  generateProto.dependsOn(":servicetalk-grpc-protoc:buildExecutable")
+}

--- a/servicetalk-examples/grpc/protoc-options/src/main/java/io/servicetalk/examples/grpc/protocoptions/BlockingProtocOptionsClient.java
+++ b/servicetalk-examples/grpc/protoc-options/src/main/java/io/servicetalk/examples/grpc/protocoptions/BlockingProtocOptionsClient.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.grpc.protocoptions;
+
+import io.servicetalk.grpc.netty.GrpcClients;
+
+import io.grpc.examples.helloworld.GreeterSt.BlockingGreeterClient;
+import io.grpc.examples.helloworld.GreeterSt.ClientFactory;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+
+public final class BlockingProtocOptionsClient {
+
+    public static void main(String[] args) throws Exception {
+        try (BlockingGreeterClient client = GrpcClients.forAddress("localhost", 8080)
+                .buildBlocking(new ClientFactory())) {
+            HelloReply reply = client.sayHello(HelloRequest.newBuilder().setName("Foo").build());
+            System.out.println(reply);
+        }
+    }
+}

--- a/servicetalk-examples/grpc/protoc-options/src/main/java/io/servicetalk/examples/grpc/protocoptions/BlockingProtocOptionsClient.java
+++ b/servicetalk-examples/grpc/protoc-options/src/main/java/io/servicetalk/examples/grpc/protocoptions/BlockingProtocOptionsClient.java
@@ -17,16 +17,15 @@ package io.servicetalk.examples.grpc.protocoptions;
 
 import io.servicetalk.grpc.netty.GrpcClients;
 
-import io.grpc.examples.helloworld.GreeterSt.BlockingGreeterClient;
-import io.grpc.examples.helloworld.GreeterSt.ClientFactory;
+import io.grpc.examples.helloworld.GreeterSt;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
 
 public final class BlockingProtocOptionsClient {
 
     public static void main(String[] args) throws Exception {
-        try (BlockingGreeterClient client = GrpcClients.forAddress("localhost", 8080)
-                .buildBlocking(new ClientFactory())) {
+        try (GreeterSt.BlockingGreeterClient client = GrpcClients.forAddress("localhost", 8080)
+                .buildBlocking(new GreeterSt.ClientFactory())) {
             HelloReply reply = client.sayHello(HelloRequest.newBuilder().setName("Foo").build());
             System.out.println(reply);
         }

--- a/servicetalk-examples/grpc/protoc-options/src/main/java/io/servicetalk/examples/grpc/protocoptions/BlockingProtocOptionsServer.java
+++ b/servicetalk-examples/grpc/protoc-options/src/main/java/io/servicetalk/examples/grpc/protocoptions/BlockingProtocOptionsServer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.grpc.protocoptions;
+
+import io.servicetalk.grpc.api.GrpcServiceContext;
+import io.servicetalk.grpc.netty.GrpcServers;
+
+import io.grpc.examples.helloworld.GreeterSt.BlockingGreeterService;
+import io.grpc.examples.helloworld.GreeterSt.ServiceFactory;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+
+public class BlockingProtocOptionsServer {
+
+    public static void main(String[] args) throws Exception {
+        GrpcServers.forPort(8080)
+                .listenAndAwait(new ServiceFactory(new MyGreeterService()))
+                .awaitShutdown();
+    }
+
+    private static final class MyGreeterService implements BlockingGreeterService {
+
+        @Override
+        public HelloReply sayHello(final GrpcServiceContext ctx, final HelloRequest request) {
+            return HelloReply.newBuilder().setMessage("Hello " + request.getName()).build();
+        }
+    }
+}

--- a/servicetalk-examples/grpc/protoc-options/src/main/java/io/servicetalk/examples/grpc/protocoptions/BlockingProtocOptionsServer.java
+++ b/servicetalk-examples/grpc/protoc-options/src/main/java/io/servicetalk/examples/grpc/protocoptions/BlockingProtocOptionsServer.java
@@ -18,8 +18,7 @@ package io.servicetalk.examples.grpc.protocoptions;
 import io.servicetalk.grpc.api.GrpcServiceContext;
 import io.servicetalk.grpc.netty.GrpcServers;
 
-import io.grpc.examples.helloworld.GreeterSt.BlockingGreeterService;
-import io.grpc.examples.helloworld.GreeterSt.ServiceFactory;
+import io.grpc.examples.helloworld.GreeterSt;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
 
@@ -27,11 +26,11 @@ public class BlockingProtocOptionsServer {
 
     public static void main(String[] args) throws Exception {
         GrpcServers.forPort(8080)
-                .listenAndAwait(new ServiceFactory(new MyGreeterService()))
+                .listenAndAwait(new GreeterSt.ServiceFactory(new MyGreeterService()))
                 .awaitShutdown();
     }
 
-    private static final class MyGreeterService implements BlockingGreeterService {
+    private static final class MyGreeterService implements GreeterSt.BlockingGreeterService {
 
         @Override
         public HelloReply sayHello(final GrpcServiceContext ctx, final HelloRequest request) {

--- a/servicetalk-examples/grpc/protoc-options/src/main/java/io/servicetalk/examples/grpc/protocoptions/package-info.java
+++ b/servicetalk-examples/grpc/protoc-options/src/main/java/io/servicetalk/examples/grpc/protocoptions/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.grpc.protocoptions;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-examples/grpc/protoc-options/src/main/proto/helloworld.proto
+++ b/servicetalk-examples/grpc/protoc-options/src/main/proto/helloworld.proto
@@ -1,0 +1,37 @@
+// Copyright 2015 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.helloworld";
+option java_outer_classname = "HelloWorldProto";
+option objc_class_prefix = "HLW";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+    string message = 1;
+}

--- a/servicetalk-examples/grpc/protoc-options/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/grpc/protoc-options/src/main/resources/log4j2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="info">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d %30t [%-5level] %-30logger{1} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <!-- Prints server start and shutdown -->
+    <Logger name="io.servicetalk.http.netty.H2ServerParentConnectionContext" level="DEBUG"/>
+
+    <!-- Prints default subscriber errors-->
+    <Logger name="io.servicetalk.concurrent.api" level="DEBUG"/>
+
+    <!-- Use `-Dservicetalk.logger.level=DEBUG` to change the root logger level via command line  -->
+    <Root level="${sys:servicetalk.logger.level:-INFO}">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,6 +35,7 @@ include "servicetalk-annotations",
         "servicetalk-dns-discovery-netty",
         "servicetalk-examples:grpc:helloworld",
         "servicetalk-examples:grpc:routeguide",
+        "servicetalk-examples:grpc:protoc-options",
         "servicetalk-examples:http:helloworld",
         "servicetalk-examples:http:mutual-tls",
         "servicetalk-examples:http:http2",
@@ -78,6 +79,7 @@ include "servicetalk-annotations",
 
 project(":servicetalk-examples:grpc:helloworld").name = "servicetalk-examples-grpc-helloworld"
 project(":servicetalk-examples:grpc:routeguide").name = "servicetalk-examples-grpc-routeguide"
+project(":servicetalk-examples:grpc:protoc-options").name = "servicetalk-examples-grpc-protoc-options"
 project(":servicetalk-examples:http:http2").name = "servicetalk-examples-http-http2"
 project(":servicetalk-examples:http:helloworld").name = "servicetalk-examples-http-helloworld"
 project(":servicetalk-examples:http:jaxrs").name = "servicetalk-examples-http-jaxrs"


### PR DESCRIPTION
Motivation:
We recently added a new option to servicetalk-grpc-protoc, but don't
have an example to demonstrate its use and validate correct behavior.