### PR TITLE
idleTimeout operator to use io.servicetalk.concurrent.Executor

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -307,7 +307,8 @@ public abstract class Completable {
      * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    public final Completable idleTimeout(long duration, TimeUnit unit, Executor timeoutExecutor) {
+    public final Completable idleTimeout(long duration, TimeUnit unit,
+                                         io.servicetalk.concurrent.Executor timeoutExecutor) {
         return new TimeoutCompletable(this, duration, unit, timeoutExecutor);
     }
 
@@ -342,7 +343,7 @@ public abstract class Completable {
      * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    public final Completable idleTimeout(Duration duration, Executor timeoutExecutor) {
+    public final Completable idleTimeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
         return new TimeoutCompletable(this, duration, timeoutExecutor);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -1117,7 +1117,7 @@ public abstract class Publisher<T> {
      * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
      * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
-     * @see #idleTimeout(long, TimeUnit, Executor)
+     * @see #idleTimeout(long, TimeUnit, io.servicetalk.concurrent.Executor)
      */
     public final Publisher<T> idleTimeout(long duration, TimeUnit unit) {
         return new TimeoutPublisher<>(this, executor, duration, unit);
@@ -1135,7 +1135,7 @@ public abstract class Publisher<T> {
      * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
      * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
-     * @see #idleTimeout(long, TimeUnit, Executor)
+     * @see #idleTimeout(long, TimeUnit, io.servicetalk.concurrent.Executor)
      */
     public final Publisher<T> idleTimeout(Duration duration) {
         return new TimeoutPublisher<>(this, executor, duration);
@@ -1156,7 +1156,8 @@ public abstract class Publisher<T> {
      * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    public final Publisher<T> idleTimeout(long duration, TimeUnit unit, Executor timeoutExecutor) {
+    public final Publisher<T> idleTimeout(long duration, TimeUnit unit,
+                                          io.servicetalk.concurrent.Executor timeoutExecutor) {
         return new TimeoutPublisher<>(this, executor, duration, unit, timeoutExecutor);
     }
 
@@ -1174,7 +1175,7 @@ public abstract class Publisher<T> {
      * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    public final Publisher<T> idleTimeout(Duration duration, Executor timeoutExecutor) {
+    public final Publisher<T> idleTimeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
         return new TimeoutPublisher<>(this, executor, duration, timeoutExecutor);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -430,7 +430,8 @@ public abstract class Single<T> {
      * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    public final Single<T> idleTimeout(long duration, TimeUnit unit, Executor timeoutExecutor) {
+    public final Single<T> idleTimeout(long duration, TimeUnit unit,
+                                       io.servicetalk.concurrent.Executor timeoutExecutor) {
         return new TimeoutSingle<>(this, duration, unit, timeoutExecutor);
     }
 
@@ -466,7 +467,7 @@ public abstract class Single<T> {
      * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    public final Single<T> idleTimeout(Duration duration, Executor timeoutExecutor) {
+    public final Single<T> idleTimeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
         return new TimeoutSingle<>(this, duration, timeoutExecutor);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutCompletable.java
@@ -33,12 +33,12 @@ import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater
 
 final class TimeoutCompletable extends AbstractNoHandleSubscribeCompletable {
     private final Completable original;
-    private final Executor timeoutExecutor;
+    private final io.servicetalk.concurrent.Executor timeoutExecutor;
     private final long durationNs;
 
     TimeoutCompletable(final Completable original,
                        final Duration duration,
-                       final Executor timeoutExecutor) {
+                       final io.servicetalk.concurrent.Executor timeoutExecutor) {
         super(original.executor());
         this.original = original;
         this.durationNs = duration.toNanos();
@@ -48,7 +48,7 @@ final class TimeoutCompletable extends AbstractNoHandleSubscribeCompletable {
     TimeoutCompletable(final Completable original,
                        final long duration,
                        final TimeUnit unit,
-                       final Executor timeoutExecutor) {
+                       final io.servicetalk.concurrent.Executor timeoutExecutor) {
         super(original.executor());
         this.original = original;
         this.durationNs = unit.toNanos(duration);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutPublisher.java
@@ -35,7 +35,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 final class TimeoutPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
     private final Publisher<T> original;
-    private final Executor timeoutExecutor;
+    private final io.servicetalk.concurrent.Executor timeoutExecutor;
     private final long durationNs;
 
     TimeoutPublisher(final Publisher<T> original,
@@ -54,7 +54,7 @@ final class TimeoutPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
     TimeoutPublisher(final Publisher<T> original,
                      final Executor publisherExecutor,
                      final Duration duration,
-                     final Executor timeoutExecutor) {
+                     final io.servicetalk.concurrent.Executor timeoutExecutor) {
         this(original, publisherExecutor, duration.toNanos(), timeoutExecutor);
     }
 
@@ -62,14 +62,14 @@ final class TimeoutPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
                      final Executor publisherExecutor,
                      final long duration,
                      final TimeUnit unit,
-                     final Executor timeoutExecutor) {
+                     final io.servicetalk.concurrent.Executor timeoutExecutor) {
         this(original, publisherExecutor, unit.toNanos(duration), timeoutExecutor);
     }
 
     private TimeoutPublisher(final Publisher<T> original,
                              final Executor publisherExecutor,
                              final long durationNs,
-                             final Executor timeoutExecutor) {
+                             final io.servicetalk.concurrent.Executor timeoutExecutor) {
         super(publisherExecutor);
         this.original = requireNonNull(original);
         this.timeoutExecutor = requireNonNull(timeoutExecutor);
@@ -100,8 +100,10 @@ final class TimeoutPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
          */
         private static final Cancellable TIMER_PROCESSING = () -> { };
         private static final Cancellable TIMER_FIRED = () -> { };
+        @SuppressWarnings("rawtypes")
         private static final AtomicReferenceFieldUpdater<TimeoutSubscriber, Cancellable> timerCancellableUpdater =
                 AtomicReferenceFieldUpdater.newUpdater(TimeoutSubscriber.class, Cancellable.class, "timerCancellable");
+        @SuppressWarnings("rawtypes")
         private static final AtomicReferenceFieldUpdater<TimeoutSubscriber, Subscription> subscriptionUpdater =
                 AtomicReferenceFieldUpdater.newUpdater(TimeoutSubscriber.class, Subscription.class, "subscription");
         private final TimeoutPublisher<X> parent;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutSingle.java
@@ -33,12 +33,12 @@ import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater
 
 final class TimeoutSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
     private final Single<T> original;
-    private final Executor timeoutExecutor;
+    private final io.servicetalk.concurrent.Executor timeoutExecutor;
     private final long durationNs;
 
     TimeoutSingle(final Single<T> original,
                   final Duration duration,
-                  final Executor timeoutExecutor) {
+                  final io.servicetalk.concurrent.Executor timeoutExecutor) {
         super(original.executor());
         this.original = original;
         this.durationNs = duration.toNanos();
@@ -48,7 +48,7 @@ final class TimeoutSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
     TimeoutSingle(final Single<T> original,
                   final long duration,
                   final TimeUnit unit,
-                  final Executor timeoutExecutor) {
+                  final io.servicetalk.concurrent.Executor timeoutExecutor) {
         super(original.executor());
         this.original = original;
         this.durationNs = unit.toNanos(duration);
@@ -71,8 +71,10 @@ final class TimeoutSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
         private static final int STATE_ON_WAITING_FOR_SUBSCRIBE = 0;
         private static final int STATE_ON_SUBSCRIBE_DONE = 1;
         private static final int STATE_TIMED_OUT_ERROR = 2;
+        @SuppressWarnings("rawtypes")
         private static final AtomicReferenceFieldUpdater<TimeoutSubscriber, Cancellable>
                 cancellableUpdater = newUpdater(TimeoutSubscriber.class, Cancellable.class, "cancellable");
+        @SuppressWarnings("rawtypes")
         private static final AtomicIntegerFieldUpdater<TimeoutSubscriber> subscriberStateUpdater =
                 AtomicIntegerFieldUpdater.newUpdater(TimeoutSubscriber.class, "subscriberState");
         @Nullable


### PR DESCRIPTION
Motivation:
Publisher, Single, and Completable have a idleTimeout operator which
accepts a io.servicetalk.concurrent.api.Executor to implement the
underlying timeout. However the implementation only requires the
io.servicetalk.concurrent.Executor interface.

Motivation:
- Change Publisher, Single, and Completable idleTimeout method to accept
a io.servicetalk.concurrent.Executor instead of
io.servicetalk.concurrent.api.Executor.

Result:
Less complex type required for idleTimeout operator.