### PR TITLE
Option to configure capacity of the datagram packet buffer for DNS SD

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -106,7 +106,7 @@ final class DefaultDnsClient implements DnsClient {
     private boolean closed;
 
     DefaultDnsClient(final IoExecutor ioExecutor, final int minTTL,
-                     @Nullable Integer datagramBufferCapacity, @Nullable final Integer ndots,
+                     @Nullable Integer maxUdpPayloadSize, @Nullable final Integer ndots,
                      @Nullable final Boolean optResourceEnabled, @Nullable final Duration queryTimeout,
                      @Nullable final DnsResolverAddressTypes dnsResolverAddressTypes,
                      @Nullable final DnsServerAddressStreamProvider dnsServerAddressStreamProvider,
@@ -138,8 +138,8 @@ final class DefaultDnsClient implements DnsClient {
         if (queryTimeout != null) {
             builder.queryTimeoutMillis(queryTimeout.toMillis());
         }
-        if (datagramBufferCapacity != null) {
-            builder.maxPayloadSize(datagramBufferCapacity);
+        if (maxUdpPayloadSize != null) {
+            builder.maxPayloadSize(maxUdpPayloadSize);
         }
         if (ndots != null) {
             builder.ndots(ndots);

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -106,7 +106,7 @@ final class DefaultDnsClient implements DnsClient {
     private boolean closed;
 
     DefaultDnsClient(final IoExecutor ioExecutor, final int minTTL,
-                     @Nullable final Integer ndots,
+                     @Nullable Integer datagramBufferCapacity, @Nullable final Integer ndots,
                      @Nullable final Boolean optResourceEnabled, @Nullable final Duration queryTimeout,
                      @Nullable final DnsResolverAddressTypes dnsResolverAddressTypes,
                      @Nullable final DnsServerAddressStreamProvider dnsServerAddressStreamProvider,
@@ -137,6 +137,9 @@ final class DefaultDnsClient implements DnsClient {
                 .completeOncePreferredResolved(true);
         if (queryTimeout != null) {
             builder.queryTimeoutMillis(queryTimeout.toMillis());
+        }
+        if (datagramBufferCapacity != null) {
+            builder.maxPayloadSize(datagramBufferCapacity);
         }
         if (ndots != null) {
             builder.ndots(ndots);

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -39,7 +39,7 @@ public final class DefaultDnsServiceDiscovererBuilder {
     @Nullable
     private DnsResolverAddressTypes dnsResolverAddressTypes;
     @Nullable
-    private Integer datagramBufferCapacity;
+    private Integer maxUdpPayloadSize;
     @Nullable
     private Integer ndots;
     @Nullable
@@ -95,16 +95,18 @@ public final class DefaultDnsServiceDiscovererBuilder {
     }
 
     /**
-     * Set the capacity of the datagram packet buffer (in bytes).
+     * Set the maximum size of the receiving UDP datagram (in bytes).
+     * <p>
+     * If the DNS response exceeds this amount the request will be automatically retried via TCP.
      *
-     * @param datagramBufferCapacity the capacity of the datagram packet buffer
+     * @param maxUdpPayloadSize the maximum size of the receiving UDP datagram (in bytes)
      * @return {@code this}.
      */
-    public DefaultDnsServiceDiscovererBuilder datagramBufferCapacity(final int datagramBufferCapacity) {
-        if (datagramBufferCapacity <= 0) {
-            throw new IllegalArgumentException("datagramBufferCapacity: " + minTTLSeconds + " (expected > 0)");
+    public DefaultDnsServiceDiscovererBuilder maxUdpPayloadSize(final int maxUdpPayloadSize) {
+        if (maxUdpPayloadSize <= 0) {
+            throw new IllegalArgumentException("maxUdpPayloadSize: " + minTTLSeconds + " (expected > 0)");
         }
-        this.datagramBufferCapacity = datagramBufferCapacity;
+        this.maxUdpPayloadSize = maxUdpPayloadSize;
         return this;
     }
 
@@ -225,7 +227,7 @@ public final class DefaultDnsServiceDiscovererBuilder {
     DnsClient build() {
         final DnsClient rawClient = new DefaultDnsClient(
                 ioExecutor == null ? globalExecutionContext().ioExecutor() : ioExecutor, minTTLSeconds,
-                datagramBufferCapacity, ndots,
+                maxUdpPayloadSize, ndots,
                 optResourceEnabled, queryTimeout, dnsResolverAddressTypes,
                 dnsServerAddressStreamProvider, observer);
         return filterFactory == null ? rawClient : filterFactory.create(rawClient);

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -39,6 +39,8 @@ public final class DefaultDnsServiceDiscovererBuilder {
     @Nullable
     private DnsResolverAddressTypes dnsResolverAddressTypes;
     @Nullable
+    private Integer datagramBufferCapacity;
+    @Nullable
     private Integer ndots;
     @Nullable
     private Boolean optResourceEnabled;
@@ -59,8 +61,8 @@ public final class DefaultDnsServiceDiscovererBuilder {
      * @return {@code this}.
      */
     public DefaultDnsServiceDiscovererBuilder minTTL(final int minTTLSeconds) {
-        if (minTTLSeconds < 1) {
-            throw new IllegalArgumentException("minTTLSeconds: " + minTTLSeconds + " (expected > 1)");
+        if (minTTLSeconds <= 0) {
+            throw new IllegalArgumentException("minTTLSeconds: " + minTTLSeconds + " (expected > 0)");
         }
         this.minTTLSeconds = minTTLSeconds;
         return this;
@@ -89,6 +91,20 @@ public final class DefaultDnsServiceDiscovererBuilder {
      */
     public DefaultDnsServiceDiscovererBuilder optResourceEnabled(final boolean optResourceEnabled) {
         this.optResourceEnabled = optResourceEnabled;
+        return this;
+    }
+
+    /**
+     * Set the capacity of the datagram packet buffer (in bytes).
+     *
+     * @param datagramBufferCapacity the capacity of the datagram packet buffer
+     * @return {@code this}.
+     */
+    public DefaultDnsServiceDiscovererBuilder datagramBufferCapacity(final int datagramBufferCapacity) {
+        if (datagramBufferCapacity <= 0) {
+            throw new IllegalArgumentException("datagramBufferCapacity: " + minTTLSeconds + " (expected > 0)");
+        }
+        this.datagramBufferCapacity = datagramBufferCapacity;
         return this;
     }
 
@@ -208,7 +224,8 @@ public final class DefaultDnsServiceDiscovererBuilder {
      */
     DnsClient build() {
         final DnsClient rawClient = new DefaultDnsClient(
-                ioExecutor == null ? globalExecutionContext().ioExecutor() : ioExecutor, minTTLSeconds, ndots,
+                ioExecutor == null ? globalExecutionContext().ioExecutor() : ioExecutor, minTTLSeconds,
+                datagramBufferCapacity, ndots,
                 optResourceEnabled, queryTimeout, dnsResolverAddressTypes,
                 dnsServerAddressStreamProvider, observer);
         return filterFactory == null ? rawClient : filterFactory.create(rawClient);


### PR DESCRIPTION
Motivation:

UDP packet may be truncated if it exceeds the maximum payload size of 4096
bytes. In this case, DNS ServiceDiscoverer will retry with TCP. However,
users should be able to configure higher capacity of the datagram packet
buffer.

Modifications:

- Add `DefaultDnsServiceDiscovererBuilder#maxUdpPayloadSize` method;
- Fix `IllegalArgumentException` message for `minTTL` option;

Result:

Users can control the capacity of the datagram packet buffer.