### PR TITLE
Publisher#flatMapConcatIterable error recovery from Subscriber#onNext…

### DIFF
--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherConcatMapIterableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherConcatMapIterableTest.java
@@ -21,6 +21,7 @@ import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.internal.DeliberateException;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -315,6 +316,7 @@ public class PublisherConcatMapIterableTest {
         testExceptionFromBufferedOnNextThenTerminalIsPropagated(publisher::onError);
     }
 
+    @Ignore("fixed in https://github.com/apple/servicetalk/pull/1229")
     @Test
     public void exceptionFromBufferedOnNextThenOnCompleteIsPropagated() {
         testExceptionFromBufferedOnNextThenTerminalIsPropagated(__ -> publisher.onComplete());


### PR DESCRIPTION
… throwing

Motivation:
If Subscriber#onNext throws in Publisher#flatMapConcatIterable we don't
reset the currentIterator state if there is no pending requestN demand.
This may result in not propagating the error to the downstream
subscriber.

Modifications:
- PublisherConcatMapIterable should reset the currentIterator state when
catching an exception from Subscriber#onNext
- PublisherConcatMapIterable should also attempt to close the Iterator
if an exception is caught from Subscriber methods

Result:
Publisher#flatMapConcatIterable has more robust exception handling and
error propagation.