### PR TITLE
Make `HttpObjectDecoder` more RFC7230 compatible and other improvements

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -226,9 +226,6 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                 currentState = State.READ_INITIAL;
             }
             case READ_INITIAL: {
-                if (!buffer.isReadable()) {
-                    return;
-                }
                 final int lfIndex = findCRLF(buffer, maxStartLineLength);
                 if (lfIndex < 0) {
                     handlePartialInitialLine(ctx, buffer);


### PR DESCRIPTION
Motivation:

RFC7230 defines `obs-text` as `%x80-FF` (any negative byte value), and
reason-phrase as `*( HTAB / SP / VCHAR / obs-text )`.

Modifications:

- Adjust `isObsText` and reason-phrase validation according to RFC7230;
- Verify that the passed `closeHandler` is non-null;

Result:

`HttpObjectDecoder` is more robust and RFC7230 compatible.