### PR TITLE
Enhance null header value exception

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeaders.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeaders.java
@@ -59,17 +59,6 @@ final class DefaultHttpHeaders extends MultiMap<CharSequence, CharSequence> impl
     }
 
     @Override
-    MultiMapEntry<CharSequence, CharSequence> newEntry(final CharSequence key,
-                                                       final CharSequence value, final int keyHash) {
-        return new MultiMapEntry<CharSequence, CharSequence>(value, keyHash) {
-            @Override
-            public CharSequence getKey() {
-                return key;
-            }
-        };
-    }
-
-    @Override
     public boolean containsIgnoreCase(final CharSequence name, final CharSequence value) {
         return contains(name, value, CharSequences::contentEqualsIgnoreCase);
     }


### PR DESCRIPTION
Motivation:
For HTTP null header values are not allowed. An exception is thrown but
doesn't include the key which makes it more difficult for users to
understand the root cause.

Modifications:
- Enrich the null value exception to include the key

Result:
More informative exceptions.