### PR TITLE
Improve exception messages from `HttpObjectDecoder`

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -49,6 +49,9 @@ import static io.servicetalk.http.api.HttpHeaderNames.VARY;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.http.api.NetUtils.isValidIpV4Address;
 import static io.servicetalk.http.api.NetUtils.isValidIpV6Address;
+import static io.servicetalk.http.api.UriUtils.TCHAR_HMASK;
+import static io.servicetalk.http.api.UriUtils.TCHAR_LMASK;
+import static io.servicetalk.http.api.UriUtils.isBitSet;
 import static java.lang.Math.min;
 import static java.lang.System.lineSeparator;
 import static java.nio.charset.Charset.availableCharsets;
@@ -903,33 +906,16 @@ public final class HeaderUtils {
         //                      | "," | ";" | ":" | "\" | <">
         //                      | "/" | "[" | "]" | "?" | "="
         //                      | "{" | "}" | SP | HT
-
-        if (value < '!') { // '!' is the first visible character of ascii table
+        //
+        // field-name's token is equivalent to cookie-name's token, we can reuse the tchar mask for both:
+        if (!isTchar(value)) {
             throw new IllegalCharacterException(value,
                     "! / # / $ / % / & / ' / * / + / - / . / ^ / _ / ` / | / ~ / DIGIT / ALPHA");
         }
-        switch (value) {
-            case '(':
-            case ')':
-            case '<':
-            case '>':
-            case '@':
-            case ',':
-            case ';':
-            case ':':
-            case '\\':
-            case '"':
-            case '/':
-            case '[':
-            case ']':
-            case '?':
-            case '=':
-            case '{':
-            case '}':
-                throw new IllegalCharacterException(value,
-                        "! / # / $ / % / & / ' / * / + / - / . / ^ / _ / ` / | / ~ / DIGIT / ALPHA");
-            default:
-                break;
-        }
+    }
+
+    // visible for testing
+    static boolean isTchar(final byte value) {
+        return isBitSet(value, TCHAR_LMASK, TCHAR_HMASK);
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import io.servicetalk.buffer.api.ByteProcessor;
 import io.servicetalk.encoding.api.ContentCodec;
 import io.servicetalk.encoding.api.ContentCodings;
 import io.servicetalk.serialization.api.SerializationException;
+import io.servicetalk.utils.internal.IllegalCharacterException;
 
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -82,8 +83,8 @@ public final class HeaderUtils {
                 }
                 return "<filtered>";
             };
-    private static final ByteProcessor HEADER_NAME_VALIDATOR = value -> {
-        validateHeaderNameToken(value);
+    private static final ByteProcessor TOKEN_VALIDATOR = value -> {
+        validateToken(value);
         return true;
     };
 
@@ -275,7 +276,7 @@ public final class HeaderUtils {
      */
     static void validateCookieTokenAndHeaderName(final CharSequence key) {
         if (key.getClass() == AsciiBuffer.class) {
-            ((AsciiBuffer) key).forEachByte(HEADER_NAME_VALIDATOR);
+            ((AsciiBuffer) key).forEachByte(TOKEN_VALIDATOR);
         } else {
             validateCookieTokenAndHeaderName0(key);
         }
@@ -867,6 +868,17 @@ public final class HeaderUtils {
     }
 
     private static void validateCookieTokenAndHeaderName0(final CharSequence key) {
+        for (int i = 0; i < key.length(); ++i) {
+            validateToken((byte) key.charAt(i));
+        }
+    }
+
+    /**
+     * Validate char is valid <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">token</a> character.
+     *
+     * @param value the character to validate.
+     */
+    private static void validateToken(final byte value) {
         // HEADER
         // header-field   = field-name ":" OWS field-value OWS
         //
@@ -891,50 +903,10 @@ public final class HeaderUtils {
         //                      | "," | ";" | ":" | "\" | <">
         //                      | "/" | "[" | "]" | "?" | "="
         //                      | "{" | "}" | SP | HT
-        for (int i = 0; i < key.length(); ++i) {
-            final char value = key.charAt(i);
-            // CTL = <any US-ASCII control character
-            //       (octets 0 - 31) and DEL (127)>
-            // separators     = "(" | ")" | "<" | ">" | "@"
-            //                      | "," | ";" | ":" | "\" | <">
-            //                      | "/" | "[" | "]" | "?" | "="
-            //                      | "{" | "}" | SP | HT
-            if (value <= 32 || value >= 127) {
-                throw new IllegalArgumentException("invalid token detected at index: " + i);
-            }
-            switch (value) {
-                case '(':
-                case ')':
-                case '<':
-                case '>':
-                case '@':
-                case ',':
-                case ';':
-                case ':':
-                case '\\':
-                case '"':
-                case '/':
-                case '[':
-                case ']':
-                case '?':
-                case '=':
-                case '{':
-                case '}':
-                    throw new IllegalArgumentException("invalid token detected at index: " + i);
-                default:
-                    break;
-            }
-        }
-    }
 
-    /**
-     * Validate char is valid <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">token</a> character.
-     *
-     * @param value the character to validate.
-     */
-    private static void validateHeaderNameToken(final byte value) {
-        if (value <= 32) {
-            throw new IllegalArgumentException("invalid token detected: " + value);
+        if (value < '!') { // '!' is the first visible character of ascii table
+            throw new IllegalCharacterException(value,
+                    "! / # / $ / % / & / ' / * / + / - / . / ^ / _ / ` / | / ~ / DIGIT / ALPHA");
         }
         switch (value) {
             case '(':
@@ -954,7 +926,8 @@ public final class HeaderUtils {
             case '=':
             case '{':
             case '}':
-                throw new IllegalArgumentException("invalid token detected: " + value);
+                throw new IllegalCharacterException(value,
+                        "! / # / $ / % / & / ' / * / + / - / . / ^ / _ / ` / | / ~ / DIGIT / ALPHA");
             default:
                 break;
         }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/UriUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/UriUtils.java
@@ -89,6 +89,10 @@ final class UriUtils {
     static final long HOST_NON_IP_LMASK = UNRESERVED_LMASK | SUBDELIM_LMASK;
     static final long HOST_NON_IP_HMASK = UNRESERVED_HMASK | SUBDELIM_HMASK;
 
+    // tchar       = unreserved / "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "^" / "`" / "|"
+    static final long TCHAR_LMASK = UNRESERVED_LMASK | lowMask("!#$%&'*+^`|");
+    static final long TCHAR_HMASK = UNRESERVED_HMASK | highMask("!#$%&'*+^`|");
+
     private UriUtils() {
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestDecoder.java
@@ -76,21 +76,20 @@ final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> {
         try {
             buffer.forEachByte(FIND_WS_AFTER_METHOD_NAME);
         } catch (IllegalCharacterException cause) {
-            throw newInvalidMethodException(buffer.toString(US_ASCII), cause);
+            throw newInvalidMethodException(cause);
         }
     }
 
-    private static DecoderException newInvalidMethodException(final String found,
-                                                              final IllegalCharacterException cause) {
-        return new DecoderException(
-                "Invalid start-line: HTTP request method must contain only upper case letters, found: " + found, cause);
+    private static DecoderException newInvalidMethodException(final IllegalCharacterException cause) {
+        return new StacklessDecoderException(
+                "Invalid start-line: HTTP request method must contain only upper case letters", cause);
     }
 
     private static void ensureUpperCase(final byte value) {
         // As per the RFC, request method is case-sensitive, and all valid methods are uppercase.
         // https://tools.ietf.org/html/rfc7231#section-4.1
         if (value < 'A' || value > 'Z') {
-            throw new IllegalCharacterException(value, "A-Z (0x41-0x5A)");
+            throw new IllegalCharacterException(value, "A-Z (0x41-0x5a)");
         }
     }
 
@@ -114,7 +113,7 @@ final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> {
         try {
             buffer.forEachByte(start, length, ENSURE_UPPER_CASE);
         } catch (IllegalCharacterException cause) {
-            throw newInvalidMethodException(methodName, cause);
+            throw newInvalidMethodException(cause);
         }
         return HttpRequestMethod.of(methodName, NONE);
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestDecoder.java
@@ -19,10 +19,12 @@ import io.servicetalk.http.api.HttpHeadersFactory;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.transport.netty.internal.CloseHandler;
+import io.servicetalk.utils.internal.IllegalCharacterException;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.DecoderException;
 import io.netty.util.ByteProcessor;
 
 import java.util.Queue;
@@ -71,14 +73,24 @@ final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> {
 
     @Override
     protected void handlePartialInitialLine(final ChannelHandlerContext ctx, final ByteBuf buffer) {
-        buffer.forEachByte(FIND_WS_AFTER_METHOD_NAME);
+        try {
+            buffer.forEachByte(FIND_WS_AFTER_METHOD_NAME);
+        } catch (IllegalCharacterException cause) {
+            throw newInvalidMethodException(buffer.toString(US_ASCII), cause);
+        }
+    }
+
+    private static DecoderException newInvalidMethodException(final String found,
+                                                              final IllegalCharacterException cause) {
+        return new DecoderException(
+                "Invalid start-line: HTTP request method must contain only upper case letters, found: " + found, cause);
     }
 
     private static void ensureUpperCase(final byte value) {
         // As per the RFC, request method is case-sensitive, and all valid methods are uppercase.
         // https://tools.ietf.org/html/rfc7231#section-4.1
         if (value < 'A' || value > 'Z') {
-            throw new IllegalArgumentException("HTTP request method MUST contain only upper case letters");
+            throw new IllegalCharacterException(value, "A-Z (0x41-0x5A)");
         }
     }
 
@@ -99,7 +111,11 @@ final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> {
         if (method != null) {
             return method;
         }
-        buffer.forEachByte(start, length, ENSURE_UPPER_CASE);
+        try {
+            buffer.forEachByte(start, length, ENSURE_UPPER_CASE);
+        } catch (IllegalCharacterException cause) {
+            throw newInvalidMethodException(methodName, cause);
+        }
         return HttpRequestMethod.of(methodName, NONE);
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseDecoder.java
@@ -20,10 +20,12 @@ import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.transport.netty.internal.CloseHandler;
+import io.servicetalk.utils.internal.IllegalCharacterException;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.DecoderException;
 import io.netty.util.ByteProcessor;
 
 import java.util.Queue;
@@ -53,7 +55,7 @@ final class HttpResponseDecoder extends HttpObjectDecoder<HttpResponseMetaData> 
     private static final ByteProcessor ENSURE_REASON_PHRASE = value -> {
         // Any control character (0x00-0x1F) except HT
         if (((value & 0xE0) == 0 && value != HT) || value == DEL) {
-            throw newIllegalCharacter(value);
+            throw new IllegalCharacterException(value, "HTAB / SP / VCHAR / obs-text");
         }
         return true;
     };
@@ -82,11 +84,12 @@ final class HttpResponseDecoder extends HttpObjectDecoder<HttpResponseMetaData> 
     @Override
     protected void handlePartialInitialLine(final ChannelHandlerContext ctx, final ByteBuf buffer) {
         final int len = min(FIRST_BYTES.length, buffer.readableBytes());
+        final int rIdx = buffer.readerIndex();
         for (int i = 0; i < len; ++i) {
-            byte b = buffer.getByte(buffer.readerIndex() + i);
+            final byte b = buffer.getByte(rIdx + i);
             if (b != FIRST_BYTES[i]) {
-                // Illegal response if it doesn't start with 'HTTP'
-                splitInitialLineError();
+                throw new DecoderException("Invalid start-line: HTTP response must start with HTTP-version, found: " +
+                        buffer.toString(US_ASCII) + ", expected: HTTP/", new IllegalCharacterException(b));
             }
         }
     }
@@ -105,9 +108,14 @@ final class HttpResponseDecoder extends HttpObjectDecoder<HttpResponseMetaData> 
         if (length <= 0) {
             return EMPTY_STRING;
         }
-        // Verify reason-phrase = *( HTAB / SP / VCHAR / obs-text )
-        buffer.forEachByte(start, length, ENSURE_REASON_PHRASE);
-        return buffer.toString(start, length, US_ASCII);
+        final String reasonPhrase = buffer.toString(start, length, US_ASCII);
+        try {
+            buffer.forEachByte(start, length, ENSURE_REASON_PHRASE);
+        } catch (IllegalCharacterException cause) {
+            throw new DecoderException("Invalid start-line: HTTP reason-phrase contains an illegal character: " +
+                    reasonPhrase, cause);
+        }
+        return reasonPhrase;
     }
 
     @Override
@@ -142,12 +150,18 @@ final class HttpResponseDecoder extends HttpObjectDecoder<HttpResponseMetaData> 
 
     private static int nettyBufferToStatusCode(final ByteBuf buffer, final int start, final int length) {
         if (length != 3) {
-            splitInitialLineError();
+            throw new DecoderException("Invalid start-line: HTTP status-code must contain only 3 digits, found: " +
+                    buffer.toString(start, length, US_ASCII));
         }
 
         final int medium = buffer.getUnsignedMedium(start);
-        return toDecimal((medium & 0xff0000) >> 16) * 100 +
-                toDecimal((medium & 0xff00) >> 8) * 10 +
-                toDecimal(medium & 0xff);
+        try {
+            return toDecimal((medium & 0xff0000) >> 16) * 100 +
+                    toDecimal((medium & 0xff00) >> 8) * 10 +
+                    toDecimal(medium & 0xff);
+        } catch (IllegalCharacterException cause) {
+            throw new DecoderException("Invalid start-line: HTTP status-code must contain only 3 digits, found: " +
+                    buffer.toString(start, length, US_ASCII), cause);
+        }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -188,7 +188,7 @@ abstract class HttpObjectDecoderTest {
 
     @Test
     public void startLineWithoutCR() {
-        assertDecoderException(startLine() + '\n', "Found LF but no CR before");
+        assertDecoderException(startLine() + '\n', "Found LF (0x0a) but no CR (0x0d) before");
     }
 
     @Test
@@ -241,50 +241,50 @@ abstract class HttpObjectDecoderTest {
     public void tooManyPrefaceCharacters() {
         DecoderException ex = assertThrows(DecoderException.class,
                 () -> writeMsg("\r\n\r\n\r\n" + startLine() + "\r\n" + "\r\n"));
-        assertThat(ex.getMessage(), startsWith("Too many prefacing CRLF characters"));
+        assertThat(ex.getMessage(), startsWith("Too many prefacing CRLF (0x0d0a) characters"));
         assertThat(channel().inboundMessages(), is(empty()));
     }
 
     @Test
     public void whitespaceNotAllowedBeforeHeaderFieldName() {
         assertDecoderExceptionWithCause(startLine() + "\r\n" +
-                " Host: servicetalk.io" + "\r\n" + "\r\n", "Invalid header filed-name");
+                " Host: servicetalk.io" + "\r\n" + "\r\n", "Invalid header name");
     }
 
     @Test
     public void whitespaceNotAllowedBetweenHeaderFieldNameAndColon() {
         assertDecoderExceptionWithCause(startLine() + "\r\n" +
-                "Host : servicetalk.io" + "\r\n" + "\r\n", "Invalid header filed-name");
+                "Host : servicetalk.io" + "\r\n" + "\r\n", "Invalid header name");
     }
 
     @Test
     public void controlCharNotAllowedBeforeHeaderFieldValue() {
         assertDecoderExceptionWithCause(startLine() + "\r\n" +
-                "Host: \fservicetalk.io" + "\r\n" + "\r\n", "Invalid header filed-value");
+                "Host: \fservicetalk.io" + "\r\n" + "\r\n", "Invalid value for the header");
     }
 
     @Test
     public void noEndOfHeaderName() {
         assertDecoderException(startLine() + "\r\n" +
-                "Host" + "\r\n" + "\r\n", "Unable to find end of header field-name");
+                "Host" + "\r\n" + "\r\n", "Unable to find end of a header name");
     }
 
     @Test
     public void emptyHeaderName() {
         assertDecoderException(startLine() + "\r\n" +
-                ": some-value" + "\r\n" + "\r\n", "Empty header field-name");
+                ": some-value" + "\r\n" + "\r\n", "Empty header name");
     }
 
     @Test
     public void headerNameWithControlChar() {
         assertDecoderExceptionWithCause(startLine() + "\r\n" +
-                "H\0st: servicetalk.io" + "\r\n" + "\r\n", "Invalid header filed-name");
+                "H\0st: servicetalk.io" + "\r\n" + "\r\n", "Invalid header name");
     }
 
     @Test
     public void headerNameWithObsText() {
         assertDecoderExceptionWithCause(startLine() + "\r\n" +
-                "Hóst: servicetalk.io" + "\r\n" + "\r\n", "Invalid header filed-name");
+                "Hóst: servicetalk.io" + "\r\n" + "\r\n", "Invalid header name");
     }
 
     @Test

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -18,6 +18,7 @@ package io.servicetalk.http.netty;
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpMetaData;
+import io.servicetalk.utils.internal.IllegalCharacterException;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
@@ -30,7 +31,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
-import javax.annotation.Nullable;
 
 import static io.netty.buffer.ByteBufUtil.writeAscii;
 import static io.netty.buffer.Unpooled.wrappedBuffer;
@@ -46,9 +46,9 @@ import static java.lang.Integer.toHexString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -90,12 +90,12 @@ abstract class HttpObjectDecoderTest {
                 channel().writeInbound(content(length)), is(true));
     }
 
-    final void writeChunkLength(int length) {
+    final void writeChunkSize(int length) {
         writeMsg(toHexString(length) + "\r\n");
     }
 
     final void writeChunk(int length) {
-        writeChunkLength(length);
+        writeChunkSize(length);
         writeContent(length);
         writeMsg("\r\n");
     }
@@ -104,12 +104,17 @@ abstract class HttpObjectDecoderTest {
         writeMsg("0\r\n\r\n");
     }
 
-    final void assertDecoderException(String msg, @Nullable String expectedExceptionMsg) {
+    final void assertDecoderException(String msg, String expectedExceptionMsg) {
         DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg));
-        assertThat(e.getCause(), is(instanceOf(IllegalArgumentException.class)));
-        if (expectedExceptionMsg != null) {
-            assertThat(e.getCause().getMessage(), startsWith(expectedExceptionMsg));
-        }
+        assertThat(e.getMessage(), startsWith(expectedExceptionMsg));
+        assertThat(channel().inboundMessages(), is(empty()));
+    }
+
+    final void assertDecoderExceptionWithCause(String msg, String expectedExceptionMsg) {
+        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg));
+        assertThat(e.getMessage(), startsWith(expectedExceptionMsg));
+        assertThat(e.getCause(), is(instanceOf(IllegalCharacterException.class)));
+        assertThat(e.getCause().getMessage(), not(isEmptyString()));
         assertThat(channel().inboundMessages(), is(empty()));
     }
 
@@ -236,50 +241,50 @@ abstract class HttpObjectDecoderTest {
     public void tooManyPrefaceCharacters() {
         DecoderException ex = assertThrows(DecoderException.class,
                 () -> writeMsg("\r\n\r\n\r\n" + startLine() + "\r\n" + "\r\n"));
-        assertThat(ex.getMessage(), equalTo("Too many prefacing CRLF characters"));
+        assertThat(ex.getMessage(), startsWith("Too many prefacing CRLF characters"));
         assertThat(channel().inboundMessages(), is(empty()));
     }
 
     @Test
     public void whitespaceNotAllowedBeforeHeaderFieldName() {
-        assertDecoderException(startLine() + "\r\n" +
-                " Host: servicetalk.io" + "\r\n" + "\r\n", "invalid token detected: 32");
+        assertDecoderExceptionWithCause(startLine() + "\r\n" +
+                " Host: servicetalk.io" + "\r\n" + "\r\n", "Invalid header filed-name");
     }
 
     @Test
     public void whitespaceNotAllowedBetweenHeaderFieldNameAndColon() {
-        assertDecoderException(startLine() + "\r\n" +
-                "Host : servicetalk.io" + "\r\n" + "\r\n", "invalid token detected: 32");
+        assertDecoderExceptionWithCause(startLine() + "\r\n" +
+                "Host : servicetalk.io" + "\r\n" + "\r\n", "Invalid header filed-name");
     }
 
     @Test
     public void controlCharNotAllowedBeforeHeaderFieldValue() {
-        assertDecoderException(startLine() + "\r\n" +
-                "Host: \fservicetalk.io" + "\r\n" + "\r\n", "Illegal character: 0x0C");
+        assertDecoderExceptionWithCause(startLine() + "\r\n" +
+                "Host: \fservicetalk.io" + "\r\n" + "\r\n", "Invalid header filed-value");
     }
 
     @Test
     public void noEndOfHeaderName() {
         assertDecoderException(startLine() + "\r\n" +
-                "Host" + "\r\n" + "\r\n", "Unable to find end of header name");
+                "Host" + "\r\n" + "\r\n", "Unable to find end of header field-name");
     }
 
     @Test
     public void emptyHeaderName() {
         assertDecoderException(startLine() + "\r\n" +
-                ": some-value" + "\r\n" + "\r\n", "Empty header name");
+                ": some-value" + "\r\n" + "\r\n", "Empty header field-name");
     }
 
     @Test
-    public void headValueWithControlChar() {
-        assertDecoderException(startLine() + "\r\n" +
-                "H\0st: servicetalk.io" + "\r\n" + "\r\n", "invalid token detected");
+    public void headerNameWithControlChar() {
+        assertDecoderExceptionWithCause(startLine() + "\r\n" +
+                "H\0st: servicetalk.io" + "\r\n" + "\r\n", "Invalid header filed-name");
     }
 
     @Test
-    public void headValueWithObsText() {
-        assertDecoderException(startLine() + "\r\n" +
-                "Hóst: servicetalk.io" + "\r\n" + "\r\n", "invalid token detected");
+    public void headerNameWithObsText() {
+        assertDecoderExceptionWithCause(startLine() + "\r\n" +
+                "Hóst: servicetalk.io" + "\r\n" + "\r\n", "Invalid header filed-name");
     }
 
     @Test
@@ -383,31 +388,31 @@ abstract class HttpObjectDecoderTest {
     }
 
     private void chunkedNoTrailers(boolean addSemicolon) {
-        int chunkLength = 128;
+        int chunkSize = 128;
         writeMsg(startLineForContent() + "\r\n" +
                 "Host: servicetalk.io" + "\r\n" +
                 "Connection: keep-alive" + "\r\n" +
                 "Transfer-Encoding: chunked" + "\r\n" + "\r\n");
-        writeMsg(toHexString(chunkLength) + (addSemicolon ? ";" : "") + "\r\n");
-        writeContent(chunkLength);
+        writeMsg(toHexString(chunkSize) + (addSemicolon ? ";" : "") + "\r\n");
+        writeContent(chunkSize);
         writeMsg("\r\n");
         writeLastChunk();
-        validateWithContent(-chunkLength, false);
+        validateWithContent(-chunkSize, false);
     }
 
     @Test
     public void chunkedNoTrailersMultipleLargeContent() {
-        int chunkLength = 4096;
+        int chunkSize = 4096;
         int numChunks = 5;
         writeMsg(startLineForContent() + "\r\n" +
                 "Host: servicetalk.io" + "\r\n" +
                 "Connection: keep-alive" + "\r\n" +
                 "Transfer-Encoding: chunked" + "\r\n" + "\r\n");
         for (int i = 0; i < numChunks; ++i) {
-            writeChunk(chunkLength);
+            writeChunk(chunkSize);
         }
         writeLastChunk();
-        validateWithContent(-(chunkLength * numChunks), false);
+        validateWithContent(-(chunkSize * numChunks), false);
     }
 
     @Test
@@ -436,17 +441,16 @@ abstract class HttpObjectDecoderTest {
 
     @Test
     public void chunkedNoTrailersNoChunkCRLF() {
-        int chunkLength = 128;
+        int chunkSize = 128;
         writeMsg(startLineForContent() + "\r\n" +
                 "Host: servicetalk.io" + "\r\n" +
                 "Connection: keep-alive" + "\r\n" +
                 "Transfer-Encoding: chunked" + "\r\n" + "\r\n");
-        writeChunkLength(chunkLength);
-        writeContent(chunkLength);
+        writeChunkSize(chunkSize);
+        writeContent(chunkSize);
         // we omit writing the "\r\n" after chunk-data intentionally
         DecoderException e = assertThrows(DecoderException.class, this::writeLastChunk);
-        assertThat(e.getCause(), is(instanceOf(IllegalArgumentException.class)));
-        assertThat(e.getCause().getMessage(), startsWith("Could not find CRLF"));
+        assertThat(e.getMessage(), startsWith("Could not find CRLF"));
         assertThat(channel().inboundMessages(), is(not(empty())));
     }
 
@@ -463,14 +467,14 @@ abstract class HttpObjectDecoderTest {
 
     @Test
     public void chunkedContentWithTrailers() {
-        int chunkLength = 128;
+        int chunkSize = 128;
         writeMsg(startLineForContent() + "\r\n" +
                 "Host: servicetalk.io" + "\r\n" +
                 "Connection: keep-alive" + "\r\n" +
                 "Transfer-Encoding: chunked" + "\r\n" + "\r\n");
-        writeChunk(chunkLength);
+        writeChunk(chunkSize);
         writeMsg("0\r\n" + "TrailerStatus: good" + "\r\n" + "\r\n");
-        validateWithContent(-chunkLength, true);
+        validateWithContent(-chunkSize, true);
     }
 
     @Test
@@ -499,7 +503,7 @@ abstract class HttpObjectDecoderTest {
         // https://tools.ietf.org/html/rfc7230#section-3.3
         DecoderException e = assertThrows(DecoderException.class,
                 () -> writeMsg("TrailerStatus: good" + "\r\n" + "\r\n"));
-        assertThat(e.getCause(), is(instanceOf(IllegalArgumentException.class)));
+        assertThat(e.getMessage(), startsWith("Invalid start-line"));
         assertThat(channel().inboundMessages(), is(not(empty())));
     }
 
@@ -524,7 +528,7 @@ abstract class HttpObjectDecoderTest {
                         "Smuggled: " + startLine() + "\r\n\r\n" + "Content-Length: 0" + "\r\n" :
                         "Content-Length: 0" + "\r\n" + "Smuggled: " + startLine() + "\r\n\r\n") +
                 "Connection: keep-alive" + "\r\n\r\n"));
-        assertThat(e.getCause(), is(instanceOf(IllegalArgumentException.class)));
+        assertThat(e.getMessage(), startsWith("Invalid start-line"));
 
         HttpMetaData metaData = assertStartLine();
         assertSingleHeaderValue(metaData.headers(), HOST, "servicetalk.io");
@@ -538,7 +542,7 @@ abstract class HttpObjectDecoderTest {
     }
 
     protected void smuggleTransferEncoding(boolean smuggleBeforeTransferEncoding) {
-        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + "\r\n" +
+        assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + "\r\n" +
                 "Host: servicetalk.io" + "\r\n" +
                 // Smuggled requests injected into a header will terminate the current request due to valid \r\n\r\n
                 // framing terminating the request with no content-length or transfer-encoding, or with known zero
@@ -548,7 +552,6 @@ abstract class HttpObjectDecoderTest {
                         "Smuggled: " + startLine() + "\r\n\r\n" + TRANSFER_ENCODING + ":" + CHUNKED + "\r\n" :
                         TRANSFER_ENCODING + ":" + CHUNKED + "\r\n" + "Smuggled: " + startLine() + "\r\n\r\n") +
                 "Connection: keep-alive" + "\r\n\r\n"));
-        assertThat(e.getCause(), is(instanceOf(IllegalArgumentException.class)));
 
         HttpMetaData metaData = assertStartLineForContent();
         assertSingleHeaderValue(metaData.headers(), HOST, "servicetalk.io");
@@ -566,12 +569,11 @@ abstract class HttpObjectDecoderTest {
     }
 
     private void smuggleNameZeroContentLengthHeader(boolean smuggleBeforeContentLength) {
-        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + "\r\n" +
+        assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + "\r\n" +
                 "Host: servicetalk.io" + "\r\n" +
                         (smuggleBeforeContentLength ?
                                 startLine() + "\r\n\r\n" + "Content-Length: 0" + "\r\n" :
                                 "Content-Length: 0" + "\r\n" + startLine() + "\r\n\r\n") +
                 "Connection: keep-alive" + "\r\n\r\n"));
-        assertThat(e.getCause(), is(instanceOf(IllegalArgumentException.class)));
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
@@ -43,7 +43,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 
@@ -262,8 +261,7 @@ public class HttpRequestDecoderTest extends HttpObjectDecoderTest {
                 "Host: servicetalk.io" + "\r\n" +
                 "Connection: keep-alive" + "\r\n" + "\r\n");
         // Content is not expected for requests if no "content-length" nor "transfer-encoding: chunked" is present
-        DecoderException e = assertThrows(DecoderException.class, () -> writeContent(128));
-        assertThat(e.getCause(), is(instanceOf(IllegalArgumentException.class)));
+        assertThrows(DecoderException.class, () -> writeContent(128));
         assertThat(channel.inboundMessages(), is(not(empty())));
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
@@ -291,7 +291,7 @@ public class HttpRequestDecoderTest extends HttpObjectDecoderTest {
     @Test
     public void smuggleBeforeNonZeroContentLengthHeader() {
         int contentLength = 128;
-        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + "\r\n" +
+        assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + "\r\n" +
                 "Host: servicetalk.io" + "\r\n" +
                 // Smuggled requests injected into a header will terminate the current request due to valid \r\n\r\n
                 // framing terminating the request with no content-length or transfer-encoding, or with known zero

--- a/servicetalk-utils-internal/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-utils-internal/gradle/spotbugs/test-exclusions.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<FindBugsFilter>
+  <!-- We test a constructor of IllegalCharacterException without throwing it -->
+  <Match>
+    <Class name="io.servicetalk.utils.internal.IllegalCharacterExceptionTest"/>
+    <Bug pattern="RV_EXCEPTION_NOT_THROWN"/>
+  </Match>
+</FindBugsFilter>

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/IllegalCharacterException.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/IllegalCharacterException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.utils.internal;
+
+import static java.lang.String.format;
+
+/**
+ * Exception that clarifies an illegal character and expected values.
+ */
+public final class IllegalCharacterException extends IllegalArgumentException {
+    private static final long serialVersionUID = 5109746801766842145L;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param value value of the character
+     */
+    public IllegalCharacterException(final byte value) {
+        super(format("'%1$c' (0x%1$02X)", value & 0xff));
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param value value of the character
+     * @param expected definition of expected value(s)
+     */
+    public IllegalCharacterException(final byte value, final String expected) {
+        super(format("'%1$c' (0x%1$02X), expected [%2$s]", value & 0xff, expected));
+    }
+}

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/IllegalCharacterException.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/IllegalCharacterException.java
@@ -15,7 +15,10 @@
  */
 package io.servicetalk.utils.internal;
 
-import static java.lang.String.format;
+import javax.annotation.Nullable;
+
+import static java.lang.Character.toChars;
+import static java.lang.Integer.toHexString;
 
 /**
  * Exception that clarifies an illegal character and expected values.
@@ -29,7 +32,7 @@ public final class IllegalCharacterException extends IllegalArgumentException {
      * @param value value of the character
      */
     public IllegalCharacterException(final byte value) {
-        super(format("'%1$c' (0x%1$02X)", value & 0xff));
+        super(message(value, null));
     }
 
     /**
@@ -39,6 +42,16 @@ public final class IllegalCharacterException extends IllegalArgumentException {
      * @param expected definition of expected value(s)
      */
     public IllegalCharacterException(final byte value, final String expected) {
-        super(format("'%1$c' (0x%1$02X), expected [%2$s]", value & 0xff, expected));
+        super(message(value, expected));
+    }
+
+    private static String message(final byte value, @Nullable final String expected) {
+        final int codePoint = value & 0xff;
+        final StringBuilder sb = new StringBuilder(expected == null ? 10 : 23 + expected.length())
+                .append('\'')
+                .append(toChars(codePoint))
+                .append("' (0x")
+                .append(toHexString(0x100 | codePoint), 1, 3);  // to 2 digit hex number
+        return (expected == null ? sb.append(')') : sb.append("), expected [").append(expected).append(']')).toString();
     }
 }

--- a/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/IllegalCharacterExceptionTest.java
+++ b/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/IllegalCharacterExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.servicetalk.utils.internal;
 
-apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
+import org.junit.Test;
 
-dependencies {
-    implementation project(":servicetalk-annotations")
-    implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-    implementation "org.jctools:jctools-core:$jcToolsVersion"
-    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+public class IllegalCharacterExceptionTest {
 
-    testImplementation "junit:junit:$junitVersion"
+    @Test
+    @SuppressWarnings("ThrowableNotThrown")
+    public void messageCanBeGeneratedForAnyByteValue() {
+        for (int value = Byte.MIN_VALUE; value <= Byte.MAX_VALUE; ++value) {
+            new IllegalCharacterException((byte) value);
+            new IllegalCharacterException((byte) value, "something");
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

`HttpObjectDecoder` and its subclasses may throw an exception if the received
HTTP message violates the RFC and can not be parsed. However, exception messages
are short and hard to understand, without any pointers to what part of the
message caused an exception. Those cases are hard to debug and usually require
knowledge of RFC.

Modifications:

- Introduce `IllegalCharacterException` type that shows an illegal character as
a `char` and in hex format, as well as expected values;
- `try-catch` an `IllegalCharacterException` and wrap it with `DecoderException`
that clarifies where the illegal character was found;
- Adjust tests for new exception messages;

Result:

More understandable exception messages from `HttpObjectDecoder`.

Depends on #1227.