### PR TITLE
Remove deprecated methods effectivePort and effectiveHost from HttpRe…

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractDelegatingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractDelegatingHttpRequest.java
@@ -167,17 +167,6 @@ abstract class AbstractDelegatingHttpRequest implements PayloadInfo, HttpRequest
         return original.hasQueryParameter(key);
     }
 
-    @Override
-    @Nullable
-    public String effectiveHost() {
-        return original.effectiveHost();
-    }
-
-    @Override
-    public int effectivePort() {
-        return original.effectivePort();
-    }
-
     @Nullable
     @Override
     public HostAndPort effectiveHostAndPort() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMetaData.java
@@ -405,37 +405,6 @@ public interface HttpRequestMetaData extends HttpMetaData {
     boolean removeQueryParameters(String key, String value);
 
     /**
-     * The <a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">host component</a> derived
-     * from {@link #requestTarget()} and the {@code Host} header field value. This is the scheme component to use
-     * when computing an <a href="https://tools.ietf.org/html/rfc7230#section-5.5">effective request URI</a>.
-     * <p>
-     * @deprecated Use {@link #effectiveHostAndPort()}.
-     * @return The <a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">host component</a> derived
-     * from {@link #requestTarget()} and the {@code Host} header field value, or {@code null} if none can be derived.
-     */
-    @Deprecated
-    @Nullable
-    default String effectiveHost() {
-        HostAndPort hostAndPort = effectiveHostAndPort();
-        return hostAndPort == null ? null : hostAndPort.hostName();
-    }
-
-    /**
-     * The <a href="https://tools.ietf.org/html/rfc3986#section-3.2.3">port component</a> derived
-     * from {@link #requestTarget()} and the {@code Host} header field value. This is the scheme component to use
-     * when computing an <a href="https://tools.ietf.org/html/rfc7230#section-5.5">effective request URI</a>.
-     * <p>
-     * @deprecated Use {@link #effectiveHostAndPort()}.
-     * @return The <a href="https://tools.ietf.org/html/rfc3986#section-3.2.3">port component</a> derived
-     * from {@link #requestTarget()}, and the {@code Host} header field value, or {@code <0} if none can be derived.
-     */
-    @Deprecated
-    default int effectivePort() {
-        HostAndPort hostAndPort = effectiveHostAndPort();
-        return hostAndPort == null ? -1 : hostAndPort.port();
-    }
-
-    /**
      * Get the <a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">host</a> and
      * <a href="https://tools.ietf.org/html/rfc3986#section-3.2.3">port</a> components
      * of the <a href="https://tools.ietf.org/html/rfc7230#section-5.5">effective request URI</a>.

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
@@ -79,13 +79,15 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         assertEquals("foo=bar&abc=def&foo=baz", fixture.rawQuery());
         assertEquals("/some/path?foo=bar&abc=def&foo=baz", fixture.requestTarget());
 
-        assertNull(fixture.effectiveHost());
-        assertThat(fixture.effectivePort(), lessThan(0));
+        HostAndPort effectiveHostAndPort = fixture.effectiveHostAndPort();
+        assertNull(effectiveHostAndPort);
 
         // Host header provides effective host and port
         fixture.headers().set(HOST, "other.site.com:8080");
-        assertEquals("other.site.com", fixture.effectiveHost());
-        assertEquals(8080, fixture.effectivePort());
+        effectiveHostAndPort = fixture.effectiveHostAndPort();
+        assertNotNull(effectiveHostAndPort);
+        assertEquals("other.site.com", effectiveHostAndPort.hostName());
+        assertEquals(8080, effectiveHostAndPort.port());
     }
 
     // https://tools.ietf.org/html/rfc7230#section-5.3.2
@@ -102,13 +104,17 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         assertEquals("foo=bar&abc=def&foo=baz", fixture.rawQuery());
         assertEquals("http://my.site.com/some/path?foo=bar&abc=def&foo=baz", fixture.requestTarget());
 
-        assertEquals("my.site.com", fixture.effectiveHost());
-        assertThat(fixture.effectivePort(), lessThan(0));
+        HostAndPort effectiveHostAndPort = fixture.effectiveHostAndPort();
+        assertNotNull(effectiveHostAndPort);
+        assertEquals("my.site.com", effectiveHostAndPort.hostName());
+        assertThat(effectiveHostAndPort.port(), lessThan(0));
 
         // Host header ignored when request-target is absolute.
         fixture.headers().set(HOST, "other.site.com:8080");
-        assertEquals("my.site.com", fixture.effectiveHost());
-        assertThat(fixture.effectivePort(), lessThan(0));
+        effectiveHostAndPort = fixture.effectiveHostAndPort();
+        assertNotNull(effectiveHostAndPort);
+        assertEquals("my.site.com", effectiveHostAndPort.hostName());
+        assertThat(effectiveHostAndPort.port(), lessThan(0));
     }
 
     @Test
@@ -124,13 +130,17 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         assertEquals("foo=bar&abc=def&foo=baz", fixture.rawQuery());
         assertEquals("https://jdoe@my.site.com/some/path?foo=bar&abc=def&foo=baz", fixture.requestTarget());
 
-        assertEquals("my.site.com", fixture.effectiveHost());
-        assertThat(fixture.effectivePort(), lessThan(0));
+        HostAndPort effectiveHostAndPort = fixture.effectiveHostAndPort();
+        assertNotNull(effectiveHostAndPort);
+        assertEquals("my.site.com", effectiveHostAndPort.hostName());
+        assertThat(effectiveHostAndPort.port(), lessThan(0));
 
         // Host header ignored when request-target is absolute
         fixture.headers().set(HOST, "other.site.com:8080");
-        assertEquals("my.site.com", fixture.effectiveHost());
-        assertThat(fixture.effectivePort(), lessThan(0));
+        effectiveHostAndPort = fixture.effectiveHostAndPort();
+        assertNotNull(effectiveHostAndPort);
+        assertEquals("my.site.com", effectiveHostAndPort.hostName());
+        assertThat(effectiveHostAndPort.port(), lessThan(0));
     }
 
     // https://tools.ietf.org/html/rfc7230#section-5.3.3
@@ -147,13 +157,17 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         assertNull(fixture.rawQuery());
         assertEquals("my.site.com:80", fixture.requestTarget());
 
-        assertEquals("my.site.com", fixture.effectiveHost());
-        assertEquals(80, fixture.effectivePort());
+        HostAndPort effectiveHostAndPort = fixture.effectiveHostAndPort();
+        assertNotNull(effectiveHostAndPort);
+        assertEquals("my.site.com", effectiveHostAndPort.hostName());
+        assertEquals(80, effectiveHostAndPort.port());
 
         // Host header ignored when request-target has authority form
         fixture.headers().set(HOST, "other.site.com:8080");
-        assertEquals("my.site.com", fixture.effectiveHost());
-        assertEquals(80, fixture.effectivePort());
+        effectiveHostAndPort = fixture.effectiveHostAndPort();
+        assertNotNull(effectiveHostAndPort);
+        assertEquals("my.site.com", effectiveHostAndPort.hostName());
+        assertEquals(80, effectiveHostAndPort.port());
     }
 
     // https://tools.ietf.org/html/rfc7230#section-5.3.4
@@ -170,13 +184,15 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         assertNull(fixture.rawQuery());
         assertEquals("*", fixture.requestTarget());
 
-        assertNull(fixture.effectiveHost());
-        assertThat(fixture.effectivePort(), lessThan(0));
+        HostAndPort effectiveHostAndPort = fixture.effectiveHostAndPort();
+        assertNull(effectiveHostAndPort);
 
         // Host header provides effective host and port
         fixture.headers().set(HOST, "other.site.com:8080");
-        assertEquals("other.site.com", fixture.effectiveHost());
-        assertEquals(8080, fixture.effectivePort());
+        effectiveHostAndPort = fixture.effectiveHostAndPort();
+        assertNotNull(effectiveHostAndPort);
+        assertEquals("other.site.com", effectiveHostAndPort.hostName());
+        assertEquals(8080, effectiveHostAndPort.port());
     }
 
     @Test
@@ -193,18 +209,24 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         assertEquals("foo=bar&abc=def&foo=baz", fixture.rawQuery());
         assertEquals("/some/path?foo=bar&abc=def&foo=baz", fixture.requestTarget());
 
-        assertEquals("host.header.com", fixture.effectiveHost());
-        assertThat(fixture.effectivePort(), lessThan(0));
+        HostAndPort effectiveHostAndPort = fixture.effectiveHostAndPort();
+        assertNotNull(effectiveHostAndPort);
+        assertEquals("host.header.com", effectiveHostAndPort.hostName());
+        assertThat(effectiveHostAndPort.port(), lessThan(0));
 
         // Host header provides effective host and port
         fixture.headers().set(HOST, "other.site.com:8080");
-        assertEquals("other.site.com", fixture.effectiveHost());
-        assertEquals(8080, fixture.effectivePort());
+        effectiveHostAndPort = fixture.effectiveHostAndPort();
+        assertNotNull(effectiveHostAndPort);
+        assertEquals("other.site.com", effectiveHostAndPort.hostName());
+        assertEquals(8080, effectiveHostAndPort.port());
 
         // Test host header changes port, but keeps the same hostname.
         fixture.headers().set(HOST, "other.site.com:8081");
-        assertEquals("other.site.com", fixture.effectiveHost());
-        assertEquals(8081, fixture.effectivePort());
+        effectiveHostAndPort = fixture.effectiveHostAndPort();
+        assertNotNull(effectiveHostAndPort);
+        assertEquals("other.site.com", effectiveHostAndPort.hostName());
+        assertEquals(8081, effectiveHostAndPort.port());
     }
 
     @Test
@@ -221,13 +243,17 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         assertEquals("foo=bar&abc=def&foo=baz", fixture.rawQuery());
         assertEquals("http://my.site.com/some/path?foo=bar&abc=def&foo=baz", fixture.requestTarget());
 
-        assertEquals("my.site.com", fixture.effectiveHost());
-        assertThat(fixture.effectivePort(), lessThan(0));
+        HostAndPort effectiveHostAndPort = fixture.effectiveHostAndPort();
+        assertNotNull(effectiveHostAndPort);
+        assertEquals("my.site.com", effectiveHostAndPort.hostName());
+        assertThat(effectiveHostAndPort.port(), lessThan(0));
 
         // Host header ignored when request-target is absolute.
         fixture.headers().set(HOST, "other.site.com:8080");
-        assertEquals("my.site.com", fixture.effectiveHost());
-        assertThat(fixture.effectivePort(), lessThan(0));
+        effectiveHostAndPort = fixture.effectiveHostAndPort();
+        assertNotNull(effectiveHostAndPort);
+        assertEquals("my.site.com", effectiveHostAndPort.hostName());
+        assertThat(effectiveHostAndPort.port(), lessThan(0));
     }
 
     @Test
@@ -724,8 +750,10 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
 
         assertEquals("http://my.site.com/some/path?foo=new&abc=def#fragment", fixture.requestTarget());
 
-        assertEquals("my.site.com", fixture.effectiveHost());
-        assertThat(fixture.effectivePort(), lessThan(0));
+        HostAndPort effectiveHostAndPort = fixture.effectiveHostAndPort();
+        assertNotNull(effectiveHostAndPort);
+        assertEquals("my.site.com", effectiveHostAndPort.hostName());
+        assertThat(effectiveHostAndPort.port(), lessThan(0));
     }
 
     @Test

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
@@ -79,15 +79,11 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         assertEquals("foo=bar&abc=def&foo=baz", fixture.rawQuery());
         assertEquals("/some/path?foo=bar&abc=def&foo=baz", fixture.requestTarget());
 
-        HostAndPort effectiveHostAndPort = fixture.effectiveHostAndPort();
-        assertNull(effectiveHostAndPort);
+        assertNull(fixture.effectiveHostAndPort());
 
         // Host header provides effective host and port
         fixture.headers().set(HOST, "other.site.com:8080");
-        effectiveHostAndPort = fixture.effectiveHostAndPort();
-        assertNotNull(effectiveHostAndPort);
-        assertEquals("other.site.com", effectiveHostAndPort.hostName());
-        assertEquals(8080, effectiveHostAndPort.port());
+        assertEffectiveHostAndPort("other.site.com", 8080);
     }
 
     // https://tools.ietf.org/html/rfc7230#section-5.3.2
@@ -104,17 +100,11 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         assertEquals("foo=bar&abc=def&foo=baz", fixture.rawQuery());
         assertEquals("http://my.site.com/some/path?foo=bar&abc=def&foo=baz", fixture.requestTarget());
 
-        HostAndPort effectiveHostAndPort = fixture.effectiveHostAndPort();
-        assertNotNull(effectiveHostAndPort);
-        assertEquals("my.site.com", effectiveHostAndPort.hostName());
-        assertThat(effectiveHostAndPort.port(), lessThan(0));
+        assertEffectiveHostAndPort("my.site.com");
 
         // Host header ignored when request-target is absolute.
         fixture.headers().set(HOST, "other.site.com:8080");
-        effectiveHostAndPort = fixture.effectiveHostAndPort();
-        assertNotNull(effectiveHostAndPort);
-        assertEquals("my.site.com", effectiveHostAndPort.hostName());
-        assertThat(effectiveHostAndPort.port(), lessThan(0));
+        assertEffectiveHostAndPort("my.site.com");
     }
 
     @Test
@@ -130,17 +120,11 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         assertEquals("foo=bar&abc=def&foo=baz", fixture.rawQuery());
         assertEquals("https://jdoe@my.site.com/some/path?foo=bar&abc=def&foo=baz", fixture.requestTarget());
 
-        HostAndPort effectiveHostAndPort = fixture.effectiveHostAndPort();
-        assertNotNull(effectiveHostAndPort);
-        assertEquals("my.site.com", effectiveHostAndPort.hostName());
-        assertThat(effectiveHostAndPort.port(), lessThan(0));
+        assertEffectiveHostAndPort("my.site.com");
 
         // Host header ignored when request-target is absolute
         fixture.headers().set(HOST, "other.site.com:8080");
-        effectiveHostAndPort = fixture.effectiveHostAndPort();
-        assertNotNull(effectiveHostAndPort);
-        assertEquals("my.site.com", effectiveHostAndPort.hostName());
-        assertThat(effectiveHostAndPort.port(), lessThan(0));
+        assertEffectiveHostAndPort("my.site.com");
     }
 
     // https://tools.ietf.org/html/rfc7230#section-5.3.3
@@ -157,17 +141,11 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         assertNull(fixture.rawQuery());
         assertEquals("my.site.com:80", fixture.requestTarget());
 
-        HostAndPort effectiveHostAndPort = fixture.effectiveHostAndPort();
-        assertNotNull(effectiveHostAndPort);
-        assertEquals("my.site.com", effectiveHostAndPort.hostName());
-        assertEquals(80, effectiveHostAndPort.port());
+        assertEffectiveHostAndPort("my.site.com", 80);
 
         // Host header ignored when request-target has authority form
         fixture.headers().set(HOST, "other.site.com:8080");
-        effectiveHostAndPort = fixture.effectiveHostAndPort();
-        assertNotNull(effectiveHostAndPort);
-        assertEquals("my.site.com", effectiveHostAndPort.hostName());
-        assertEquals(80, effectiveHostAndPort.port());
+        assertEffectiveHostAndPort("my.site.com", 80);
     }
 
     // https://tools.ietf.org/html/rfc7230#section-5.3.4
@@ -184,15 +162,11 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         assertNull(fixture.rawQuery());
         assertEquals("*", fixture.requestTarget());
 
-        HostAndPort effectiveHostAndPort = fixture.effectiveHostAndPort();
-        assertNull(effectiveHostAndPort);
+        assertNull(fixture.effectiveHostAndPort());
 
         // Host header provides effective host and port
         fixture.headers().set(HOST, "other.site.com:8080");
-        effectiveHostAndPort = fixture.effectiveHostAndPort();
-        assertNotNull(effectiveHostAndPort);
-        assertEquals("other.site.com", effectiveHostAndPort.hostName());
-        assertEquals(8080, effectiveHostAndPort.port());
+        assertEffectiveHostAndPort("other.site.com", 8080);
     }
 
     @Test
@@ -209,24 +183,15 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         assertEquals("foo=bar&abc=def&foo=baz", fixture.rawQuery());
         assertEquals("/some/path?foo=bar&abc=def&foo=baz", fixture.requestTarget());
 
-        HostAndPort effectiveHostAndPort = fixture.effectiveHostAndPort();
-        assertNotNull(effectiveHostAndPort);
-        assertEquals("host.header.com", effectiveHostAndPort.hostName());
-        assertThat(effectiveHostAndPort.port(), lessThan(0));
+        assertEffectiveHostAndPort("host.header.com");
 
         // Host header provides effective host and port
         fixture.headers().set(HOST, "other.site.com:8080");
-        effectiveHostAndPort = fixture.effectiveHostAndPort();
-        assertNotNull(effectiveHostAndPort);
-        assertEquals("other.site.com", effectiveHostAndPort.hostName());
-        assertEquals(8080, effectiveHostAndPort.port());
+        assertEffectiveHostAndPort("other.site.com", 8080);
 
         // Test host header changes port, but keeps the same hostname.
         fixture.headers().set(HOST, "other.site.com:8081");
-        effectiveHostAndPort = fixture.effectiveHostAndPort();
-        assertNotNull(effectiveHostAndPort);
-        assertEquals("other.site.com", effectiveHostAndPort.hostName());
-        assertEquals(8081, effectiveHostAndPort.port());
+        assertEffectiveHostAndPort("other.site.com", 8081);
     }
 
     @Test
@@ -243,17 +208,11 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         assertEquals("foo=bar&abc=def&foo=baz", fixture.rawQuery());
         assertEquals("http://my.site.com/some/path?foo=bar&abc=def&foo=baz", fixture.requestTarget());
 
-        HostAndPort effectiveHostAndPort = fixture.effectiveHostAndPort();
-        assertNotNull(effectiveHostAndPort);
-        assertEquals("my.site.com", effectiveHostAndPort.hostName());
-        assertThat(effectiveHostAndPort.port(), lessThan(0));
+        assertEffectiveHostAndPort("my.site.com");
 
         // Host header ignored when request-target is absolute.
         fixture.headers().set(HOST, "other.site.com:8080");
-        effectiveHostAndPort = fixture.effectiveHostAndPort();
-        assertNotNull(effectiveHostAndPort);
-        assertEquals("my.site.com", effectiveHostAndPort.hostName());
-        assertThat(effectiveHostAndPort.port(), lessThan(0));
+        assertEffectiveHostAndPort("my.site.com");
     }
 
     @Test
@@ -261,10 +220,7 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         createFixture("some/path?foo=bar&abc=def&foo=baz");
         fixture.headers().set(HOST, "[1:2:3::5]");
 
-        HostAndPort hostAndPort = fixture.effectiveHostAndPort();
-        assertNotNull(hostAndPort);
-        assertEquals("[1:2:3::5]", hostAndPort.hostName());
-        assertThat(hostAndPort.port(), lessThan(0));
+        assertEffectiveHostAndPort("[1:2:3::5]");
     }
 
     @Test
@@ -272,10 +228,7 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         createFixture("some/path?foo=bar&abc=def&foo=baz");
         fixture.headers().set(HOST, "[1:2:3::5]:8080");
 
-        HostAndPort hostAndPort = fixture.effectiveHostAndPort();
-        assertNotNull(hostAndPort);
-        assertEquals("[1:2:3::5]", hostAndPort.hostName());
-        assertEquals(8080, hostAndPort.port());
+        assertEffectiveHostAndPort("[1:2:3::5]", 8080);
     }
 
     @Test
@@ -750,10 +703,7 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
 
         assertEquals("http://my.site.com/some/path?foo=new&abc=def#fragment", fixture.requestTarget());
 
-        HostAndPort effectiveHostAndPort = fixture.effectiveHostAndPort();
-        assertNotNull(effectiveHostAndPort);
-        assertEquals("my.site.com", effectiveHostAndPort.hostName());
-        assertThat(effectiveHostAndPort.port(), lessThan(0));
+        assertEffectiveHostAndPort("my.site.com");
     }
 
     @Test
@@ -763,10 +713,7 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
 
         assertEquals("http://my.site.com:8080/some/path?foo=new&abc=def#fragment", fixture.requestTarget());
 
-        HostAndPort hostAndPort = fixture.effectiveHostAndPort();
-        assertNotNull(hostAndPort);
-        assertEquals("my.site.com", hostAndPort.hostName());
-        assertEquals(8080, hostAndPort.port());
+        assertEffectiveHostAndPort("my.site.com", 8080);
     }
 
     @Test
@@ -812,6 +759,20 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         assertEquals("GET /some/path?a=query HTTP/1.1" + lineSeparator() +
                 "DefaultHttpHeaders[authorization: redacted" + lineSeparator() +
                 "host: redacted]", fixture.toString((k, v) -> "redacted"));
+    }
+
+    private void assertEffectiveHostAndPort(String hostName) {
+        HostAndPort effectiveHostAndPort = fixture.effectiveHostAndPort();
+        assertNotNull(effectiveHostAndPort);
+        assertEquals(hostName, effectiveHostAndPort.hostName());
+        assertThat(effectiveHostAndPort.port(), lessThan(0));
+    }
+
+    private void assertEffectiveHostAndPort(String hostName, int port) {
+        HostAndPort effectiveHostAndPort = fixture.effectiveHostAndPort();
+        assertNotNull(effectiveHostAndPort);
+        assertEquals(hostName, effectiveHostAndPort.hostName());
+        assertEquals(port, effectiveHostAndPort.port());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
…questMetaData

Motivation:
HttpRequestMetaData methods effectivePort and effectiveHost have been
deprecated in favor of effectiveHostAndPort.

Modifications:
- Remove HttpRequestMetaData#effectiveHost()
- Remove HttpRequestMetaData#effectivePort()

Result:
Less deprecated methods, users must migrate to use non-deprecated APIs.