### PR TITLE
Github Actions PRB, use pull_request_target event

### DIFF
--- a/.github/workflows/prb.yml
+++ b/.github/workflows/prb.yml
@@ -1,6 +1,6 @@
 name: Pull Request Builder
 on:
-  pull_request:
+  pull_request_target:
     branches: [ main ]
 jobs:
   build:


### PR DESCRIPTION
Motivation:
For the pull_request event the permissions for the GITHUB_TOKEN in
forked repositories is read-only. This means that pull requests from
forks will not be able to publish updates to the pull request. This
means that test results, checkstyle, and other reports will fail to
publish on pull requests, making debugging more difficult.

Modifications:
- use pull_request_target [3] instead of pull_request.

Result:
PRs from forks will be able to publish test results, checkstyle, and
other quality reports.

[1] https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request
[2] https://docs.github.com/en/free-pro-team@latest/actions/configuring-and-managing-workflows/authenticating-with-the-github_token
[3] https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target