### PR TITLE
[Retry|Repeat]Strategies add jitter delta methods 

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
@@ -23,6 +23,7 @@ import static io.servicetalk.concurrent.api.RetryStrategies.checkJitterDelta;
 import static io.servicetalk.concurrent.api.RetryStrategies.checkMaxRetries;
 import static io.servicetalk.concurrent.api.RetryStrategies.maxShift;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
+import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.ThreadLocalRandom.current;
@@ -56,6 +57,23 @@ public final class RepeatStrategies {
     /**
      * Creates a new repeat function that adds the passed constant {@link Duration} as delay between repeats.
      *
+     * @param delay Constant {@link Duration} of delay between repeats.
+     * @param timerExecutor {@link Executor} to be used to schedule timers for delay.
+     *
+     * @return An {@link IntFunction} to be used for repeats which given a repeat count returns a {@link Completable}
+     * that terminates successfully when the source has to be repeated or terminates with error if the source should not
+     * be repeated.
+     */
+    public static IntFunction<Completable> repeatWithConstantBackoffFullJitter(final Duration delay,
+                                                                               final Executor timerExecutor) {
+        requireNonNull(timerExecutor);
+        final long delayNanos = delay.toNanos();
+        return repeatCount -> timerExecutor.timer(current().nextLong(0, delayNanos), NANOSECONDS);
+    }
+
+    /**
+     * Creates a new repeat function that adds the passed constant {@link Duration} as delay between repeats.
+     *
      * @param maxRepeats Maximum number of allowed repeats, after which the returned {@link IntFunction} will return
      *                   a failed {@link Completable} with {@link TerminateRepeatException} as the cause.
      * @param delay Constant {@link Duration} of delay between repeats.
@@ -73,6 +91,29 @@ public final class RepeatStrategies {
         final long delayNanos = delay.toNanos();
         return repeatCount -> repeatCount <= maxRepeats ?
                 timerExecutor.timer(current().nextLong(0, delayNanos), NANOSECONDS) : terminateRepeat();
+    }
+
+    /**
+     * Creates a new repeat function that adds the passed constant {@link Duration} as delay between repeats.
+     *
+     * @param delay Constant {@link Duration} of delay between repeats.
+     * @param jitter The jitter to apply to {@code delay} on each repeat.
+     * @param timerExecutor {@link Executor} to be used to schedule timers for delay.
+     *
+     * @return An {@link IntFunction} to be used for repeats which given a repeat count returns a {@link Completable}
+     * that terminates successfully when the source has to be repeated or terminates with error if the source should not
+     * be repeated.
+     */
+    public static IntFunction<Completable> repeatWithConstantBackoffDeltaJitter(final Duration delay,
+                                                                                final Duration jitter,
+                                                                                final Executor timerExecutor) {
+        requireNonNull(timerExecutor);
+        final long delayNanos = delay.toNanos();
+        final long jitterNanos = jitter.toNanos();
+        checkJitterDelta(jitterNanos, delayNanos);
+        final long lowerBound = delayNanos - jitterNanos;
+        final long upperBound = delayNanos + jitterNanos;
+        return repeatCount -> timerExecutor.timer(current().nextLong(lowerBound, upperBound), NANOSECONDS);
     }
 
     /**
@@ -104,26 +145,28 @@ public final class RepeatStrategies {
     }
 
     /**
-     * Creates a new repeat function that adds the passed constant {@link Duration} as delay between repeats.
+     * Creates a new repeat function that adds a delay between repeats. For first repeat, the delay is
+     * {@code initialDelay} which is increased exponentially for subsequent repeats.
+     * This additionally adds a "Full Jitter" for the backoff as described
+     * <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/">here</a>.
      *
-     * @param delay Constant {@link Duration} of delay between repeats.
-     * @param jitter The jitter to apply to {@code delay} on each repeat.
-     * @param timerExecutor {@link Executor} to be used to schedule timers for delay.
+     * @param initialDelay Delay {@link Duration} for the first repeat and increased exponentially with each repeat.
+     * @param maxDelay The maximum amount of delay that will be introduced.
+     * @param timerExecutor {@link Executor} to be used to schedule timers for backoff.
      *
      * @return An {@link IntFunction} to be used for repeats which given a repeat count returns a {@link Completable}
      * that terminates successfully when the source has to be repeated or terminates with error if the source should not
      * be repeated.
      */
-    public static IntFunction<Completable> repeatWithConstantBackoffDeltaJitter(final Duration delay,
-                                                                                final Duration jitter,
-                                                                                final Executor timerExecutor) {
+    public static IntFunction<Completable> repeatWithExponentialBackoffFullJitter(final Duration initialDelay,
+                                                                                  final Duration maxDelay,
+                                                                                  final Executor timerExecutor) {
         requireNonNull(timerExecutor);
-        final long delayNanos = delay.toNanos();
-        final long jitterNanos = jitter.toNanos();
-        checkJitterDelta(jitterNanos, delayNanos);
-        final long lowerBound = delayNanos - jitterNanos;
-        final long upperBound = delayNanos + jitterNanos;
-        return repeatCount -> timerExecutor.timer(current().nextLong(lowerBound, upperBound), NANOSECONDS);
+        final long initialDelayNanos = initialDelay.toNanos();
+        final long maxDelayNanos = maxDelay.toNanos();
+        final long maxInitialShift = maxShift(initialDelayNanos);
+        return repeatCount -> timerExecutor.timer(current().nextLong(0,
+                        min(maxDelayNanos, initialDelayNanos << min(maxInitialShift, repeatCount - 1))), NANOSECONDS);
     }
 
     /**
@@ -161,6 +204,37 @@ public final class RepeatStrategies {
      * Creates a new repeat function that adds a delay between repeats. For first repeat, the delay is
      * {@code initialDelay} which is increased exponentially for subsequent repeats.
      *
+     * @param initialDelay Delay {@link Duration} for the first repeat and increased exponentially with each repeat.
+     * @param jitter The jitter to apply to {@code initialDelay} on each repeat.
+     * @param maxDelay The maximum amount of delay that will be introduced.
+     * @param timerExecutor {@link Executor} to be used to schedule timers for backoff.
+     *
+     * @return An {@link IntFunction} to be used for repeats which given a repeat count returns a {@link Completable}
+     * that terminates successfully when the source has to be repeated or terminates with error if the source should not
+     * be repeated.
+     */
+    public static IntFunction<Completable> repeatWithExponentialBackoffDeltaJitter(final Duration initialDelay,
+                                                                                   final Duration jitter,
+                                                                                   final Duration maxDelay,
+                                                                                   final Executor timerExecutor) {
+        requireNonNull(timerExecutor);
+        final long initialDelayNanos = initialDelay.toNanos();
+        final long jitterNanos = jitter.toNanos();
+        final long maxDelayNanos = maxDelay.toNanos();
+        final long maxInitialShift = maxShift(initialDelayNanos);
+        return repeatCount -> {
+            final long baseDelayNanos = initialDelayNanos << min(maxInitialShift, repeatCount - 1);
+            return timerExecutor.timer(
+                    current().nextLong(max(0, baseDelayNanos - jitterNanos),
+                            min(maxDelayNanos, addWithOverflowProtection(baseDelayNanos, jitterNanos))),
+                    NANOSECONDS);
+        };
+    }
+
+    /**
+     * Creates a new repeat function that adds a delay between repeats. For first repeat, the delay is
+     * {@code initialDelay} which is increased exponentially for subsequent repeats.
+     *
      * @param maxRepeats Maximum number of allowed repeats, after which the returned {@link IntFunction} will return
      *                   a failed {@link Completable} with {@link TerminateRepeatException} as the cause.
      * @param initialDelay Delay {@link Duration} for the first repeat and increased exponentially with each repeat.
@@ -189,7 +263,7 @@ public final class RepeatStrategies {
             }
             final long baseDelayNanos = initialDelayNanos << min(maxInitialShift, repeatCount - 1);
             return timerExecutor.timer(
-                    current().nextLong(min(0, baseDelayNanos - jitterNanos),
+                    current().nextLong(max(0, baseDelayNanos - jitterNanos),
                             min(maxDelayNanos, addWithOverflowProtection(baseDelayNanos, jitterNanos))),
                     NANOSECONDS);
         };

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
@@ -16,11 +16,16 @@
 package io.servicetalk.concurrent.api;
 
 import java.time.Duration;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.IntFunction;
 
 import static io.servicetalk.concurrent.api.Completable.failed;
+import static io.servicetalk.concurrent.api.RetryStrategies.checkJitterDelta;
+import static io.servicetalk.concurrent.api.RetryStrategies.checkMaxRetries;
+import static io.servicetalk.concurrent.api.RetryStrategies.maxShift;
+import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
+import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
@@ -53,80 +58,139 @@ public final class RepeatStrategies {
      *
      * @param maxRepeats Maximum number of allowed repeats, after which the returned {@link IntFunction} will return
      *                   a failed {@link Completable} with {@link TerminateRepeatException} as the cause.
-     * @param backoff Constant {@link Duration} of backoff between repeats.
-     * @param timerExecutor {@link Executor} to be used to schedule timers for backoff.
+     * @param delay Constant {@link Duration} of delay between repeats.
+     * @param timerExecutor {@link Executor} to be used to schedule timers for delay.
      *
      * @return An {@link IntFunction} to be used for repeats which given a repeat count returns a {@link Completable}
      * that terminates successfully when the source has to be repeated or terminates with error if the source should not
      * be repeated.
      */
-    public static IntFunction<Completable> repeatWithConstantBackoff(final int maxRepeats, final Duration backoff,
-                                                                     final Executor timerExecutor) {
+    public static IntFunction<Completable> repeatWithConstantBackoffFullJitter(final int maxRepeats,
+                                                                               final Duration delay,
+                                                                               final Executor timerExecutor) {
+        checkMaxRetries(maxRepeats);
         requireNonNull(timerExecutor);
-        final long backoffNanos = backoff.toNanos();
-        return repeatCount -> {
-            if (repeatCount > maxRepeats) {
-                return terminateRepeat();
-            }
-            return timerExecutor.timer(backoffNanos, NANOSECONDS);
-        };
+        final long delayNanos = delay.toNanos();
+        return repeatCount -> repeatCount <= maxRepeats ?
+                timerExecutor.timer(current().nextLong(0, delayNanos), NANOSECONDS) : terminateRepeat();
     }
 
     /**
-     * Creates a new repeat function that adds a delay between repeats. For first repeat, the delay is
-     * {@code initialDelay} which is increased exponentially for subsequent repeats. <p>
-     * This method may not attempt to check for overflow if the repeat count is high enough that an exponential
-     * delay causes {@link Long} overflow.
+     * Creates a new repeat function that adds the passed constant {@link Duration} as delay between repeats.
      *
      * @param maxRepeats Maximum number of allowed repeats, after which the returned {@link IntFunction} will return
-     * a failed {@link Completable} with {@link TerminateRepeatException} as the cause.
-     * @param initialDelay Delay {@link Duration} for the first repeat and increased exponentially with each repeat.
-     * @param timerExecutor {@link Executor} to be used to schedule timers for backoff.
+     *                   a failed {@link Completable} with {@link TerminateRepeatException} as the cause.
+     * @param delay Constant {@link Duration} of delay between repeats.
+     * @param jitter The jitter to apply to {@code delay} on each repeat.
+     * @param timerExecutor {@link Executor} to be used to schedule timers for delay.
      *
      * @return An {@link IntFunction} to be used for repeats which given a repeat count returns a {@link Completable}
      * that terminates successfully when the source has to be repeated or terminates with error if the source should not
      * be repeated.
      */
-    public static IntFunction<Completable> repeatWithExponentialBackoff(final int maxRepeats,
-                                                                        final Duration initialDelay,
-                                                                        final Executor timerExecutor) {
+    public static IntFunction<Completable> repeatWithConstantBackoffDeltaJitter(final int maxRepeats,
+                                                                                final Duration delay,
+                                                                                final Duration jitter,
+                                                                                final Executor timerExecutor) {
+        checkMaxRetries(maxRepeats);
         requireNonNull(timerExecutor);
-        final long initialDelayNanos = initialDelay.toNanos();
-        return repeatCount -> {
-            if (repeatCount > maxRepeats) {
-                return terminateRepeat();
-            }
-            return timerExecutor.timer(initialDelayNanos << (repeatCount - 1), NANOSECONDS);
-        };
+        final long delayNanos = delay.toNanos();
+        final long jitterNanos = jitter.toNanos();
+        checkJitterDelta(jitterNanos, delayNanos);
+        final long lowerBound = delayNanos - jitterNanos;
+        final long upperBound = delayNanos + jitterNanos;
+        return repeatCount -> repeatCount <= maxRepeats ?
+                timerExecutor.timer(current().nextLong(lowerBound, upperBound), NANOSECONDS) : terminateRepeat();
+    }
+
+    /**
+     * Creates a new repeat function that adds the passed constant {@link Duration} as delay between repeats.
+     *
+     * @param delay Constant {@link Duration} of delay between repeats.
+     * @param jitter The jitter to apply to {@code delay} on each repeat.
+     * @param timerExecutor {@link Executor} to be used to schedule timers for delay.
+     *
+     * @return An {@link IntFunction} to be used for repeats which given a repeat count returns a {@link Completable}
+     * that terminates successfully when the source has to be repeated or terminates with error if the source should not
+     * be repeated.
+     */
+    public static IntFunction<Completable> repeatWithConstantBackoffDeltaJitter(final Duration delay,
+                                                                                final Duration jitter,
+                                                                                final Executor timerExecutor) {
+        requireNonNull(timerExecutor);
+        final long delayNanos = delay.toNanos();
+        final long jitterNanos = jitter.toNanos();
+        checkJitterDelta(jitterNanos, delayNanos);
+        final long lowerBound = delayNanos - jitterNanos;
+        final long upperBound = delayNanos + jitterNanos;
+        return repeatCount -> timerExecutor.timer(current().nextLong(lowerBound, upperBound), NANOSECONDS);
     }
 
     /**
      * Creates a new repeat function that adds a delay between repeats. For first repeat, the delay is
      * {@code initialDelay} which is increased exponentially for subsequent repeats.
      * This additionally adds a "Full Jitter" for the backoff as described
-     * <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/">here</a>.<p>
-     * This method may not attempt to check for overflow if the repeat count is high enough that an exponential delay
-     * causes {@link Long} overflow.
+     * <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/">here</a>.
      *
      * @param maxRepeats Maximum number of allowed repeats, after which the returned {@link IntFunction} will return
      *                   a failed {@link Completable} with {@link TerminateRepeatException} as the cause.
      * @param initialDelay Delay {@link Duration} for the first repeat and increased exponentially with each repeat.
+     * @param maxDelay The maximum amount of delay that will be introduced.
      * @param timerExecutor {@link Executor} to be used to schedule timers for backoff.
      *
      * @return An {@link IntFunction} to be used for repeats which given a repeat count returns a {@link Completable}
      * that terminates successfully when the source has to be repeated or terminates with error if the source should not
      * be repeated.
      */
-    public static IntFunction<Completable> repeatWithExponentialBackoffAndJitter(final int maxRepeats,
-                                                                                 final Duration initialDelay,
-                                                                                 final Executor timerExecutor) {
+    public static IntFunction<Completable> repeatWithExponentialBackoffFullJitter(final int maxRepeats,
+                                                                                  final Duration initialDelay,
+                                                                                  final Duration maxDelay,
+                                                                                  final Executor timerExecutor) {
+        checkMaxRetries(maxRepeats);
         requireNonNull(timerExecutor);
         final long initialDelayNanos = initialDelay.toNanos();
+        final long maxDelayNanos = maxDelay.toNanos();
+        final long maxInitialShift = maxShift(initialDelayNanos);
+        return repeatCount -> repeatCount <= maxRepeats ?
+                timerExecutor.timer(current().nextLong(0,
+                        min(maxDelayNanos, initialDelayNanos << min(maxInitialShift, repeatCount - 1))), NANOSECONDS) :
+                terminateRepeat();
+    }
+
+    /**
+     * Creates a new repeat function that adds a delay between repeats. For first repeat, the delay is
+     * {@code initialDelay} which is increased exponentially for subsequent repeats.
+     *
+     * @param maxRepeats Maximum number of allowed repeats, after which the returned {@link IntFunction} will return
+     *                   a failed {@link Completable} with {@link TerminateRepeatException} as the cause.
+     * @param initialDelay Delay {@link Duration} for the first repeat and increased exponentially with each repeat.
+     * @param jitter The jitter to apply to {@code initialDelay} on each repeat.
+     * @param maxDelay The maximum amount of delay that will be introduced.
+     * @param timerExecutor {@link Executor} to be used to schedule timers for backoff.
+     *
+     * @return An {@link IntFunction} to be used for repeats which given a repeat count returns a {@link Completable}
+     * that terminates successfully when the source has to be repeated or terminates with error if the source should not
+     * be repeated.
+     */
+    public static IntFunction<Completable> repeatWithExponentialBackoffDeltaJitter(final int maxRepeats,
+                                                                                   final Duration initialDelay,
+                                                                                   final Duration jitter,
+                                                                                   final Duration maxDelay,
+                                                                                   final Executor timerExecutor) {
+        checkMaxRetries(maxRepeats);
+        requireNonNull(timerExecutor);
+        final long initialDelayNanos = initialDelay.toNanos();
+        final long jitterNanos = jitter.toNanos();
+        final long maxDelayNanos = maxDelay.toNanos();
+        final long maxInitialShift = maxShift(initialDelayNanos);
         return repeatCount -> {
             if (repeatCount > maxRepeats) {
                 return terminateRepeat();
             }
-            return timerExecutor.timer(ThreadLocalRandom.current().nextLong(0, initialDelayNanos << (repeatCount - 1)),
+            final long baseDelayNanos = initialDelayNanos << min(maxInitialShift, repeatCount - 1);
+            return timerExecutor.timer(
+                    current().nextLong(min(0, baseDelayNanos - jitterNanos),
+                            min(maxDelayNanos, addWithOverflowProtection(baseDelayNanos, jitterNanos))),
                     NANOSECONDS);
         };
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetryStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetryStrategies.java
@@ -16,11 +16,14 @@
 package io.servicetalk.concurrent.api;
 
 import java.time.Duration;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Predicate;
 
 import static io.servicetalk.concurrent.api.Completable.failed;
+import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
+import static java.lang.Long.numberOfLeadingZeros;
+import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
@@ -35,37 +38,8 @@ public final class RetryStrategies {
 
     /**
      * Creates a new retry function that adds the passed constant {@link Duration} as a delay between retries.
-     *
-     * @param maxRetries Maximum number of allowed retries, after which the returned {@link BiIntFunction} will return
-     * a failed {@link Completable} with the passed {@link Throwable} as the cause
-     * @param causeFilter A {@link Predicate} that selects whether a {@link Throwable} cause should be retried
-     * @param delay Constant {@link Duration} of delay between retries
-     * @param timerExecutor {@link Executor} to be used to schedule timers for backoff
-     * @return A {@link BiIntFunction} to be used for retries which given a retry count and a {@link Throwable} returns
-     * a {@link Completable} that terminates successfully when the source has to be retried or terminates with error
-     * if the source should not be retried for the passed {@link Throwable}
-     */
-    public static BiIntFunction<Throwable, Completable> retryWithConstantBackoff(final int maxRetries,
-                                                                                 final Predicate<Throwable> causeFilter,
-                                                                                 final Duration delay,
-                                                                                 final Executor timerExecutor) {
-        checkMaxRetries(maxRetries);
-        requireNonNull(timerExecutor);
-        requireNonNull(causeFilter);
-        final long delayNanos = delay.toNanos();
-        return (retryCount, cause) -> {
-            if (retryCount > maxRetries || !causeFilter.test(cause)) {
-                return failed(cause);
-            }
-            return timerExecutor.timer(delayNanos, NANOSECONDS);
-        };
-    }
-
-    /**
-     * Creates a new retry function that adds the passed constant {@link Duration} as a delay between retries.
      * This additionally adds a "Full Jitter" for the backoff as described
-     * <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/">here</a>.
-     *
+     * <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter">here</a>.
      * @param maxRetries Maximum number of allowed retries, after which the returned {@link BiIntFunction} will return
      * a failed {@link Completable} with the passed {@link Throwable} as the cause
      * @param causeFilter A {@link Predicate} that selects whether a {@link Throwable} cause should be retried
@@ -75,98 +49,165 @@ public final class RetryStrategies {
      * a {@link Completable} that terminates successfully when the source has to be retried or terminates with error
      * if the source should not be retried for the passed {@link Throwable}
      */
-    public static BiIntFunction<Throwable, Completable> retryWithConstantBackoffAndJitter(
+    public static BiIntFunction<Throwable, Completable> retryWithConstantBackoffFullJitter(
             final int maxRetries,
             final Predicate<Throwable> causeFilter,
             final Duration delay,
             final Executor timerExecutor) {
-
         checkMaxRetries(maxRetries);
         requireNonNull(timerExecutor);
         requireNonNull(causeFilter);
         final long delayNanos = delay.toNanos();
-        return (retryCount, cause) -> {
-            if (retryCount > maxRetries || !causeFilter.test(cause)) {
-                return failed(cause);
-            }
-            return timerExecutor.timer(ThreadLocalRandom.current().nextLong(0, delayNanos), NANOSECONDS);
-        };
+        return (retryCount, cause) -> retryCount <= maxRetries && causeFilter.test(cause) ?
+                timerExecutor.timer(current().nextLong(0, delayNanos), NANOSECONDS) : failed(cause);
     }
 
     /**
-     * Creates a new retry function that adds a delay between retries. For first retry, the delay is
-     * {@code initialDelay} which is increased exponentially for subsequent retries.
-     * <p>
-     * This method may not attempt to check for overflow if the retry count is high enough that an exponential delay
-     * causes {@link Long} overflow.
+     * Creates a new retry function that adds the passed constant {@link Duration} as a delay between retries.
      *
      * @param maxRetries Maximum number of allowed retries, after which the returned {@link BiIntFunction} will return
      * a failed {@link Completable} with the passed {@link Throwable} as the cause
      * @param causeFilter A {@link Predicate} that selects whether a {@link Throwable} cause should be retried
-     * @param initialDelay Delay {@link Duration} for the first retry and increased exponentially with each retry
+     * @param delay Constant {@link Duration} of delay between retries
+     * @param jitter The jitter to apply to {@code delay} on each retry.
      * @param timerExecutor {@link Executor} to be used to schedule timers for backoff
      * @return A {@link BiIntFunction} to be used for retries which given a retry count and a {@link Throwable} returns
      * a {@link Completable} that terminates successfully when the source has to be retried or terminates with error
      * if the source should not be retried for the passed {@link Throwable}
      */
-    public static BiIntFunction<Throwable, Completable> retryWithExponentialBackoff(
+    public static BiIntFunction<Throwable, Completable> retryWithConstantBackoffDeltaJitter(
             final int maxRetries,
             final Predicate<Throwable> causeFilter,
-            final Duration initialDelay,
+            final Duration delay,
+            final Duration jitter,
             final Executor timerExecutor) {
-
         checkMaxRetries(maxRetries);
         requireNonNull(timerExecutor);
         requireNonNull(causeFilter);
-        final long initialDelayNanos = initialDelay.toNanos();
-        return (retryCount, cause) -> {
-            if (retryCount > maxRetries || !causeFilter.test(cause)) {
-                return failed(cause);
-            }
-            return timerExecutor.timer(initialDelayNanos << (retryCount - 1), NANOSECONDS);
-        };
+        final long delayNanos = delay.toNanos();
+        final long jitterNanos = jitter.toNanos();
+        checkJitterDelta(jitterNanos, delayNanos);
+        final long lowerBound = delayNanos - jitterNanos;
+        final long upperBound = delayNanos + jitterNanos;
+        return (retryCount, cause) -> retryCount <= maxRetries && causeFilter.test(cause) ?
+                timerExecutor.timer(current().nextLong(lowerBound, upperBound), NANOSECONDS) : failed(cause);
+    }
+
+    /**
+     * Creates a new retry function that adds the passed constant {@link Duration} as a delay between retries.
+     *
+     * @param causeFilter A {@link Predicate} that selects whether a {@link Throwable} cause should be retried
+     * @param delay Constant {@link Duration} of delay between retries
+     * @param jitter The jitter to apply to {@code delay} on each retry.
+     * @param timerExecutor {@link Executor} to be used to schedule timers for backoff
+     * @return A {@link BiIntFunction} to be used for retries which given a retry count and a {@link Throwable} returns
+     * a {@link Completable} that terminates successfully when the source has to be retried or terminates with error
+     * if the source should not be retried for the passed {@link Throwable}
+     */
+    public static BiIntFunction<Throwable, Completable> retryWithConstantBackoffDeltaJitter(
+            final Predicate<Throwable> causeFilter,
+            final Duration delay,
+            final Duration jitter,
+            final Executor timerExecutor) {
+        requireNonNull(timerExecutor);
+        requireNonNull(causeFilter);
+        final long delayNanos = delay.toNanos();
+        final long jitterNanos = jitter.toNanos();
+        checkJitterDelta(jitterNanos, delayNanos);
+        final long lowerBound = delayNanos - jitterNanos;
+        final long upperBound = delayNanos + jitterNanos;
+        return (retryCount, cause) -> causeFilter.test(cause) ?
+                timerExecutor.timer(current().nextLong(lowerBound, upperBound), NANOSECONDS) : failed(cause);
     }
 
     /**
      * Creates a new retry function that adds a delay between retries. For first retry, the delay is
      * {@code initialDelay} which is increased exponentially for subsequent retries.
      * This additionally adds a "Full Jitter" for the backoff as described
-     * <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/">here</a>.
-     * <p>
-     * This method may not attempt to check for overflow if the retry count is high enough that an exponential delay
-     * causes {@link Long} overflow.
+     * <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter">here</a>.
      *
      * @param maxRetries Maximum number of allowed retries, after which the returned {@link BiIntFunction} will return
      * a failed {@link Completable} with the passed {@link Throwable} as the cause
      * @param causeFilter A {@link Predicate} that selects whether a {@link Throwable} cause should be retried
      * @param initialDelay Delay {@link Duration} for the first retry and increased exponentially with each retry
+     * @param maxDelay The maximum amount of delay that will be introduced.
      * @param timerExecutor {@link Executor} to be used to schedule timers for backoff
      * @return A {@link BiIntFunction} to be used for retries which given a retry count and a {@link Throwable} returns
      * a {@link Completable} that terminates successfully when the source has to be retried or terminates with error
      * if the source should not be retried for the passed {@link Throwable}
      */
-    public static BiIntFunction<Throwable, Completable> retryWithExponentialBackoffAndJitter(
+    public static BiIntFunction<Throwable, Completable> retryWithExponentialBackoffFullJitter(
             final int maxRetries,
             final Predicate<Throwable> causeFilter,
             final Duration initialDelay,
+            final Duration maxDelay,
             final Executor timerExecutor) {
+        requireNonNull(timerExecutor);
+        requireNonNull(causeFilter);
+        final long initialDelayNanos = initialDelay.toNanos();
+        final long maxDelayNanos = maxDelay.toNanos();
+        final long maxInitialShift = maxShift(initialDelayNanos);
+        return (retryCount, cause) -> retryCount <= maxRetries && causeFilter.test(cause) ?
+                timerExecutor.timer(current().nextLong(0,
+                        min(maxDelayNanos, initialDelayNanos << min(maxInitialShift, retryCount - 1))), NANOSECONDS) :
+                failed(cause);
+    }
 
+    /**
+     * Creates a new retry function that adds a delay between retries. For first retry, the delay is
+     * {@code initialDelay} which is increased exponentially for subsequent retries.
+     *
+     * @param maxRetries Maximum number of allowed retries, after which the returned {@link BiIntFunction} will return
+     * a failed {@link Completable} with the passed {@link Throwable} as the cause
+     * @param causeFilter A {@link Predicate} that selects whether a {@link Throwable} cause should be retried
+     * @param initialDelay Delay {@link Duration} for the first retry and increased exponentially with each retry
+     * @param jitter The jitter to apply to {@code delay} on each retry.
+     * @param maxDelay The maximum amount of delay that will be introduced.
+     * @param timerExecutor {@link Executor} to be used to schedule timers for backoff
+     * @return A {@link BiIntFunction} to be used for retries which given a retry count and a {@link Throwable} returns
+     * a {@link Completable} that terminates successfully when the source has to be retried or terminates with error
+     * if the source should not be retried for the passed {@link Throwable}
+     */
+    public static BiIntFunction<Throwable, Completable> retryWithExponentialBackoffDeltaJitter(
+            final int maxRetries,
+            final Predicate<Throwable> causeFilter,
+            final Duration initialDelay,
+            final Duration jitter,
+            final Duration maxDelay,
+            final Executor timerExecutor) {
         checkMaxRetries(maxRetries);
         requireNonNull(timerExecutor);
         requireNonNull(causeFilter);
         final long initialDelayNanos = initialDelay.toNanos();
+        final long jitterNanos = jitter.toNanos();
+        final long maxDelayNanos = maxDelay.toNanos();
+        final long maxInitialShift = maxShift(initialDelayNanos);
         return (retryCount, cause) -> {
             if (retryCount > maxRetries || !causeFilter.test(cause)) {
                 return failed(cause);
             }
-            return timerExecutor.timer(ThreadLocalRandom.current().nextLong(0, initialDelayNanos << (retryCount - 1)),
+            final long baseDelayNanos = initialDelayNanos << min(maxInitialShift, retryCount - 1);
+            return timerExecutor.timer(
+                    current().nextLong(min(0, baseDelayNanos - jitterNanos),
+                            min(maxDelayNanos, addWithOverflowProtection(baseDelayNanos, jitterNanos))),
                     NANOSECONDS);
         };
     }
 
-    private static void checkMaxRetries(final int maxRetries) {
+    static void checkMaxRetries(final int maxRetries) {
         if (maxRetries <= 0) {
             throw new IllegalArgumentException("maxRetries: " + maxRetries + " (expected: >0)");
         }
+    }
+
+    static void checkJitterDelta(long jitterNanos, long delayNanos) {
+        if (jitterNanos > delayNanos || Long.MAX_VALUE - delayNanos < jitterNanos) {
+            throw new IllegalArgumentException("jitter " + jitterNanos +
+                    "ns would result in [under|over]flow as a delta to delay " + delayNanos + "ns");
+        }
+    }
+
+    static long maxShift(long v) {
+        return numberOfLeadingZeros(v) - 1;
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RedoStrategiesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RedoStrategiesTest.java
@@ -56,7 +56,15 @@ public class RedoStrategiesTest {
         });
     }
 
-    protected void verifyDelayWithJitter(long delayNanos, int invocationCount) {
+    protected void verifyDelayWithDeltaJitter(long delayNanos, long jitterNanos, int invocationCount) {
+        ArgumentCaptor<Long> backoffWithJitter = ArgumentCaptor.forClass(Long.class);
+        verify(timerExecutor, times(invocationCount)).timer(backoffWithJitter.capture(), eq(NANOSECONDS));
+        assertThat("Unexpected backoff value.", backoffWithJitter.getValue(), greaterThanOrEqualTo(0L));
+        assertThat("Unexpected backoff value.", backoffWithJitter.getValue(),
+                lessThanOrEqualTo(delayNanos + jitterNanos));
+    }
+
+    protected void verifyDelayWithFullJitter(long delayNanos, int invocationCount) {
         ArgumentCaptor<Long> backoffWithJitter = ArgumentCaptor.forClass(Long.class);
         verify(timerExecutor, times(invocationCount)).timer(backoffWithJitter.capture(), eq(NANOSECONDS));
         assertThat("Unexpected backoff value.", backoffWithJitter.getValue(), greaterThanOrEqualTo(0L));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RetryStrategiesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RetryStrategiesTest.java
@@ -21,14 +21,17 @@ import org.junit.Test;
 
 import java.time.Duration;
 
-import static io.servicetalk.concurrent.api.RetryStrategies.retryWithConstantBackoff;
-import static io.servicetalk.concurrent.api.RetryStrategies.retryWithConstantBackoffAndJitter;
-import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponentialBackoff;
-import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponentialBackoffAndJitter;
+import static io.servicetalk.concurrent.api.RetryStrategies.retryWithConstantBackoffDeltaJitter;
+import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponentialBackoffDeltaJitter;
+import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponentialBackoffFullJitter;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static java.time.Duration.ofDays;
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofNanos;
 import static java.time.Duration.ofSeconds;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static org.mockito.Mockito.verify;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class RetryStrategiesTest extends RedoStrategiesTest {
@@ -36,127 +39,132 @@ public class RetryStrategiesTest extends RedoStrategiesTest {
     @Test
     public void testBackoff() throws Exception {
         Duration backoff = ofSeconds(1);
-        RetryStrategy strategy = new RetryStrategy(retryWithConstantBackoff(2, cause -> true, backoff,
-                timerExecutor));
-        LegacyMockedCompletableListenerRule signalListener = strategy.invokeAndListen(DELIBERATE_EXCEPTION);
-        verify(timerExecutor).timer(backoff.toNanos(), NANOSECONDS);
+        RetryStrategy strategy = new RetryStrategy(retryWithConstantBackoffDeltaJitter(2, cause -> true, backoff,
+                ofNanos(1), timerExecutor));
+        TestCollectingCompletableSubscriber subscriber = strategy.invokeAndListen(DELIBERATE_EXCEPTION);
+        verifyDelayWithDeltaJitter(backoff.toNanos(), 1, 1);
         timers.take().verifyListenCalled().onComplete();
-        signalListener.verifyCompletion();
+        subscriber.awaitOnComplete();
         verifyNoMoreInteractions(timerExecutor);
     }
 
     @Test
     public void testBackoffWithJitter() throws Exception {
         Duration backoff = ofSeconds(1);
-        RetryStrategy strategy = new RetryStrategy(retryWithConstantBackoffAndJitter(2, cause -> true,
-                backoff, timerExecutor));
-        LegacyMockedCompletableListenerRule signalListener = strategy.invokeAndListen(DELIBERATE_EXCEPTION);
-        verifyDelayWithJitter(backoff.toNanos(), 1);
+        Duration jitter = ofMillis(10);
+        RetryStrategy strategy = new RetryStrategy(retryWithConstantBackoffDeltaJitter(2, cause -> true,
+                backoff, jitter, timerExecutor));
+        TestCollectingCompletableSubscriber subscriber = strategy.invokeAndListen(DELIBERATE_EXCEPTION);
+        verifyDelayWithDeltaJitter(backoff.toNanos(), jitter.toNanos(), 1);
         timers.take().verifyListenCalled().onComplete();
-        signalListener.verifyCompletion();
+        subscriber.awaitOnComplete();
         verifyNoMoreInteractions(timerExecutor);
     }
 
     @Test
     public void testBackoffMaxRetries() throws Exception {
         Duration backoff = ofSeconds(1);
-        testMaxRetries(retryWithExponentialBackoff(1, cause -> true, backoff, timerExecutor), backoff);
+        testMaxRetries(retryWithExponentialBackoffFullJitter(1, cause -> true, backoff, ofDays(10), timerExecutor),
+                backoff);
     }
 
     @Test
-    public void testBackoffCauseFilter() {
-        testCauseFilter(retryWithConstantBackoff(1, cause -> cause instanceof IllegalStateException,
-                ofSeconds(1), timerExecutor));
+    public void testBackoffCauseFilter() throws Exception {
+        testCauseFilter(retryWithExponentialBackoffFullJitter(1, cause -> cause instanceof IllegalStateException,
+                ofSeconds(1), ofDays(10), timerExecutor));
     }
 
     @Test
     public void testExpBackoff() throws Exception {
         Duration initialDelay = ofSeconds(1);
-        RetryStrategy strategy = new RetryStrategy(retryWithExponentialBackoff(2, cause -> true, initialDelay,
-                timerExecutor));
-        LegacyMockedCompletableListenerRule signalListener = strategy.invokeAndListen(DELIBERATE_EXCEPTION);
-        verify(timerExecutor).timer(initialDelay.toNanos(), NANOSECONDS);
+        RetryStrategy strategy = new RetryStrategy(retryWithExponentialBackoffFullJitter(2, cause -> true, initialDelay,
+                ofDays(10), timerExecutor));
+        TestCollectingCompletableSubscriber subscriber = strategy.invokeAndListen(DELIBERATE_EXCEPTION);
+        verifyDelayWithFullJitter(initialDelay.toNanos(), 1);
         timers.take().verifyListenCalled().onComplete();
-        signalListener.verifyCompletion();
+        subscriber.awaitOnComplete();
         verifyNoMoreInteractions(timerExecutor);
 
-        signalListener = strategy.invokeAndListen(DELIBERATE_EXCEPTION);
-        verify(timerExecutor).timer(initialDelay.toNanos() << 1, NANOSECONDS);
+        subscriber = strategy.invokeAndListen(DELIBERATE_EXCEPTION);
+        verifyDelayWithFullJitter(initialDelay.toNanos() << 1, 2);
         timers.take().verifyListenCalled().onComplete();
-        signalListener.verifyCompletion();
+        subscriber.awaitOnComplete();
         verifyNoMoreInteractions(timerExecutor);
     }
 
     @Test
     public void testExpBackoffMaxRetries() throws Exception {
         Duration backoff = ofSeconds(1);
-        testMaxRetries(retryWithExponentialBackoff(1, cause -> true, backoff, timerExecutor), backoff);
+        testMaxRetries(retryWithExponentialBackoffFullJitter(1, cause -> true, backoff, ofDays(10), timerExecutor),
+                backoff);
     }
 
     @Test
-    public void testExpBackoffCauseFilter() {
-        testCauseFilter(retryWithExponentialBackoff(1, cause -> cause instanceof IllegalStateException,
-                ofSeconds(1), timerExecutor));
+    public void testExpBackoffCauseFilter() throws Exception {
+        testCauseFilter(retryWithExponentialBackoffFullJitter(1, cause -> cause instanceof IllegalStateException,
+                ofSeconds(1), ofDays(10), timerExecutor));
     }
 
     @Test
     public void testExpBackoffWithJitter() throws Exception {
         Duration initialDelay = ofSeconds(1);
-        RetryStrategy strategy = new RetryStrategy(retryWithExponentialBackoffAndJitter(2, cause -> true,
-                initialDelay, timerExecutor));
-        LegacyMockedCompletableListenerRule signalListener = strategy.invokeAndListen(DELIBERATE_EXCEPTION);
-        verifyDelayWithJitter(initialDelay.toNanos(), 1);
+        Duration jitter = ofMillis(10);
+        RetryStrategy strategy = new RetryStrategy(retryWithExponentialBackoffDeltaJitter(2, cause -> true,
+                initialDelay, jitter, ofDays(10), timerExecutor));
+        TestCollectingCompletableSubscriber subscriber = strategy.invokeAndListen(DELIBERATE_EXCEPTION);
+        verifyDelayWithDeltaJitter(initialDelay.toNanos(), jitter.toNanos(), 1);
 
         timers.take().verifyListenCalled().onComplete();
-        signalListener.verifyCompletion();
+        subscriber.awaitOnComplete();
         verifyNoMoreInteractions(timerExecutor);
 
-        signalListener = strategy.invokeAndListen(DELIBERATE_EXCEPTION);
+        subscriber = strategy.invokeAndListen(DELIBERATE_EXCEPTION);
         long nextDelay = initialDelay.toNanos() << 1;
-        verifyDelayWithJitter(nextDelay, 2);
+        verifyDelayWithDeltaJitter(nextDelay, jitter.toNanos(), 2);
         timers.take().verifyListenCalled().onComplete();
-        signalListener.verifyCompletion();
+        subscriber.awaitOnComplete();
         verifyNoMoreInteractions(timerExecutor);
     }
 
     @Test
     public void testExpBackoffWithJitterMaxRetries() throws Exception {
         Duration backoff = ofSeconds(1);
-        testMaxRetries(retryWithExponentialBackoffAndJitter(1, cause -> true, backoff, timerExecutor),
-                () -> verifyDelayWithJitter(backoff.toNanos(), 1));
+        Duration jitter = ofMillis(10);
+        testMaxRetries(retryWithExponentialBackoffDeltaJitter(1, cause -> true, backoff, jitter, ofDays(10),
+                timerExecutor), () -> verifyDelayWithDeltaJitter(backoff.toNanos(), jitter.toNanos(), 1));
     }
 
     @Test
-    public void testExpBackoffWithJitterCauseFilter() {
-        testCauseFilter(retryWithExponentialBackoffAndJitter(1,
-                cause -> cause instanceof IllegalStateException, ofSeconds(1), timerExecutor));
+    public void testExpBackoffWithJitterCauseFilter() throws Exception {
+        testCauseFilter(retryWithExponentialBackoffDeltaJitter(1, cause -> cause instanceof IllegalStateException,
+                ofSeconds(1), ofMillis(10), ofDays(10), timerExecutor));
     }
 
-    private void testCauseFilter(BiIntFunction<Throwable, Completable> actualStrategy) {
+    private void testCauseFilter(BiIntFunction<Throwable, Completable> actualStrategy) throws Exception {
         RetryStrategy strategy = new RetryStrategy(actualStrategy);
-        LegacyMockedCompletableListenerRule signalListener = strategy.invokeAndListen(DELIBERATE_EXCEPTION);
+        TestCollectingCompletableSubscriber subscriber = strategy.invokeAndListen(DELIBERATE_EXCEPTION);
         verifyNoMoreInteractions(timerExecutor);
-        signalListener.verifyFailure(DELIBERATE_EXCEPTION);
+        assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
 
     private void testMaxRetries(BiIntFunction<Throwable, Completable> actualStrategy, Duration backoff)
             throws Exception {
-        testMaxRetries(actualStrategy, () -> verify(timerExecutor).timer(backoff.toNanos(), NANOSECONDS));
+        testMaxRetries(actualStrategy, () -> verifyDelayWithFullJitter(backoff.toNanos(), 1));
     }
 
     private void testMaxRetries(BiIntFunction<Throwable, Completable> actualStrategy, Runnable verifyTimerProvider)
             throws Exception {
         RetryStrategy strategy = new RetryStrategy(actualStrategy);
-        LegacyMockedCompletableListenerRule signalListener = strategy.invokeAndListen(DELIBERATE_EXCEPTION);
+        TestCollectingCompletableSubscriber subscriber = strategy.invokeAndListen(DELIBERATE_EXCEPTION);
         verifyTimerProvider.run();
         timers.take().verifyListenCalled().onComplete();
-        signalListener.verifyCompletion();
+        subscriber.awaitOnComplete();
         verifyNoMoreInteractions(timerExecutor);
 
         DeliberateException de = new DeliberateException();
-        signalListener = strategy.invokeAndListen(de);
+        subscriber = strategy.invokeAndListen(de);
         verifyNoMoreInteractions(timerExecutor);
-        signalListener.verifyFailure(de);
+        assertThat(subscriber.awaitOnError(), is(de));
     }
 
     private static final class RetryStrategy {
@@ -168,10 +176,10 @@ public class RetryStrategiesTest extends RedoStrategiesTest {
             this.actual = actual;
         }
 
-        LegacyMockedCompletableListenerRule invokeAndListen(Throwable cause) {
-            LegacyMockedCompletableListenerRule listenerRule = new LegacyMockedCompletableListenerRule();
-            listenerRule.listen(actual.apply(++count, cause));
-            return listenerRule;
+        TestCollectingCompletableSubscriber invokeAndListen(Throwable cause) {
+            TestCollectingCompletableSubscriber subscriber = new TestCollectingCompletableSubscriber();
+            toSource(actual.apply(++count, cause)).subscribe(subscriber);
+            return subscriber;
         }
     }
 }

--- a/servicetalk-examples/http/service-composition/src/main/java/io/servicetalk/examples/http/service/composition/GatewayServer.java
+++ b/servicetalk-examples/http/service-composition/src/main/java/io/servicetalk/examples/http/service/composition/GatewayServer.java
@@ -41,6 +41,7 @@ import static io.servicetalk.examples.http.service.composition.backends.PortRegi
 import static io.servicetalk.http.api.HttpSerializationProviders.jsonSerializer;
 import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
 import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
 
 /**
  * A server starter for gateway to all backends.
@@ -119,7 +120,7 @@ public final class GatewayServer {
                         // Set retry and timeout filters for all clients.
                         .appendClientFilter(new RetryingHttpRequesterFilter.Builder()
                                 .maxRetries(3)
-                                .buildWithExponentialBackoffAndJitter(ofMillis(100)))
+                                .buildWithExponentialBackoffDeltaJitter(ofMillis(100), ofMillis(50), ofSeconds(30)))
                         // Apply a timeout filter for the client to guard against latent clients.
                         .appendClientFilter(new TimeoutHttpRequesterFilter(ofMillis(500)))
                         // Apply a filter that returns an error if any response status code is not 200 OK

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategyTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategyTest.java
@@ -37,6 +37,7 @@ import static io.servicetalk.concurrent.api.Publisher.defer;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static java.lang.Long.MAX_VALUE;
+import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofSeconds;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -180,14 +181,16 @@ public class DefaultServiceDiscoveryRetryStrategyTest {
         assertThat("Unexpected event received", state.subscriber.takeItems(), hasSize(0));
     }
 
-    private TestPublisher<Collection<ServiceDiscovererEvent<String>>> triggerRetry(final State state,
-            final TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents) throws Exception {
+    private TestPublisher<Collection<ServiceDiscovererEvent<String>>> triggerRetry(
+            final State state, final TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents)
+            throws Exception {
         sdEvents.onError(DELIBERATE_EXCEPTION);
         executorRule.executor().advanceTimeBy(1, MINUTES);
         return state.pubs.take();
     }
 
-    private DefaultServiceDiscovererEvent<String> sendUpAndVerifyReceive(final State state, final String addr,
+    private DefaultServiceDiscovererEvent<String> sendUpAndVerifyReceive(
+            final State state, final String addr,
             final TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents) {
         final DefaultServiceDiscovererEvent<String> evt = new DefaultServiceDiscovererEvent<>(addr, true);
         sdEvents.onNext(singletonList(evt));
@@ -211,7 +214,7 @@ public class DefaultServiceDiscoveryRetryStrategyTest {
 
         State(final boolean retainAddressesTillSuccess) {
             ServiceDiscoveryRetryStrategy<String, ServiceDiscovererEvent<String>> strategy =
-                    Builder.<String>withDefaults(executorRule.executor(), ofSeconds(1))
+                    Builder.<String>withDefaults(executorRule.executor(), ofSeconds(1), ofMillis(500))
                             .retainAddressesTillSuccess(retainAddressesTillSuccess)
                             .build();
             pubs = new LinkedBlockingQueue<>();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -68,7 +68,8 @@ import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.failed;
-import static java.time.Duration.ofSeconds;
+import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.SD_RETRY_STRATEGY_INIT_DURATION;
+import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.SD_RETRY_STRATEGY_JITTER;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 
@@ -99,7 +100,8 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
                 new DefaultSingleAddressHttpClientBuilder.RetryingServiceDiscoverer<>(serviceDiscoverer,
                         serviceDiscovererRetryStrategy == null ?
                                 DefaultServiceDiscoveryRetryStrategy.Builder.<R>withDefaultsForPartitions(
-                                        buildContext.executionContext.executor(), ofSeconds(60)).build() :
+                                        buildContext.executionContext.executor(), SD_RETRY_STRATEGY_INIT_DURATION,
+                                        SD_RETRY_STRATEGY_JITTER).build() :
                                 serviceDiscovererRetryStrategy);
 
         final PartitionedClientFactory<U, R, FilterableStreamingHttpClient> clientFactory = (pa, sd) -> {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -58,6 +58,7 @@ import io.netty.util.NetUtil;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.SocketOption;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
@@ -89,6 +90,8 @@ import static java.util.function.Function.identity;
  * @param <R> the type of address after resolution (resolved address)
  */
 final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHttpClientBuilder<U, R> {
+    static final Duration SD_RETRY_STRATEGY_INIT_DURATION = ofSeconds(10);
+    static final Duration SD_RETRY_STRATEGY_JITTER = ofSeconds(5);
     @Nullable
     private final U address;
     @Nullable
@@ -368,8 +371,8 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
                 new RetryingServiceDiscoverer<>(new StatusAwareServiceDiscoverer<>(serviceDiscoverer, sdStatus),
                         serviceDiscovererRetryStrategy == null ?
                                 DefaultServiceDiscoveryRetryStrategy.Builder.<R>withDefaults(exec.executor(),
-                                        ofSeconds(60)).build()
-                                : serviceDiscovererRetryStrategy);
+                                        SD_RETRY_STRATEGY_INIT_DURATION, SD_RETRY_STRATEGY_JITTER).build() :
+                                serviceDiscovererRetryStrategy);
         return new HttpClientBuildContext<>(clonedBuilder, exec, reqRespFactory, sd, sdStatus, proxyAddress);
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractEchoServerBasedHttpRequesterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractEchoServerBasedHttpRequesterTest.java
@@ -34,13 +34,12 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.Timeout;
 
-import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.concurrent.api.BlockingTestUtils.awaitIndefinitelyNonNull;
 import static io.servicetalk.concurrent.api.Publisher.from;
-import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponentialBackoff;
+import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponentialBackoffFullJitter;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
@@ -49,6 +48,8 @@ import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.ExecutionContextRule.immediate;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.Duration.ofDays;
+import static java.time.Duration.ofMillis;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -104,7 +105,7 @@ public abstract class AbstractEchoServerBasedHttpRequesterTest {
             StreamingHttpResponse resp = awaitIndefinitelyNonNull(
                     requester.request(defaultStrategy(), request)
                             .retryWhen(
-                                    retryWithExponentialBackoff(10, t -> true, Duration.ofMillis(100),
+                                    retryWithExponentialBackoffFullJitter(10, t -> true, ofMillis(100), ofDays(10),
                                             CTX.executor())));
 
             assertThat(resp.status(), equalTo(OK));


### PR DESCRIPTION
Motivation:
[Retry|Repeat]Strategies provides utility methods with strategies that
can apply a jitter to a delay scheme (e.g. fixed, exponential). However
we currently only offer "Full Jitter" variants which vary delay in the
range [0, max delay]. This works well to maximize variance of client
request arrival for exclusive resource operations (e.g. all clients
attempt to lock the same row in a DB) but may not be optimal in cases
which don't require mutual exclusion and instead value more predictable
and faster repeat intervals.

Modifications:
- [Retry|Repeat]Strategies rename the existing jitter methods to
"FullJitter"
- [Retry|Repeat]Strategies now include an alternative jitter method
"DeltaJitter" which applies a delta to the base distribution
[delay-jitter, delay+jitter].

Result:
More options to apply jitter in [Retry|Repeat]Strategies