### PR TITLE
DynamicCompositeCancellable race condition fix

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DynamicCompositeCancellable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DynamicCompositeCancellable.java
@@ -34,8 +34,9 @@ interface DynamicCompositeCancellable extends Cancellable {
      * Add a {@link Cancellable} that will be cancelled when this object's {@link #cancel()} method is called,
      * or be cancelled immediately if this object's {@link #cancel()} method has already been called.
      * @param toAdd The {@link Cancellable} to add.
-     * @return {@code true} if the {@code toAdd} was added, and {@code false} if {@code toAdd} was not added and
-     * {@link Cancellable#cancel()} was called on {@code toAdd}.
+     * @return {@code true} if the {@code toAdd} was added, and {@code false} if {@code toAdd} was not added because
+     * it already exists. If {@code false} then {@link Cancellable#cancel()} will be called unless the reason is this
+     * implementation does not supporting duplicates and {@code toAdd} has already been added.
      */
     boolean add(Cancellable toAdd);
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractDynamicCompositeCancellableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractDynamicCompositeCancellableTest.java
@@ -77,9 +77,7 @@ public abstract class AbstractDynamicCompositeCancellableTest {
             cancellableSingles.add(EXECUTOR_RULE.executor().submit(() -> {
                 Cancellable c = mock(Cancellable.class);
                 barrier.await();
-                if (!dynamicCancellable.add(c)) {
-                    verify(c).cancel();
-                }
+                dynamicCancellable.add(c);
                 return c;
             }));
         }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractDynamicCompositeCancellableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractDynamicCompositeCancellableTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.Cancellable;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Future;
+
+import static io.servicetalk.concurrent.api.Single.collectUnordered;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public abstract class AbstractDynamicCompositeCancellableTest {
+    @ClassRule
+    public static final ExecutorRule<Executor> EXECUTOR_RULE = ExecutorRule.newRule();
+
+    protected abstract DynamicCompositeCancellable newCompositeCancellable();
+
+    @Test
+    public void testAddAndRemove() {
+        DynamicCompositeCancellable c = newCompositeCancellable();
+        Cancellable cancellable = mock(Cancellable.class);
+        c.add(cancellable);
+        c.remove(cancellable);
+        c.cancel();
+        verifyZeroInteractions(cancellable);
+    }
+
+    @Test
+    public void testCancel() {
+        DynamicCompositeCancellable c = newCompositeCancellable();
+        Cancellable cancellable = mock(Cancellable.class);
+        c.add(cancellable);
+        c.cancel();
+        verify(cancellable).cancel();
+        c.remove(cancellable);
+    }
+
+    @Test
+    public void testAddPostCancel() {
+        DynamicCompositeCancellable c = newCompositeCancellable();
+        c.cancel();
+        Cancellable cancellable = mock(Cancellable.class);
+        c.add(cancellable);
+        verify(cancellable).cancel();
+        c.remove(cancellable);
+    }
+
+    @Test
+    public void multiThreadedAddCancel() throws Exception {
+        final int addThreads = 1000;
+        final CyclicBarrier barrier = new CyclicBarrier(addThreads + 1);
+        final List<Single<Cancellable>> cancellableSingles = new ArrayList<>(addThreads);
+        DynamicCompositeCancellable dynamicCancellable = newCompositeCancellable();
+        for (int i = 0; i < addThreads; ++i) {
+            cancellableSingles.add(EXECUTOR_RULE.executor().submit(() -> {
+                Cancellable c = mock(Cancellable.class);
+                barrier.await();
+                dynamicCancellable.add(c);
+                return c;
+            }));
+        }
+
+        Future<Collection<Cancellable>> future = collectUnordered(cancellableSingles, addThreads).toFuture();
+        barrier.await();
+        dynamicCancellable.cancel();
+        Collection<Cancellable> cancellables = future.get();
+        for (Cancellable c : cancellables) {
+            verify(c).cancel();
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractDynamicCompositeCancellableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractDynamicCompositeCancellableTest.java
@@ -27,7 +27,9 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Future;
 
 import static io.servicetalk.concurrent.api.Single.collectUnordered;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
@@ -65,6 +67,26 @@ public abstract class AbstractDynamicCompositeCancellableTest {
         c.add(cancellable);
         verify(cancellable).cancel();
         c.remove(cancellable);
+    }
+
+    @Test
+    public void duplicateAddDoesNotCancel() {
+        DynamicCompositeCancellable c = newCompositeCancellable();
+        Cancellable cancellable = mock(Cancellable.class);
+        int addCount = 0;
+        if (c.add(cancellable)) {
+            ++addCount;
+        }
+        if (c.add(cancellable)) {
+            ++addCount;
+        }
+        verify(cancellable, never()).cancel();
+
+        for (int i = 0; i < addCount; ++i) {
+            assertTrue(c.remove(cancellable));
+        }
+        c.cancel();
+        verify(cancellable, never()).cancel();
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractDynamicCompositeCancellableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractDynamicCompositeCancellableTest.java
@@ -77,7 +77,9 @@ public abstract class AbstractDynamicCompositeCancellableTest {
             cancellableSingles.add(EXECUTOR_RULE.executor().submit(() -> {
                 Cancellable c = mock(Cancellable.class);
                 barrier.await();
-                dynamicCancellable.add(c);
+                if (!dynamicCancellable.add(c)) {
+                    verify(c).cancel();
+                }
                 return c;
             }));
         }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/QueueDynamicCompositeCancellableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/QueueDynamicCompositeCancellableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package io.servicetalk.concurrent.api;
 
-public class SetDynamicCompositeCancellableTest extends AbstractDynamicCompositeCancellableTest {
+public class QueueDynamicCompositeCancellableTest extends AbstractDynamicCompositeCancellableTest {
     @Override
     protected DynamicCompositeCancellable newCompositeCancellable() {
-        return new SetDynamicCompositeCancellable();
+        return new QueueDynamicCompositeCancellable();
     }
 }

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FlowControlUtils.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FlowControlUtils.java
@@ -139,26 +139,6 @@ public final class FlowControlUtils {
     }
 
     /**
-     * Try to increment the value associated with {@code updater} if the existing value isn't negative, and the
-     * increment operation wouldn't cause overflow.
-     * @param updater The {@link AtomicLongFieldUpdater} used to increment.
-     * @param owner The owner object to use for {@code updater}.
-     * @param <T> The type of {@code owner}.
-     * @return {@code true} if the increment was successful, {@code false} if the existing value was negative or the
-     * increment would result in overflow.
-     */
-    public static <T> boolean tryIncrementIfNotNegative(AtomicLongFieldUpdater<T> updater, T owner) {
-        for (;;) {
-            final long currValue = updater.get(owner);
-            if (currValue < 0 || currValue == Long.MAX_VALUE) {
-                return false;
-            } else if (updater.compareAndSet(owner, currValue, currValue + 1)) {
-                return true;
-            }
-        }
-    }
-
-    /**
      * Increment an {@code integer} referred by {@link AtomicIntegerFieldUpdater} atomically
      * and saturate to {@link Integer#MAX_VALUE} if overflow occurs.
      *

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FlowControlUtils.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FlowControlUtils.java
@@ -139,6 +139,26 @@ public final class FlowControlUtils {
     }
 
     /**
+     * Try to increment the value associated with {@code updater} if the existing value isn't negative, and the
+     * increment operation wouldn't cause overflow.
+     * @param updater The {@link AtomicLongFieldUpdater} used to increment.
+     * @param owner The owner object to use for {@code updater}.
+     * @param <T> The type of {@code owner}.
+     * @return {@code true} if the increment was successful, {@code false} if the existing value was negative or the
+     * increment would result in overflow.
+     */
+    public static <T> boolean tryIncrementIfNotNegative(AtomicLongFieldUpdater<T> updater, T owner) {
+        for (;;) {
+            final long currValue = updater.get(owner);
+            if (currValue < 0 || currValue == Long.MAX_VALUE) {
+                return false;
+            } else if (updater.compareAndSet(owner, currValue, currValue + 1)) {
+                return true;
+            }
+        }
+    }
+
+    /**
      * Increment an {@code integer} referred by {@link AtomicIntegerFieldUpdater} atomically
      * and saturate to {@link Integer#MAX_VALUE} if overflow occurs.
      *


### PR DESCRIPTION
Motivation:
DynamicCompositeCancellable are used in operators that keep a collection
of Cancellable objects (e.g. flatMap, merge, etc.). The implementations
are intended to be thread safe between adding Cancellables and
cancelling Cancellables that have been previously add (and not removed).
The DynamicCompositeCancellable implementations rely upon
reading volatile state after an element is added to a concurrent
collection to cancel the new element if there is a race. However the add
thread is not gaurenteed to observe a write from the cancel thread, and
if this is the case an element maybe added and never cancelled.

Modifications:
- The add thread should attempt to read/modify state in coordination
with the cancel thread to gaurentee that element will be cancelled.

Result:
More correct concurrency code in DynamicCompositeCancellable.