### PR TITLE
Github Actions CI, 3rd party action dependencies to use SHA instead o…

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -36,28 +36,32 @@ jobs:
         run: ./gradlew --parallel --max-workers=4 -PreleaseBuild=true clean check && ./gradlew -PreleaseBuild=true publish
       - name: Publish Test Results
         if: ${{ always() }}
-        uses: scacap/action-surefire-report@v1
+        # v1.0.5
+        uses: scacap/action-surefire-report@ad808943e6bfbd2e6acba7c53fdb5c89534da533
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/test/TEST-*.xml'
           check_name: Test Report
       - name: Publish Checkstyle Report
         if: ${{ always() }}
-        uses: jwgmeligmeyling/checkstyle-github-action@v1.2
+        # v1.2
+        uses: jwgmeligmeyling/checkstyle-github-action@50292990e18466f2c5d95d04ff5fab931254fa5f
         with:
           name: Checkstyle Report
           path: '**/build/reports/checkstyle/*.xml'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish PMD Report
         if: ${{ always() }}
-        uses: jwgmeligmeyling/pmd-github-action@v1.2
+        # v1.2
+        uses: jwgmeligmeyling/pmd-github-action@322e346bd76a0757c4d54ff9209e245965aa066d
         with:
           name: PMD Report
           path: '**/build/reports/pmd/*.xml'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish SpotBugs Report
         if: ${{ always() }}
-        uses: jwgmeligmeyling/spotbugs-github-action@v1.2
+        # v1.2
+        uses: jwgmeligmeyling/spotbugs-github-action@b8e2c3523acb34c87f14e18cbcd2d87db8c8584e
         with:
           name: SpotBugs Report
           path: '**/build/reports/spotbugs/*.xml'

--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -36,28 +36,32 @@ jobs:
         run: ./gradlew --parallel --max-workers=4 clean check && ./gradlew publish
       - name: Publish Test Results
         if: ${{ always() }}
-        uses: scacap/action-surefire-report@v1
+        # v1.0.5
+        uses: scacap/action-surefire-report@ad808943e6bfbd2e6acba7c53fdb5c89534da533
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/test/TEST-*.xml'
           check_name: Test Report
       - name: Publish Checkstyle Report
         if: ${{ always() }}
-        uses: jwgmeligmeyling/checkstyle-github-action@v1.2
+        # v1.2
+        uses: jwgmeligmeyling/checkstyle-github-action@50292990e18466f2c5d95d04ff5fab931254fa5f
         with:
           name: Checkstyle Report
           path: '**/build/reports/checkstyle/*.xml'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish PMD Report
         if: ${{ always() }}
-        uses: jwgmeligmeyling/pmd-github-action@v1.2
+        # v1.2
+        uses: jwgmeligmeyling/pmd-github-action@322e346bd76a0757c4d54ff9209e245965aa066d
         with:
           name: PMD Report
           path: '**/build/reports/pmd/*.xml'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish SpotBugs Report
         if: ${{ always() }}
-        uses: jwgmeligmeyling/spotbugs-github-action@v1.2
+        # v1.2
+        uses: jwgmeligmeyling/spotbugs-github-action@b8e2c3523acb34c87f14e18cbcd2d87db8c8584e
         with:
           name: SpotBugs Report
           path: '**/build/reports/spotbugs/*.xml'

--- a/.github/workflows/prb.yml
+++ b/.github/workflows/prb.yml
@@ -34,10 +34,11 @@ jobs:
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
+      # https://github.community/t/error-the-paging-file-is-too-small-for-this-operation-to-complete/17141
       - name: Configure Windows Pagefile
         if: ${{ runner.os == 'Windows' }}
-        # https://github.community/t/error-the-paging-file-is-too-small-for-this-operation-to-complete/17141
-        uses: al-cheb/configure-pagefile-action@v1.2
+        # v1.2
+        uses: al-cheb/configure-pagefile-action@7e234852c937eea04d6ee627c599fb24a5bfffee
         with:
           minimum-size: 8GB
           maximum-size: 16GB
@@ -48,7 +49,8 @@ jobs:
         run: ./gradlew --parallel --max-workers=4 clean test
       - name: Publish Test Report
         if: ${{ always() }}
-        uses: scacap/action-surefire-report@v1
+        # v1.0.5
+        uses: scacap/action-surefire-report@ad808943e6bfbd2e6acba7c53fdb5c89534da533
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/test/TEST-*.xml'
@@ -83,21 +85,24 @@ jobs:
         run: ./gradlew --parallel --max-workers=4 clean quality
       - name: Publish Checkstyle Report
         if: ${{ always() }}
-        uses: jwgmeligmeyling/checkstyle-github-action@v1.2
+        # v1.2
+        uses: jwgmeligmeyling/checkstyle-github-action@50292990e18466f2c5d95d04ff5fab931254fa5f
         with:
           name: JDK ${{ matrix.java }} Checkstyle Report
           path: '**/build/reports/checkstyle/*.xml'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish PMD Report
         if: ${{ always() }}
-        uses: jwgmeligmeyling/pmd-github-action@v1.2
+        # v1.2
+        uses: jwgmeligmeyling/pmd-github-action@322e346bd76a0757c4d54ff9209e245965aa066d
         with:
           name: JDK ${{ matrix.java }} PMD Report
           path: '**/build/reports/pmd/*.xml'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish SpotBugs Report
         if: ${{ always() }}
-        uses: jwgmeligmeyling/spotbugs-github-action@v1.2
+        # v1.2
+        uses: jwgmeligmeyling/spotbugs-github-action@b8e2c3523acb34c87f14e18cbcd2d87db8c8584e
         with:
           name: JDK ${{ matrix.java }} SpotBugs Report
           path: '**/build/reports/spotbugs/*.xml'


### PR DESCRIPTION
…f implicit version

Motivation:
The code associated with version strings maybe modified, resulting in
unknown code running during builds/releases. Using an explicit SHA makes
the software being used much more explicit and very unlikely to change.