### PR TITLE
Improve DefaultHttpRequestMetaData query manipulator methods

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/api/QueryAddBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/api/QueryAddBenchmark.java
@@ -27,6 +27,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
+import static io.servicetalk.http.api.DefaultHttpHeadersFactory.INSTANCE;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
 
@@ -42,7 +43,7 @@ public class QueryAddBenchmark {
     private boolean needsEncoding;
     private String[] values;
     private DefaultHttpRequestMetaData stMetaData;
-    private final HttpHeaders headers = new DefaultHttpHeadersFactory(false, false).newHeaders();
+    private final HttpHeaders headers = INSTANCE.newHeaders();
 
     @Setup(Level.Trial)
     public void setup() {

--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/api/QueryAddBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/api/QueryAddBenchmark.java
@@ -56,12 +56,13 @@ public class QueryAddBenchmark {
     }
 
     @Benchmark
-    public String addParam() {
+    public int addParam() {
         final String name = "name";
         for (final String value : values) {
             stMetaData.addQueryParameter(name, value);
         }
+        String beforeRemoveTarget = stMetaData.requestTarget();
         stMetaData.removeQueryParameters(name);
-        return stMetaData.requestTarget();
+        return beforeRemoveTarget.length() - stMetaData.requestTarget().length();
     }
 }

--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/api/QueryAddBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/api/QueryAddBenchmark.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.HttpRequestMethod.GET;
+
+@Fork(value = 1)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 5)
+@Measurement(iterations = 5, time = 5)
+@BenchmarkMode(Mode.Throughput)
+public class QueryAddBenchmark {
+    @Param({"1", "10", "100"})
+    private int numValues;
+    @Param({"false", "true"})
+    private boolean needsEncoding;
+    private String[] values;
+    private DefaultHttpRequestMetaData stMetaData;
+    private final HttpHeaders headers = new DefaultHttpHeadersFactory(false, false).newHeaders();
+
+    @Setup(Level.Trial)
+    public void setup() {
+        values = new String[numValues];
+        String baseValue = needsEncoding ? "my value" : "myxvalue";
+        for (int i = 0; i < values.length; ++i) {
+            values[i] = baseValue + i;
+        }
+        stMetaData = new DefaultHttpRequestMetaData(GET, "", HTTP_1_1, headers);
+    }
+
+    @Benchmark
+    public String addParam() {
+        final String name = "name";
+        for (final String value : values) {
+            stMetaData.addQueryParameter(name, value);
+        }
+        stMetaData.removeQueryParameters(name);
+        return stMetaData.requestTarget();
+    }
+}

--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/api/QueryStringEncodingBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/api/QueryStringEncodingBenchmark.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.HttpRequestMethod.GET;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+@Fork(value = 1)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 5)
+@Measurement(iterations = 5, time = 5)
+@BenchmarkMode(Mode.Throughput)
+public class QueryStringEncodingBenchmark {
+    private String value;
+    @Param({"100", "1000", "10000"})
+    private int length;
+    @Param({"false", "true"})
+    private boolean needsEncoding;
+    private DefaultHttpRequestMetaData stMetaData;
+    private final HttpHeaders headers = new DefaultHttpHeadersFactory(false, false).newHeaders();
+
+    @Setup(Level.Trial)
+    public void setup() {
+        StringBuilder sb = new StringBuilder(length);
+        if (needsEncoding) {
+            final int halfLength = length >>> 1;
+            int i = 0;
+            for (; i < halfLength; ++i) {
+                sb.append('a');
+            }
+            sb.append(' ');
+            for (; i < length; ++i) {
+                sb.append('b');
+            }
+        } else {
+            for (int i = 0; i < length; ++i) {
+                sb.append('a');
+            }
+        }
+        value = sb.toString();
+        stMetaData = new DefaultHttpRequestMetaData(GET, "", HTTP_1_1, headers);
+    }
+
+    @Benchmark
+    public HttpRequestMetaData stEncoding() {
+        return stMetaData.query(value);
+    }
+
+    @Benchmark
+    public String jdkURLEncoder() throws UnsupportedEncodingException {
+        return jdkBuildURL("", URLEncoder.encode(value, UTF_8.name()));
+    }
+
+    private static String jdkBuildURL(final String uri, @Nullable String query) {
+        // replicating what is done in DefaultHttpHeadersFactory to build the URI
+        StringBuilder sb = query != null ? new StringBuilder(uri.length() + query.length()) :
+                new StringBuilder(uri.length());
+        sb.append(uri);
+        if (query != null) {
+            sb.append('?').append(query);
+        }
+        return sb.toString();
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequestMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequestMetaData.java
@@ -218,7 +218,7 @@ class DefaultHttpRequestMetaData extends AbstractHttpMetaData implements HttpReq
     public HttpRequestMetaData rawQuery(@Nullable final String query) {
         Uri httpUri = lazyParseRequestTarget();
         // Potentially over estimate the size of the URL to avoid resize/copy
-        StringBuilder sb = query != null ? new StringBuilder(httpUri.uri().length() + query.length()) :
+        StringBuilder sb = query != null ? new StringBuilder(httpUri.uri().length() + query.length() + 1) :
                                            new StringBuilder(httpUri.uri().length());
         appendScheme(sb, httpUri);
         appendAuthority(sb, httpUri);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequestMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequestMetaData.java
@@ -82,13 +82,14 @@ class DefaultHttpRequestMetaData extends AbstractHttpMetaData implements HttpReq
 
     @Override
     public final String requestTarget() {
+        checkDirtyQuery();
         return requestTarget;
     }
 
     @Override
     public String requestTarget(final Charset encoding) {
-        return CONNECT.equals(method) ? HttpAuthorityFormUri.decode(requestTarget, encoding) :
-                Uri3986.decode(requestTarget, encoding);
+        return CONNECT.equals(method) ? HttpAuthorityFormUri.decode(requestTarget(), encoding) :
+                Uri3986.decode(requestTarget(), encoding);
     }
 
     @Override
@@ -209,6 +210,7 @@ class DefaultHttpRequestMetaData extends AbstractHttpMetaData implements HttpReq
 
     @Override
     public final String rawQuery() {
+        checkDirtyQuery();
         return lazyParseRequestTarget().query();
     }
 
@@ -233,6 +235,7 @@ class DefaultHttpRequestMetaData extends AbstractHttpMetaData implements HttpReq
 
     @Override
     public String query() {
+        checkDirtyQuery();
         if (queryDecoded != null) {
             return queryDecoded;
         }
@@ -340,10 +343,17 @@ class DefaultHttpRequestMetaData extends AbstractHttpMetaData implements HttpReq
         return null;
     }
 
+    private void checkDirtyQuery() {
+        if (httpQuery != null && httpQuery.isDirty()) {
+            httpQuery.resetDirty();
+            query(httpQuery.queryParameters());
+        }
+    }
+
     private HttpQuery lazyParseQueryString() {
         if (httpQuery == null) {
             httpQuery = new HttpQuery(decodeQueryParams(lazyParseRequestTarget().query(),
-                    REQUEST_TARGET_CHARSET, DEFAULT_MAX_QUERY_PARAMS), this::setQueryParams);
+                    REQUEST_TARGET_CHARSET, DEFAULT_MAX_QUERY_PARAMS));
         }
         return httpQuery;
     }
@@ -354,6 +364,79 @@ class DefaultHttpRequestMetaData extends AbstractHttpMetaData implements HttpReq
                     new Uri3986(requestTarget());
         }
         return requestTargetUri;
+    }
+
+    private void query(final Map<String, List<String>> params) {
+        Uri httpUri = lazyParseRequestTarget();
+        StringBuilder sb = new StringBuilder(httpUri.uri().length() + params.size() * 8);
+
+        appendScheme(sb, httpUri);
+        appendAuthority(sb, httpUri);
+        sb.append(httpUri.path());
+
+        // Append query params
+        Iterator<Entry<String, List<String>>> itr = params.entrySet().iterator();
+        char prefixChar = '?';
+        while (itr.hasNext()) {
+            Entry<String, List<String>> next = itr.next();
+            String encodedKey = encodeComponent(QUERY, next.getKey(), REQUEST_TARGET_CHARSET, true);
+            sb.append(prefixChar).append(encodedKey);
+            List<String> values = next.getValue();
+            if (values != null) {
+                Iterator<String> valuesItr = values.iterator();
+                if (valuesItr.hasNext()) {
+                    String value = valuesItr.next();
+                    sb.append('=').append(encodeComponent(QUERY_VALUE, value, REQUEST_TARGET_CHARSET, true));
+                    while (valuesItr.hasNext()) {
+                        value = valuesItr.next();
+                        sb.append('&').append(encodedKey).append('=')
+                                .append(encodeComponent(QUERY_VALUE, value, REQUEST_TARGET_CHARSET, true));
+                    }
+                }
+            }
+            prefixChar = '&';
+        }
+
+        appendFragment(sb, httpUri);
+
+        requestTarget(sb.toString());
+    }
+
+    private void invalidateParsedUri() {
+        requestTargetUri = null;
+        httpQuery = null;
+        pathDecoded = null;
+        queryDecoded = null;
+    }
+
+    @Override
+    public final String toString() {
+        return method().toString() + " " + requestTarget() + " " + version();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        final DefaultHttpRequestMetaData that = (DefaultHttpRequestMetaData) o;
+
+        return method.equals(that.method) && requestTarget().equals(that.requestTarget());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + method.hashCode();
+        result = 31 * result + requestTarget().hashCode();
+        return result;
     }
 
     private static void validateFirstPathSegment(final Uri httpUri, final String path) {
@@ -418,81 +501,6 @@ class DefaultHttpRequestMetaData extends AbstractHttpMetaData implements HttpReq
             }
         }
         return HostAndPort.of(parsedHost, parsedPort);
-    }
-
-    // package-private for testing.
-    void setQueryParams(final Map<String, List<String>> params) {
-        Uri httpUri = lazyParseRequestTarget();
-        StringBuilder sb = new StringBuilder(httpUri.uri().length() + params.size() * 8);
-
-        appendScheme(sb, httpUri);
-        appendAuthority(sb, httpUri);
-        sb.append(httpUri.path());
-
-        // Append query params
-        Iterator<Entry<String, List<String>>> itr = params.entrySet().iterator();
-        char prefixChar = '?';
-        while (itr.hasNext()) {
-            Entry<String, List<String>> next = itr.next();
-            String encodedKey = encodeComponent(QUERY, next.getKey(), REQUEST_TARGET_CHARSET, true);
-            sb.append(prefixChar).append(encodedKey);
-            List<String> values = next.getValue();
-            if (values == null) {
-                continue;
-            }
-            Iterator<String> valuesItr = values.iterator();
-            if (valuesItr.hasNext()) {
-                String value = valuesItr.next();
-                sb.append('=').append(encodeComponent(QUERY_VALUE, value, REQUEST_TARGET_CHARSET, true));
-                while (valuesItr.hasNext()) {
-                    value = valuesItr.next();
-                    sb.append('&').append(encodedKey).append('=')
-                      .append(encodeComponent(QUERY_VALUE, value, REQUEST_TARGET_CHARSET, true));
-                }
-            }
-            prefixChar = '&';
-        }
-
-        appendFragment(sb, httpUri);
-
-        requestTarget(sb.toString());
-    }
-
-    private void invalidateParsedUri() {
-        requestTargetUri = null;
-        httpQuery = null;
-        pathDecoded = null;
-        queryDecoded = null;
-    }
-
-    @Override
-    public final String toString() {
-        return method().toString() + " " + requestTarget() + " " + version();
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-
-        final DefaultHttpRequestMetaData that = (DefaultHttpRequestMetaData) o;
-
-        return method.equals(that.method) && requestTarget.equals(that.requestTarget);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + method.hashCode();
-        result = 31 * result + requestTarget.hashCode();
-        return result;
     }
 
     private static void appendScheme(StringBuilder sb, Uri httpUri) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpQuery.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpQuery.java
@@ -67,7 +67,7 @@ final class HttpQuery implements Iterable<Map.Entry<String, String>> {
             if (values.isEmpty()) {
                 params.remove(key);
             }
-            dirty = true;
+            markDirty();
         });
     }
 
@@ -93,7 +93,7 @@ final class HttpQuery implements Iterable<Map.Entry<String, String>> {
     public HttpQuery add(final String key, final String value) {
         validateQueryParam(key, value);
         getValues(key).add(value);
-        dirty = true;
+        markDirty();
         return this;
     }
 
@@ -102,14 +102,14 @@ final class HttpQuery implements Iterable<Map.Entry<String, String>> {
         for (final String value : values) {
             paramValues.add(value);
         }
-        dirty = true;
+        markDirty();
         return this;
     }
 
     public HttpQuery add(final String key, final String... values) {
         final List<String> paramValues = getValues(key);
         addAll(paramValues, values);
-        dirty = true;
+        markDirty();
         return this;
     }
 
@@ -117,7 +117,7 @@ final class HttpQuery implements Iterable<Map.Entry<String, String>> {
         validateQueryParam(key, value);
         final ArrayList<String> list = new ArrayList<>(DEFAULT_LIST_SIZE);
         list.add(value);
-        dirty = true;
+        markDirty();
         params.put(key, list);
         return this;
     }
@@ -125,16 +125,18 @@ final class HttpQuery implements Iterable<Map.Entry<String, String>> {
     public HttpQuery set(final String key, final Iterable<String> values) {
         final ArrayList<String> list = new ArrayList<>(DEFAULT_LIST_SIZE);
         for (final String value : values) {
-            dirty |= list.add(value);
+            list.add(value);
         }
         params.put(key, list);
+        markDirty();
         return this;
     }
 
     public HttpQuery set(final String key, final String... values) {
         final ArrayList<String> list = new ArrayList<>(DEFAULT_LIST_SIZE);
-        dirty |= addAll(list, values);
+        addAll(list, values);
         params.put(key, list);
+        markDirty();
         return this;
     }
 
@@ -149,12 +151,11 @@ final class HttpQuery implements Iterable<Map.Entry<String, String>> {
     }
 
     public boolean remove(final String key) {
-        final List<String> removedValues = params.remove(key);
-        boolean removed = removedValues != null && !removedValues.isEmpty();
-        if (removed) {
-            dirty = true;
+        if (params.remove(key) != null) {
+            markDirty();
+            return true;
         }
-        return removed;
+        return false;
     }
 
     public boolean remove(final String key, final String value) {
@@ -162,7 +163,7 @@ final class HttpQuery implements Iterable<Map.Entry<String, String>> {
         while (values.hasNext()) {
             if (value.equals(values.next())) {
                 values.remove();
-                dirty = true;
+                markDirty();
                 return true;
             }
         }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/UriUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/UriUtils.java
@@ -108,7 +108,7 @@ final class UriUtils {
         }
 
         if (rawQuery == null || rawQuery.isEmpty()) {
-            return new LinkedHashMap<>(2);
+            return new LinkedHashMap<>(8);
         }
 
         final Map<String, List<String>> params = new LinkedHashMap<>();

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
@@ -34,6 +34,7 @@ import static io.servicetalk.http.api.HttpHeaderNames.AUTHORIZATION;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.HttpRequestMethod.CONNECT;
 import static java.lang.System.lineSeparator;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Collections.addAll;
 import static java.util.Collections.emptyList;
@@ -45,6 +46,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -528,10 +530,25 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
     }
 
     @Test
+    public void testAddQueryEquals() {
+        createFixture("/some/path");
+        fixture.addQueryParameter("foo", "bar");
+        T oldFixture = fixture;
+        createFixture("/some/path");
+        assertNotEquals(fixture, oldFixture);
+    }
+
+    @Test
+    public void testAddQueryDecode() {
+        createFixture("/some/path");
+        fixture.addQueryParameter("foo", "bar");
+        assertEquals("/some/path?foo=bar", fixture.requestTarget(UTF_8));
+    }
+
+    @Test
     public void testParseEmptyAndEncodeQuery() {
         createFixture("/some/path");
         fixture.addQueryParameter("foo", "bar");
-
         assertEquals("/some/path?foo=bar", fixture.requestTarget());
     }
 

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
@@ -25,9 +25,7 @@ import org.mockito.junit.MockitoRule;
 
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Spliterator;
 import java.util.stream.StreamSupport;
@@ -38,6 +36,7 @@ import static io.servicetalk.http.api.HttpRequestMethod.CONNECT;
 import static java.lang.System.lineSeparator;
 import static java.util.Arrays.asList;
 import static java.util.Collections.addAll;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Spliterators.spliteratorUnknownSize;
@@ -60,13 +59,9 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
 
     protected T fixture;
 
-    private final Map<String, List<String>> params = new LinkedHashMap<>();
-
     protected abstract void createFixture(String uri);
 
     protected abstract void createFixture(String uri, HttpRequestMethod method);
-
-    protected abstract void setFixtureQueryParams(Map<String, List<String>> params);
 
     // https://tools.ietf.org/html/rfc7230#section-5.3.1
     @Test
@@ -562,6 +557,7 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
 
         fixture.addQueryParameters("foo", asList("bar", "baz"));
         assertEquals("/some/path?abc=new&foo=bar&foo=baz", fixture.requestTarget());
+        assertEquals("abc=new&foo=bar&foo=baz", fixture.query());
 
         assertTrue(fixture.removeQueryParameters("foo"));
         assertEquals("/some/path?abc=new", fixture.requestTarget());
@@ -569,9 +565,11 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
 
         fixture.addQueryParameters("foo", "bar", "baz");
         assertEquals("/some/path?abc=new&foo=bar&foo=baz", fixture.requestTarget());
+        assertEquals("abc=new&foo=bar&foo=baz", fixture.query());
 
         assertTrue(fixture.removeQueryParameters("foo", "baz"));
         assertEquals("/some/path?abc=new&foo=bar", fixture.requestTarget());
+        assertEquals("abc=new&foo=bar", fixture.query());
 
         fixture.setQueryParameters("foo", singletonList("baz"));
         fixture.setQueryParameters("abc", "ghi", "jkl");
@@ -585,6 +583,7 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
             i.remove();
         }
         assertEquals("/some/path", fixture.requestTarget());
+        assertNull(fixture.query());
         assertEquals(fixture.queryParametersSize(), 0);
         assertTrue(fixture.queryParametersKeys().isEmpty());
     }
@@ -663,16 +662,15 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
     @Test
     public void testEncodeToRequestTargetWithNoParams() {
         createFixture("/some/path#fragment");
-        setFixtureQueryParams(params);
+        fixture.addQueryParameters("", emptyList());
 
-        assertEquals("/some/path#fragment", fixture.requestTarget());
+        assertEquals("/some/path?#fragment", fixture.requestTarget());
     }
 
     @Test
     public void testEncodeToRequestTargetWithParam() {
         createFixture("/some/path");
-        params.put("foo", newList("bar", "baz"));
-        setFixtureQueryParams(params);
+        fixture.addQueryParameters("foo", newList("bar", "baz"));
 
         assertEquals("/some/path?foo=bar&foo=baz", fixture.requestTarget());
     }
@@ -680,9 +678,8 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
     @Test
     public void testEncodeToRequestTargetWithMultipleParams() {
         createFixture("/some/path#fragment");
-        params.put("foo", newList("bar", "baz"));
-        params.put("abc", newList("123", "456"));
-        setFixtureQueryParams(params);
+        fixture.addQueryParameters("foo", newList("bar", "baz"));
+        fixture.addQueryParameters("abc", newList("123", "456"));
 
         assertEquals("/some/path?foo=bar&foo=baz&abc=123&abc=456#fragment", fixture.requestTarget());
     }
@@ -690,8 +687,7 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
     @Test
     public void testEncodeToRequestTargetWithSpecialCharacters() {
         createFixture("/some/path#fragment");
-        params.put("pair", newList("key1=value1", "key2=value2"));
-        setFixtureQueryParams(params);
+        fixture.addQueryParameters("pair", newList("key1=value1", "key2=value2"));
 
         assertEquals("/some/path?pair=key1%3Dvalue1&pair=key2%3Dvalue2#fragment", fixture.requestTarget());
     }
@@ -699,10 +695,9 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
     @Test
     public void testEncodeToRequestTargetWithAbsoluteForm() {
         createFixture("http://my.site.com/some/path?foo=bar&abc=def&foo=baz#fragment");
-        params.put("foo", newList("new"));
-        setFixtureQueryParams(params);
+        fixture.setQueryParameters("foo", newList("new"));
 
-        assertEquals("http://my.site.com/some/path?foo=new#fragment", fixture.requestTarget());
+        assertEquals("http://my.site.com/some/path?foo=new&abc=def#fragment", fixture.requestTarget());
 
         assertEquals("my.site.com", fixture.effectiveHost());
         assertThat(fixture.effectivePort(), lessThan(0));
@@ -711,10 +706,9 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
     @Test
     public void testEncodeToRequestTargetWithAbsoluteFormWithPort() {
         createFixture("http://my.site.com:8080/some/path?foo=bar&abc=def&foo=baz#fragment");
-        params.put("foo", newList("new"));
-        setFixtureQueryParams(params);
+        fixture.setQueryParameters("foo", newList("new"));
 
-        assertEquals("http://my.site.com:8080/some/path?foo=new#fragment", fixture.requestTarget());
+        assertEquals("http://my.site.com:8080/some/path?foo=new&abc=def#fragment", fixture.requestTarget());
 
         HostAndPort hostAndPort = fixture.effectiveHostAndPort();
         assertNotNull(hostAndPort);
@@ -725,16 +719,15 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
     @Test
     public void testEncodeToRequestTargetWithAbsoluteFormWithUserInfo() {
         createFixture("http://user@my.site.com/some/path?foo=bar&abc=def&foo=baz#fragment");
-        params.put("foo", newList("new"));
-        setFixtureQueryParams(params);
+        fixture.setQueryParameters("foo", newList("new"));
 
-        assertEquals("http://user@my.site.com/some/path?foo=new#fragment", fixture.requestTarget());
+        assertEquals("http://user@my.site.com/some/path?foo=new&abc=def#fragment", fixture.requestTarget());
         fixture.path("");
-        assertEquals("http://user@my.site.com?foo=new#fragment", fixture.requestTarget());
+        assertEquals("http://user@my.site.com?foo=new&abc=def#fragment", fixture.requestTarget());
         assertEquals("", fixture.path());
         assertEquals("", fixture.path()); // check cached value
-        assertEquals("foo=new", fixture.query());
-        assertEquals("foo=new", fixture.query()); // check cached value
+        assertEquals("foo=new&abc=def", fixture.query());
+        assertEquals("foo=new&abc=def", fixture.query()); // check cached value
     }
 
     @Test

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
@@ -539,10 +539,18 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
     }
 
     @Test
-    public void testAddQueryDecode() {
+    public void testAddQueryDecodeRequestTarget() {
         createFixture("/some/path");
         fixture.addQueryParameter("foo", "bar");
         assertEquals("/some/path?foo=bar", fixture.requestTarget(UTF_8));
+    }
+
+    @Test
+    public void testAddQueryEncodeRequestTarget() {
+        createFixture("/some/path");
+        fixture.addQueryParameter("foo", "bar");
+        fixture.requestTarget("/some/new/path");
+        assertEquals("/some/new/path", fixture.requestTarget(UTF_8));
     }
 
     @Test

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpRequestMetaDataTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpRequestMetaDataTest.java
@@ -15,9 +15,6 @@
  */
 package io.servicetalk.http.api;
 
-import java.util.List;
-import java.util.Map;
-
 import static io.servicetalk.http.api.DefaultHttpHeadersFactory.INSTANCE;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
@@ -32,10 +29,5 @@ public class DefaultHttpRequestMetaDataTest extends AbstractHttpRequestMetaDataT
     @Override
     protected void createFixture(final String uri, final HttpRequestMethod method) {
         fixture = new DefaultHttpRequestMetaData(method, uri, HTTP_1_1, INSTANCE.newHeaders());
-    }
-
-    @Override
-    protected void setFixtureQueryParams(final Map<String, List<String>> params) {
-        fixture.setQueryParams(params);
     }
 }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpQueryTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpQueryTest.java
@@ -18,7 +18,6 @@ package io.servicetalk.http.api;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
@@ -30,7 +29,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Spliterator;
 import java.util.Spliterators;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -49,22 +47,19 @@ public class HttpQueryTest {
     @Rule
     public final ExpectedException expected = ExpectedException.none();
 
-    @Mock
-    private Consumer<Map<String, List<String>>> queryParamsUpdater;
-
     private final Map<String, List<String>> params = new LinkedHashMap<>();
 
     @Test
     public void testGetFirstValue() {
         params.put("foo", newList("bar", "baz"));
-        final HttpQuery query = new HttpQuery(params, queryParamsUpdater);
+        final HttpQuery query = new HttpQuery(params);
 
         assertEquals("bar", query.get("foo"));
     }
 
     @Test
     public void testGetFirstValueNone() {
-        final HttpQuery query = new HttpQuery(params, queryParamsUpdater);
+        final HttpQuery query = new HttpQuery(params);
 
         assertNull(query.get("foo"));
     }
@@ -72,14 +67,14 @@ public class HttpQueryTest {
     @Test
     public void testGetAll() {
         params.put("foo", newList("bar", "baz"));
-        final HttpQuery query = new HttpQuery(params, queryParamsUpdater);
+        final HttpQuery query = new HttpQuery(params);
 
         assertEquals(asList("bar", "baz"), iteratorAsList(query.valuesIterator("foo")));
     }
 
     @Test
     public void testGetAllEmpty() {
-        final HttpQuery query = new HttpQuery(params, queryParamsUpdater);
+        final HttpQuery query = new HttpQuery(params);
 
         assertFalse(query.valuesIterator("foo").hasNext());
     }
@@ -87,7 +82,7 @@ public class HttpQueryTest {
     @Test
     public void testGetKeys() {
         params.put("foo", newList("bar", "baz"));
-        final HttpQuery query = new HttpQuery(params, queryParamsUpdater);
+        final HttpQuery query = new HttpQuery(params);
 
         assertEquals(asList("bar", "baz"), iteratorAsList(query.valuesIterator("foo")));
     }
@@ -96,7 +91,7 @@ public class HttpQueryTest {
     public void testSet() {
         params.put("foo", newList("bar", "baz"));
         params.put("abc", newList("def"));
-        final HttpQuery query = new HttpQuery(params, queryParamsUpdater);
+        final HttpQuery query = new HttpQuery(params);
         query.set("abc", "new");
 
         assertEquals(singletonList("new"), iteratorAsList(query.valuesIterator("abc")));
@@ -107,7 +102,7 @@ public class HttpQueryTest {
     public void testSetValues() {
         params.put("foo", newList("bar", "baz"));
         params.put("abc", newList("def"));
-        final HttpQuery query = new HttpQuery(params, queryParamsUpdater);
+        final HttpQuery query = new HttpQuery(params);
         query.set("abc", newList("new1", "new2"));
 
         assertEquals(asList("new1", "new2"), iteratorAsList(query.valuesIterator("abc")));
@@ -118,7 +113,7 @@ public class HttpQueryTest {
     public void testAdd() {
         params.put("foo", newList("bar", "baz"));
         params.put("abc", newList("def"));
-        final HttpQuery query = new HttpQuery(params, queryParamsUpdater);
+        final HttpQuery query = new HttpQuery(params);
         query.add("abc", "new");
 
         assertEquals(asList("def", "new"), iteratorAsList(query.valuesIterator("abc")));
@@ -129,7 +124,7 @@ public class HttpQueryTest {
     public void testAddValues() {
         params.put("foo", newList("bar", "baz"));
         params.put("abc", newList("def"));
-        final HttpQuery query = new HttpQuery(params, queryParamsUpdater);
+        final HttpQuery query = new HttpQuery(params);
         query.add("abc", newList("new1", "new2"));
 
         assertEquals(asList("def", "new1", "new2"), iteratorAsList(query.valuesIterator("abc")));
@@ -139,7 +134,7 @@ public class HttpQueryTest {
     @Test
     public void testContainsKey() {
         params.put("foo", newList("bar", "baz"));
-        final HttpQuery query = new HttpQuery(params, queryParamsUpdater);
+        final HttpQuery query = new HttpQuery(params);
 
         assertTrue(query.keys().contains("foo"));
         assertFalse(query.keys().contains("abc"));
@@ -148,7 +143,7 @@ public class HttpQueryTest {
     @Test
     public void testContainsKeyAndValue() {
         params.put("foo", newList("bar", "baz"));
-        final HttpQuery query = new HttpQuery(params, queryParamsUpdater);
+        final HttpQuery query = new HttpQuery(params);
 
         assertTrue(query.contains("foo", "bar"));
         assertFalse(query.contains("foo", "new"));
@@ -157,7 +152,7 @@ public class HttpQueryTest {
     @Test
     public void testRemoveKey() {
         params.put("foo", newList("bar", "baz"));
-        final HttpQuery query = new HttpQuery(params, queryParamsUpdater);
+        final HttpQuery query = new HttpQuery(params);
         assertTrue(query.remove("foo"));
         assertFalse(query.keys().contains("foo"));
         assertFalse(query.remove("foo"));
@@ -172,7 +167,7 @@ public class HttpQueryTest {
     @Test
     public void testRemoveKeyAndValue() {
         params.put("foo", newList("bar", "baz"));
-        final HttpQuery query = new HttpQuery(params, queryParamsUpdater);
+        final HttpQuery query = new HttpQuery(params);
         assertTrue(query.remove("foo", "bar"));
         assertFalse(query.remove("foo", "bar"));
 
@@ -184,7 +179,7 @@ public class HttpQueryTest {
     public void testSize() {
         params.put("foo", newList("bar", "baz"));
         params.put("abc", newList("def", "123"));
-        final HttpQuery query = new HttpQuery(params, queryParamsUpdater);
+        final HttpQuery query = new HttpQuery(params);
 
         assertEquals(4, query.size());
         query.remove("abc", "123");
@@ -201,7 +196,7 @@ public class HttpQueryTest {
     public void testIterator() {
         params.put("foo", newList("bar", "baz"));
         params.put("abc", newList("def", "123"));
-        final HttpQuery query = new HttpQuery(params, queryParamsUpdater);
+        final HttpQuery query = new HttpQuery(params);
 
         final Iterator<Map.Entry<String, String>> iterator = query.iterator();
 
@@ -235,7 +230,7 @@ public class HttpQueryTest {
     public void testIteratorAfterRemoval() {
         params.put("foo", newList("bar", "baz"));
         params.put("abc", newList("def", "123"));
-        final HttpQuery query = new HttpQuery(params, queryParamsUpdater);
+        final HttpQuery query = new HttpQuery(params);
 
         query.remove("abc", "def");
         query.remove("abc", "123");
@@ -262,7 +257,7 @@ public class HttpQueryTest {
     public void testIteratorRemove() {
         params.put("foo", newList("bar", "baz"));
         params.put("abc", newList("def", "123"));
-        final HttpQuery query = new HttpQuery(params, queryParamsUpdater);
+        final HttpQuery query = new HttpQuery(params);
 
         final Iterator<Map.Entry<String, String>> iterator = query.iterator();
 
@@ -302,7 +297,7 @@ public class HttpQueryTest {
     public void testIteratorRemoveTwice() {
         params.put("foo", newList("bar", "baz"));
         params.put("abc", newList("def", "123"));
-        final HttpQuery query = new HttpQuery(params, queryParamsUpdater);
+        final HttpQuery query = new HttpQuery(params);
 
         final Iterator<Map.Entry<String, String>> iterator = query.iterator();
 


### PR DESCRIPTION
Motivation:
DefaultHttpRequestMetaData has methods that focus on mainpulating the
query string such as addQueryParameters and setQueryParameter. These
methods all re-encode the entire query string and request target on each
modification. However these methods are often used multiple times
sequentially, and the duplicate encoding is wasteful.

Modifications:
- Defer encoding the query string and request target until other methods
on the DefaultHttpRequestMetaData require it (e.g. requestTarget() and
other query accessor methods).

Result:
Less overhead for DefaultHttpRequestMetaData#addQueryParameters and
related query manipulator methods.