### PR TITLE
CompletableProcessor and SingleProcessor race condition fix

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableProcessor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableProcessor.java
@@ -18,27 +18,18 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.CompletableSource.Processor;
 import io.servicetalk.concurrent.internal.DelayedCancellable;
-import io.servicetalk.concurrent.internal.QueueFullAndRejectedSubscribeException;
 import io.servicetalk.concurrent.internal.TerminalNotification;
 
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
-import static io.servicetalk.concurrent.internal.ThrowableUtils.catchUnexpected;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 
 /**
  * A {@link Completable} which is also a {@link Subscriber}. State of this {@link Completable} can be modified by using
  * the {@link Subscriber} methods which is forwarded to all existing or subsequent {@link Subscriber}s.
  */
 final class CompletableProcessor extends Completable implements Processor {
-    private static final AtomicLongFieldUpdater<CompletableProcessor> counterUpdater =
-            AtomicLongFieldUpdater.newUpdater(CompletableProcessor.class, "counter");
-    private final Queue<Subscriber> queue = new ConcurrentLinkedQueue<>();
-    private volatile long counter;
+    private final ConcurrentStack<Subscriber> stack = new ConcurrentStack<>();
     @Nullable
     private TerminalNotification terminalSignal;
 
@@ -50,24 +41,14 @@ final class CompletableProcessor extends Completable implements Processor {
         // we would add the subscriber to the queue and possibly never (until termination) dereference the subscriber.
         DelayedCancellable delayedCancellable = new DelayedCancellable();
         subscriber.onSubscribe(delayedCancellable);
-        if (counter < 0) { // best effort to short circuit and avoid the queue if terminated already
-            terminateLateSubscriber(subscriber);
-        } else if (queue.offer(subscriber)) {
-            // We must check the state after we insert into the queue as the terminal event could have raced with this
-            // method and we need to ensure the subscriber is terminated.
-            // We don't check for overflow as we assume we will never exceed Long number of elements.
-            if (counterUpdater.incrementAndGet(this) > 0) {
-                delayedCancellable.delayedCancellable(() -> {
-                    // Cancel in this case will just cleanup references from the queue to ensure we don't prevent GC of
-                    // these references.
-                    queue.remove(subscriber);
-                });
-            } else if (queue.remove(subscriber)) {
-                // We don't decrement counter, we assume there will be no overflow from Long.MIN_VALUE.
-                terminateLateSubscriber(subscriber);
-            }
+        if (stack.push(subscriber)) {
+            delayedCancellable.delayedCancellable(() -> {
+                // Cancel in this case will just cleanup references from the queue to ensure we don't prevent GC of
+                // these references.
+                stack.relaxedRemove(subscriber);
+            });
         } else {
-            subscriber.onError(new QueueFullAndRejectedSubscribeException("queue"));
+            terminateLateSubscriber(subscriber);
         }
     }
 
@@ -94,23 +75,10 @@ final class CompletableProcessor extends Completable implements Processor {
 
     private void terminate(TerminalNotification terminalSignal) {
         if (this.terminalSignal == null) {
-            // We must set terminalSignal before counter as we depend upon happens-before relationship for this value
+            // We must set terminalSignal before close as we depend upon happens-before relationship for this value
             // to be visible for any future late subscribers.
             this.terminalSignal = terminalSignal;
-            if (counterUpdater.getAndSet(this, Long.MIN_VALUE) >= 0) {
-                Throwable delayedCause = null;
-                Subscriber subscriber;
-                while ((subscriber = queue.poll()) != null) {
-                    try {
-                        terminalSignal.terminate(subscriber);
-                    } catch (Throwable cause) {
-                        delayedCause = catchUnexpected(delayedCause, cause);
-                    }
-                }
-                if (delayedCause != null) {
-                    throwException(delayedCause);
-                }
-            }
+            stack.close(terminalSignal::terminate);
         }
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ConcurrentStack.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ConcurrentStack.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Consumer;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.internal.ThrowableUtils.catchUnexpected;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
+
+final class ConcurrentStack<T> {
+    private static final Node<?> CLOSED = new Node<>();
+    @SuppressWarnings("rawtypes")
+    private static final AtomicReferenceFieldUpdater<ConcurrentStack, Node> topUpdater =
+            newUpdater(ConcurrentStack.class, Node.class, "top");
+    @Nullable
+    private volatile Node<T> top;
+
+    boolean push(T item) {
+        final Node<T> newTop = new Node<>(item);
+        Node<T> oldTop;
+        do {
+            oldTop = top;
+            if (oldTop == CLOSED) {
+                return false;
+            }
+            newTop.next = oldTop;
+        } while (!topUpdater.compareAndSet(this, oldTop, newTop));
+        return true;
+    }
+
+    @Nullable
+    T pop() {
+        for (;;) {
+            final Node<T> oldTop = top;
+            if (oldTop == null) {
+                return null;
+            } else if (topUpdater.compareAndSet(this, oldTop, oldTop.next)) {
+                final T item = oldTop.item;
+                if (item != null) {
+                    return item;
+                }
+            }
+        }
+    }
+
+    /**
+     * Best effort removal of {@code item} from this stack.
+     * @param item The item to remove.
+     * @return {@code true} if the item was found in this stack and marked for removal. The "relaxed" nature of
+     * this method means {@code true} might be returned in the following scenarios without external synchronization:
+     * <ul>
+     *     <li>invoked multiple times with the same {@code item} from different threads</li>
+     *     <li>{@link #pop()} removes this item from another thread</li>
+     * </ul>
+     */
+    boolean relaxedRemove(T item) {
+        requireNonNull(item);
+        Node<T> currTop = top;
+        while (currTop != null) {
+            if (item.equals(currTop.item)) {
+                currTop.item = null; // best effort null out the item. pop/close will discard the Node later.
+                return true;
+            } else {
+                currTop = currTop.next;
+            }
+        }
+        return false;
+    }
+
+    void close(Consumer<T> closer) {
+        @SuppressWarnings("unchecked")
+        Node<T> oldTop = topUpdater.getAndSet(this, closedNode());
+        Throwable delayedCause = null;
+        while (oldTop != null && oldTop != CLOSED) {
+            final Node<T> next = oldTop.next;
+            final T item = oldTop.item;
+            oldTop = next;
+            if (item != null) {
+                try {
+                    closer.accept(item);
+                } catch (Throwable cause) {
+                    delayedCause = catchUnexpected(delayedCause, cause);
+                }
+            }
+        }
+
+        if (delayedCause != null) {
+            throwException(delayedCause);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <X> Node<X> closedNode() {
+        return (Node<X>) CLOSED;
+    }
+
+    private static final class Node<T> {
+        @Nullable
+        T item;
+        @Nullable
+        Node<T> next;
+
+        Node() {
+            this.item = null;
+        }
+
+        Node(T item) {
+            this.item = requireNonNull(item);
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ConcurrentStack.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ConcurrentStack.java
@@ -49,7 +49,7 @@ final class ConcurrentStack<T> {
     T pop() {
         for (;;) {
             final Node<T> oldTop = top;
-            if (oldTop == null) {
+            if (oldTop == null || oldTop == CLOSED) {
                 return null;
             } else if (topUpdater.compareAndSet(this, oldTop, oldTop.next)) {
                 final T item = oldTop.item;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleProcessor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleProcessor.java
@@ -23,12 +23,11 @@ import io.servicetalk.concurrent.internal.TerminalNotification;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.internal.ThrowableUtils.catchUnexpected;
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
-import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
 /**
  * A {@link Single} which is also a {@link Subscriber}. State of this {@link Single} can be modified by using the
@@ -36,12 +35,12 @@ import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater
  * @param <T> The type of result of the {@link Single}.
  */
 final class SingleProcessor<T> extends Single<T> implements Processor<T, T> {
-    private static final Object TERMINAL_UNSET = new Object();
     @SuppressWarnings("rawtypes")
-    private static final AtomicReferenceFieldUpdater<SingleProcessor, Queue> queueUpdater =
-            newUpdater(SingleProcessor.class, Queue.class, "queue");
-    @Nullable
-    private volatile Queue<Subscriber<? super T>> queue = new ConcurrentLinkedQueue<>();
+    private static final AtomicLongFieldUpdater<SingleProcessor> counterUpdater =
+            AtomicLongFieldUpdater.newUpdater(SingleProcessor.class, "counter");
+    private static final Object TERMINAL_UNSET = new Object();
+    private final Queue<Subscriber<? super T>> queue = new ConcurrentLinkedQueue<>();
+    private volatile long counter;
     @Nullable
     private Object terminalSignal = TERMINAL_UNSET;
 
@@ -53,20 +52,21 @@ final class SingleProcessor<T> extends Single<T> implements Processor<T, T> {
         // we would add the subscriber to the queue and possibly never (until termination) dereference the subscriber.
         DelayedCancellable delayedCancellable = new DelayedCancellable();
         subscriber.onSubscribe(delayedCancellable);
-        final Queue<Subscriber<? super T>> currentQueue = queue;
-        if (currentQueue == null) {
+        if (counter < 0) { // best effort to short circuit and avoid the queue if terminated already
             terminateLateSubscriber(subscriber);
-        } else if (currentQueue.offer(subscriber)) {
-            if (!queueUpdater.compareAndSet(this, currentQueue, currentQueue)) {
-                if (currentQueue.remove(subscriber)) {
-                    terminateLateSubscriber(subscriber);
-                }
-            } else {
+        } else if (queue.offer(subscriber)) {
+            // We must check the state after we insert into the queue as the terminal event could have raced with this
+            // method and we need to ensure the subscriber is terminated.
+            // We don't check for overflow as we assume we will never exceed Long number of elements.
+            if (counterUpdater.incrementAndGet(this) > 0) {
                 delayedCancellable.delayedCancellable(() -> {
                     // Cancel in this case will just cleanup references from the queue to ensure we don't prevent GC of
                     // these references.
-                    currentQueue.remove(subscriber);
+                    queue.remove(subscriber);
                 });
+            } else if (queue.remove(subscriber)) {
+                // We don't decrement counter, we assume there will be no overflow from Long.MIN_VALUE.
+                terminateLateSubscriber(subscriber);
             }
         } else {
             subscriber.onError(new QueueFullAndRejectedSubscribeException("queue"));
@@ -104,17 +104,16 @@ final class SingleProcessor<T> extends Single<T> implements Processor<T, T> {
 
     private void terminate(@Nullable Object terminalSignal) {
         if (this.terminalSignal == TERMINAL_UNSET) {
+            // We must set terminalSignal before counter as we depend upon happens-before relationship for this value
+            // to be visible for any future late subscribers.
             this.terminalSignal = terminalSignal;
-            @SuppressWarnings("unchecked")
-            Queue<Subscriber<? super T>> currentQueue =
-                    (Queue<Subscriber<? super T>>) queueUpdater.getAndSet(this, null);
-            if (currentQueue != null) {
+            if (counterUpdater.getAndSet(this, Long.MIN_VALUE) >= 0) {
                 Throwable delayedCause = null;
                 Subscriber<? super T> subscriber;
                 if (terminalSignal instanceof TerminalNotification) {
                     final Throwable error = ((TerminalNotification) terminalSignal).cause();
                     assert error != null;
-                    while ((subscriber = currentQueue.poll()) != null) {
+                    while ((subscriber = queue.poll()) != null) {
                         try {
                             subscriber.onError(error);
                         } catch (Throwable cause) {
@@ -124,7 +123,7 @@ final class SingleProcessor<T> extends Single<T> implements Processor<T, T> {
                 } else {
                     @SuppressWarnings("unchecked")
                     final T value = (T) terminalSignal;
-                    while ((subscriber = currentQueue.poll()) != null) {
+                    while ((subscriber = queue.poll()) != null) {
                         try {
                             subscriber.onSuccess(value);
                         } catch (Throwable cause) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleProcessor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleProcessor.java
@@ -83,7 +83,7 @@ final class SingleProcessor<T> extends Single<T> implements Processor<T, T> {
 
     private void terminate(@Nullable Object terminalSignal) {
         if (this.terminalSignal == TERMINAL_UNSET) {
-            // We must set terminalSignal before counter as we depend upon happens-before relationship for this value
+            // We must set terminalSignal before close as we depend upon happens-before relationship for this value
             // to be visible for any future late subscribers.
             this.terminalSignal = terminalSignal;
             if (terminalSignal instanceof TerminalNotification) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcurrentStackTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcurrentStackTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.Cancellable;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Future;
+
+import static io.servicetalk.concurrent.api.Completable.mergeAll;
+import static io.servicetalk.concurrent.api.Single.collectUnordered;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ConcurrentStackTest {
+    @ClassRule
+    public static final ExecutorRule<Executor> EXECUTOR_RULE = ExecutorRule.newRule();
+
+    @Test
+    public void singleThreadPushPop() {
+        ConcurrentStack<Integer> stack = new ConcurrentStack<>();
+        final int itemCount = 1000;
+        for (int i = 0; i < itemCount; ++i) {
+            stack.push(i);
+        }
+
+        for (int i = itemCount - 1; i >= 0; --i) {
+            assertThat(stack.pop(), is(i));
+        }
+    }
+
+    @Test
+    public void singleThreadPushRemove() {
+        ConcurrentStack<Integer> stack = new ConcurrentStack<>();
+        final int itemCount = 1000;
+        for (int i = 0; i < itemCount; ++i) {
+            stack.push(i);
+        }
+
+        for (int i = 0; i < itemCount; ++i) {
+            assertTrue(stack.relaxedRemove(i));
+        }
+        assertNull(stack.pop());
+    }
+
+    @Test
+    public void concurrentPushRemove() throws Exception {
+        ConcurrentStack<Integer> stack = new ConcurrentStack<>();
+        final int itemCount = 1000;
+        CyclicBarrier barrier = new CyclicBarrier(itemCount + 1);
+        List<Completable> completableList = new ArrayList<>(itemCount);
+        for (int i = 0; i < itemCount; ++i) {
+            final int finalI = i;
+            completableList.add(EXECUTOR_RULE.executor().submit(() -> {
+                try {
+                    barrier.await();
+                } catch (Exception e) {
+                    throw new AssertionError(e);
+                }
+                stack.push(finalI);
+                assertTrue("failed for index: " + finalI, stack.relaxedRemove(finalI));
+            }));
+        }
+
+        Future<Void> future = mergeAll(completableList, itemCount).toFuture();
+        barrier.await();
+        future.get();
+        assertNull(stack.pop());
+    }
+
+    @Test
+    public void concurrentPushRemoveDifferentThread() throws Exception {
+        ConcurrentStack<Integer> stack = new ConcurrentStack<>();
+        final int itemCount = 1000;
+        CyclicBarrier barrier = new CyclicBarrier(itemCount + 1);
+        List<Completable> completableList = new ArrayList<>(itemCount);
+        for (int i = 0; i < itemCount; ++i) {
+            final int finalI = i;
+            completableList.add(EXECUTOR_RULE.executor().submit(() -> {
+                try {
+                    barrier.await();
+                } catch (Exception e) {
+                    throw new AssertionError(e);
+                }
+                stack.push(finalI);
+            }).concat(EXECUTOR_RULE.executor().submit(() ->
+                    assertTrue("failed for index: " + finalI, stack.relaxedRemove(finalI)))));
+        }
+
+        Future<Void> future = mergeAll(completableList, itemCount).toFuture();
+        barrier.await();
+        future.get();
+        assertNull(stack.pop());
+    }
+
+    @Test
+    public void concurrentClosePushRemove() throws Exception {
+        ConcurrentStack<Cancellable> stack = new ConcurrentStack<>();
+        final int itemCount = 1000;
+        CyclicBarrier barrier = new CyclicBarrier(itemCount + 1);
+        List<Single<Cancellable>> completableList = new ArrayList<>(itemCount);
+        for (int i = 0; i < itemCount; ++i) {
+            completableList.add(EXECUTOR_RULE.executor().submit(() -> {
+                Cancellable c = mock(Cancellable.class);
+                try {
+                    barrier.await();
+                } catch (Exception e) {
+                    throw new AssertionError(e);
+                }
+                assertTrue(stack.push(c));
+                return c;
+            }));
+        }
+
+        Future<Collection<Cancellable>> future = collectUnordered(completableList, itemCount).toFuture();
+        barrier.await();
+        Collection<Cancellable> cancellables = future.get();
+        stack.close(Cancellable::cancel);
+        assertFalse(stack.push(() -> { }));
+        assertNull(stack.pop());
+        for (Cancellable c : cancellables) {
+            verify(c).cancel();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
CompletableProcessor and SingleProcessor maintain a queue and an
independent state for termination. It is possible that a Subscriber
maybe added on different thread than is terminating the Processor, and
the terminal state may not be visible yet such that the Subscriber never
gets terminated.

Modifications:
- The thread adding the the queue should attempt to read/modify state in
coordination with the thread terminating to gaurentee the new Subscriber
will be terminated.
- Allow for out of order termination in the event that the processor
completes before the subscribe operation happens.

Result:
Fixes https://github.com/apple/servicetalk/issues/1033