### PR TITLE
[Retry|Repeat]Strategies add deprecated methods to temporarily avoid …

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
@@ -56,6 +56,103 @@ public final class RepeatStrategies {
 
     /**
      * Creates a new repeat function that adds the passed constant {@link Duration} as delay between repeats.
+     * <p>
+     * @deprecated Use one of the following methods that employ Jitter:
+     * <ul>
+     *     <li>{@link #repeatWithConstantBackoffFullJitter(int, Duration, Executor)} </li>
+     *     <li>{@link #repeatWithConstantBackoffDeltaJitter(int, Duration, Duration, Executor)}</li>
+     * </ul>
+     * @param maxRepeats Maximum number of allowed repeats, after which the returned {@link IntFunction} will return
+     *                   a failed {@link Completable} with {@link TerminateRepeatException} as the cause.
+     * @param backoff Constant {@link Duration} of backoff between repeats.
+     * @param timerExecutor {@link Executor} to be used to schedule timers for backoff.
+     * @return An {@link IntFunction} to be used for repeats which given a repeat count returns a {@link Completable}
+     * that terminates successfully when the source has to be repeated or terminates with error if the source should not
+     * be repeated.
+     */
+    @Deprecated
+    public static IntFunction<Completable> repeatWithConstantBackoff(final int maxRepeats, final Duration backoff,
+                                                                     final Executor timerExecutor) {
+        requireNonNull(timerExecutor);
+        final long backoffNanos = backoff.toNanos();
+        return repeatCount -> {
+            if (repeatCount > maxRepeats) {
+                return terminateRepeat();
+            }
+            return timerExecutor.timer(backoffNanos, NANOSECONDS);
+        };
+    }
+
+    /**
+     * Creates a new repeat function that adds a delay between repeats. For first repeat, the delay is
+     * {@code initialDelay} which is increased exponentially for subsequent repeats. <p>
+     * This method may not attempt to check for overflow if the repeat count is high enough that an exponential
+     * delay causes {@link Long} overflow.
+     * <p>
+     * @deprecated Use one of the following methods that employ Jitter:
+     * <ul>
+     *     <li>{@link #repeatWithExponentialBackoffFullJitter(int, Duration, Duration, Executor)}</li>
+     *     <li>{@link #repeatWithExponentialBackoffDeltaJitter(int, Duration, Duration, Duration, Executor)}</li>
+     * </ul>
+     * @param maxRepeats Maximum number of allowed repeats, after which the returned {@link IntFunction} will return
+     * a failed {@link Completable} with {@link TerminateRepeatException} as the cause.
+     * @param initialDelay Delay {@link Duration} for the first repeat and increased exponentially with each repeat.
+     * @param timerExecutor {@link Executor} to be used to schedule timers for backoff.
+     * @return An {@link IntFunction} to be used for repeats which given a repeat count returns a {@link Completable}
+     * that terminates successfully when the source has to be repeated or terminates with error if the source should not
+     * be repeated.
+     */
+    @Deprecated
+    public static IntFunction<Completable> repeatWithExponentialBackoff(final int maxRepeats,
+                                                                        final Duration initialDelay,
+                                                                        final Executor timerExecutor) {
+        requireNonNull(timerExecutor);
+        final long initialDelayNanos = initialDelay.toNanos();
+        return repeatCount -> {
+            if (repeatCount > maxRepeats) {
+                return terminateRepeat();
+            }
+            return timerExecutor.timer(initialDelayNanos << (repeatCount - 1), NANOSECONDS);
+        };
+    }
+
+    /**
+     * Creates a new repeat function that adds a delay between repeats. For first repeat, the delay is
+     * {@code initialDelay} which is increased exponentially for subsequent repeats.
+     * This additionally adds a "Full Jitter" for the backoff as described
+     * <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/">here</a>.<p>
+     * This method may not attempt to check for overflow if the repeat count is high enough that an exponential delay
+     * causes {@link Long} overflow.
+     * <p>
+     * @deprecated Use one of the following methods that employ Jitter:
+     * <ul>
+     *     <li>{@link #repeatWithExponentialBackoffFullJitter(int, Duration, Duration, Executor)}</li>
+     *     <li>{@link #repeatWithExponentialBackoffDeltaJitter(int, Duration, Duration, Duration, Executor)}</li>
+     * </ul>
+     * @param maxRepeats Maximum number of allowed repeats, after which the returned {@link IntFunction} will return
+     *                   a failed {@link Completable} with {@link TerminateRepeatException} as the cause.
+     * @param initialDelay Delay {@link Duration} for the first repeat and increased exponentially with each repeat.
+     * @param timerExecutor {@link Executor} to be used to schedule timers for backoff.
+     * @return An {@link IntFunction} to be used for repeats which given a repeat count returns a {@link Completable}
+     * that terminates successfully when the source has to be repeated or terminates with error if the source should not
+     * be repeated.
+     */
+    @Deprecated
+    public static IntFunction<Completable> repeatWithExponentialBackoffAndJitter(final int maxRepeats,
+                                                                                 final Duration initialDelay,
+                                                                                 final Executor timerExecutor) {
+        requireNonNull(timerExecutor);
+        final long initialDelayNanos = initialDelay.toNanos();
+        return repeatCount -> {
+            if (repeatCount > maxRepeats) {
+                return terminateRepeat();
+            }
+            return timerExecutor.timer(current().nextLong(0, initialDelayNanos << (repeatCount - 1)), NANOSECONDS);
+        };
+    }
+
+    /**
+     * Creates a new repeat function that adds the passed constant {@link Duration} as delay between repeats.
      *
      * @param delay Constant {@link Duration} of delay between repeats.
      * @param timerExecutor {@link Executor} to be used to schedule timers for delay.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetryStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetryStrategies.java
@@ -39,6 +39,157 @@ public final class RetryStrategies {
 
     /**
      * Creates a new retry function that adds the passed constant {@link Duration} as a delay between retries.
+     * <p>
+     * @deprecated Use one of the following methods that employ Jitter:
+     * <ul>
+     *     <li>{@link #retryWithConstantBackoffFullJitter(int, Predicate, Duration, Executor)}</li>
+     *     <li>{@link #retryWithConstantBackoffDeltaJitter(int, Predicate, Duration, Duration, Executor)}</li>
+     * </ul>
+     * @param maxRetries Maximum number of allowed retries, after which the returned {@link BiIntFunction} will return
+     * a failed {@link Completable} with the passed {@link Throwable} as the cause
+     * @param causeFilter A {@link Predicate} that selects whether a {@link Throwable} cause should be retried
+     * @param delay Constant {@link Duration} of delay between retries
+     * @param timerExecutor {@link Executor} to be used to schedule timers for backoff
+     * @return A {@link BiIntFunction} to be used for retries which given a retry count and a {@link Throwable} returns
+     * a {@link Completable} that terminates successfully when the source has to be retried or terminates with error
+     * if the source should not be retried for the passed {@link Throwable}
+     */
+    @Deprecated
+    public static BiIntFunction<Throwable, Completable> retryWithConstantBackoff(final int maxRetries,
+                                                                                 final Predicate<Throwable> causeFilter,
+                                                                                 final Duration delay,
+                                                                                 final Executor timerExecutor) {
+        checkMaxRetries(maxRetries);
+        requireNonNull(timerExecutor);
+        requireNonNull(causeFilter);
+        final long delayNanos = delay.toNanos();
+        return (retryCount, cause) -> {
+            if (retryCount > maxRetries || !causeFilter.test(cause)) {
+                return failed(cause);
+            }
+            return timerExecutor.timer(delayNanos, NANOSECONDS);
+        };
+    }
+
+    /**
+     * Creates a new retry function that adds the passed constant {@link Duration} as a delay between retries.
+     * This additionally adds a "Full Jitter" for the backoff as described
+     * <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/">here</a>.
+     * <p>
+     * @deprecated Use one of the following methods that employ Jitter:
+     * <ul>
+     *     <li>{@link #retryWithConstantBackoffFullJitter(int, Predicate, Duration, Executor)}</li>
+     *     <li>{@link #retryWithConstantBackoffDeltaJitter(int, Predicate, Duration, Duration, Executor)}</li>
+     * </ul>
+     * @param maxRetries Maximum number of allowed retries, after which the returned {@link BiIntFunction} will return
+     * a failed {@link Completable} with the passed {@link Throwable} as the cause
+     * @param causeFilter A {@link Predicate} that selects whether a {@link Throwable} cause should be retried
+     * @param delay Constant {@link Duration} of delay between retries
+     * @param timerExecutor {@link Executor} to be used to schedule timers for backoff
+     * @return A {@link BiIntFunction} to be used for retries which given a retry count and a {@link Throwable} returns
+     * a {@link Completable} that terminates successfully when the source has to be retried or terminates with error
+     * if the source should not be retried for the passed {@link Throwable}
+     */
+    @Deprecated
+    public static BiIntFunction<Throwable, Completable> retryWithConstantBackoffAndJitter(
+            final int maxRetries,
+            final Predicate<Throwable> causeFilter,
+            final Duration delay,
+            final Executor timerExecutor) {
+        checkMaxRetries(maxRetries);
+        requireNonNull(timerExecutor);
+        requireNonNull(causeFilter);
+        final long delayNanos = delay.toNanos();
+        return (retryCount, cause) -> {
+            if (retryCount > maxRetries || !causeFilter.test(cause)) {
+                return failed(cause);
+            }
+            return timerExecutor.timer(current().nextLong(0, delayNanos), NANOSECONDS);
+        };
+    }
+
+    /**
+     * Creates a new retry function that adds a delay between retries. For first retry, the delay is
+     * {@code initialDelay} which is increased exponentially for subsequent retries.
+     * <p>
+     * This method may not attempt to check for overflow if the retry count is high enough that an exponential delay
+     * causes {@link Long} overflow.
+     * <p>
+     * @deprecated Use one of the following methods that employ Jitter:
+     * <ul>
+     *  <li>{@link #retryWithExponentialBackoffFullJitter(int, Predicate, Duration, Duration, Executor)} </li>
+     *  <li>{@link #retryWithExponentialBackoffDeltaJitter(int, Predicate, Duration, Duration, Duration, Executor)}</li>
+     * </ul>
+     * @param maxRetries Maximum number of allowed retries, after which the returned {@link BiIntFunction} will return
+     * a failed {@link Completable} with the passed {@link Throwable} as the cause
+     * @param causeFilter A {@link Predicate} that selects whether a {@link Throwable} cause should be retried
+     * @param initialDelay Delay {@link Duration} for the first retry and increased exponentially with each retry
+     * @param timerExecutor {@link Executor} to be used to schedule timers for backoff
+     * @return A {@link BiIntFunction} to be used for retries which given a retry count and a {@link Throwable} returns
+     * a {@link Completable} that terminates successfully when the source has to be retried or terminates with error
+     * if the source should not be retried for the passed {@link Throwable}
+     */
+    @Deprecated
+    public static BiIntFunction<Throwable, Completable> retryWithExponentialBackoff(
+            final int maxRetries,
+            final Predicate<Throwable> causeFilter,
+            final Duration initialDelay,
+            final Executor timerExecutor) {
+        checkMaxRetries(maxRetries);
+        requireNonNull(timerExecutor);
+        requireNonNull(causeFilter);
+        final long initialDelayNanos = initialDelay.toNanos();
+        return (retryCount, cause) -> {
+            if (retryCount > maxRetries || !causeFilter.test(cause)) {
+                return failed(cause);
+            }
+            return timerExecutor.timer(initialDelayNanos << (retryCount - 1), NANOSECONDS);
+        };
+    }
+
+    /**
+     * Creates a new retry function that adds a delay between retries. For first retry, the delay is
+     * {@code initialDelay} which is increased exponentially for subsequent retries.
+     * This additionally adds a "Full Jitter" for the backoff as described
+     * <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/">here</a>.
+     * <p>
+     * This method may not attempt to check for overflow if the retry count is high enough that an exponential delay
+     * causes {@link Long} overflow.
+     * <p>
+     * @deprecated Use one of the following methods that employ Jitter:
+     * <ul>
+     *  <li>{@link #retryWithExponentialBackoffFullJitter(int, Predicate, Duration, Duration, Executor)} </li>
+     *  <li>{@link #retryWithExponentialBackoffDeltaJitter(int, Predicate, Duration, Duration, Duration, Executor)}</li>
+     * </ul>
+     * @param maxRetries Maximum number of allowed retries, after which the returned {@link BiIntFunction} will return
+     * a failed {@link Completable} with the passed {@link Throwable} as the cause
+     * @param causeFilter A {@link Predicate} that selects whether a {@link Throwable} cause should be retried
+     * @param initialDelay Delay {@link Duration} for the first retry and increased exponentially with each retry
+     * @param timerExecutor {@link Executor} to be used to schedule timers for backoff
+     * @return A {@link BiIntFunction} to be used for retries which given a retry count and a {@link Throwable} returns
+     * a {@link Completable} that terminates successfully when the source has to be retried or terminates with error
+     * if the source should not be retried for the passed {@link Throwable}
+     */
+    @Deprecated
+    public static BiIntFunction<Throwable, Completable> retryWithExponentialBackoffAndJitter(
+            final int maxRetries,
+            final Predicate<Throwable> causeFilter,
+            final Duration initialDelay,
+            final Executor timerExecutor) {
+        checkMaxRetries(maxRetries);
+        requireNonNull(timerExecutor);
+        requireNonNull(causeFilter);
+        final long initialDelayNanos = initialDelay.toNanos();
+        return (retryCount, cause) -> {
+            if (retryCount > maxRetries || !causeFilter.test(cause)) {
+                return failed(cause);
+            }
+            return timerExecutor.timer(current().nextLong(0, initialDelayNanos << (retryCount - 1)), NANOSECONDS);
+        };
+    }
+
+    /**
+     * Creates a new retry function that adds the passed constant {@link Duration} as a delay between retries.
      * This additionally adds a "Full Jitter" for the backoff as described
      * <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter">here</a>.
      * @param maxRetries Maximum number of allowed retries, after which the returned {@link BiIntFunction} will return


### PR DESCRIPTION
…API breakage introduced by f30df63215c9056f4568ac974663797c04e220d6

Motivation:
f30df63215c9056f4568ac974663797c04e220d6 removed methods from
[Retry|Repeat]Strategies due to being not recommended for general use
and replaced by more descriptive methods. However breaking APIs without
deprecating for a release makes it more challenging to update.

Modifications:
- Add back methods in [Retry|Repeat]Strategies that were removed in
f30df63215c9056f4568ac974663797c04e220d6

Result:
Deprecated methods exist for a release to ease upgrade path for users.