### PR TITLE
Include `netty-resolver-dns-native-macos` dependency by default

### DIFF
--- a/servicetalk-client-api/docs/modules/ROOT/pages/service-discovery.adoc
+++ b/servicetalk-client-api/docs/modules/ROOT/pages/service-discovery.adoc
@@ -67,6 +67,7 @@ configured when users create a _Client_ instance.
 
 This implementation is backed by `io.netty:netty-resolver-dns` and provides non-blocking DNS resolutions.
 
-IMPORTANT: _macOS_ users may experience problems with resolving host addresses in certain environments. In this case,
-users need to add the additional dependency on the classpath which will ensure the right nameservers are selected when
-running on macOS: `io.netty:netty-resolver-dns-native-macos:$nettyVersion:osx-x86_64`.
+NOTE: By default, ServiceTalk implementation adds `io.netty:netty-resolver-dns-native-macos:$nettyVersion:osx-x86_64`
+dependency to support native _macOS_ API for retrieving the current nameserver configuration of the system. Users who
+never use _macOS_ may safely exclude this dependency from the classpath. _macOS_ users may experience problems with
+resolving host addresses in certain environments without this dependency.

--- a/servicetalk-dns-discovery-netty/build.gradle
+++ b/servicetalk-dns-discovery-netty/build.gradle
@@ -29,7 +29,7 @@ dependencies {
   implementation "io.netty:netty-resolver-dns:$nettyVersion"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
-  runtime "io.netty:netty-resolver-dns-native-macos:$nettyVersion:osx-x86_64"
+  runtimeOnly "io.netty:netty-resolver-dns-native-macos:$nettyVersion:osx-x86_64"
 
   testImplementation testFixtures(project(":servicetalk-client-api-internal"))
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))

--- a/servicetalk-dns-discovery-netty/build.gradle
+++ b/servicetalk-dns-discovery-netty/build.gradle
@@ -29,6 +29,8 @@ dependencies {
   implementation "io.netty:netty-resolver-dns:$nettyVersion"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
+  runtime "io.netty:netty-resolver-dns-native-macos:$nettyVersion:osx-x86_64"
+
   testImplementation testFixtures(project(":servicetalk-client-api-internal"))
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))


### PR DESCRIPTION
Motivation:

`macOS` users frequently experience problems with DNS resolutions without
this dependency. Those problems are hard to debug and understand without
knowing implementation details of netty's DNS codec. We can safely include
it by default, because the load of its classes is performed only on `macOS`
platform.

Modifications:

- Include `netty-resolver-dns-native-macos` dependency in `runtimeOnly`
classpath;
- Update `service-discovery.adoc`;

Result:

`macOS` users have correct DNS setup by default.