### PR TITLE
TestPublisherSubscriber API updates

### DIFF
--- a/servicetalk-client-api/src/test/java/io/servicetalk/client/api/DefaultAutoRetryStrategyProviderTest.java
+++ b/servicetalk-client-api/src/test/java/io/servicetalk/client/api/DefaultAutoRetryStrategyProviderTest.java
@@ -35,6 +35,7 @@ import static java.util.function.UnaryOperator.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.core.IsNull.nullValue;
 
 public class DefaultAutoRetryStrategyProviderTest {
     private static final RetryableConnectException RETRYABLE_EXCEPTION =
@@ -75,7 +76,7 @@ public class DefaultAutoRetryStrategyProviderTest {
         AutoRetryStrategy strategy = newStrategy(Builder::disableRetryAllRetryableExceptions);
         Completable retry = strategy.apply(1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
-        assertThat(retrySubscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(retrySubscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         lbEvents.onNext(LOAD_BALANCER_READY_EVENT);
         verifyRetryResultCompleted();
     }
@@ -85,7 +86,7 @@ public class DefaultAutoRetryStrategyProviderTest {
         AutoRetryStrategy strategy = newStrategy(Builder::disableRetryAllRetryableExceptions);
         Completable retry = strategy.apply(1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
-        assertThat(retrySubscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(retrySubscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         sdStatus.onError(UNKNOWN_HOST_EXCEPTION);
         verifyRetryResultError(UNKNOWN_HOST_EXCEPTION);
     }
@@ -121,7 +122,7 @@ public class DefaultAutoRetryStrategyProviderTest {
         AutoRetryStrategy strategy = newStrategy(identity());
         Completable retry = strategy.apply(1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
-        assertThat(retrySubscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(retrySubscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         lbEvents.onNext(LOAD_BALANCER_READY_EVENT);
         verifyRetryResultCompleted();
     }
@@ -131,7 +132,7 @@ public class DefaultAutoRetryStrategyProviderTest {
         AutoRetryStrategy strategy = newStrategy(identity());
         Completable retry = strategy.apply(1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
-        assertThat(retrySubscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(retrySubscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         sdStatus.onError(UNKNOWN_HOST_EXCEPTION);
         verifyRetryResultError(UNKNOWN_HOST_EXCEPTION);
     }
@@ -141,7 +142,7 @@ public class DefaultAutoRetryStrategyProviderTest {
         AutoRetryStrategy strategy = newStrategy(identity());
         Completable retry = strategy.apply(1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
-        assertThat(retrySubscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(retrySubscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         sdStatus.onError(DELIBERATE_EXCEPTION);
         verifyRetryResultError(DELIBERATE_EXCEPTION);
     }
@@ -152,7 +153,7 @@ public class DefaultAutoRetryStrategyProviderTest {
         Completable retry = strategy.apply(1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
         assertThat("Unexpected subscribe for SD errors.", sdStatus.isSubscribed(), is(false));
-        assertThat(retrySubscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(retrySubscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         lbEvents.onNext(LOAD_BALANCER_READY_EVENT);
         verifyRetryResultCompleted();
     }
@@ -162,7 +163,7 @@ public class DefaultAutoRetryStrategyProviderTest {
         AutoRetryStrategy strategy = newStrategy(identity());
         Completable retry = strategy.apply(1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
-        assertThat(retrySubscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(retrySubscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         sdStatus.onComplete();
         verifyRetryResultCompleted();
     }

--- a/servicetalk-client-api/src/test/java/io/servicetalk/client/api/LimitingConnectionFactoryFilterTest.java
+++ b/servicetalk-client-api/src/test/java/io/servicetalk/client/api/LimitingConnectionFactoryFilterTest.java
@@ -40,6 +40,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -101,7 +102,7 @@ public class LimitingConnectionFactoryFilterTest {
         ConnectionFactory<String, ? extends ListenableAsyncCloseable> cf =
                 makeCF(LimitingConnectionFactoryFilter.withMax(1), o);
         toSource(cf.newConnection("c1", null)).subscribe(connectlistener);
-        assertThat(connectlistener.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(connectlistener.pollTerminal(10, MILLISECONDS), is(nullValue()));
         connectAndVerifyFailed(cf);
         connectlistener.awaitSubscription().cancel();
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableMergeWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableMergeWithPublisherTest.java
@@ -111,7 +111,7 @@ public class CompletableMergeWithPublisherTest {
         assertTrue(subscription.isCancelled());
         completable.verifyCancelled();
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test
@@ -126,7 +126,7 @@ public class CompletableMergeWithPublisherTest {
         assertThat(subscriber.takeOnNext(2), contains("one", "two"));
         assertTrue(subscription.isCancelled());
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test
@@ -139,7 +139,7 @@ public class CompletableMergeWithPublisherTest {
         subscriber.awaitSubscription().cancel();
         assertThat(subscriber.takeOnNext(2), contains("one", "two"));
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         completable.verifyCancelled();
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableProcessorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableProcessorTest.java
@@ -27,6 +27,7 @@ import java.lang.ref.WeakReference;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -55,7 +56,7 @@ public class CompletableProcessorTest {
     public void testCompleteAfterListen() {
         CompletableProcessor processor = new CompletableProcessor();
         toSource(processor).subscribe(rule);
-        assertThat(rule.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(rule.pollTerminal(10, MILLISECONDS), is(nullValue()));
         processor.onComplete();
         rule.awaitOnComplete();
     }
@@ -64,7 +65,7 @@ public class CompletableProcessorTest {
     public void testErrorAfterListen() {
         CompletableProcessor processor = new CompletableProcessor();
         toSource(processor).subscribe(rule);
-        assertThat(rule.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(rule.pollTerminal(10, MILLISECONDS), is(nullValue()));
         processor.onError(DELIBERATE_EXCEPTION);
         assertThat(rule.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
@@ -91,12 +92,12 @@ public class CompletableProcessorTest {
     public void cancelRemovesListenerAndStillAllowsOtherListenersToBeNotified() {
         CompletableProcessor processor = new CompletableProcessor();
         toSource(processor).subscribe(rule);
-        assertThat(rule.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(rule.pollTerminal(10, MILLISECONDS), is(nullValue()));
         toSource(processor).subscribe(rule2);
-        assertThat(rule2.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(rule2.pollTerminal(10, MILLISECONDS), is(nullValue()));
         rule.awaitSubscription().cancel();
         processor.onComplete();
-        assertThat(rule.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(rule.pollTerminal(10, MILLISECONDS), is(nullValue()));
         rule2.awaitOnComplete();
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/IterableMergeCompletableDelayErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/IterableMergeCompletableDelayErrorTest.java
@@ -29,6 +29,7 @@ import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class IterableMergeCompletableDelayErrorTest {
 
@@ -60,7 +61,7 @@ public class IterableMergeCompletableDelayErrorTest {
     public void testCollectionCompletionFew() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         collectionHolder.init(2).listen(subscriber).complete(1, 2);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         collectionHolder.complete(0);
         subscriber.awaitOnComplete();
     }
@@ -69,7 +70,7 @@ public class IterableMergeCompletableDelayErrorTest {
     public void testCollectionFailFirstEvent() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         collectionHolder.init(2).listen(subscriber).fail(1);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         collectionHolder.complete(0, 2);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
@@ -78,7 +79,7 @@ public class IterableMergeCompletableDelayErrorTest {
     public void testCollectionFailLastEvent() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         collectionHolder.init(2).listen(subscriber).complete(0, 2);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         collectionHolder.fail(1);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
@@ -87,9 +88,9 @@ public class IterableMergeCompletableDelayErrorTest {
     public void testCollectionFailMiddleEvent() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         collectionHolder.init(2).listen(subscriber).complete(0);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         collectionHolder.fail(1);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         collectionHolder.complete(2);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
@@ -112,7 +113,7 @@ public class IterableMergeCompletableDelayErrorTest {
     public void testIterableCompletionFew() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         iterableHolder.init(2).listen(subscriber).complete(1, 2);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         iterableHolder.complete(0);
         subscriber.awaitOnComplete();
     }
@@ -121,7 +122,7 @@ public class IterableMergeCompletableDelayErrorTest {
     public void testIterableFailFirstEvent() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         iterableHolder.init(2).listen(subscriber).fail(1);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         iterableHolder.complete(0, 2);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
@@ -130,7 +131,7 @@ public class IterableMergeCompletableDelayErrorTest {
     public void testIterableFailLastEvent() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         iterableHolder.init(2).listen(subscriber).complete(0, 2);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         iterableHolder.fail(1);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
@@ -139,9 +140,9 @@ public class IterableMergeCompletableDelayErrorTest {
     public void testIterableFailMiddleEvent() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         iterableHolder.init(2).listen(subscriber).complete(0);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         iterableHolder.fail(1);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         iterableHolder.complete(2);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/IterableMergeCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/IterableMergeCompletableTest.java
@@ -25,6 +25,7 @@ import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class IterableMergeCompletableTest {
     private final MergeCompletableTest.CompletableHolder collectionHolder =
@@ -54,7 +55,7 @@ public class IterableMergeCompletableTest {
     public void testCollectionCompletionFew() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         collectionHolder.init(2).listen(subscriber).complete(1, 2);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         collectionHolder.complete(0);
         subscriber.awaitOnComplete();
     }
@@ -85,7 +86,7 @@ public class IterableMergeCompletableTest {
     public void testIterableCompletionFew() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         iterableHolder.init(2).listen(subscriber).complete(1, 2);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         iterableHolder.complete(0);
         subscriber.awaitOnComplete();
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MergeCompletableDelayErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MergeCompletableDelayErrorTest.java
@@ -23,6 +23,7 @@ import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static java.util.Arrays.copyOfRange;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -46,7 +47,7 @@ public class MergeCompletableDelayErrorTest {
     public void testCompletionFew() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         holder.init(2).listen(subscriber).complete(1, 2);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         holder.complete(0);
         subscriber.awaitOnComplete();
     }
@@ -55,7 +56,7 @@ public class MergeCompletableDelayErrorTest {
     public void testFailFirstEvent() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         holder.init(2).listen(subscriber).fail(1);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         holder.complete(0, 2);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
@@ -64,7 +65,7 @@ public class MergeCompletableDelayErrorTest {
     public void testFailLastEvent() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         holder.init(2).listen(subscriber).complete(0, 2);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         holder.fail(1);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
@@ -73,9 +74,9 @@ public class MergeCompletableDelayErrorTest {
     public void testFailMiddleEvent() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         holder.init(2).listen(subscriber).complete(0);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         holder.fail(1);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         holder.complete(2);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MergeCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MergeCompletableTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -61,7 +62,7 @@ public class MergeCompletableTest {
     public void testCompletionFew() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         holder.init(2).listen(subscriber).complete(1, 2);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         holder.complete(0);
         subscriber.awaitOnComplete();
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MulticastPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MulticastPublisherTest.java
@@ -123,7 +123,7 @@ public class MulticastPublisherTest {
         assertThat(subscriber1.takeOnNext(2), contains(1, 2));
         subscriber2.awaitSubscription();
         assertThat(subscriber2.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber2.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber2.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferTest.java
@@ -250,7 +250,7 @@ public class PublisherBufferTest {
 
     private void verifyNoBuffersNoTerminal() {
         assertThat(bufferSubscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(bufferSubscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(bufferSubscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     private void emitBoundary() {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherConcatMapIterableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherConcatMapIterableTest.java
@@ -122,7 +122,7 @@ public class PublisherConcatMapIterableTest {
                 (time, unit) -> { }, (time, unit) -> { }, () -> cancelled.set(true)));
         assertThat(subscriber.takeOnNext(), is("one"));
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         assertTrue(cancelled.get());
     }
@@ -160,7 +160,7 @@ public class PublisherConcatMapIterableTest {
         publisher.onNext(singletonList("one"));
         assertThat(subscriber.takeOnNext(), is("one"));
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
 
         verifyTermination(success);
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
@@ -195,7 +195,7 @@ public class PublisherFlatMapMergeTest {
         publisher.onNext(1);
         publisher.onComplete();
         assertThat(subscriber.pollAllOnNext(), is(empty()));
-        assertFalse(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS));
+        assertThat(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS), is(nullValue()));
 
         mappedPublisher.onNext(2);
         Integer nextItem = subscriber.takeOnNext();
@@ -219,7 +219,7 @@ public class PublisherFlatMapMergeTest {
         assertEquals(2, nextItem.intValue());
 
         mappedPublisher.onComplete();
-        assertFalse(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS));
+        assertThat(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS), is(nullValue()));
 
         publisher.onComplete();
         subscriber.awaitOnComplete();
@@ -334,7 +334,7 @@ public class PublisherFlatMapMergeTest {
         }
         // Since FlatMap needs to track the requestN amount leased to mapped Publishers, the cancel state is
         // aggressive in suppressing onNext signals (tck tests fail if signals are delivered after cancel).
-        assertFalse(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS));
+        assertThat(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS), is(nullValue()));
     }
 
     @Test
@@ -462,7 +462,7 @@ public class PublisherFlatMapMergeTest {
         assertThat(subscriber.pollAllOnNext(), contains(6, 7, 8));
 
         first.mappedPublisher.onComplete();
-        assertFalse(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS));
+        assertThat(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS), is(nullValue()));
 
         verifyCumulativeDemand(upstreamSubscription, 4);
 
@@ -475,7 +475,7 @@ public class PublisherFlatMapMergeTest {
 
         // terminate the Publisher, verify mapped items still emitted and termination delayed.
         publisher.onComplete();
-        assertFalse(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS));
+        assertThat(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS), is(nullValue()));
 
         // terminate the outstanding mapped publisher and verify the Publisher terminates
         third.mappedPublisher.onComplete();
@@ -547,7 +547,7 @@ public class PublisherFlatMapMergeTest {
         verifyCumulativeDemand(upstreamSubscription, 2);
 
         publisher.onNext(1, 2);
-        assertFalse(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS));
+        assertThat(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS), is(nullValue()));
         publisher.onComplete();
         verifySuppressed(subscriber.awaitOnError(), DELIBERATE_EXCEPTION);
     }
@@ -966,7 +966,7 @@ public class PublisherFlatMapMergeTest {
 
         third.mappedPublisher.onComplete();
         first.mappedPublisher.onComplete();
-        assertFalse(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS));
+        assertThat(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS), is(nullValue()));
 
         publisher.onComplete();
         subscriber.awaitOnComplete();
@@ -1008,7 +1008,7 @@ public class PublisherFlatMapMergeTest {
         assertThat(subscriber.pollAllOnNext(), contains(1, 2, 3, 4));
         first.mappedPublisher.onComplete();
         second.mappedPublisher.onComplete();
-        assertFalse(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS));
+        assertThat(subscriber.pollTerminal(TERMINAL_POLL_MS, MILLISECONDS), is(nullValue()));
 
         publisher.onComplete();
         subscriber.awaitOnComplete();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
@@ -230,7 +230,7 @@ public class PublisherFlatMapSingleTest {
         subscriber.awaitSubscription().cancel();
         single.verifyCancelled();
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test
@@ -242,8 +242,8 @@ public class PublisherFlatMapSingleTest {
         source.onNext(1);
         subscriber.awaitSubscription().cancel();
         single.verifyCancelled();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         single.onSuccess(4);
         assertThat(subscriber.takeOnNext(), is(4));
         source.onComplete();
@@ -258,8 +258,8 @@ public class PublisherFlatMapSingleTest {
         source.onNext(1);
         subscriber.awaitSubscription().cancel();
         single.verifyCancelled();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         single.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
     }
@@ -356,8 +356,8 @@ public class PublisherFlatMapSingleTest {
         subscriber.awaitSubscription().request(3);
         assertThat(subscription.requested(), is(2L));
         source.onNext(1); // Request no more than max concurrency.
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         assertThat(subscription.requested(), is(3L));
         source.onNext(1); // Request more with 1 single completion.
         assertThat(subscription.requested(), is(3L));
@@ -530,7 +530,7 @@ public class PublisherFlatMapSingleTest {
         nextItem = subscriber.takeOnNext();
         assertNotNull(nextItem);
         assertEquals(3, nextItem.intValue());
-        assertFalse(subscriber.pollTerminal(200, MILLISECONDS));
+        assertThat(subscriber.pollTerminal(200, MILLISECONDS), is(nullValue()));
 
         source.onComplete();
         subscriber.awaitOnComplete();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherGroupByTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherGroupByTest.java
@@ -123,7 +123,7 @@ public class PublisherGroupByTest {
         assertThat(subscriber.takeOnNext(), is(Boolean.FALSE));
         source.onNext(2);
         subscriber.awaitSubscription();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(Long.MAX_VALUE);
         assertThat("Unexpected group subscribers.", groupSubs, hasSize(2));
         assertThat(subscriber.takeOnNext(), is(Boolean.TRUE));
@@ -142,7 +142,7 @@ public class PublisherGroupByTest {
         assertThat(subscriber.takeOnNext(), is(Boolean.FALSE));
         source.onNext(2);
         subscriber.awaitSubscription();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         assertThat("Unexpected group subscribers.", groupSubs, hasSize(1));
         source.onNext(3);
         assertThat(groupSubs.get(0).takeOnNext(), is(3));
@@ -166,11 +166,11 @@ public class PublisherGroupByTest {
         source.onNext(2);
         source.onNext(3);
         subscriber.awaitSubscription();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         assertThat("Unexpected group subscribers.", groupSubs, hasSize(1));
         source.onComplete();
         groupSubs.get(0).awaitSubscription();
-        assertThat(groupSubs.get(0).pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(groupSubs.get(0).pollTerminal(10, MILLISECONDS), is(nullValue()));
         groupSubs.get(0).awaitSubscription().request(1);
         assertThat(groupSubs.get(0).takeOnNext(), is(3));
         subscriber.awaitSubscription().request(1);
@@ -195,11 +195,11 @@ public class PublisherGroupByTest {
         source.onNext(2);
         source.onNext(3);
         subscriber.awaitSubscription();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         assertThat("Unexpected group subscribers.", groupSubs, hasSize(1));
         source.onError(DELIBERATE_EXCEPTION);
         groupSubs.get(0).awaitSubscription();
-        assertThat(groupSubs.get(0).pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(groupSubs.get(0).pollTerminal(10, MILLISECONDS), is(nullValue()));
         groupSubs.get(0).awaitSubscription().request(1);
         assertThat(groupSubs.get(0).takeOnNext(), is(3));
         subscriber.awaitSubscription().request(1);
@@ -267,7 +267,7 @@ public class PublisherGroupByTest {
         assertThat(groupSubs.get(1).awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
         subscriber.awaitSubscription();
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test
@@ -307,7 +307,7 @@ public class PublisherGroupByTest {
             groupSubRef.set(groupSub);
             groupSub.awaitSubscription();
             assertThat(groupSub.pollOnNext(10, MILLISECONDS), is(nullValue()));
-            assertThat(groupSub.pollTerminal(10, MILLISECONDS), is(false));
+            assertThat(groupSub.pollTerminal(10, MILLISECONDS), is(nullValue()));
             latch2.countDown();
 
             // writerThread
@@ -344,7 +344,7 @@ public class PublisherGroupByTest {
         sub.awaitSubscription().request(requestFromGroupOnSubscribe);
         assertThat(sub.takeOnNext(), is(1));
         sub.awaitSubscription().cancel();
-        assertThat(sub.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(sub.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherProcessorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherProcessorTest.java
@@ -105,7 +105,7 @@ public class PublisherProcessorTest {
         subscriber.awaitSubscription().request(1);
         assertThat("Unexpected items requested from subscription.", subscription.requested(), is(1L));
         assertThat("Unexpected items received.", subscriber.takeOnNext(), is(1));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test
@@ -115,7 +115,7 @@ public class PublisherProcessorTest {
         subscriber.awaitSubscription().request(1);
         assertThat("Unexpected items requested from subscription.", subscription.requested(), is(1L));
         assertThat("Unexpected items received.", subscriber.takeOnNext(), is(1));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test
@@ -163,7 +163,7 @@ public class PublisherProcessorTest {
         toSource(processor).subscribe(subscriber);
         processor.onNext(1);
         processor.onComplete();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
 
         subscriber.awaitSubscription().request(1);
         assertThat("Unexpected items requested from subscription.", subscription.requested(), is(1L));
@@ -187,7 +187,7 @@ public class PublisherProcessorTest {
         toSource(processor).subscribe(subscriber);
         processor.onNext(1);
         processor.onError(DELIBERATE_EXCEPTION);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
 
         subscriber.awaitSubscription().request(1);
         assertThat("Unexpected items requested from subscription.", subscription.requested(), is(1L));
@@ -201,7 +201,7 @@ public class PublisherProcessorTest {
         TestPublisherSubscriber<Integer> subscriber2 = new TestPublisherSubscriber<>();
         toSource(processor).subscribe(subscriber2);
         assertThat(subscriber2.awaitOnError(), instanceOf(DuplicateSubscribeException.class));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test
@@ -211,6 +211,6 @@ public class PublisherProcessorTest {
         TestPublisherSubscriber<Integer> subscriber2 = new TestPublisherSubscriber<>();
         toSource(processor).subscribe(subscriber2);
         assertThat(subscriber2.awaitOnError(), instanceOf(DuplicateSubscribeException.class));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ResumeCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ResumeCompletableTest.java
@@ -26,6 +26,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
@@ -54,7 +55,7 @@ public final class ResumeCompletableTest {
     @Test
     public void testFirstErrorSecondComplete() {
         first.onError(DELIBERATE_EXCEPTION);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         second.onComplete();
         subscriber.awaitOnComplete();
     }
@@ -62,7 +63,7 @@ public final class ResumeCompletableTest {
     @Test
     public void testFirstErrorSecondError() {
         first.onError(new DeliberateException());
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         second.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
@@ -73,13 +74,13 @@ public final class ResumeCompletableTest {
         TestCancellable cancellable = new TestCancellable();
         first.onSubscribe(cancellable);
         assertTrue(cancellable.isCancelled());
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test
     public void testCancelSecondActive() {
         first.onError(DELIBERATE_EXCEPTION);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
 
         TestCancellable secondCancellable = new TestCancellable();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ResumePublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ResumePublisherTest.java
@@ -54,7 +54,7 @@ public final class ResumePublisherTest {
         subscriber.awaitSubscription().request(1);
         first.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         second.onNext(1);
         second.onComplete();
         assertThat(subscriber.takeOnNext(), is(1));
@@ -67,7 +67,7 @@ public final class ResumePublisherTest {
         subscriber.awaitSubscription().request(1);
         first.onError(new DeliberateException());
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         second.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
     }
@@ -81,7 +81,7 @@ public final class ResumePublisherTest {
         subscriber.awaitSubscription().cancel();
         assertTrue(subscription.isCancelled());
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test
@@ -93,7 +93,7 @@ public final class ResumePublisherTest {
         second.onSubscribe(subscription);
         assertTrue(second.isSubscribed());
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         assertTrue(subscription.isCancelled());
     }
@@ -105,7 +105,7 @@ public final class ResumePublisherTest {
         first.onNext(1);
         first.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.takeOnNext(), is(1));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         second.onNext(2);
         second.onComplete();
         assertThat(subscriber.takeOnNext(), is(2));
@@ -118,7 +118,7 @@ public final class ResumePublisherTest {
         subscriber.awaitSubscription().request(1);
         first.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         second.onNext(1);
         second.onComplete();
         assertThat(subscriber.takeOnNext(), is(1));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ResumeSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ResumeSingleTest.java
@@ -26,6 +26,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -55,7 +56,7 @@ public final class ResumeSingleTest {
     @Test
     public void testFirstErrorSecondComplete() {
         first.onError(DELIBERATE_EXCEPTION);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         second.onSuccess(1);
         assertThat(subscriber.awaitOnSuccess(), is(1));
     }
@@ -63,7 +64,7 @@ public final class ResumeSingleTest {
     @Test
     public void testFirstErrorSecondError() {
         first.onError(new DeliberateException());
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         second.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
     }
@@ -74,13 +75,13 @@ public final class ResumeSingleTest {
         TestCancellable cancellable = new TestCancellable();
         first.onSubscribe(cancellable);
         assertTrue(cancellable.isCancelled());
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test
     public void testCancelSecondActive() {
         first.onError(DELIBERATE_EXCEPTION);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         TestCancellable firstCancellable = new TestCancellable();
         TestCancellable secondCancellable = new TestCancellable();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleProcessorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleProcessorTest.java
@@ -29,6 +29,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 
 public class SingleProcessorTest {
@@ -84,7 +85,7 @@ public class SingleProcessorTest {
         SingleProcessor<T> processor = new SingleProcessor<>();
         TestSingleSubscriber<T> subscriber = new TestSingleSubscriber<>();
         processor.subscribe(subscriber);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         processor.onSuccess(expected);
         assertThat(subscriber.awaitOnSuccess(), is(expected));
     }
@@ -94,7 +95,7 @@ public class SingleProcessorTest {
         SingleProcessor<String> processor = new SingleProcessor<>();
         TestSingleSubscriber<String> subscriber = new TestSingleSubscriber<>();
         processor.subscribe(subscriber);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         processor.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
@@ -167,12 +168,12 @@ public class SingleProcessorTest {
         TestSingleSubscriber<T> subscriber = new TestSingleSubscriber<>();
         TestSingleSubscriber<T> subscriber2 = new TestSingleSubscriber<>();
         processor.subscribe(subscriber);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         processor.subscribe(subscriber2);
-        assertThat(subscriber2.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber2.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         processor.onSuccess(expected);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         assertThat(subscriber2.awaitOnSuccess(), is(expected));
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestCompletableTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 public class TestCompletableTest {
@@ -67,7 +68,7 @@ public class TestCompletableTest {
         subscriber1.awaitOnComplete();
 
         source.subscribe(subscriber2);
-        assertThat(subscriber2.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber2.pollTerminal(10, MILLISECONDS), is(nullValue()));
         source.onComplete();
         subscriber2.awaitOnComplete();
     }
@@ -82,8 +83,8 @@ public class TestCompletableTest {
 
         source.subscribe(subscriber2);
 
-        assertThat(subscriber1.pollTerminal(10, MILLISECONDS), is(false));
-        assertThat(subscriber2.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber1.pollTerminal(10, MILLISECONDS), is(nullValue()));
+        assertThat(subscriber2.pollTerminal(10, MILLISECONDS), is(nullValue()));
 
         source.onComplete();
         subscriber1.awaitOnComplete();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithCompletableTest.java
@@ -27,6 +27,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -47,7 +48,7 @@ public class CompletableConcatWithCompletableTest {
     public void testSourceSuccessNextSuccess() {
         toSource(source.concat(next)).subscribe(subscriber);
         source.onComplete();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         next.onComplete();
         subscriber.awaitOnComplete();
     }
@@ -56,7 +57,7 @@ public class CompletableConcatWithCompletableTest {
     public void testSourceSuccessNextError() {
         toSource(source.concat(next)).subscribe(subscriber);
         source.onComplete();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         next.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
@@ -72,7 +73,7 @@ public class CompletableConcatWithCompletableTest {
     @Test
     public void testCancelSource() {
         toSource(source.concat(next)).subscribe(subscriber);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         TestCancellable cancellable = new TestCancellable();
         source.onSubscribe(cancellable);
@@ -84,7 +85,7 @@ public class CompletableConcatWithCompletableTest {
     public void testCancelNext() {
         toSource(source.concat(next)).subscribe(subscriber);
         source.onComplete();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
 
         TestCancellable sourceCancellable = new TestCancellable();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithPublisherTest.java
@@ -32,6 +32,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -61,7 +62,7 @@ public class CompletableConcatWithPublisherTest {
     @Test
     public void bothCompletion() {
         triggerNextSubscribe();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(1);
         assertThat("Unexpected items requested.", subscription.requested(), is(1L));
         next.onNext(1);
@@ -73,7 +74,7 @@ public class CompletableConcatWithPublisherTest {
     @Test
     public void sourceCompletionNextError() {
         triggerNextSubscribe();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         next.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
     }
@@ -147,7 +148,7 @@ public class CompletableConcatWithPublisherTest {
 
     @Test
     public void cancelSource() {
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         assertTrue("Original completable not cancelled.", cancellable.isCancelled());
         assertFalse("Next source subscribed unexpectedly.", next.isSubscribed());
@@ -157,7 +158,7 @@ public class CompletableConcatWithPublisherTest {
 
     @Test
     public void cancelSourcePostRequest() {
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(1);
         subscriber.awaitSubscription().cancel();
         assertTrue("Original completable not cancelled.", cancellable.isCancelled());
@@ -167,7 +168,7 @@ public class CompletableConcatWithPublisherTest {
     @Test
     public void cancelNext() {
         triggerNextSubscribe();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         assertFalse("Original completable cancelled unexpectedly.", cancellable.isCancelled());
         assertTrue("Next source not cancelled.", subscription.isCancelled());

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithSingleTest.java
@@ -28,6 +28,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -49,7 +50,7 @@ public class CompletableConcatWithSingleTest {
     @Test
     public void testSourceSuccessNextSuccess() {
         source.onComplete();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         next.onSuccess(1);
         assertThat(subscriber.awaitOnSuccess(), is(1));
     }
@@ -57,7 +58,7 @@ public class CompletableConcatWithSingleTest {
     @Test
     public void testSourceSuccessNextError() {
         source.onComplete();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         next.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
     }
@@ -71,7 +72,7 @@ public class CompletableConcatWithSingleTest {
 
     @Test
     public void testCancelSource() {
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         TestCancellable cancellable = new TestCancellable();
         source.onSubscribe(cancellable);
@@ -82,7 +83,7 @@ public class CompletableConcatWithSingleTest {
     @Test
     public void testCancelNext() {
         source.onComplete();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         TestCancellable sourceCancellable = new TestCancellable();
         source.onSubscribe(sourceCancellable);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/TimeoutCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/TimeoutCompletableTest.java
@@ -40,6 +40,7 @@ import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -146,7 +147,7 @@ public class TimeoutCompletableTest {
         toSource(source.idleTimeout(1, NANOSECONDS, testExecutor)).subscribe(listener);
         assertThat(testExecutor.scheduledTasksPending(), is(1));
         if (expectOnSubscribe) {
-            assertThat(listener.pollTerminal(10, MILLISECONDS), is(false));
+            assertThat(listener.pollTerminal(10, MILLISECONDS), is(nullValue()));
         }
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenRequestTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenRequestTest.java
@@ -77,7 +77,7 @@ public abstract class AbstractWhenRequestTest {
         doRequest(publisher, onRequest).subscribe(subscriber);
         subscriber.awaitSubscription().request(10);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         verify(onRequest).accept(10L);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromInMemoryPublisherAbstractTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromInMemoryPublisherAbstractTest.java
@@ -138,10 +138,10 @@ public abstract class FromInMemoryPublisherAbstractTest {
         requestItemsAndVerifyEmissions(source);
         subscriber.awaitSubscription().cancel();
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(1);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test
@@ -154,7 +154,7 @@ public abstract class FromInMemoryPublisherAbstractTest {
         assertThat(subscriber.takeOnNext(), is("Hello0"));
         subscriber.awaitSubscription().request(1);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test
@@ -286,7 +286,7 @@ public abstract class FromInMemoryPublisherAbstractTest {
         toSource(source.publisher()).subscribe(subscriber);
         subscriber.awaitSubscription().request(3);
         assertThat(subscriber.takeOnNext(3), contains(copyOf(source.values(), 3)));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     final InMemorySource newSource(int size) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubFirstOrErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubFirstOrErrorTest.java
@@ -33,6 +33,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class PubFirstOrErrorTest {
     @Rule
@@ -78,7 +79,7 @@ public class PubFirstOrErrorTest {
     public void singleItemNoComplete() {
         toSource(publisher.firstOrError()).subscribe(listenerRule);
         publisher.onNext("hello");
-        assertThat(listenerRule.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(listenerRule.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherConcatWithCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherConcatWithCompletableTest.java
@@ -28,6 +28,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class PublisherConcatWithCompletableTest {
 
@@ -40,7 +41,7 @@ public class PublisherConcatWithCompletableTest {
     public PublisherConcatWithCompletableTest() {
         toSource(source.concat(completable)).subscribe(subscriber);
         source.onSubscribe(subscription);
-        assertThat("Unexpected termination.", subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat("Unexpected termination.", subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         assertThat("Next source subscribed before termination.", completable.isSubscribed(), is(false));
     }
 
@@ -51,7 +52,7 @@ public class PublisherConcatWithCompletableTest {
         source.onComplete();
         assertThat("Unexpected items emitted.", subscriber.takeOnNext(), is(1));
         assertThat("Next source not subscribed.", completable.isSubscribed(), is(true));
-        assertThat("Unexpected termination.", subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat("Unexpected termination.", subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         completable.onComplete();
         subscriber.awaitOnComplete();
     }
@@ -72,7 +73,7 @@ public class PublisherConcatWithCompletableTest {
         source.onComplete();
         assertThat("Unexpected items emitted.", subscriber.takeOnNext(), is(1));
         assertThat("Next source not subscribed.", completable.isSubscribed(), is(true));
-        assertThat("Unexpected termination.", subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat("Unexpected termination.", subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         completable.onError(DELIBERATE_EXCEPTION);
         verifySubscriberErrored();
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherConcatWithSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherConcatWithSingleTest.java
@@ -34,24 +34,41 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class PublisherConcatWithSingleTest {
-    private final TestSubscription subscription = new TestSubscription();
-    private final TestCancellable cancellable = new TestCancellable();
-    private final TestPublisher<Long> source = new TestPublisher<>();
-    private final TestPublisherSubscriber<Long> subscriber = new TestPublisherSubscriber<>();
-    private final TestSingle<Long> single = new TestSingle<>();
+    private TestSubscription subscription;
+    private TestCancellable cancellable;
+    private TestPublisher<Long> source;
+    private TestPublisherSubscriber<Long> subscriber;
+    private TestSingle<Long> single;
 
     public PublisherConcatWithSingleTest() {
+        initState();
         toSource(source.concat(single)).subscribe(subscriber);
         source.onSubscribe(subscription);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         assertThat("Next source subscribed before termination.", single.isSubscribed(), is(false));
+    }
+
+    private void initState() {
+        subscription = new TestSubscription();
+        cancellable = new TestCancellable();
+        source = new TestPublisher<>();
+        subscriber = new TestPublisherSubscriber<>();
+        single = new TestSingle<>();
+    }
+
+    private void initStateOnNextThrows() {
+        initState();
+        toSource(source.concat(single)
+                .beforeOnNext(n -> {
+                    throw DELIBERATE_EXCEPTION;
+                })
+        ).subscribe(subscriber);
     }
 
     @Test
     public void subscriberDemandThenOnNextThrowsSendsOnError() {
-        subscriber.onNextConsumer(l -> {
-            throw DELIBERATE_EXCEPTION;
-        });
+        initStateOnNextThrows();
+        source.onSubscribe(subscription);
         subscriber.awaitSubscription().request(1);
         source.onSubscribe(subscription);
         source.onComplete();
@@ -61,9 +78,7 @@ public class PublisherConcatWithSingleTest {
 
     @Test
     public void subscriberOnNextThenDemandThrowsSendsOnError() {
-        subscriber.onNextConsumer(l -> {
-            throw DELIBERATE_EXCEPTION;
-        });
+        initStateOnNextThrows();
         source.onSubscribe(subscription);
         source.onComplete();
         single.onSuccess(1L);
@@ -105,7 +120,7 @@ public class PublisherConcatWithSingleTest {
         source.onComplete();
         assertThat("Unexpected items emitted.", subscriber.takeOnNext(), is(1L));
         assertThat("Next source not subscribed.", single.isSubscribed(), is(true));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         single.onError(DELIBERATE_EXCEPTION);
         verifySubscriberErrored();
     }
@@ -253,7 +268,7 @@ public class PublisherConcatWithSingleTest {
     private void completeSource() {
         source.onComplete();
         assertThat("Next source not subscribed.", single.isSubscribed(), is(true));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     private void emitOneItemFromSource() {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RangeIntPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RangeIntPublisherTest.java
@@ -171,7 +171,7 @@ public class RangeIntPublisherTest {
         })).subscribe(subscriber);
         subscriber.awaitSubscription().request(5);
         assertThat(subscriber.takeOnNext(), is(0));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatTest.java
@@ -30,6 +30,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -84,7 +85,7 @@ public class RepeatTest {
         assertTrue(source.isSubscribed());
         source.onNext(3);
         assertThat(subscriber.takeOnNext(), is(3));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test
@@ -94,7 +95,7 @@ public class RepeatTest {
         source.onNext(1, 2);
         source.onComplete();
         assertThat(subscriber.takeOnNext(2), contains(1, 2));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         verify(shouldRepeat).test(1);
         assertTrue(source.isSubscribed());
         source.onNext(3);
@@ -112,7 +113,7 @@ public class RepeatTest {
         source.onNext(1, 2);
         source.onComplete();
         assertThat(subscriber.takeOnNext(2), contains(1, 2));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         verify(shouldRepeat).test(1);
         shouldRepeatValue = false;
         source.onComplete();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatWhenTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatWhenTest.java
@@ -39,6 +39,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -111,7 +112,7 @@ public class RepeatWhenTest {
         assertTrue(source.isSubscribed());
         source.onNext(3);
         assertThat(subscriber.takeOnNext(), is(3));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test
@@ -121,7 +122,7 @@ public class RepeatWhenTest {
         source.onNext(1, 2);
         source.onComplete();
         assertThat(subscriber.takeOnNext(2), contains(1, 2));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         verify(shouldRepeat).apply(1);
         repeatSignal.onComplete(); // trigger repeat
         assertTrue(source.isSubscribed());
@@ -142,7 +143,7 @@ public class RepeatWhenTest {
         source.onComplete();
         repeatSignal.onComplete(); // trigger repeat
         assertThat(subscriber.takeOnNext(2), contains(1, 2));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         verify(shouldRepeat).apply(1);
         assertTrue(source.isSubscribed());
         source.onComplete();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RetryTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RetryTest.java
@@ -30,6 +30,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -90,7 +91,7 @@ public class RetryTest {
         assertTrue(source.isSubscribed());
         source.onNext(3);
         assertThat(subscriber.takeOnNext(), is(3));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test
@@ -100,7 +101,7 @@ public class RetryTest {
         source.onNext(1, 2);
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.takeOnNext(2), contains(1, 2));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         verify(shouldRetry).test(1, DELIBERATE_EXCEPTION);
         assertTrue(source.isSubscribed());
         source.onNext(3);
@@ -118,7 +119,7 @@ public class RetryTest {
         source.onNext(1, 2);
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.takeOnNext(2), contains(1, 2));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         verify(shouldRetry).test(1, DELIBERATE_EXCEPTION);
         shouldRetryValue = false;
         DeliberateException fatal = new DeliberateException();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RetryWhenTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RetryWhenTest.java
@@ -42,6 +42,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -137,7 +138,7 @@ public class RetryWhenTest {
         assertTrue(source.isSubscribed());
         source.onNext(3);
         assertThat(subscriber.takeOnNext(), is(3));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test
@@ -146,7 +147,7 @@ public class RetryWhenTest {
         source.onNext(1, 2);
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.takeOnNext(2), contains(1, 2));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         verify(shouldRetry).apply(1, DELIBERATE_EXCEPTION);
         retrySignal.onComplete(); // trigger retry
         assertTrue(source.isSubscribed());
@@ -166,7 +167,7 @@ public class RetryWhenTest {
         source.onError(DELIBERATE_EXCEPTION);
         retrySignal.onComplete(); // trigger retry
         assertThat(subscriber.takeOnNext(2), contains(1, 2));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         verify(shouldRetry).apply(1, DELIBERATE_EXCEPTION);
         assertTrue(source.isSubscribed());
         source.onError(DELIBERATE_EXCEPTION);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/ScalarResultPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/ScalarResultPublisherTest.java
@@ -26,6 +26,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class ScalarResultPublisherTest {
@@ -56,7 +57,7 @@ public class ScalarResultPublisherTest {
     public void testNever() {
         toSource(Publisher.<String>never()).subscribe(subscriber);
         subscriber.awaitSubscription();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/TimeoutPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/TimeoutPublisherTest.java
@@ -95,7 +95,7 @@ public class TimeoutPublisherTest {
 
         subscriber.awaitSubscription().request(10);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         publisher.onComplete();
         subscriber.awaitOnComplete();
 
@@ -109,7 +109,7 @@ public class TimeoutPublisherTest {
 
         subscriber.awaitSubscription().request(10);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         publisher.onNext(1, 2, 3);
         assertThat(subscriber.takeOnNext(3), contains(1, 2, 3));
         publisher.onComplete();
@@ -125,7 +125,7 @@ public class TimeoutPublisherTest {
 
         subscriber.awaitSubscription().request(10);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         publisher.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
 
@@ -139,7 +139,7 @@ public class TimeoutPublisherTest {
 
         subscriber.awaitSubscription().request(10);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         publisher.onNext(1, 2, 3);
         assertThat(subscriber.takeOnNext(3), contains(1, 2, 3));
         publisher.onError(DELIBERATE_EXCEPTION);
@@ -176,7 +176,7 @@ public class TimeoutPublisherTest {
 
         subscriber.awaitSubscription().request(10);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         publisher.onNext(1, 2, 3);
         assertThat(subscriber.takeOnNext(3), contains(1, 2, 3));
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/ConcatWithCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/ConcatWithCompletableTest.java
@@ -30,6 +30,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class ConcatWithCompletableTest {
     @Rule
@@ -44,7 +45,7 @@ public class ConcatWithCompletableTest {
     public void concatWaitsForCompletableSuccess() {
         toSource(single.concat(completable)).subscribe(listener);
         single.onSuccess("foo");
-        assertThat(listener.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(listener.pollTerminal(10, MILLISECONDS), is(nullValue()));
         completable.onComplete();
         assertThat(listener.awaitOnSuccess(), is("foo"));
     }
@@ -53,7 +54,7 @@ public class ConcatWithCompletableTest {
     public void concatPropagatesCompletableFailure() {
         toSource(single.concat(completable)).subscribe(listener);
         single.onSuccess("foo");
-        assertThat(listener.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(listener.pollTerminal(10, MILLISECONDS), is(nullValue()));
         completable.onError(DELIBERATE_EXCEPTION);
         assertThat(listener.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/RetryTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/RetryTest.java
@@ -28,6 +28,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.any;
@@ -78,7 +79,7 @@ public class RetryTest {
     public void testTwoFailures() {
         shouldRetryValue = true;
         source.onError(DELIBERATE_EXCEPTION);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         verify(shouldRetry).test(1, DELIBERATE_EXCEPTION);
         source.onError(DELIBERATE_EXCEPTION);
         verify(shouldRetry).test(2, DELIBERATE_EXCEPTION);
@@ -90,7 +91,7 @@ public class RetryTest {
     public void testMaxRetries() {
         shouldRetryValue = true;
         source.onError(DELIBERATE_EXCEPTION);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         verify(shouldRetry).test(1, DELIBERATE_EXCEPTION);
         shouldRetryValue = false;
         DeliberateException fatal = new DeliberateException();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/RetryWhenTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/RetryWhenTest.java
@@ -40,6 +40,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.any;
@@ -110,7 +111,7 @@ public class RetryWhenTest {
     @Test
     public void testRetryCount() {
         source.onError(DELIBERATE_EXCEPTION);
-        assertThat(subscriberRule.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriberRule.pollTerminal(10, MILLISECONDS), is(nullValue()));
         DeliberateException fatal = new DeliberateException();
         retrySignal.onError(fatal); // stop retry
         assertThat(subscriberRule.awaitOnError(), is(fatal));
@@ -121,7 +122,7 @@ public class RetryWhenTest {
     @Test
     public void testTwoError() {
         source.onError(DELIBERATE_EXCEPTION);
-        assertThat(subscriberRule.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriberRule.pollTerminal(10, MILLISECONDS), is(nullValue()));
         verify(shouldRetry).apply(1, DELIBERATE_EXCEPTION);
         retrySignal.onComplete(); // trigger retry
         source.verifyListenCalled();
@@ -136,7 +137,7 @@ public class RetryWhenTest {
     public void testMaxRetries() {
         source.onError(DELIBERATE_EXCEPTION);
         retrySignal.onComplete(); // trigger retry
-        assertThat(subscriberRule.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriberRule.pollTerminal(10, MILLISECONDS), is(nullValue()));
         verify(shouldRetry).apply(1, DELIBERATE_EXCEPTION);
         source.verifyListenCalled().onError(DELIBERATE_EXCEPTION);
         DeliberateException fatal = new DeliberateException();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithCompletableTest.java
@@ -28,6 +28,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -49,7 +50,7 @@ public class SingleConcatWithCompletableTest {
     @Test
     public void testSourceSuccessNextComplete() {
         source.onSuccess(1);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         next.onComplete();
         assertThat(subscriber.awaitOnSuccess(), is(1));
     }
@@ -57,7 +58,7 @@ public class SingleConcatWithCompletableTest {
     @Test
     public void testSourceSuccessNextError() {
         source.onSuccess(1);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         next.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
     }
@@ -71,7 +72,7 @@ public class SingleConcatWithCompletableTest {
 
     @Test
     public void testCancelSource() {
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         TestCancellable cancellable = new TestCancellable();
         source.onSubscribe(cancellable);
@@ -82,7 +83,7 @@ public class SingleConcatWithCompletableTest {
     @Test
     public void testCancelNext() {
         source.onSuccess(1);
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         TestCancellable sourceCancellable = new TestCancellable();
         source.onSubscribe(sourceCancellable);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
@@ -37,6 +37,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class SingleConcatWithPublisherTest {
@@ -64,7 +65,7 @@ public class SingleConcatWithPublisherTest {
     @Test
     public void bothCompletion() {
         triggerNextSubscribe();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(2);
         assertThat("Unexpected items requested.", subscription.requested(), is(2L));
         next.onNext(2);
@@ -76,7 +77,7 @@ public class SingleConcatWithPublisherTest {
     @Test
     public void sourceCompletionNextError() {
         triggerNextSubscribe();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         next.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.takeOnNext(), is(1));
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
@@ -156,7 +157,7 @@ public class SingleConcatWithPublisherTest {
 
     @Test
     public void cancelSource() {
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         assertThat("Original single not cancelled.", cancellable.isCancelled(), is(true));
         assertThat("Next source subscribed unexpectedly.", next.isSubscribed(), is(false));
@@ -164,7 +165,7 @@ public class SingleConcatWithPublisherTest {
 
     @Test
     public void cancelSourcePostRequest() {
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(1);
         subscriber.awaitSubscription().cancel();
         assertThat("Original single not cancelled.", cancellable.isCancelled(), is(true));
@@ -174,7 +175,7 @@ public class SingleConcatWithPublisherTest {
     @Test
     public void cancelNext() {
         triggerNextSubscribe();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         assertThat("Original single cancelled unexpectedly.", cancellable.isCancelled(), is(false));
         assertThat("Next source not cancelled.", subscription.isCancelled(), is(true));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleFlatMapPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleFlatMapPublisherTest.java
@@ -121,7 +121,7 @@ public final class SingleFlatMapPublisherTest {
         publisher.onSubscribe(subscription);
         assertTrue(subscription.isCancelled());
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToPublisherTest.java
@@ -89,7 +89,7 @@ public class SingleToPublisherTest {
         toSource(Single.succeeded("Hello").toPublisher()).subscribe(verifier);
         verifier.awaitSubscription();
         assertThat(verifier.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(verifier.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(verifier.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/TimeoutSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/TimeoutSingleTest.java
@@ -42,6 +42,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -82,7 +83,7 @@ public class TimeoutSingleTest {
     public void noDataOnCompletionNoTimeout() {
         init();
 
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         source.onSuccess(1);
         assertThat(subscriber.awaitOnSuccess(), is(1));
 
@@ -94,7 +95,7 @@ public class TimeoutSingleTest {
     public void noDataOnErrorNoTimeout() {
         init();
 
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
 

--- a/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestCompletableSubscriber.java
+++ b/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestCompletableSubscriber.java
@@ -20,6 +20,8 @@ import io.servicetalk.concurrent.CompletableSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
 
 /**
  * A {@link Subscriber} that enqueues signals and provides blocking methods to consume them.
@@ -82,9 +84,12 @@ public final class TestCompletableSubscriber implements Subscriber {
      *
      * @param timeout The duration of time to wait.
      * @param unit The unit of time to apply to the duration.
-     * @return {@code true} if a terminal event has been received before the timeout duration.
+     * @return {@code null} if a the timeout expires before a terminal event is received. A non-{@code null}
+     * {@link Supplier} that returns {@code null} if {@link #onComplete()}, or the {@link Throwable} from
+     * {@link #onError(Throwable)}.
      */
-    public boolean pollTerminal(long timeout, TimeUnit unit) {
+    @Nullable
+    public Supplier<Throwable> pollTerminal(long timeout, TimeUnit unit) {
         return publisherSubscriber.pollTerminal(timeout, unit);
     }
 }

--- a/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriber.java
+++ b/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriber.java
@@ -217,8 +217,8 @@ public final class TestPublisherSubscriber<T> implements Subscriber<T> {
      *
      * @param timeout The amount of time to wait.
      * @param unit The units of {@code timeout}.
-     * @return item delivered to {@link #onNext(Object)}, or {@code null} if a timeout occurred or a terminal signal
-     * has been received.
+     * @return A {@link Supplier} that returns the signal delivered to {@link #onNext(Object)},
+     * or {@code null} if a timeout occurred or a terminal signal has been received.
      */
     @Nullable
     public Supplier<T> pollOnNext(long timeout, TimeUnit unit) {

--- a/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriber.java
+++ b/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriber.java
@@ -23,20 +23,18 @@ import io.servicetalk.concurrent.internal.TerminalNotification;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
 import static java.util.Objects.requireNonNull;
-import static java.util.Optional.ofNullable;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.stream.Collectors.toList;
 
@@ -68,10 +66,6 @@ public final class TestPublisherSubscriber<T> implements Subscriber<T> {
     private TerminalNotification onTerminal;
     @Nullable
     private Subscription subscription;
-    @Nullable
-    private Consumer<T> onNextConsumer;
-    @Nullable
-    private Consumer<Subscription> onSubscribeConsumer;
 
     /**
      * Create a new instance.
@@ -82,23 +76,6 @@ public final class TestPublisherSubscriber<T> implements Subscriber<T> {
 
     TestPublisherSubscriber(long initialDemand) {
         outstandingDemand = new AtomicLong(initialDemand);
-    }
-
-    /**
-     * Set a {@link Consumer} that is invoked in {@link PublisherSource.Subscriber#onSubscribe(Subscription)}.
-     * @param onSubscribeConsumer a {@link Consumer} that is invoked in
-     * {@link PublisherSource.Subscriber#onSubscribe(Subscription)}.
-     */
-    public void onSubscribeConsumer(@Nullable Consumer<Subscription> onSubscribeConsumer) {
-        this.onSubscribeConsumer = onSubscribeConsumer;
-    }
-
-    /**
-     * Set a {@link Consumer} that is invoked in {@link #onNext(Object)}.
-     * @param onNextConsumer a {@link Consumer} that is invoked in {@link #onNext(Object)}.
-     */
-    public void onNextConsumer(@Nullable Consumer<T> onNextConsumer) {
-        this.onNextConsumer = onNextConsumer;
     }
 
     @Override
@@ -128,9 +105,6 @@ public final class TestPublisherSubscriber<T> implements Subscriber<T> {
                 subscription.cancel();
             }
         };
-        if (onSubscribeConsumer != null) {
-            onSubscribeConsumer.accept(this.subscription);
-        }
         onSubscribeLatch.countDown();
     }
 
@@ -140,9 +114,6 @@ public final class TestPublisherSubscriber<T> implements Subscriber<T> {
         if (outstandingDemand.decrementAndGet() < 0) {
             throw new IllegalStateException("Too many onNext signals relative to Subscription request(n). " +
                     "https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#1.1");
-        }
-        if (onNextConsumer != null) {
-            onNextConsumer.accept(t);
         }
         items.add(wrapNull(t));
     }
@@ -246,12 +217,13 @@ public final class TestPublisherSubscriber<T> implements Subscriber<T> {
      *
      * @param timeout The amount of time to wait.
      * @param unit The units of {@code timeout}.
-     * @return item delivered to {@link #onNext(Object)}, or {@code null} if a timeout occurred.
+     * @return item delivered to {@link #onNext(Object)}, or {@code null} if a timeout occurred or a terminal signal
+     * has been received.
      */
     @Nullable
-    public Optional<T> pollOnNext(long timeout, TimeUnit unit) {
+    public Supplier<T> pollOnNext(long timeout, TimeUnit unit) {
         Object item = pollUninterruptibly(items, timeout, unit);
-        return item == null ? null : ofNullable(unwrapNull(item));
+        return item == null ? null : () -> unwrapNull(item);
     }
 
     /**
@@ -318,10 +290,17 @@ public final class TestPublisherSubscriber<T> implements Subscriber<T> {
      *
      * @param timeout The duration of time to wait.
      * @param unit The unit of time to apply to the duration.
-     * @return {@code true} if a terminal event has been received before the timeout duration.
+     * @return {@code null} if a the timeout expires before a terminal event is received. A non-{@code null}
+     * {@link Supplier} that returns {@code null} if {@link #onComplete()}, or the {@link Throwable} from
+     * {@link #onError(Throwable)}.
      */
-    public boolean pollTerminal(long timeout, TimeUnit unit) {
-        return awaitUninterruptibly(onTerminalLatch, timeout, unit);
+    @Nullable
+    public Supplier<Throwable> pollTerminal(long timeout, TimeUnit unit) {
+        if (awaitUninterruptibly(onTerminalLatch, timeout, unit)) {
+            assert onTerminal != null;
+            return onTerminal == complete() ? () -> null : onTerminal::cause;
+        }
+        return null;
     }
 
     private void verifyAllOnNextProcessed() {

--- a/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestSingleSubscriber.java
+++ b/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestSingleSubscriber.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.SingleSource.Subscriber;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /**
@@ -95,9 +96,12 @@ public final class TestSingleSubscriber<T> implements Subscriber<T> {
      *
      * @param timeout The duration of time to wait.
      * @param unit The unit of time to apply to the duration.
-     * @return {@code true} if a terminal event has been received before the timeout duration.
+     * @return {@code null} if a the timeout expires before a terminal event is received. A non-{@code null}
+     * {@link Supplier} that returns {@code null} if {@link #onSuccess(Object)}, or the {@link Throwable} from
+     * {@link #onError(Throwable)}.
      */
-    public boolean pollTerminal(long timeout, TimeUnit unit) {
+    @Nullable
+    public Supplier<Throwable> pollTerminal(long timeout, TimeUnit unit) {
         return publisherSubscriber.pollTerminal(timeout, unit);
     }
 }

--- a/servicetalk-concurrent-test-internal/src/test/java/io/servicetalk/concurrent/test/internal/TestCompletableSubscriberTest.java
+++ b/servicetalk-concurrent-test-internal/src/test/java/io/servicetalk/concurrent/test/internal/TestCompletableSubscriberTest.java
@@ -23,8 +23,9 @@ import org.junit.Test;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertFalse;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 
@@ -33,7 +34,7 @@ public class TestCompletableSubscriberTest {
     public void onSubscribe() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         doOnSubscribe(subscriber);
-        assertFalse(subscriber.pollTerminal(200, MILLISECONDS));
+        assertThat(subscriber.pollTerminal(200, MILLISECONDS), is(nullValue()));
     }
 
     @Test
@@ -49,7 +50,7 @@ public class TestCompletableSubscriberTest {
     private static void onSubscribeOnTerminal(boolean onComplete) {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         doOnSubscribe(subscriber);
-        assertFalse(subscriber.pollTerminal(200, MILLISECONDS));
+        assertThat(subscriber.pollTerminal(200, MILLISECONDS), is(nullValue()));
         doTerminalSignal(subscriber, onComplete);
     }
 

--- a/servicetalk-concurrent-test-internal/src/test/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriberTest.java
+++ b/servicetalk-concurrent-test-internal/src/test/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriberTest.java
@@ -26,8 +26,8 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -39,7 +39,7 @@ public class TestPublisherSubscriberTest {
         TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
         doOnSubscribe(subscriber);
         assertThat(subscriber.pollAllOnNext(), is(empty()));
-        assertFalse(subscriber.pollTerminal(200, MILLISECONDS));
+        assertThat(subscriber.pollTerminal(200, MILLISECONDS), is(nullValue()));
     }
 
     @Test

--- a/servicetalk-concurrent-test-internal/src/test/java/io/servicetalk/concurrent/test/internal/TestSingleSubscriberTest.java
+++ b/servicetalk-concurrent-test-internal/src/test/java/io/servicetalk/concurrent/test/internal/TestSingleSubscriberTest.java
@@ -28,7 +28,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertFalse;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 
@@ -37,7 +37,7 @@ public class TestSingleSubscriberTest {
     public void onSubscribe() {
         TestSingleSubscriber<Integer> subscriber = new TestSingleSubscriber<>();
         doOnSubscribe(subscriber);
-        assertFalse(subscriber.pollTerminal(200, MILLISECONDS));
+        assertThat(subscriber.pollTerminal(200, MILLISECONDS), is(nullValue()));
     }
 
     @Test
@@ -53,7 +53,7 @@ public class TestSingleSubscriberTest {
     private static void onSubscribeOnTerminal(boolean onComplete) {
         TestSingleSubscriber<Integer> subscriber = new TestSingleSubscriber<>();
         doOnSubscribe(subscriber);
-        assertFalse(subscriber.pollTerminal(200, MILLISECONDS));
+        assertThat(subscriber.pollTerminal(200, MILLISECONDS), is(nullValue()));
         doTerminalSignal(subscriber, onComplete);
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerTest.java
@@ -80,6 +80,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.CombinableMatcher.either;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -350,7 +351,7 @@ public class NettyHttpServerTest extends AbstractNettyHttpServerTest {
         // cancelling the Completable while in the timeout cancels the forceful shutdown.
         closeAsyncGracefully(serverContext(), 1000, SECONDS).afterOnSubscribe(Cancellable::cancel).subscribe();
 
-        assertThat(completableListenerRule.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(completableListenerRule.pollTerminal(10, MILLISECONDS), is(nullValue()));
 
         closeAsyncGracefully(serverContext(), 10, MILLISECONDS).toFuture().get();
 
@@ -371,7 +372,7 @@ public class NettyHttpServerTest extends AbstractNettyHttpServerTest {
         // cancelling the Completable while in the timeout cancels the forceful shutdown.
         closeAsyncGracefully(serverContext(), 1000, SECONDS).afterOnSubscribe(Cancellable::cancel).subscribe();
 
-        assertThat(completableListenerRule.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(completableListenerRule.pollTerminal(10, MILLISECONDS), is(nullValue()));
 
         serverContext().closeAsync().toFuture().get();
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilterTest.java
@@ -56,6 +56,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -259,7 +260,7 @@ public class ProxyConnectConnectionFactoryFilterTest {
         subscribeToProxyConnectionFactory();
 
         Cancellable cancellable = subscriber.awaitSubscription();
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         assertThat(connectionClose.isSubscribed(), is(false));
         cancellable.cancel();
         assertConnectPayloadConsumed(true);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/ChannelSetTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/ChannelSetTest.java
@@ -48,7 +48,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/ChannelSetTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/ChannelSetTest.java
@@ -45,6 +45,9 @@ import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.transport.netty.internal.ChannelSet.CHANNEL_CLOSEABLE_KEY;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -118,9 +121,9 @@ public class ChannelSetTest {
         toSource(completable).subscribe(subscriber);
         verify(nettyConnection).closeAsyncGracefully();
         verify(channel, never()).close();
-        assertFalse(subscriber.pollTerminal(10, MILLISECONDS));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         closeAsyncGracefullyCompletable.onComplete();
-        assertFalse(subscriber.pollTerminal(10, MILLISECONDS));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         listener.operationComplete(channelCloseFuture);
         subscriber.awaitOnComplete();
     }
@@ -190,9 +193,9 @@ public class ChannelSetTest {
         toSource(gracefulCompletable2).subscribe(subscriber2);
         verify(nettyConnection, times(1)).closeAsyncGracefully();
 
-        assertFalse(subscriber.pollTerminal(10, MILLISECONDS));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         closeAsyncGracefullyCompletable.onComplete();
-        assertFalse(subscriber.pollTerminal(10, MILLISECONDS));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
 
         listener.operationComplete(channelCloseFuture);
 

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
@@ -143,7 +143,7 @@ public class DefaultNettyConnectionTest {
     @Test
     public void testConcurrentWritePubAndPub() {
         toSource(conn.write(Publisher.never())).subscribe(writeListener);
-        assertThat(writeListener.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(writeListener.pollTerminal(10, MILLISECONDS), is(nullValue()));
         toSource(conn.write(Publisher.never())).subscribe(secondWriteListener);
         assertThat(secondWriteListener.awaitOnError(), instanceOf(IllegalStateException.class));
     }
@@ -225,7 +225,7 @@ public class DefaultNettyConnectionTest {
         Buffer expected = allocator.fromAscii("data");
         channel.writeInbound(expected.duplicate());
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(1);
         assertThat(subscriber.takeOnNext(), is(expected));
         subscriber.awaitOnComplete();

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/FlushTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/FlushTest.java
@@ -88,7 +88,7 @@ public class FlushTest extends AbstractFlushTest {
         verify(channel).eventLoop();
         verifyZeroInteractions(channel);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
 
         assertTrue(subscription.isCancelled());
         strategy.verifyWriteCancelled();

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherTest.java
@@ -61,6 +61,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -436,13 +437,13 @@ public class NettyChannelPublisherTest {
         toSource(publisher).subscribe(subscriber2);
         subscriber2.awaitSubscription();
         assertThat(subscriber2.pollAllOnNext(), hasSize(0));
-        assertThat(subscriber2.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber2.pollTerminal(10, MILLISECONDS), is(nullValue()));
 
         firstSubscription.request(3);
 
         subscriber2.awaitSubscription();
         assertThat(subscriber2.pollAllOnNext(), hasSize(0));
-        assertThat(subscriber2.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriber2.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber2.awaitSubscription().request(1);
         assertThat(subscriber2.takeOnNext(), is(2));
         subscriber2.awaitOnComplete();

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyServerContextTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyServerContextTest.java
@@ -46,6 +46,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -153,7 +154,7 @@ public class NettyServerContextTest {
         channelSetCloseAsyncGracefulCompletable.verifyListenNotCalled();
 
         toSource(fixture.onClose()).subscribe(subscriberRule);
-        assertThat(subscriberRule.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriberRule.pollTerminal(10, MILLISECONDS), is(nullValue()));
 
         channelSetCloseAsyncCompletable.onComplete();
         subscriberRule.awaitOnComplete();
@@ -174,7 +175,7 @@ public class NettyServerContextTest {
         channelSetCloseAsyncCompletable.verifyListenNotCalled();
 
         toSource(fixture.onClose()).subscribe(subscriberRule);
-        assertThat(subscriberRule.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriberRule.pollTerminal(10, MILLISECONDS), is(nullValue()));
 
         channelSetCloseAsyncGracefulCompletable.onComplete();
         subscriberRule.awaitOnComplete();
@@ -203,7 +204,7 @@ public class NettyServerContextTest {
         channelSetCloseAsyncGracefulCompletable.verifyListenNotCalled();
 
         toSource(fixture.onClose()).subscribe(subscriberRule);
-        assertThat(subscriberRule.pollTerminal(10, MILLISECONDS), is(false));
+        assertThat(subscriberRule.pollTerminal(10, MILLISECONDS), is(nullValue()));
 
         channelSetCloseAsyncCompletable.onComplete();
         subscriberRule.awaitOnComplete();


### PR DESCRIPTION
Motivation:
TestPublisherSubscriber supports some consumers which can be tested via
other means. TestPublisherSubscriber#pollTerminal doesn't inform the
caller as to which terminal event has arrived, and there are only
blocking alternatives to get the terminal event, so if you call the
wrong method you may block indefinitely.

Modifications:
- Remove onSubscribe and onNext Consumers
- Change the return type of TestPublisherSubscriber#pollTerminal so the
caller knows which type of terminal was processed
- Change the pollOnNext to avoid a null Optional value which is
generally discouraged, and make the API more inline with pollTerminal

Result:
TestPublisherSubscriber has smaller API surface and poll methods provide
results in a more consistent fashion.