### PR TITLE
Publisher#flatMap*DelayError limit queued exceptions

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompositeException.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompositeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,11 @@ package io.servicetalk.concurrent.api;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import static io.servicetalk.concurrent.internal.ThrowableUtils.catchUnexpected;
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 
 /**
  * A {@link RuntimeException} that allows to add {@link Throwable} instances at a lower cost than
@@ -27,16 +29,26 @@ import static io.servicetalk.utils.internal.PlatformDependent.throwException;
  * {@link #addSuppressed(Throwable)}.
  */
 final class CompositeException extends RuntimeException {
+    private static final int DEFAULT_MAX_EXCEPTIONS = 32;
     private static final long serialVersionUID = 7827495486030277692L;
+    private static final AtomicIntegerFieldUpdater<CompositeException> sizeUpdater =
+            newUpdater(CompositeException.class, "size");
     private final Queue<Throwable> suppressed = new ConcurrentLinkedQueue<>();
+    private final int maxExceptions;
+    private volatile int size;
 
     /**
      * New instance.
      *
      * @param cause of the exception.
+     * @param maxExceptions the limit on the number of {@link #add(Throwable)} that will be queued.
      */
-    CompositeException(Throwable cause) {
+    CompositeException(Throwable cause, int maxExceptions) {
         super(cause);
+        if (maxExceptions <= 0) {
+            throw new IllegalArgumentException("maxExceptions: " + maxExceptions + " (expected >0)");
+        }
+        this.maxExceptions = maxExceptions;
     }
 
     /**
@@ -46,11 +58,17 @@ final class CompositeException extends RuntimeException {
      * @param toAdd {@link Throwable} to finally add as {@link #addSuppressed(Throwable)}.
      */
     void add(Throwable toAdd) {
-        if (!suppressed.offer(toAdd)) {
-            addSuppressed(toAdd);
+        // optimistically increment, recover after the fact if necessary.
+        final int newSize = sizeUpdater.incrementAndGet(this);
+        if (newSize < 0) {
+            size = Integer.MAX_VALUE;
+        } else if (newSize <= maxExceptions) {
+            suppressed.offer(toAdd);
+            // if addAllPendingSuppressed has already been called don't bother trying to synchronize/drain the queue
+            // as it is assumed the exception will be thrown after that method is called.
+        } else {
+            sizeUpdater.decrementAndGet(this);
         }
-        // if addAllPendingSuppressed has already been called don't bother trying to synchronize/drain the queue
-        // as it is assumed the exception will be thrown after that method is called.
     }
 
     /**
@@ -60,6 +78,7 @@ final class CompositeException extends RuntimeException {
      * It is assumed that {@link #add(Throwable)} won't be called after this method.
      */
     void transferPendingToSuppressed() {
+        size = Integer.MAX_VALUE; // Disable adding further exceptions
         Throwable delayedCause = null;
         Throwable next;
         while ((next = suppressed.poll()) != null) {
@@ -72,5 +91,9 @@ final class CompositeException extends RuntimeException {
         if (delayedCause != null) {
             throwException(delayedCause);
         }
+    }
+
+    static int maxDelayedErrors(boolean delayError) {
+        return delayError ? DEFAULT_MAX_EXCEPTIONS : 0;
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -404,6 +404,9 @@ public abstract class Publisher<T> {
      */
     public final <R> Publisher<R> flatMapMergeDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper,
                                                          int maxConcurrency, int maxDelayedErrorsHint) {
+        if (maxDelayedErrorsHint <= 0) {
+            throw new IllegalArgumentException("maxDelayedErrorsHint " + maxDelayedErrorsHint + " (expected >0)");
+        }
         return new PublisherFlatMapMerge<>(this, mapper, maxDelayedErrorsHint, maxConcurrency, executor);
     }
 
@@ -644,6 +647,9 @@ public abstract class Publisher<T> {
      */
     public final <R> Publisher<R> flatMapMergeSingleDelayError(
             Function<? super T, ? extends Single<? extends R>> mapper, int maxConcurrency, int maxDelayedErrorsHint) {
+        if (maxDelayedErrorsHint <= 0) {
+            throw new IllegalArgumentException("maxDelayedErrorsHint " + maxDelayedErrorsHint + " (expected >0)");
+        }
         return new PublisherFlatMapSingle<>(this, mapper, maxDelayedErrorsHint, maxConcurrency, executor);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -358,6 +358,56 @@ public abstract class Publisher<T> {
     }
 
     /**
+     * Map each element of this {@link Publisher} into a {@link Publisher}&lt;{@link R}&gt; and flatten all signals
+     * emitted from each mapped {@link Publisher}&lt;{@link R}&gt; into the returned
+     * {@link Publisher}&lt;{@link R}&gt;.
+     * <p>
+     * This is the same as {@link #flatMapMerge(Function)} just that if any mapped {@link Publisher} returned by
+     * {@code mapper}, terminates with an error, the returned {@link Publisher} will not immediately terminate. Instead,
+     * it will wait for this {@link Publisher} and all mapped {@link Publisher}s to terminate and then terminate the
+     * returned {@link Publisher} with all errors emitted by the mapped {@link Publisher}s.
+     * <p>
+     * This method is similar to {@link #map(Function)} but the result is an asynchronous stream, and provides a data
+     * transformation in sequential programming similar to:
+     * <pre>{@code
+     *     Executor e = ...;
+     *     List<T> tResults = resultOfThisPublisher();
+     *     List<R> rResults = ...; // assume this is thread safe
+     *     List<Throwable> errors = ...;  // assume this is thread safe
+     *     CountDownLatch latch =  new CountDownLatch(tResults.size());
+     *     for (T t : resultOfThisPublisher()) {
+     *         // Note that flatMap process results in parallel.
+     *         e.execute(() -> {
+     *             try {
+     *                 List<R> rList = mapper.apply(t); // Asynchronous result is flatten into a value by this operator.
+     *                 rResults.addAll(rList);
+     *             } catch (Throwable cause) {
+     *                 errors.add(cause);  // Asynchronous error is flatten into an error by this operator.
+     *             } finally {
+     *                 latch.countdown();
+     *             }
+     *         });
+     *     }
+     *     latch.await();
+     *     if (errors.isEmpty()) {
+     *         return rResults;
+     *     }
+     *     createAndThrowACompositeException(errors);
+     * }</pre>
+     * @param mapper Convert each item emitted by this {@link Publisher} into another {@link Publisher}.
+     * @param maxConcurrency Maximum amount of outstanding upstream {@link Subscription#request(long) demand}.
+     * @param maxDelayedErrorsHint The maximum amount of errors that will be queued. After this point exceptions maybe
+     * discarded to reduce memory consumption.
+     * @param <R> The type of mapped {@link Publisher}.
+     * @return A new {@link Publisher} which flattens the emissions from all mapped {@link Publisher}s.
+     * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX flatMap operator.</a>
+     */
+    public final <R> Publisher<R> flatMapMergeDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper,
+                                                         int maxConcurrency, int maxDelayedErrorsHint) {
+        return new PublisherFlatMapMerge<>(this, mapper, maxDelayedErrorsHint, maxConcurrency, executor);
+    }
+
+    /**
      * Map each element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all signals
      * emitted from each mapped {@link Single}&lt;{@link R}&gt; into the returned
      * {@link Publisher}&lt;{@link R}&gt;.
@@ -432,7 +482,7 @@ public abstract class Publisher<T> {
      */
     public final <R> Publisher<R> flatMapMergeSingle(Function<? super T, ? extends Single<? extends R>> mapper,
                                                      int maxConcurrency) {
-        return new PublisherFlatMapSingle<>(this, mapper, maxConcurrency, false, executor);
+        return new PublisherFlatMapSingle<>(this, mapper, false, maxConcurrency, executor);
     }
 
     /**
@@ -539,7 +589,62 @@ public abstract class Publisher<T> {
      */
     public final <R> Publisher<R> flatMapMergeSingleDelayError(
             Function<? super T, ? extends Single<? extends R>> mapper, int maxConcurrency) {
-        return new PublisherFlatMapSingle<>(this, mapper, maxConcurrency, true, executor);
+        return new PublisherFlatMapSingle<>(this, mapper, true, maxConcurrency, executor);
+    }
+
+    /**
+     * Map each element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all signals
+     * emitted from each mapped {@link Single}&lt;{@link R}&gt; into the returned
+     * {@link Publisher}&lt;{@link R}&gt;.
+     * <p>
+     * The behavior is the same as {@link #flatMapMergeSingle(Function, int)} with the exception that if any
+     * {@link Single} returned by {@code mapper}, terminates with an error, the returned {@link Publisher} will not
+     * immediately terminate. Instead, it will wait for this {@link Publisher} and all {@link Single}s to terminate and
+     * then terminate the returned {@link Publisher} with all errors emitted by the {@link Single}s produced by the
+     * {@code mapper}.
+     * <p>
+     * This method is similar to {@link #map(Function)} but the result is asynchronous, and provides a data
+     * transformation in sequential programming similar to:
+     * <pre>{@code
+     *     Executor e = ...;
+     *     List<T> tResults = resultOfThisPublisher();
+     *     List<R> rResults = ...; // assume this is thread safe
+     *     List<Throwable> errors = ...;  // assume this is thread safe
+     *     CountDownLatch latch =  new CountDownLatch(tResults.size());
+     *     for (T t : tResults) {
+     *         // Note that flatMap process results in parallel.
+     *         e.execute(() -> {
+     *             try {
+     *                 R r = mapper.apply(t); // Asynchronous result is flatten into a value by this operator.
+     *                 rResults.add(r);
+     *             } catch (Throwable cause) {
+     *                 errors.add(cause);  // Asynchronous error is flatten into an error by this operator.
+     *             } finally {
+     *                 latch.countdown();
+     *             }
+     *         });
+     *     }
+     *     latch.await();
+     *     if (errors.isEmpty()) {
+     *         return rResults;
+     *     }
+     *     createAndThrowACompositeException(errors);
+     * }</pre>
+     *
+     * @param mapper {@link Function} to convert each item emitted by this {@link Publisher} into a {@link Single}.
+     * @param maxConcurrency Maximum active {@link Single}s at any time.
+     * Even if the number of items requested by a {@link Subscriber} is more than this number,
+     * this will never request more than this number at any point.
+     * @param maxDelayedErrorsHint The maximum amount of errors that will be queued. After this point exceptions maybe
+     * discarded to reduce memory consumption.
+     * @param <R> Type of items emitted by the returned {@link Publisher}.
+     * @return A new {@link Publisher} that emits all items emitted by each single produced by {@code mapper}.
+     *
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX merge operator.</a>
+     */
+    public final <R> Publisher<R> flatMapMergeSingleDelayError(
+            Function<? super T, ? extends Single<? extends R>> mapper, int maxConcurrency, int maxDelayedErrorsHint) {
+        return new PublisherFlatMapSingle<>(this, mapper, maxDelayedErrorsHint, maxConcurrency, executor);
     }
 
     /**
@@ -709,6 +814,54 @@ public abstract class Publisher<T> {
     public final Completable flatMapCompletableDelayError(Function<? super T, ? extends Completable> mapper,
                                                           int maxConcurrency) {
         return flatMapMergeSingleDelayError(t -> mapper.apply(t).toSingle(), maxConcurrency).ignoreElements();
+    }
+
+    /**
+     * Map each element of this {@link Publisher} into a {@link Completable} and flatten all signals
+     * such that the returned {@link Completable} terminates when all mapped {@link Completable}s have terminated
+     * successfully or any one of them has terminated with a failure.
+     * <p>
+     * If any mapped {@link Completable} terminates with an error the returned {@link Completable} will not immediately
+     * terminate. Instead, it will wait for this {@link Publisher} and all mapped {@link Completable}s to terminate.
+     * <p>
+     * This method is similar to {@link #map(Function)} but the result is asynchronous, and provides a data
+     * transformation in sequential programming similar to:
+     * <pre>{@code
+     *     Executor e = ...;
+     *     List<Throwable> errors = ...;  // assume this is thread safe
+     *     CountDownLatch latch =  new CountDownLatch(tResults.size());
+     *     for (T t : tResults) {
+     *         // Note that flatMap process results in parallel.
+     *         e.execute(() -> {
+     *             try {
+     *                 mapper.apply(t); // Asynchronous result is flattened by this operator.
+     *             } catch (Throwable cause) {
+     *                 errors.add(cause);  // Asynchronous error is flatten into an error by this operator.
+     *             } finally {
+     *                 latch.countdown();
+     *             }
+     *         });
+     *     }
+     *     latch.await();
+     *     if (!errors.isEmpty()) {
+     *         createAndThrowACompositeException(errors);
+     *     }
+     * }</pre>
+     *
+     * @param mapper Function to convert each item emitted by this {@link Publisher} into a {@link Completable}.
+     * @param maxConcurrency Maximum active {@link Completable}s at any time.
+     * @param maxDelayedErrorsHint The maximum amount of errors that will be queued. After this point exceptions maybe
+     * discarded to reduce memory consumption.
+     * @return A new {@link Completable} that terminates successfully if all the intermediate {@link Completable}s have
+     * terminated successfully or any one of them has terminated with a failure.
+     *
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX merge operator.</a>
+     * @see #flatMapMergeSingleDelayError(Function, int)
+     */
+    public final Completable flatMapCompletableDelayError(Function<? super T, ? extends Completable> mapper,
+                                                          int maxConcurrency, int maxDelayedErrorsHint) {
+        return flatMapMergeSingleDelayError(t -> mapper.apply(t).toSingle(), maxConcurrency, maxDelayedErrorsHint)
+                .ignoreElements();
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
@@ -93,7 +93,7 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
             throw new IllegalArgumentException("maxConcurrency: " + maxConcurrency + " (expected >0)");
         }
         if (maxDelayedErrors < 0) {
-            throw new IllegalArgumentException("maxConcurrency: " + maxDelayedErrors + " (expected >=0)");
+            throw new IllegalArgumentException("maxDelayedErrors: " + maxDelayedErrors + " (expected >=0)");
         }
         this.mapper = requireNonNull(mapper);
         this.maxConcurrency = maxConcurrency;
@@ -599,7 +599,7 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
 
             @Override
             public void onError(final Throwable t) {
-                if (parent.source.maxDelayedErrors <= 0) {
+                if (parent.source.maxDelayedErrors == 0) {
                     // Make sure errors aren't delivered out of order relative to onNext signals which maybe queued.
                     try {
                         parent.doCancel(true, false);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,8 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.CompositeException.maxDelayedErrors;
+import static io.servicetalk.concurrent.api.PublisherFlatMapMerge.FLAT_MAP_DEFAULT_CONCURRENCY;
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNullUnchecked;
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.releaseLock;
@@ -56,25 +58,32 @@ import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater
  */
 final class PublisherFlatMapSingle<T, R> extends AbstractAsynchronousPublisherOperator<T, R> {
     private static final Logger LOGGER = LoggerFactory.getLogger(PublisherFlatMapSingle.class);
-
     private final Function<? super T, ? extends Single<? extends R>> mapper;
     private final int maxConcurrency;
-    private final boolean delayError;
+    private final int maxDelayedErrors;
 
     PublisherFlatMapSingle(Publisher<T> original, Function<? super T, ? extends Single<? extends R>> mapper,
                            boolean delayError, Executor executor) {
-        this(original, mapper, 16, delayError, executor);
+        this(original, mapper, delayError, FLAT_MAP_DEFAULT_CONCURRENCY, executor);
     }
 
     PublisherFlatMapSingle(Publisher<T> original, Function<? super T, ? extends Single<? extends R>> mapper,
-                           int maxConcurrency, boolean delayError, Executor executor) {
+                           boolean delayError, int maxConcurrency, Executor executor) {
+        this(original, mapper, maxDelayedErrors(delayError), maxConcurrency, executor);
+    }
+
+    PublisherFlatMapSingle(Publisher<T> original, Function<? super T, ? extends Single<? extends R>> mapper,
+                           int maxDelayedErrors, int maxConcurrency, Executor executor) {
         super(original, executor);
-        this.mapper = requireNonNull(mapper);
         if (maxConcurrency <= 0) {
             throw new IllegalArgumentException("maxConcurrency: " + maxConcurrency + " (expected > 0)");
         }
+        if (maxDelayedErrors < 0) {
+            throw new IllegalArgumentException("maxConcurrency: " + maxDelayedErrors + " (expected >=0)");
+        }
+        this.mapper = requireNonNull(mapper);
         this.maxConcurrency = maxConcurrency;
-        this.delayError = delayError;
+        this.maxDelayedErrors = maxDelayedErrors;
     }
 
     @Override
@@ -390,12 +399,12 @@ final class PublisherFlatMapSingle<T, R> extends AbstractAsynchronousPublisherOp
 
             @Override
             public void onError(Throwable t) {
-                if (!source.delayError) {
+                if (source.maxDelayedErrors <= 0) {
                     onError0(t, true, true);
                 } else {
                     CompositeException de = FlatMapSubscriber.this.delayedError;
                     if (de == null) {
-                        de = new CompositeException(t);
+                        de = new CompositeException(t, source.maxDelayedErrors);
                         if (!delayedErrorUpdater.compareAndSet(FlatMapSubscriber.this, null, de)) {
                             de = FlatMapSubscriber.this.delayedError;
                             assert de != null;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
@@ -79,7 +79,7 @@ final class PublisherFlatMapSingle<T, R> extends AbstractAsynchronousPublisherOp
             throw new IllegalArgumentException("maxConcurrency: " + maxConcurrency + " (expected > 0)");
         }
         if (maxDelayedErrors < 0) {
-            throw new IllegalArgumentException("maxConcurrency: " + maxDelayedErrors + " (expected >=0)");
+            throw new IllegalArgumentException("maxDelayedErrors: " + maxDelayedErrors + " (expected >=0)");
         }
         this.mapper = requireNonNull(mapper);
         this.maxConcurrency = maxConcurrency;
@@ -399,7 +399,7 @@ final class PublisherFlatMapSingle<T, R> extends AbstractAsynchronousPublisherOp
 
             @Override
             public void onError(Throwable t) {
-                if (source.maxDelayedErrors <= 0) {
+                if (source.maxDelayedErrors == 0) {
                     onError0(t, true, true);
                 } else {
                     CompositeException de = FlatMapSubscriber.this.delayedError;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompositeExceptionTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompositeExceptionTest.java
@@ -27,7 +27,7 @@ public class CompositeExceptionTest {
 
     @Test
     public void testCauseAndSuppressed() {
-        CompositeException e = new CompositeException(DELIBERATE_EXCEPTION);
+        CompositeException e = new CompositeException(DELIBERATE_EXCEPTION, 2);
         DeliberateException suppressed1 = new DeliberateException();
         e.add(suppressed1);
         DeliberateException suppressed2 = new DeliberateException();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
@@ -863,7 +863,7 @@ public class PublisherFlatMapMergeTest {
                         return i;
                     }
                     throw new DeliberateException();
-                }).toPublisher(), 1024)
+                }).toPublisher(), 1024, 500)
                 .recoverWith(t -> {
                     error.set(t);
                     return Publisher.empty();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
@@ -110,7 +110,7 @@ public class PublisherFlatMapSingleTest {
                 return x;
             }
             throw new DeliberateException();
-        }), 1024).recoverWith(t -> {
+        }), 1024, 500).recoverWith(t -> {
             error.set(t);
             return Publisher.empty();
         }).collect(ArrayList::new, (ints, s) -> {
@@ -479,7 +479,7 @@ public class PublisherFlatMapSingleTest {
         }
         PublisherFlatMapSingle<Integer, String> pub = new PublisherFlatMapSingle<>(Publisher.from(expectedNumbers),
                 value -> Single.succeeded(Integer.toString(value)),
-                1, false, immediate());
+                false, 1, immediate());
         toSource(pub).subscribe(new Subscriber<String>() {
             private Subscription subscription;
 


### PR DESCRIPTION
Motivation:
Publisher#flatMap*DelayError operators will queue exceptions and add
them all as suppressed exceptions once the upstream source and all
mapped publishers have terminated. However this operator maybe used for
unbounded streams, with retry operators, and this may result in a large
amount of exceptions which will exhaust memory over time.

Modifications:
- Limit the number of exception that is accumulated, and allow users to
override the default value.

Result:
Publisher#flatMap*DelayError bounds the number of accumulated exceptions
and will not exhaust memory for infinite streams.