### PR TITLE
`Publisher` to `InputStream` adapters should return a read byte in -1..255 range

### DIFF
--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/CloseableIteratorBufferAsInputStreamTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/CloseableIteratorBufferAsInputStreamTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.DEFAULT_RO_ALLOCATOR;
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.concurrent.internal.BlockingIterables.from;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Arrays.asList;
@@ -146,6 +147,24 @@ public class CloseableIteratorBufferAsInputStreamTest {
         try (InputStream stream = new CloseableIteratorBufferAsInputStream(createIterator(src))) {
             int read = stream.read();
             assertThat("Unexpected bytes read.", (char) read, equalTo('1'));
+            assertThat("Bytes read after complete.", stream.read(), is(-1));
+        }
+    }
+
+    @Test
+    public void singleByteReadWithingRange() throws IOException {
+        singleByteReadWithingRange((byte) 0, 0);
+        singleByteReadWithingRange((byte) 255, 255);
+        singleByteReadWithingRange((byte) -1, 255);
+        singleByteReadWithingRange((byte) -117, 139);
+    }
+
+    private static void singleByteReadWithingRange(byte actual, int expected) throws IOException {
+        Buffer src = DEFAULT_ALLOCATOR.newBuffer(1)
+                .writeByte(actual);
+        try (InputStream stream = new CloseableIteratorBufferAsInputStream(createIterator(src))) {
+            int read = stream.read();
+            assertThat("Unexpected bytes read.", read, is(expected));
             assertThat("Bytes read after complete.", stream.read(), is(-1));
         }
     }

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/AbstractCloseableIteratorAsInputStream.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/AbstractCloseableIteratorAsInputStream.java
@@ -148,7 +148,7 @@ public abstract class AbstractCloseableIteratorAsInputStream<T> extends InputStr
     public final int read() throws IOException {
         checkAlreadyClosed();
         if (hasLeftOver()) {
-            return leftOverReadSingleByte();
+            return leftOverReadSingleByte() & 0xff;
         }
         for (;;) {
             if (!iterator.hasNext()) {
@@ -157,7 +157,7 @@ public abstract class AbstractCloseableIteratorAsInputStream<T> extends InputStr
             nextLeftOver(iterator);
             if (hasLeftOver()) {
                 if (leftOverReadableBytes() != 0) {
-                    return leftOverReadSingleByte();
+                    return leftOverReadSingleByte() & 0xff;
                 }
                 leftOverReset();
             }


### PR DESCRIPTION
Motivation:

Users of `InputStream#read()` API expect to see return values in -1..255 range.
However, we do not apply this constraint when we cast `byte` to `int` for impls
that convert `Publisher` to `InputStream`.

Modifications:

- Apply `& 0xFF` when we cast `byte` to `int`;

Result:

Our `InputStream` implementations return values within expected range.