### PR TITLE
Ignore Http2SettingsAckFrame frame

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -256,7 +256,7 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
                 parentContext.keepAliveManager.initiateGracefulClose(parentContext.onClosing::onComplete);
             } else if (msg instanceof Http2PingFrame) {
                 parentContext.keepAliveManager.pingReceived((Http2PingFrame) msg);
-            } else {
+            } else if (!(msg instanceof Http2SettingsAckFrame)) { // we ignore SETTINGS(ACK)
                 ctx.fireChannelRead(msg);
             }
         }


### PR DESCRIPTION
Motivation:
We currently don't handle the Http2SettingsAckFrame. We should ignore it
but instead let it propagate to the end of the pipeline and get a
warning debug message from Netty.

Modifications:
- Ignore the Http2SettingsAckFrame as we don't do anything with it.

Result:
Fixes https://github.com/apple/servicetalk/issues/1122.