### PR TITLE
Update http example docs index

### DIFF
--- a/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
@@ -5,6 +5,8 @@
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#JAXRS[JAX-RS]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#MetaData[MetaData]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#HTTP2[HTTP/2]
+** xref:{page-version}@servicetalk-examples::http/index.adoc#Mutual-TLS[Mutual TLS]
+** xref:{page-version}@servicetalk-examples::http/index.adoc#uds[Unix Domain Sockets]
 ** xref:{page-version}@servicetalk-examples::http/service-composition.adoc[Service Composition]
 * xref:{page-version}@servicetalk-examples::grpc/index.adoc[gRPC]
 ** xref:{page-version}@servicetalk-examples::grpc/index.adoc#HelloWorld[Hello World]

--- a/servicetalk-examples/docs/modules/ROOT/pages/grpc/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/grpc/index.adoc
@@ -79,5 +79,4 @@ xref:{page-version}@servicetalk::programming-paradigms.adoc#asynchronous-and-str
 == Protoc Options
 
 This example demonstrates how options for the servicetalk-grpc-protoc plugin can be used. See
-link:{source-root}/servicetalk-examples/grpc/routeguide/src/main/java/io/servicetalk/examples/grpc/protoc-options[protoc-options]
-for more details.
+link:{source-root}/servicetalk-examples/grpc/protoc-options[protoc-options] for more details.

--- a/servicetalk-examples/docs/modules/ROOT/pages/grpc/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/grpc/index.adoc
@@ -79,5 +79,5 @@ xref:{page-version}@servicetalk::programming-paradigms.adoc#asynchronous-and-str
 == Protoc Options
 
 This example demonstrates how options for the servicetalk-grpc-protoc plugin can be used. See
-* link:{source-root}/servicetalk-examples/grpc/routeguide/src/main/java/io/servicetalk/examples/grpc/protoc-options[protoc-options]
+link:{source-root}/servicetalk-examples/grpc/routeguide/src/main/java/io/servicetalk/examples/grpc/protoc-options[protoc-options]
 for more details.

--- a/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
@@ -177,3 +177,12 @@ builder API is the same across all the HTTP APIs.
 
 An advanced example which demonstrates a composition of various ServiceTalks services in one application.
 For more information see xref:http/service-composition.adoc[Service Composition].
+
+[#uds]
+== Unix Domain Sockets (UDS)
+
+This example demonstrates how client and server can use unix domain sockets. See
+the link:{source-root}/servicetalk-examples/http/uds[uds example code] for more details.
+
+NOTE: This example uses the link:#blocking-aggregated[blocking + aggregated] API, as the UDS configuration API is the
+same across all the HTTP APIs.


### PR DESCRIPTION
Motivation:
The mutual-tls and uds examples were added recently but the example docs index doesn't include them.