### PR TITLE
Handle `close_notify` TLS alert

### DIFF
--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -36,6 +36,7 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-test-resources")
+  testImplementation project(":servicetalk-concurrent-api-test")
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation "junit:junit:$junitVersion"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
@@ -133,7 +133,8 @@ public abstract class CloseHandler {
     /**
      * Request {@link Channel} outbound close, to be emitted from the {@link EventLoop} for the channel.
      * <p>
-     * This method will not ensure graceful closure of the channel outbound and may abort reads.
+     * This method will not ensure graceful closure of the channel outbound and may abort reads. The implementations of
+     * this method should be idempotent because it may be invoked multiple times.
      *
      * @param channel {@link Channel}
      */

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
@@ -157,6 +157,7 @@ class RequestResponseCloseHandler extends CloseHandler {
     public void protocolPayloadBeginInbound(final ChannelHandlerContext ctx) {
         assert ctx.executor().inEventLoop();
         pending = isClient ? pending - 1 : pending + 1;
+        assert pending >= 0 : "Negative pending counter";
         state = set(state, READ);
     }
 
@@ -174,6 +175,7 @@ class RequestResponseCloseHandler extends CloseHandler {
     public void protocolPayloadBeginOutbound(final ChannelHandlerContext ctx) {
         assert ctx.executor().inEventLoop();
         pending = isClient ? pending + 1 : pending - 1;
+        assert pending >= 0 : "Negative pending counter";
         state = set(state, WRITE);
     }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RetryableClosureException.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RetryableClosureException.java
@@ -23,6 +23,8 @@ import java.nio.channels.ClosedChannelException;
  * Indicates that an error happened due to connection closure, but is retryable.
  */
 class RetryableClosureException extends ClosedChannelException implements RetryableException {
+    private static final long serialVersionUID = 2006969744518089407L;
+
     RetryableClosureException(final Throwable cause) {
         initCause(cause);
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ServiceTalkWireLogger.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ServiceTalkWireLogger.java
@@ -22,6 +22,7 @@ import io.servicetalk.logging.slf4j.internal.FixedLevelLogger;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 
@@ -36,6 +37,7 @@ import static io.netty.util.internal.StringUtil.NEWLINE;
 import static io.servicetalk.buffer.netty.BufferUtils.toByteBuf;
 import static java.util.Objects.requireNonNull;
 
+@Sharable
 final class ServiceTalkWireLogger extends ChannelDuplexHandler {
     private final FixedLevelLogger logger;
     private final BooleanSupplier logUserDataSupplier;

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
@@ -16,7 +16,7 @@
 package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.PublisherSource;
-import io.servicetalk.concurrent.api.test.FirstSteps;
+import io.servicetalk.concurrent.api.test.StepVerifiers;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.ConnectionInfo.Protocol;
@@ -98,7 +98,7 @@ abstract class AbstractSslCloseNotifyAlertHandlingTest {
             assertThat("Underlying Channel is not closed", channel.isOpen(), is(false));
             assertThat("Unexpected inbound messages", channel.inboundMessages(), hasSize(0));
             assertThat("Unexpected outbound messages", channel.outboundMessages(), hasSize(0));
-            FirstSteps.create(conn.onClose()).expectComplete().verify();
+            StepVerifiers.create(conn.onClose()).expectComplete().verify();
         } finally {
             // In case of test errors, do the clean up:
             try {
@@ -117,7 +117,7 @@ abstract class AbstractSslCloseNotifyAlertHandlingTest {
 
     protected final void closeNotifyAndVerifyClosing() {
         channel.pipeline().fireUserEventTriggered(SslCloseCompletionEvent.SUCCESS);
-        FirstSteps.create(conn.onClosing()).expectComplete().verify();
+        StepVerifiers.create(conn.onClosing()).expectComplete().verify();
     }
 
     protected final void writeMsg(PublisherSource.Processor<String, String> writeSource, String msg) {

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
@@ -35,7 +35,7 @@ import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.transport.netty.internal.CloseHandler.forPipelinedRequestResponse;
 import static io.servicetalk.transport.netty.internal.FlushStrategies.defaultFlushStrategy;
-import static io.servicetalk.transport.netty.internal.OffloadAllExecutionStrategy.OFFLOAD_ALL_STRATEGY;
+import static io.servicetalk.transport.netty.internal.NoopExecutionStrategy.NOOP_STRATEGY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -87,7 +87,7 @@ abstract class AbstractSslCloseNotifyAlertHandlingTest {
                         }
                         ctx.write(msg, promise);
                     }
-                })), OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE, isClient)
+                })), NOOP_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE, isClient)
                 .toFuture().get();
     }
 

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.api.test.FirstSteps;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.logging.api.LogLevel;
+import io.servicetalk.transport.api.ConnectionInfo.Protocol;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.ssl.SslCloseCompletionEvent;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.concurrent.api.Executors.immediate;
+import static io.servicetalk.transport.netty.internal.CloseHandler.forPipelinedRequestResponse;
+import static io.servicetalk.transport.netty.internal.FlushStrategies.defaultFlushStrategy;
+import static io.servicetalk.transport.netty.internal.OffloadAllExecutionStrategy.OFFLOAD_ALL_STRATEGY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+abstract class AbstractSslCloseNotifyAlertHandlingTest {
+
+    private static final WireLoggingInitializer WIRE_LOGGING_INITIALIZER =
+            new WireLoggingInitializer("servicetalk-tests-wire-logger", LogLevel.TRACE, () -> true);
+
+    protected static final String BEGIN = "MSG_BEGIN";
+    protected static final String END = "MSG_END";
+
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+
+    protected final EmbeddedDuplexChannel channel;
+    protected final DefaultNettyConnection<String, String> conn;
+
+    AbstractSslCloseNotifyAlertHandlingTest(boolean isClient) throws Exception {
+        channel = new EmbeddedDuplexChannel(false);
+        final CloseHandler closeHandler = forPipelinedRequestResponse(isClient, channel.config());
+        conn = DefaultNettyConnection.<String, String>initChannel(channel, DEFAULT_ALLOCATOR, immediate(),
+                END::equals, closeHandler, defaultFlushStrategy(), null,
+                WIRE_LOGGING_INITIALIZER.andThen(ch -> ch.pipeline().addLast(new ChannelDuplexHandler() {
+                    @Override
+                    public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
+                        if (BEGIN.equals(msg)) {
+                            closeHandler.protocolPayloadBeginInbound(ctx);
+                        }
+                        ctx.fireChannelRead(msg);
+                        if (END.equals(msg)) {
+                            closeHandler.protocolPayloadEndInbound(ctx);
+                        }
+                    }
+
+                    @Override
+                    public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise promise) {
+                        if (BEGIN.equals(msg)) {
+                            closeHandler.protocolPayloadBeginOutbound(ctx);
+                        }
+                        if (END.equals(msg)) {
+                            closeHandler.protocolPayloadEndOutbound(ctx);
+                            promise.addListener(f -> {
+                                if (f.isSuccess()) {
+                                    closeHandler.protocolPayloadEndOutboundSuccess(ctx);
+                                }
+                            });
+                        }
+                        ctx.write(msg, promise);
+                    }
+                })), OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE, isClient)
+                .toFuture().get();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        try {
+            // Make sure the connection and channel are closed after each test:
+            assertThat("Underlying Channel is not closed", channel.isOpen(), is(false));
+            assertThat("Unexpected inbound messages", channel.inboundMessages(), hasSize(0));
+            assertThat("Unexpected outbound messages", channel.outboundMessages(), hasSize(0));
+            FirstSteps.create(conn.onClose()).expectComplete().verify();
+        } finally {
+            // In case of test errors, do the clean up:
+            try {
+                conn.closeAsync().toFuture().get();
+            } finally {
+                channel.finishAndReleaseAll();
+                channel.close().syncUninterruptibly();
+            }
+        }
+    }
+
+    @Test
+    public void neverUsedIdleConnection() {
+        closeNotifyAndVerifyClosing();
+    }
+
+    protected final void closeNotifyAndVerifyClosing() {
+        channel.pipeline().fireUserEventTriggered(SslCloseCompletionEvent.SUCCESS);
+        FirstSteps.create(conn.onClosing()).expectComplete().verify();
+    }
+
+    protected final void writeMsg(PublisherSource.Processor<String, String> writeSource, String msg) {
+        writeSource.onNext(msg);
+        assertThat("Unexpected outbound message", channel.readOutbound(), is(msg));
+    }
+}

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NoopExecutionStrategy.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NoopExecutionStrategy.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.transport.api.ExecutionStrategy;
+
+import javax.annotation.Nullable;
+
+final class NoopExecutionStrategy implements ExecutionStrategy {
+
+    static final ExecutionStrategy NOOP_STRATEGY = new NoopExecutionStrategy();
+
+    private NoopExecutionStrategy() {
+        // Singleton
+    }
+
+    @Override
+    public <T> Single<T> offloadSend(final Executor fallback, final Single<T> original) {
+        return original;
+    }
+
+    @Override
+    public <T> Single<T> offloadReceive(final Executor fallback, final Single<T> original) {
+        return original;
+    }
+
+    @Override
+    public <T> Publisher<T> offloadSend(final Executor fallback, final Publisher<T> original) {
+        return original;
+    }
+
+    @Override
+    public <T> Publisher<T> offloadReceive(final Executor fallback, final Publisher<T> original) {
+        return original;
+    }
+
+    @Nullable
+    @Override
+    public Executor executor() {
+        return null;
+    }
+}

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertClientHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertClientHandlingTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.api.test.FirstSteps;
+
+import org.junit.Test;
+
+import java.nio.channels.ClosedChannelException;
+
+import static io.servicetalk.concurrent.api.Processors.newPublisherProcessor;
+import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
+
+public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotifyAlertHandlingTest {
+
+    public SslCloseNotifyAlertClientHandlingTest() throws Exception {
+        super(true);
+    }
+
+    @Test
+    public void afterExchangeIdleConnection() {
+        sendRequest();
+        FirstSteps.create(conn.read())
+                .then(() -> channel.writeInbound(BEGIN))
+                .expectNext(BEGIN)
+                .then(() -> channel.writeInbound(END))
+                .expectNext(END)
+                .expectComplete()
+                .verify();
+        closeNotifyAndVerifyClosing();
+    }
+
+    @Test
+    public void afterRequestBeforeReadingResponse() {
+        sendRequest();
+        FirstSteps.create(conn.read())
+                .then(this::closeNotifyAndVerifyClosing)
+                .expectError(ClosedChannelException.class)
+                .verify();
+    }
+
+    @Test
+    public void afterRequestWhileReadingResponse() {
+        sendRequest();
+        FirstSteps.create(conn.read())
+                .then(() -> channel.writeInbound(BEGIN))
+                .expectNext(BEGIN)
+                .then(this::closeNotifyAndVerifyClosing)
+                .expectError(ClosedChannelException.class)
+                .verify();
+    }
+
+    @Test
+    public void whileWritingRequestBeforeReadingResponse() {
+        PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
+        FirstSteps.create(conn.write(fromSource(writeSource)).merge(conn.read()))
+                .then(() -> {
+                    // Start writing request
+                    writeMsg(writeSource, BEGIN);
+                    closeNotifyAndVerifyClosing();
+                })
+                .expectError(ClosedChannelException.class)
+                .verify();
+    }
+
+    @Test
+    public void whileWritingRequestAndReadingResponse() {
+        PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
+        FirstSteps.create(conn.write(fromSource(writeSource)).merge(conn.read()))
+                .then(() -> {
+                    // Start writing request
+                    writeMsg(writeSource, BEGIN);
+                    // Start reading response
+                    channel.writeInbound(BEGIN);
+                })
+                .expectNext(BEGIN)
+                .then(this::closeNotifyAndVerifyClosing)
+                .expectError(ClosedChannelException.class)
+                .verify();
+    }
+
+    @Test
+    public void whileWritingRequestAfterReadingResponse() {
+        PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
+        FirstSteps.create(conn.write(fromSource(writeSource)).merge(conn.read()))
+                .then(() -> {
+                    // Start writing request
+                    writeMsg(writeSource, BEGIN);
+                    // Read response
+                    channel.writeInbound(BEGIN);
+                    channel.writeInbound(END);
+                })
+                .expectNext(BEGIN, END)
+                .then(this::closeNotifyAndVerifyClosing)
+                .expectError(ClosedChannelException.class)
+                .verify();
+    }
+
+    private void sendRequest() {
+        PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
+        FirstSteps.create(conn.write(fromSource(writeSource)))
+                .then(() -> {
+                    writeMsg(writeSource, BEGIN);
+                    writeMsg(writeSource, END);
+                })
+                .expectComplete()
+                .verify();
+    }
+}

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertClientHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertClientHandlingTest.java
@@ -16,7 +16,7 @@
 package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.PublisherSource;
-import io.servicetalk.concurrent.api.test.FirstSteps;
+import io.servicetalk.concurrent.api.test.StepVerifiers;
 
 import org.junit.Test;
 
@@ -34,7 +34,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
     @Test
     public void afterExchangeIdleConnection() {
         sendRequest();
-        FirstSteps.create(conn.read())
+        StepVerifiers.create(conn.read())
                 .then(() -> channel.writeInbound(BEGIN))
                 .expectNext(BEGIN)
                 .then(() -> channel.writeInbound(END))
@@ -47,7 +47,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
     @Test
     public void afterRequestBeforeReadingResponse() {
         sendRequest();
-        FirstSteps.create(conn.read())
+        StepVerifiers.create(conn.read())
                 .then(this::closeNotifyAndVerifyClosing)
                 .expectError(ClosedChannelException.class)
                 .verify();
@@ -56,7 +56,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
     @Test
     public void afterRequestWhileReadingResponse() {
         sendRequest();
-        FirstSteps.create(conn.read())
+        StepVerifiers.create(conn.read())
                 .then(() -> channel.writeInbound(BEGIN))
                 .expectNext(BEGIN)
                 .then(this::closeNotifyAndVerifyClosing)
@@ -67,7 +67,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
     @Test
     public void whileWritingRequestBeforeReadingResponse() {
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
-        FirstSteps.create(conn.write(fromSource(writeSource)).merge(conn.read()))
+        StepVerifiers.create(conn.write(fromSource(writeSource)).merge(conn.read()))
                 .then(() -> {
                     // Start writing request
                     writeMsg(writeSource, BEGIN);
@@ -80,7 +80,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
     @Test
     public void whileWritingRequestAndReadingResponse() {
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
-        FirstSteps.create(conn.write(fromSource(writeSource)).merge(conn.read()))
+        StepVerifiers.create(conn.write(fromSource(writeSource)).merge(conn.read()))
                 .then(() -> {
                     // Start writing request
                     writeMsg(writeSource, BEGIN);
@@ -96,7 +96,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
     @Test
     public void whileWritingRequestAfterReadingResponse() {
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
-        FirstSteps.create(conn.write(fromSource(writeSource)).merge(conn.read()))
+        StepVerifiers.create(conn.write(fromSource(writeSource)).merge(conn.read()))
                 .then(() -> {
                     // Start writing request
                     writeMsg(writeSource, BEGIN);
@@ -112,7 +112,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
 
     private void sendRequest() {
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
-        FirstSteps.create(conn.write(fromSource(writeSource)))
+        StepVerifiers.create(conn.write(fromSource(writeSource)))
                 .then(() -> {
                     writeMsg(writeSource, BEGIN);
                     writeMsg(writeSource, END);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertServerHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertServerHandlingTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.api.test.FirstSteps;
+
+import org.junit.Test;
+
+import java.nio.channels.ClosedChannelException;
+
+import static io.servicetalk.concurrent.api.Processors.newPublisherProcessor;
+import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
+
+public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotifyAlertHandlingTest {
+
+    public SslCloseNotifyAlertServerHandlingTest() throws Exception {
+        super(false);
+    }
+
+    @Test
+    public void afterExchangeIdleConnection() {
+        receiveRequest();
+        PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
+        FirstSteps.create(conn.write(fromSource(writeSource)))
+                .then(() -> {
+                    writeMsg(writeSource, BEGIN);
+                    writeMsg(writeSource, END);
+                    closeNotifyAndVerifyClosing();
+                })
+                .expectError(ClosedChannelException.class)
+                .verify();
+    }
+
+    @Test
+    public void afterRequestBeforeSendingResponse() {
+        receiveRequest();
+
+        PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
+        FirstSteps.create(conn.write(fromSource(writeSource)))
+                .then(this::closeNotifyAndVerifyClosing)
+                .expectError(ClosedChannelException.class)
+                .verify();
+    }
+
+    @Test
+    public void afterRequestWhileSendingResponse() {
+        receiveRequest();
+
+        PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
+        FirstSteps.create(conn.write(fromSource(writeSource)))
+                .then(() -> {
+                    writeMsg(writeSource, BEGIN);
+                    closeNotifyAndVerifyClosing();
+                })
+                .expectError(ClosedChannelException.class)
+                .verify();
+    }
+
+    @Test
+    public void whileReadingRequestBeforeSendingResponse() {
+        FirstSteps.create(conn.write(fromSource(newPublisherProcessor())).merge(conn.read()))
+                .then(() -> {
+                    // Start reading request
+                    channel.writeInbound(BEGIN);
+                    closeNotifyAndVerifyClosing();
+                })
+                .expectNext(BEGIN)
+                .expectError(ClosedChannelException.class)
+                .verify();
+    }
+
+    @Test
+    public void whileReadingRequestAndSendingResponse() {
+        PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
+        FirstSteps.create(conn.write(fromSource(writeSource)).merge(conn.read()))
+                .then(() -> {
+                    // Start reading request
+                    channel.writeInbound(BEGIN);
+                    // Start writing response
+                    writeMsg(writeSource, BEGIN);
+                })
+                .expectNext(BEGIN)
+                .then(this::closeNotifyAndVerifyClosing)
+                .expectError(ClosedChannelException.class)
+                .verify();
+    }
+
+    @Test
+    public void whileReadingRequestAfterSendingResponse() {
+        PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
+        FirstSteps.create(conn.write(fromSource(writeSource)).merge(conn.read()))
+                .then(() -> {
+                    // Start reading request
+                    channel.writeInbound(BEGIN);
+                    // Send response
+                    writeMsg(writeSource, BEGIN);
+                    writeMsg(writeSource, END);
+                })
+                .expectNext(BEGIN)
+                .then(this::closeNotifyAndVerifyClosing)
+                .expectError(ClosedChannelException.class)
+                .verify();
+    }
+
+    private void receiveRequest() {
+        FirstSteps.create(conn.read())
+                .then(() -> channel.writeInbound(BEGIN))
+                .expectNext(BEGIN)
+                .then(() -> channel.writeInbound(END))
+                .expectNext(END)
+                .expectComplete()
+                .verify();
+    }
+}

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertServerHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertServerHandlingTest.java
@@ -16,7 +16,7 @@
 package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.PublisherSource;
-import io.servicetalk.concurrent.api.test.FirstSteps;
+import io.servicetalk.concurrent.api.test.StepVerifiers;
 
 import org.junit.Test;
 
@@ -35,7 +35,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
     public void afterExchangeIdleConnection() {
         receiveRequest();
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
-        FirstSteps.create(conn.write(fromSource(writeSource)))
+        StepVerifiers.create(conn.write(fromSource(writeSource)))
                 .then(() -> {
                     writeMsg(writeSource, BEGIN);
                     writeMsg(writeSource, END);
@@ -50,7 +50,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
         receiveRequest();
 
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
-        FirstSteps.create(conn.write(fromSource(writeSource)))
+        StepVerifiers.create(conn.write(fromSource(writeSource)))
                 .then(this::closeNotifyAndVerifyClosing)
                 .expectError(ClosedChannelException.class)
                 .verify();
@@ -61,7 +61,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
         receiveRequest();
 
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
-        FirstSteps.create(conn.write(fromSource(writeSource)))
+        StepVerifiers.create(conn.write(fromSource(writeSource)))
                 .then(() -> {
                     writeMsg(writeSource, BEGIN);
                     closeNotifyAndVerifyClosing();
@@ -72,7 +72,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
 
     @Test
     public void whileReadingRequestBeforeSendingResponse() {
-        FirstSteps.create(conn.write(fromSource(newPublisherProcessor())).merge(conn.read()))
+        StepVerifiers.create(conn.write(fromSource(newPublisherProcessor())).merge(conn.read()))
                 .then(() -> {
                     // Start reading request
                     channel.writeInbound(BEGIN);
@@ -86,7 +86,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
     @Test
     public void whileReadingRequestAndSendingResponse() {
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
-        FirstSteps.create(conn.write(fromSource(writeSource)).merge(conn.read()))
+        StepVerifiers.create(conn.write(fromSource(writeSource)).merge(conn.read()))
                 .then(() -> {
                     // Start reading request
                     channel.writeInbound(BEGIN);
@@ -102,7 +102,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
     @Test
     public void whileReadingRequestAfterSendingResponse() {
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
-        FirstSteps.create(conn.write(fromSource(writeSource)).merge(conn.read()))
+        StepVerifiers.create(conn.write(fromSource(writeSource)).merge(conn.read()))
                 .then(() -> {
                     // Start reading request
                     channel.writeInbound(BEGIN);
@@ -117,7 +117,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
     }
 
     private void receiveRequest() {
-        FirstSteps.create(conn.read())
+        StepVerifiers.create(conn.read())
                 .then(() -> channel.writeInbound(BEGIN))
                 .expectNext(BEGIN)
                 .then(() -> channel.writeInbound(END))


### PR DESCRIPTION
Motivation:

TLS protocol defined `close_notify` alert message [1], which notifies that the
sender will not send any more messages on this connection. `SslHandler`
generates `SslCloseCompletionEvent` in this case, then transport emits
`ChannelInputShutdownReadComplete` event when the FIN is received. There is a
race between these 2 user events and sending a new request on the client-side.
We MUST close down the connection immediately, discarding any pending writes,
and preventing new requests. We should also mark that the connection is
closing asap to prevent LB from selecting this connection.

1. https://tools.ietf.org/html/rfc5246#section-7.2.1

Modifications:

- Handle `SslCloseCompletionEvent` in `DefaultNettyConnection`;
- Add tests to verify client and server behavior when `SslCloseCompletionEvent`
is received;

Result:

The connection transitions to the "closing" state as soon as the
`SslCloseCompletionEvent` is observed, preventing new writes on this connection
and failing the first write, making failures retryable.