### PR TITLE
Relax can-add-content-length check

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
@@ -38,7 +38,6 @@ import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
 import static io.servicetalk.http.api.HttpApiConversions.isSafeToAggregate;
 import static io.servicetalk.http.api.HttpApiConversions.mayHaveTrailers;
-import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
@@ -113,9 +112,7 @@ final class HeaderUtils {
     }
 
     private static boolean canAddContentLength(final HttpMetaData metadata) {
-        // TODO once this bug is addressed (https://github.com/apple/servicetalk/pull/1213)
-        // we should relax the check here, remove content-encoding clause
-        return !hasContentHeaders(metadata.headers()) && !hasContentEncoding(metadata.headers()) &&
+        return !hasContentHeaders(metadata.headers()) &&
                 isSafeToAggregate(metadata) && !mayHaveTrailers(metadata);
     }
 
@@ -234,10 +231,6 @@ final class HeaderUtils {
 
     private static boolean hasContentHeaders(final HttpHeaders headers) {
         return headers.contains(CONTENT_LENGTH) || isTransferEncodingChunked(headers);
-    }
-
-    private static boolean hasContentEncoding(final HttpHeaders headers) {
-        return headers.contains(CONTENT_ENCODING);
     }
 
     private static boolean isEmptyConnectResponse(final HttpRequestMethod requestMethod, final int statusCode) {


### PR DESCRIPTION
Motivation:

The additional content-type check in`canAddContentLength`, was added due to a bug, addressed [here](**url**)  

Modifications:

Removed the additional check

Result:

Behavior restored as pre http compression feature.
