### PR TITLE
Fix incorrect numbers reported by `DnsResolutionObserver#resolutionCompleted`

### DIFF
--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ServiceDiscovererUtils.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ServiceDiscovererUtils.java
@@ -61,17 +61,19 @@ public final class ServiceDiscovererUtils {
         // Calculate additions (in newAddresses, not in activeAddresses).
         List<ServiceDiscovererEvent<T>> availableEvents =
                 relativeComplement(true, currentActiveAddresses, newActiveAddresses, comparator, null);
+        // Store nAvailable now because the List may be updated on the next step.
+        final int nAvailable = availableEvents == null ? 0 : availableEvents.size();
         // Calculate removals (in activeAddresses, not in newAddresses).
         List<ServiceDiscovererEvent<T>> allEvents =
                 relativeComplement(false, newActiveAddresses, currentActiveAddresses, comparator, availableEvents);
 
-        reportEvents(reporter, allEvents, availableEvents);
+        reportEvents(reporter, allEvents, nAvailable);
         return allEvents;
     }
 
     private static <T> void reportEvents(@Nullable final TwoIntsConsumer reporter,
                                          @Nullable final List<ServiceDiscovererEvent<T>> allEvents,
-                                         @Nullable final List<ServiceDiscovererEvent<T>> availableEvents) {
+                                         final int nAvailable) {
         if (reporter == null) {
             return;
         }
@@ -79,8 +81,7 @@ public final class ServiceDiscovererUtils {
             reporter.accept(0, 0);
             return;
         }
-        final int available = availableEvents == null ? 0 : availableEvents.size();
-        reporter.accept(available, allEvents.size() - available);
+        reporter.accept(nAvailable, allEvents.size() - nAvailable);
     }
 
     /**

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserver.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserver.java
@@ -88,16 +88,16 @@ public interface DnsServiceDiscovererObserver {
         int ttl();
 
         /**
-         * Number of records that are {@link ServiceDiscovererEvent#isAvailable() available}.
+         * Number of resolved records that became {@link ServiceDiscovererEvent#isAvailable() available}.
          *
-         * @return the number of records that are {@link ServiceDiscovererEvent#isAvailable() available}
+         * @return the number of resolved records that became {@link ServiceDiscovererEvent#isAvailable() available}
          */
         int nAvailable();
 
         /**
-         * Number of records that are {@link ServiceDiscovererEvent#isAvailable() unavailable}.
+         * Number of resolved records that became {@link ServiceDiscovererEvent#isAvailable() unavailable}.
          *
-         * @return the number of records that are {@link ServiceDiscovererEvent#isAvailable() unavailable}
+         * @return the number of resolved records that became {@link ServiceDiscovererEvent#isAvailable() unavailable}
          */
         int nUnavailable();
     }

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/TestRecordStore.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/TestRecordStore.java
@@ -74,6 +74,10 @@ final class TestRecordStore implements RecordStore {
         return removeAddresses(domain, A, ttl, ipAddresses);
     }
 
+    public synchronized boolean removeIPv4Addresses(final String domain) {
+        return removeAddresses(domain, A);
+    }
+
     public synchronized void addIPv6Address(final String domain, final int ttl, final String... ipAddresses) {
         addAddress(domain, AAAA, ttl, ipAddresses);
     }
@@ -120,6 +124,17 @@ final class TestRecordStore implements RecordStore {
         for (String ipAddress : ipAddresses) {
             recordList.add(createAddressRecord(domain, recordType, ttl, ipAddress));
         }
+    }
+
+    private boolean removeAddresses(final String domain, final RecordType recordType) {
+        Map<RecordType, List<ResourceRecord>> typeMap = getTypeMap(domain);
+        boolean removed = typeMap.remove(recordType) != null;
+        List<ResourceRecord> recordList = getRecordList(typeMap, recordType);
+        recordList.clear();
+        if (removed && typeMap.isEmpty()) {
+            recordsToReturnByDomain.remove(domain, typeMap);
+        }
+        return removed;
     }
 
     private boolean removeAddresses(final String domain, final RecordType recordType, final int ttl,


### PR DESCRIPTION
Motivation:

`DnsResolutionObserver#resolutionCompleted` returns incorrect numbers for
`ResolutionResult` when some addresses become unavailable.

Modifications:

- Fix metrics bug in `ServiceDiscovererUtils.calculateDifference`;
- Add tests to verify we correctly report numbers when DNS returns different
resolution updates;
- Use `BlockingQueue` instead of `List` in `DnsServiceDiscovererObserverTest`;

Result:

`DnsResolutionObserver#resolutionCompleted` correctly reports number of
available and unavailable records.