### PR TITLE
Jersey to return 400 response for invalid URI

### DIFF
--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultJerseyStreamingHttpRouter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultJerseyStreamingHttpRouter.java
@@ -212,7 +212,7 @@ final class DefaultJerseyStreamingHttpRouter implements StreamingHttpService {
         try {
             baseURI = URI.create(baseUri.toString());
             requestURI = URI.create(requestUriBuilder.toString());
-        } catch (Throwable cause) {
+        } catch (IllegalArgumentException cause) {
             Buffer message = serviceCtx.executionContext().bufferAllocator().fromAscii(cause.getMessage());
             StreamingHttpResponse response = factory.badRequest().payloadBody(from(message));
             response.headers().add(CONTENT_LENGTH, Integer.toString(message.readableBytes()));

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractNonParameterizedJerseyStreamingHttpServiceTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractNonParameterizedJerseyStreamingHttpServiceTest.java
@@ -30,7 +30,6 @@ import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.netty.HttpClients;
 import io.servicetalk.http.netty.HttpServers;
-import io.servicetalk.http.utils.RequestTargetEncoderHttpServiceFilter;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.ExecutionContextRule;
@@ -138,7 +137,6 @@ public abstract class AbstractNonParameterizedJerseyStreamingHttpServiceTest {
                 String.class).toLowerCase().contains("servicetalk");
 
         HttpServerBuilder httpServerBuilder = serverBuilder
-                .appendServiceFilter(new RequestTargetEncoderHttpServiceFilter())
                 .ioExecutor(SERVER_CTX.ioExecutor())
                 .bufferAllocator(SERVER_CTX.bufferAllocator());
 

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/SynchronousResourceTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/SynchronousResourceTest.java
@@ -23,6 +23,7 @@ import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_JSON;
 import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_0;
 import static io.servicetalk.http.api.HttpResponseStatus.ACCEPTED;
+import static io.servicetalk.http.api.HttpResponseStatus.BAD_REQUEST;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpResponseStatus.PARTIAL_CONTENT;
 import static io.servicetalk.http.router.jersey.TestUtils.newLargePayload;
@@ -48,7 +49,8 @@ public class SynchronousResourceTest extends AbstractResourceTest {
 
     @Test
     public void queryParameterAreEncoded() {
-        sendAndAssertResponse(get("/uris/relative?script=<foo;-/?:@=+$>"), OK, TEXT_PLAIN, "/async/text");
+        sendAndAssertResponse(get("/uris/relative?script=<foo;-/?:@=+$>"), BAD_REQUEST, TEXT_PLAIN,
+            "Illegal character in query at index 49: http://" + host() + "/sync/uris/relative?script=<foo;-/?:@=+$>");
     }
 
     @Test


### PR DESCRIPTION
Motivation:
DefaultJerseyStreamingHttpRouter must create two URI objects in order to
initialize Jersey's ContainerRequest object. URI creation will also do
validation, and may throw. In this case we should return a 400 response
instead of a 500 internal server error.

Modifications:
- DefaultJerseyStreamingHttpRouter to try/catch creation of URIs and
return a 400 if an exception is thrown.

Result:
More correct error returned in the event of invalid URI when using
Jersey.