### PR TITLE
Single#concat(Publisher) invalid demand hang

### DIFF
--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
@@ -17,12 +17,11 @@ package io.servicetalk.concurrent.api.single;
 
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.TestCancellable;
+import io.servicetalk.concurrent.api.TestCollectingPublisherSubscriber;
 import io.servicetalk.concurrent.api.TestPublisher;
-import io.servicetalk.concurrent.api.TestPublisherSubscriber;
 import io.servicetalk.concurrent.api.TestSingle;
 import io.servicetalk.concurrent.api.TestSubscription;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
-import io.servicetalk.concurrent.internal.TerminalNotification;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -32,21 +31,18 @@ import org.junit.rules.Timeout;
 import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class SingleConcatWithPublisherTest {
     @Rule
     public final Timeout timeout = new ServiceTalkTestTimeout();
 
-    private TestPublisherSubscriber<Integer> subscriber;
+    private TestCollectingPublisherSubscriber<Integer> subscriber;
     private TestSingle<Integer> source;
     private TestPublisher<Integer> next;
     private TestSubscription subscription;
@@ -54,155 +50,147 @@ public class SingleConcatWithPublisherTest {
 
     @Before
     public void setUp() throws Exception {
-        subscriber = new TestPublisherSubscriber.Builder<Integer>().disableDemandCheck().build();
+        subscriber = new TestCollectingPublisherSubscriber<>();
         cancellable = new TestCancellable();
         source = new TestSingle.Builder<Integer>().disableAutoOnSubscribe().build();
         next = new TestPublisher.Builder<Integer>().disableAutoOnSubscribe().build();
         subscription = new TestSubscription();
         toSource(source.concat(next)).subscribe(subscriber);
         source.onSubscribe(cancellable);
-        assertThat("Subscriber did not receive subscription.", subscriber.subscriptionReceived(), is(true));
+        subscriber.awaitSubscription();
     }
 
     @Test
-    public void bothCompletion() {
+    public void bothCompletion() throws InterruptedException {
         triggerNextSubscribe();
-        assertThat("Subscriber terminated unexpectedly.", subscriber.isTerminated(), is(false));
-        subscriber.request(2);
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        subscriber.awaitSubscription().request(2);
         assertThat("Unexpected items requested.", subscription.requested(), is(2L));
         next.onNext(2);
-        assertThat(subscriber.takeItems(), contains(1, 2));
+        assertThat(subscriber.takeOnNext(), is(1));
+        assertThat(subscriber.takeOnNext(), is(2));
         next.onComplete();
-        TerminalNotification terminal = subscriber.takeTerminal();
-        assertThat("Subscriber not terminated.", terminal, is(notNullValue()));
-        assertThat("Unexpected termination.", terminal.cause(), is(nullValue()));
+        subscriber.awaitOnComplete();
     }
 
     @Test
-    public void sourceCompletionNextError() {
+    public void sourceCompletionNextError() throws InterruptedException {
         triggerNextSubscribe();
-        assertThat("Subscriber terminated unexpectedly.", subscriber.isTerminated(), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
         next.onError(DELIBERATE_EXCEPTION);
-        assertThat("Unexpected subscriber termination.", subscriber.takeError(), sameInstance(DELIBERATE_EXCEPTION));
+        assertThat(subscriber.takeOnNext(), is(1));
+        assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void invalidRequestBeforeNextSubscribeNegative1() {
+    public void invalidRequestBeforeNextSubscribeNegative1() throws InterruptedException {
         invalidRequestBeforeNextSubscribe(-1);
     }
 
     @Test
-    public void invalidRequestBeforeNextSubscribeZero() {
+    public void invalidRequestBeforeNextSubscribeZero() throws InterruptedException {
         invalidRequestBeforeNextSubscribe(0);
     }
 
-    private void invalidRequestBeforeNextSubscribe(long invalidN) {
-        subscriber.request(invalidN);
+    private void invalidRequestBeforeNextSubscribe(long invalidN) throws InterruptedException {
+        subscriber.awaitSubscription().request(invalidN);
         source.onSuccess(1);
-        next.onSubscribe(subscription);
-        assertThat("Unexpected requestN amount", subscription.requested(), lessThanOrEqualTo(0L));
+        assertThat(subscriber.awaitOnError(), instanceOf(IllegalArgumentException.class));
     }
 
     @Test
-    public void invalidRequestNWithInlineSourceCompletion() {
-        TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
+    public void invalidRequestNWithInlineSourceCompletion() throws InterruptedException {
+        TestCollectingPublisherSubscriber<Integer> subscriber = new TestCollectingPublisherSubscriber<>();
         toSource(Single.succeeded(1).concat(empty())).subscribe(subscriber);
-        assertThat("Unexpected terminal.", subscriber.subscriptionReceived(), is(true));
-        subscriber.request(-1);
-        TerminalNotification term = subscriber.takeTerminal();
-        assertThat("Unexpected terminal.", term, is(notNullValue()));
-        assertThat("Unexpected terminal.", term.cause(), instanceOf(IllegalArgumentException.class));
+        subscriber.awaitSubscription().request(-1);
+        assertThat(subscriber.awaitOnError(), instanceOf(IllegalArgumentException.class));
     }
 
     @Test
-    public void invalidRequestAfterNextSubscribe() {
+    public void invalidRequestAfterNextSubscribe() throws InterruptedException {
         triggerNextSubscribe();
-        subscriber.request(-1);
+        subscriber.awaitSubscription().request(-1);
         assertThat("Invalid request-n not propagated.", subscription.requested(), is(lessThan(0L)));
     }
 
     @Test
-    public void multipleInvalidRequest() {
-        subscriber.request(-1);
-        subscriber.request(-10);
-        source.onSuccess(1);
-        next.onSubscribe(subscription);
-        assertThat("Invalid request-n not propagated " + subscription, subscription.requested(), lessThanOrEqualTo(0L));
+    public void multipleInvalidRequest() throws InterruptedException {
+        subscriber.awaitSubscription().request(-1);
+        subscriber.awaitSubscription().request(-10);
+        assertThat(subscriber.awaitOnError(), instanceOf(IllegalArgumentException.class));
     }
 
     @Test
-    public void invalidThenValidRequestNegative1() {
+    public void invalidThenValidRequestNegative1() throws InterruptedException {
         invalidThenValidRequest(-1);
     }
 
     @Test
-    public void invalidThenValidRequestZero() {
+    public void invalidThenValidRequestZero() throws InterruptedException {
         invalidThenValidRequest(0);
     }
 
-    private void invalidThenValidRequest(long invalidN) {
-        subscriber.request(invalidN);
-        subscriber.request(1);
-        source.onSuccess(1);
-        next.onSubscribe(subscription);
-        assertThat("Invalid request-n propagated " + subscription, subscription.requestedEquals(invalidN),
-                is(true));
+    private void invalidThenValidRequest(long invalidN) throws InterruptedException {
+        subscriber.awaitSubscription().request(invalidN);
+        subscriber.awaitSubscription().request(1);
+        assertThat(subscriber.awaitOnError(), instanceOf(IllegalArgumentException.class));
+        assertThat(cancellable.isCancelled(), is(true));
     }
 
     @Test
-    public void request0PropagatedAfterSuccess() {
+    public void request0PropagatedAfterSuccess() throws InterruptedException {
         source.onSuccess(1);
-        subscriber.request(1); // get the success from the Single
-        subscriber.request(0);
+        subscriber.awaitSubscription().request(1); // get the success from the Single
+        subscriber.awaitSubscription().request(0);
         next.onSubscribe(subscription);
         assertThat("Invalid request-n propagated " + subscription, subscription.requestedEquals(0),
                 is(true));
     }
 
     @Test
-    public void sourceError() {
+    public void sourceError() throws InterruptedException {
         source.onError(DELIBERATE_EXCEPTION);
-        assertThat("Unexpected subscriber termination.", subscriber.takeError(), sameInstance(DELIBERATE_EXCEPTION));
+        assertThat("Unexpected subscriber termination.", subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
         assertThat("Next source subscribed unexpectedly.", next.isSubscribed(), is(false));
     }
 
     @Test
-    public void cancelSource() {
-        assertThat("Subscriber terminated unexpectedly.", subscriber.isTerminated(), is(false));
-        subscriber.cancel();
+    public void cancelSource() throws InterruptedException {
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        subscriber.awaitSubscription().cancel();
         assertThat("Original single not cancelled.", cancellable.isCancelled(), is(true));
         assertThat("Next source subscribed unexpectedly.", next.isSubscribed(), is(false));
     }
 
     @Test
-    public void cancelSourcePostRequest() {
-        assertThat("Subscriber terminated unexpectedly.", subscriber.isTerminated(), is(false));
-        subscriber.request(1);
-        subscriber.cancel();
+    public void cancelSourcePostRequest() throws InterruptedException {
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        subscriber.awaitSubscription().request(1);
+        subscriber.awaitSubscription().cancel();
         assertThat("Original single not cancelled.", cancellable.isCancelled(), is(true));
         assertThat("Next source subscribed unexpectedly.", next.isSubscribed(), is(false));
     }
 
     @Test
-    public void cancelNext() {
+    public void cancelNext() throws InterruptedException {
         triggerNextSubscribe();
-        assertThat("Subscriber terminated unexpectedly.", subscriber.isTerminated(), is(false));
-        subscriber.cancel();
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        subscriber.awaitSubscription().cancel();
         assertThat("Original single cancelled unexpectedly.", cancellable.isCancelled(), is(false));
         assertThat("Next source not cancelled.", subscription.isCancelled(), is(true));
     }
 
     @Test
-    public void zeroIsNotRequestedOnTransitionToSubscription() {
-        subscriber.request(1);
+    public void zeroIsNotRequestedOnTransitionToSubscription() throws InterruptedException {
+        subscriber.awaitSubscription().request(1);
         source.onSuccess(1);
         next.onSubscribe(subscription);
         assertThat("Invalid request-n propagated " + subscription, subscription.requestedEquals(0),
                 is(false));
     }
 
-    private void triggerNextSubscribe() {
-        subscriber.request(1);
+    private void triggerNextSubscribe() throws InterruptedException {
+        subscriber.awaitSubscription().request(1);
         source.onSuccess(1);
         next.onSubscribe(subscription);
     }


### PR DESCRIPTION
Motivation:
If invalid demand is received by the Single#concat(Publisher) operator
before the single completed the invalid demand may be overwritten by a
subsequent request instead of propagating an error.

Modifications:
- Invalid demand should cancel the subscription and propagate an error.

Result:
Single#concat(Publisher) is more robust and follows rule 3.9 of the
reactive streams spec.