### PR TITLE
Publisher#flatMapConcatIterable drain demand on onNext exception

### DIFF
--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/SubscriberUtils.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/SubscriberUtils.java
@@ -405,4 +405,16 @@ public final class SubscriberUtils {
             LOGGER.info("Ignoring exception from onComplete of Subscriber {}.", subscriber, t);
         }
     }
+
+    /**
+     * Invokes {@link Cancellable#cancel()} ignoring any exceptions that are thrown.
+     * @param cancellable The {@link Cancellable} to {@link Cancellable#cancel() cancel}.
+     */
+    public static void safeCancel(Cancellable cancellable) {
+        try {
+            cancellable.cancel();
+        } catch (Throwable t) {
+            LOGGER.info("Ignoring exception from cancel {}.", cancellable, t);
+        }
+    }
 }

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/TaskBasedSignalOffloader.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/TaskBasedSignalOffloader.java
@@ -360,8 +360,8 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
                             try {
                                 target.onError(th);
                             } catch (Throwable throwable) {
-                                LOGGER.error("Ignored unexpected exception from onError(). Subscriber: {}",
-                                        target, t);
+                                LOGGER.error("Ignored unexpected exception from onError(). Subscriber: {}", target,
+                                        throwable);
                             } finally {
                                 assert subscription != null;
                                 subscription.cancel();

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/TaskBasedSignalOffloader.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/TaskBasedSignalOffloader.java
@@ -35,6 +35,10 @@ import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.internal.EmptySubscription.EMPTY_SUBSCRIPTION;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.safeCancel;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnComplete;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnError;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnSuccess;
 import static io.servicetalk.utils.internal.PlatformDependent.newUnboundedSpscQueue;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
@@ -228,11 +232,7 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
 
                 if (r == CANCELLED) {
                     requested = TERMINATED;
-                    try {
-                        target.cancel();
-                    } catch (Throwable t) {
-                        LOGGER.error("Ignoring unexpected exception from cancel(). Subscription {}.", target, t);
-                    }
+                    safeCancel(target);
                     return; // No more signals are required to be sent.
                 } else if (r == TERMINATED) {
                     return; // we want to hard return to avoid resetting state.
@@ -280,6 +280,7 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
         private static final int STATE_EXECUTING = 2;
         private static final int STATE_TERMINATING = 3;
         private static final int STATE_TERMINATED = 4;
+        @SuppressWarnings("rawtypes")
         private static final AtomicIntegerFieldUpdater<OffloadedSubscriber> stateUpdater =
                 newUpdater(OffloadedSubscriber.class, "state");
 
@@ -335,19 +336,17 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
                             target.onSubscribe(subscription);
                         } catch (Throwable t) {
                             clearSignalsFromExecutorThread();
-                            LOGGER.error("Ignored unexpected exception from onSubscribe. Subscriber: {}, " +
-                                    "Subscription: {}.", target, subscription, t);
-                            subscription.cancel();
+                            safeOnError(target, t);
+                            safeCancel(subscription);
                             return; // We can't interact with the queue any more because we terminated, so bail.
                         }
                     } else if (signal instanceof TerminalNotification) {
                         state = STATE_TERMINATED;
-                        try {
-                            ((TerminalNotification) signal).terminate(target);
-                        } catch (Throwable t) {
-                            LOGGER.error("Ignored unexpected exception from {}. Subscriber: {}",
-                                    ((TerminalNotification) signal).cause() == null ? "onComplete()" :
-                                            "onError()", target, t);
+                        Throwable cause = ((TerminalNotification) signal).cause();
+                        if (cause != null) {
+                            safeOnError(target, cause);
+                        } else {
+                            safeOnComplete(target);
                         }
                         return; // We can't interact with the queue any more because we terminated, so bail.
                     } else {
@@ -357,15 +356,9 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
                             target.onNext(t);
                         } catch (Throwable th) {
                             clearSignalsFromExecutorThread();
-                            try {
-                                target.onError(th);
-                            } catch (Throwable throwable) {
-                                LOGGER.error("Ignored unexpected exception from onError(). Subscriber: {}", target,
-                                        throwable);
-                            } finally {
-                                assert subscription != null;
-                                subscription.cancel();
-                            }
+                            safeOnError(target, th);
+                            assert subscription != null;
+                            safeCancel(subscription);
                             return; // We can't interact with the queue any more because we terminated, so bail.
                         }
                     }
@@ -432,25 +425,24 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
                 executor.execute(this);
             } catch (Throwable t) {
                 state = STATE_TERMINATED;
+                try {
+                    // As a policy, we call the target in the calling thread when the executor is inadequately
+                    // provisioned. In the future we could make this configurable.
+                    if (signal instanceof Subscription) {
+                        // Offloading of onSubscribe was rejected.
+                        // If target throws here, we do not attempt to do anything else as spec has been violated.
+                        target.onSubscribe(EMPTY_SUBSCRIPTION);
+                    }
+                } finally {
+                    safeOnError(target, t);
+                }
                 // This is an SPSC queue; at this point we are sure that there is no other consumer of the queue
                 // because:
                 //  - We were in STATE_IDLE and hence the task isn't running.
                 //  - The Executor threw from execute(), so we assume it will not run the task.
                 signals.clear();
                 assert subscription != null;
-                subscription.cancel();
-                // As a policy, we call the target in the calling thread when the executor is inadequately
-                // provisioned. In the future we could make this configurable.
-                if (signal instanceof Subscription) {
-                    // Offloading of onSubscribe was rejected.
-                    // If target throws here, we do not attempt to do anything else as spec has been violated.
-                    target.onSubscribe(EMPTY_SUBSCRIPTION);
-                }
-                try {
-                    target.onError(t);
-                } catch (Throwable throwable) {
-                    LOGGER.error("Ignored unexpected exception from onError. Subscriber: {}", target, throwable);
-                }
+                safeCancel(subscription);
             }
         }
     }
@@ -604,19 +596,11 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
         @Override
         void deliverTerminalToSubscriber(final Object terminal) {
             if (terminal instanceof TerminalNotification) {
-                try {
-                    final Throwable error = ((TerminalNotification) terminal).cause();
-                    assert error != null : "Cause can't be null from TerminalNotification.error(..)";
-                    target.onError(error);
-                } catch (Throwable t) {
-                    LOGGER.error("Ignored unexpected exception from onError. Subscriber: {}", target, t);
-                }
+                final Throwable error = ((TerminalNotification) terminal).cause();
+                assert error != null;
+                safeOnError(target, error);
             } else {
-                try {
-                    target.onSuccess(uncheckCast(terminal));
-                } catch (Throwable t) {
-                    LOGGER.error("Ignored unexpected exception from onSuccess. Subscriber: {}", target, t);
-                }
+                safeOnSuccess(target, uncheckCast(terminal));
             }
         }
 
@@ -626,9 +610,8 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
                 target.onSubscribe(cancellable);
             } catch (Throwable t) {
                 onSubscribeFailed();
-                LOGGER.error("Ignored unexpected exception from onSubscribe. Subscriber: {}, Cancellable: {}.",
-                        target, cancellable, t);
-                cancellable.cancel();
+                safeOnError(target, t);
+                safeCancel(cancellable);
             }
         }
 
@@ -669,15 +652,10 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
 
         @Override
         void deliverTerminalToSubscriber(final Object terminal) {
-            try {
-                if (terminal instanceof Throwable) {
-                    target.onError((Throwable) terminal);
-                } else {
-                    target.onComplete();
-                }
-            } catch (Throwable t) {
-                LOGGER.error("Ignored unexpected exception from {}. Subscriber: {}",
-                        terminal instanceof Throwable ? "onError" : "onComplete", target, t);
+            if (terminal instanceof Throwable) {
+                safeOnError(target, (Throwable) terminal);
+            } else {
+                safeOnComplete(target);
             }
         }
 
@@ -687,9 +665,8 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
                 target.onSubscribe(cancellable);
             } catch (Throwable t) {
                 onSubscribeFailed();
-                LOGGER.error("Ignored unexpected exception from onSubscribe. Subscriber: {}, Cancellable: {}.",
-                        target, cancellable, t);
-                cancellable.cancel();
+                safeOnError(target, t);
+                safeCancel(cancellable);
             }
         }
     }
@@ -706,13 +683,7 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
         @Override
         public void cancel() {
             try {
-                executor.execute(() -> {
-                    try {
-                        cancellable.cancel();
-                    } catch (Throwable t) {
-                        LOGGER.error("Ignored unexpected exception from cancel(). Cancellable: {}", cancellable, t);
-                    }
-                });
+                executor.execute(() -> safeCancel(cancellable));
             } catch (Throwable t) {
                 LOGGER.error("Failed to execute task on the executor {}. " +
                                 "Invoking Cancellable (cancel()) in the caller thread. Cancellable {}. ",

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/TaskBasedSignalOffloader.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/TaskBasedSignalOffloader.java
@@ -358,15 +358,13 @@ final class TaskBasedSignalOffloader implements SignalOffloader {
                         } catch (Throwable th) {
                             clearSignalsFromExecutorThread();
                             try {
+                                target.onError(th);
+                            } catch (Throwable throwable) {
+                                LOGGER.error("Ignored unexpected exception from onError(). Subscriber: {}",
+                                        target, t);
+                            } finally {
                                 assert subscription != null;
                                 subscription.cancel();
-                            } finally {
-                                try {
-                                    target.onError(th);
-                                } catch (Throwable throwable) {
-                                    LOGGER.error("Ignored unexpected exception from onError(). Subscriber: {}",
-                                            target, t);
-                                }
                             }
                             return; // We can't interact with the queue any more because we terminated, so bail.
                         }

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThreadBasedSignalOffloader.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThreadBasedSignalOffloader.java
@@ -499,6 +499,7 @@ final class ThreadBasedSignalOffloader implements SignalOffloader, Runnable {
                         original.onNext(signal == NULL_ON_NEXT ? null : uncheckedCast(signal));
                     } catch (Throwable throwable) {
                         setTerminated();
+                        sendOnErrorToOriginal(throwable);
                         assert subscription != null;
                         // Spec https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.2/README.md#2.13
                         // 2.13 states that a Subscriber MUST consider its Subscription cancelled if it throws from
@@ -509,7 +510,6 @@ final class ThreadBasedSignalOffloader implements SignalOffloader, Runnable {
                         // Since Subscription is practically cancelled for the original Subscriber, we can assume that
                         // it is not used.
                         sendCancel(subscription, throwable);
-                        sendOnErrorToOriginal(throwable);
                     }
                 }
             }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -84,7 +84,7 @@ import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 
 import static com.google.protobuf.Any.pack;
-import static io.grpc.Status.Code.CANCELLED;
+import static io.grpc.Status.Code.INVALID_ARGUMENT;
 import static io.servicetalk.concurrent.api.Processors.newPublisherProcessor;
 import static io.servicetalk.concurrent.api.Processors.newSingleProcessor;
 import static io.servicetalk.concurrent.api.Single.succeeded;
@@ -98,6 +98,8 @@ import static io.servicetalk.transport.api.SecurityConfigurator.SslProvider.OPEN
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -534,7 +536,7 @@ public class ProtocolCompatibilityTest {
             if (cause instanceof StatusRuntimeException) {
                 final StatusRuntimeException sre = (StatusRuntimeException) cause;
                 final Code code = sre.getStatus().getCode();
-                assertEquals("Unexpected grpc error code: " + code, CANCELLED, code);
+                assertThat(code, is(INVALID_ARGUMENT));
             } else {
                 cause.printStackTrace();
                 fail("Unexpected exception type: " + cause);


### PR DESCRIPTION
Motivation:
Publisher#flatMapConcatIterable rethrows any exceptions from donwstream
onNext delivery, but it does not attempt to drain pending demand.
Because this operator holds on to demand internally (e.g. requests 1
after each element is processed) that may result in deadlock due to
demand being swallowed in the event of exception and upstream
recoverWith continues control flow.

Modifications:
- PublisherConcatMapIterable should attempt to request more from the
subscription if demand is still pending.
- Offloaders should dispatch exception before cancellation. This will
allow control flow to get a more meaningful exception based upon
application control flow (e.g. instead of CancellationException).

Result:
Publisher#flatMapConcatIterable does not swallow demand in the event of
exceptions and can be used with upstream recoverWith operators.