### PR TITLE
Add `@FunctionalInterface` annotation for `ChannelInitializer`

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ChannelInitializer.java
@@ -21,6 +21,7 @@ import io.netty.channel.Channel;
 /**
  * Configures a {@link Channel}.
  */
+@FunctionalInterface
 public interface ChannelInitializer {
 
     /**


### PR DESCRIPTION
Motivation:

`ChannelInitializer` has exactly one abstract method and should be marked as
`@FunctionalInterface`.