### PR TITLE
Add Publisher#completableOrError operator

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPubToCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPubToCompletable.java
@@ -69,12 +69,12 @@ abstract class AbstractPubToCompletable<T> extends AbstractNoHandleSubscribeComp
         }
 
         @Override
-        public final void onError(final Throwable t) {
+        public void onError(final Throwable t) {
             subscriber.onError(t);
         }
 
         @Override
-        public final void onComplete() {
+        public void onComplete() {
             subscriber.onComplete();
         }
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PubCompletableOrError.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PubCompletableOrError.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.PublisherSource;
+
+import javax.annotation.Nullable;
+
+final class PubCompletableOrError<T> extends AbstractPubToCompletable<T> {
+    PubCompletableOrError(Publisher<T> source) {
+        super(source);
+    }
+
+    @Override
+    PublisherSource.Subscriber<T> newSubscriber(Subscriber original) {
+        return new PubToCompletableOrErrorSubscriber<>(original);
+    }
+
+    private static final class PubToCompletableOrErrorSubscriber<T> extends AbstractPubToCompletableSubscriber<T> {
+        PubToCompletableOrErrorSubscriber(final Subscriber subscriber) {
+            super(subscriber);
+        }
+
+        @Override
+        public void onNext(@Nullable final T t) {
+            throw new IllegalArgumentException("No onNext signals expected, but got: " + t);
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PubToCompletableIgnore.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PubToCompletableIgnore.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.PublisherSource;
+
+import javax.annotation.Nullable;
+
+/**
+ * A {@link Completable} created from a {@link Publisher}.
+ *
+ * @param <T> Item type emitted from the original {@link Publisher}.
+ */
+final class PubToCompletableIgnore<T> extends AbstractPubToCompletable<T> {
+    /**
+     * New instance.
+     *
+     * @param source {@link Publisher} from which this {@link Completable} is created.
+     */
+    PubToCompletableIgnore(Publisher<T> source) {
+        super(source);
+    }
+
+    @Override
+    PublisherSource.Subscriber<T> newSubscriber(Subscriber original) {
+        return new PubToCompletableIgnoreSubscriber<>(original);
+    }
+
+    private static final class PubToCompletableIgnoreSubscriber<T> extends AbstractPubToCompletableSubscriber<T> {
+        PubToCompletableIgnoreSubscriber(final Subscriber subscriber) {
+            super(subscriber);
+        }
+
+        @Override
+        public void onNext(@Nullable final T t) {
+            // Ignore elements
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2498,7 +2498,18 @@ public abstract class Publisher<T> {
      *     ReactiveX ignoreElements operator.</a>
      */
     public final Completable ignoreElements() {
-        return new PubToCompletable<>(this);
+        return new PubToCompletableIgnore<>(this);
+    }
+
+    /**
+     * Converts this {@link Publisher} to a {@link Completable}. If this {@link Publisher} emits any
+     * {@link Subscriber#onNext(Object)} signals the resulting {@link Completable} will be terminated with a
+     * {@link IllegalArgumentException}.
+     * @return A {@link Completable} that mirrors the terminal signal from this {@code Publisher}, and terminates in
+     * error if an {@link Subscriber#onNext(Object)} signals.
+     */
+    public final Completable completableOrError() {
+        return new PubCompletableOrError<>(this);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubCompletableOrErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubCompletableOrErrorTest.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.concurrent.api.publisher;
 
+import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
@@ -30,6 +31,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class PubCompletableOrErrorTest {
     @Rule
@@ -49,8 +51,18 @@ public class PubCompletableOrErrorTest {
     }
 
     @Test
-    public void onElementAlwaysFails() {
+    public void oneElementsAlwaysFails() {
         toSource(from("foo").completableOrError()).subscribe(subscriber);
+        assertThat(subscriber.awaitOnError(), instanceOf(IllegalArgumentException.class));
+    }
+
+    @Test
+    public void twoElementsAlwaysFails() {
+        // Use TestPublisher to force deliver two items, and verify the operator doesn't duplicate terminate.
+        TestPublisher<String> publisher = new TestPublisher<>();
+        toSource(publisher.completableOrError()).subscribe(subscriber);
+        assertTrue(publisher.isSubscribed());
+        publisher.onNext("foo", "bar");
         assertThat(subscriber.awaitOnError(), instanceOf(IllegalArgumentException.class));
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubCompletableOrErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubCompletableOrErrorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api.publisher;
+
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import static io.servicetalk.concurrent.api.Publisher.empty;
+import static io.servicetalk.concurrent.api.Publisher.failed;
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertSame;
+
+public class PubCompletableOrErrorTest {
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+    private final TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
+
+    @Test
+    public void noElementsCompleted() {
+        toSource(empty().completableOrError()).subscribe(subscriber);
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    public void noElementsError() {
+        toSource(failed(DELIBERATE_EXCEPTION).completableOrError()).subscribe(subscriber);
+        assertSame(DELIBERATE_EXCEPTION, subscriber.awaitOnError());
+    }
+
+    @Test
+    public void onElementAlwaysFails() {
+        toSource(from("foo").completableOrError()).subscribe(subscriber);
+        assertThat(subscriber.awaitOnError(), instanceOf(IllegalArgumentException.class));
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToCompletableIgnoreTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToCompletableIgnoreTest.java
@@ -39,7 +39,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-public class PubToCompletableTest {
+public class PubToCompletableIgnoreTest {
     @Rule
     public final Timeout timeout = new ServiceTalkTestTimeout();
     @Rule


### PR DESCRIPTION
Motivation:
We have Publisher#ignoreElements which ignores any onNext signals
emitted from the Publisher. However there are use cases where the
conversion should be more strict and fail if there are any onNext
signals.

Modifications:
- Add Publisher#completableOrError method to do a strict conversion.
Share code with Publisher#ignoreElements operator.

Result:
Operator exists which does a strict conversion from Publisher to
Completable.