### PR TITLE
Use `IoThreadFactory` for `IoExecutor` in `ExecutionContextRule`

### DIFF
--- a/servicetalk-transport-netty-internal/src/testFixtures/java/io/servicetalk/transport/netty/internal/ExecutionContextRule.java
+++ b/servicetalk-transport-netty-internal/src/testFixtures/java/io/servicetalk/transport/netty/internal/ExecutionContextRule.java
@@ -68,7 +68,7 @@ public final class ExecutionContextRule extends ExternalResource implements Exec
     }
 
     public static ExecutionContextRule immediate() {
-        return immediate(new DefaultThreadFactory(IO_THREAD_PREFIX));
+        return immediate(new IoThreadFactory(IO_THREAD_PREFIX));
     }
 
     public static ExecutionContextRule immediate(ThreadFactory ioThreadFactory) {
@@ -77,7 +77,7 @@ public final class ExecutionContextRule extends ExternalResource implements Exec
     }
 
     public static ExecutionContextRule cached() {
-        return cached(new DefaultThreadFactory(IO_THREAD_PREFIX));
+        return cached(new IoThreadFactory(IO_THREAD_PREFIX));
     }
 
     public static ExecutionContextRule cached(ThreadFactory ioThreadFactory) {
@@ -92,7 +92,7 @@ public final class ExecutionContextRule extends ExternalResource implements Exec
     }
 
     public static ExecutionContextRule fixed(int size) {
-        return fixed(size, new DefaultThreadFactory(IO_THREAD_PREFIX));
+        return fixed(size, new IoThreadFactory(IO_THREAD_PREFIX));
     }
 
     public static ExecutionContextRule fixed(int size, ThreadFactory ioThreadFactory) {


### PR DESCRIPTION
Motivation:

`ExecutionContextRule` creates an `IoExecutor` with `DefaultThreadFactory`,
but it should use `IoThreadFactory`.

Modifications:

- Use `IoThreadFactory` for `IoExecutor` in `ExecutionContextRule`;

Result:

`ExecutionContextRule` uses correct `ThreadFactory` for `IoExecutor`.