### PR TITLE
Completable#merge concurrency fix, new Completable#merge single arg o…

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractMergeCompletableOperator.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractMergeCompletableOperator.java
@@ -15,16 +15,12 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.internal.SignalOffloader;
 
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import javax.annotation.Nullable;
-
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
-abstract class AbstractMergeCompletableOperator extends AbstractNoHandleSubscribeCompletable
+abstract class AbstractMergeCompletableOperator<T extends CompletableMergeSubscriber>
+        extends AbstractNoHandleSubscribeCompletable
         implements CompletableOperator {
 
     private final Completable original;
@@ -46,7 +42,7 @@ abstract class AbstractMergeCompletableOperator extends AbstractNoHandleSubscrib
         // side of the asynchronous boundary.
         final Subscriber operatorSubscriber = signalOffloader.offloadSubscriber(
                 contextProvider.wrapCompletableSubscriberAndCancellable(subscriber, contextMap));
-        MergeSubscriber mergeSubscriber = apply(operatorSubscriber);
+        T mergeSubscriber = apply(operatorSubscriber);
         // Subscriber to use to subscribe to the original source. Since this is an asynchronous operator, it may call
         // Cancellable method from EventLoop (if the asynchronous source created/obtained inside this operator uses
         // EventLoop) which may execute blocking code on EventLoop, eg: beforeCancel(). So, we should offload
@@ -60,105 +56,12 @@ abstract class AbstractMergeCompletableOperator extends AbstractNoHandleSubscrib
     }
 
     @Override
-    public abstract MergeSubscriber apply(Subscriber subscriber);
+    public abstract T apply(Subscriber subscriber);
 
     /**
      * Called after the {@code original} {@link Completable} is subscribed and provides a way to subscribe to all other
      * {@link Completable}s that are to be merged with the {@code original} {@link Completable}.
-     * @param subscriber {@link MergeSubscriber} to be used to merge.
+     * @param subscriber {@link T} to be used to merge.
      */
-    abstract void doMerge(MergeSubscriber subscriber);
-
-    abstract static class MergeSubscriber implements Subscriber {
-        private static final AtomicReferenceFieldUpdater<MergeSubscriber, Object> terminalNotificationUpdater =
-                newUpdater(MergeSubscriber.class, Object.class, "terminalNotification");
-        private static final Object ON_COMPLETE = new Object();
-        private static final Object DELIVERED_DELAYED_ERROR = new Object();
-        @SuppressWarnings("unused")
-        @Nullable
-        private volatile Object terminalNotification;
-        private final Subscriber subscriber;
-        private final CancellableStack dynamicCancellable;
-        private final boolean delayError;
-
-        MergeSubscriber(Subscriber subscriber, boolean delayError) {
-            this.subscriber = subscriber;
-            this.delayError = delayError;
-            dynamicCancellable = new CancellableStack();
-            subscriber.onSubscribe(dynamicCancellable);
-        }
-
-        @Override
-        public final void onSubscribe(Cancellable cancellable) {
-            dynamicCancellable.add(cancellable);
-        }
-
-        @Override
-        public final void onComplete() {
-            if (onTerminate()) {
-                tryToCompleteSubscriber();
-            }
-        }
-
-        @Override
-        public final void onError(Throwable t) {
-            for (;;) {
-                Object terminalNotification = this.terminalNotification;
-                if (terminalNotification == null) {
-                    if (terminalNotificationUpdater.compareAndSet(this, null, t)) {
-                        break;
-                    } else if (!delayError) {
-                        // If we are not delaying error notification, and we fail to set the terminal event then that
-                        // means we have already notified the subscriber and should return to avoid duplicate terminal
-                        // notifications.
-                        return;
-                    }
-                } else {
-                    Throwable tmpT = (Throwable) terminalNotification;
-                    tmpT.addSuppressed(t);
-                    t = tmpT;
-                    break;
-                }
-            }
-
-            // If we are delaying the error then we need to prevent concurrent termination with the subscribe() thread,
-            // and we do this with a two phase atomic set to DELIVERED_DELAYED_ERROR.
-            // If we don't delay the error then we never increase the total completion count, so we don't have to worry
-            // about concurrent invocation.
-            if (!delayError || (onTerminate() &&
-                    t == terminalNotificationUpdater.getAndSet(this, DELIVERED_DELAYED_ERROR))) {
-                onError0(t);
-            }
-        }
-
-        final void tryToCompleteSubscriber() {
-            if (terminalNotificationUpdater.compareAndSet(this, null, ON_COMPLETE)) {
-                subscriber.onComplete();
-            } else if (delayError) {
-                // This maybe called from the subscribe() thread and also the Subscriber thread. It is possible the
-                // merge operation already completed successfully in the Subscriber thread, and then the subscribe()
-                // thread observed all merged Completables have completed and so also calls this method.
-                Object maybeThrowable = terminalNotificationUpdater.getAndSet(this, DELIVERED_DELAYED_ERROR);
-                if (maybeThrowable instanceof Throwable) {
-                    onError0((Throwable) maybeThrowable);
-                }
-            }
-        }
-
-        private void onError0(Throwable t) {
-            // If we are delaying error, then everything must have terminated by now, and there is no need to cancel
-            // anything. However if we are not delaying error then we should cancel all outstanding work.
-            if (!delayError) {
-                dynamicCancellable.cancel();
-            }
-            subscriber.onError(t);
-        }
-
-        /**
-         * Called when a terminal event is received.
-         *
-         * @return {@code true} if we are done processing after changing state due to receiving a terminal event.
-         */
-        abstract boolean onTerminate();
-    }
+    abstract void doMerge(T subscriber);
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableDynamicCountSubscriber.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableDynamicCountSubscriber.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.CompletableSource.Subscriber;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
+
+final class CompletableDynamicCountSubscriber extends CompletableMergeSubscriber {
+    private static final AtomicLongFieldUpdater<CompletableDynamicCountSubscriber> completedCountUpdater =
+            newUpdater(CompletableDynamicCountSubscriber.class, "completedCount");
+    private volatile long completedCount;
+
+    CompletableDynamicCountSubscriber(Subscriber subscriber, boolean delayError) {
+        super(subscriber, delayError);
+    }
+
+    @Override
+    boolean onTerminate() {
+        // we will go negative until setExpectedCount is called, but then we will offset by the expected amount.
+        return completedCountUpdater.decrementAndGet(this) == 0;
+    }
+
+    void setExpectedCount(final long count) {
+        // add the expected amount back, if we come to 0 that means all sources have completed.
+        if (completedCountUpdater.addAndGet(this, count) == 0) {
+            tryToCompleteSubscriber();
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableFixedCountMergeSubscriber.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableFixedCountMergeSubscriber.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.CompletableSource.Subscriber;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
+
+final class CompletableFixedCountMergeSubscriber extends CompletableMergeSubscriber {
+    private static final AtomicIntegerFieldUpdater<CompletableFixedCountMergeSubscriber> terminatedCountUpdater =
+            newUpdater(CompletableFixedCountMergeSubscriber.class, "terminatedCount");
+    private final int expectedCount;
+    private volatile int terminatedCount;
+
+    CompletableFixedCountMergeSubscriber(Subscriber subscriber, int expectedCount, boolean delayError) {
+        super(subscriber, delayError);
+        this.expectedCount = expectedCount;
+    }
+
+    @Override
+    boolean onTerminate() {
+        return terminatedCountUpdater.incrementAndGet(this) == expectedCount;
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableMergeSubscriber.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableMergeSubscriber.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.CompletableSource.Subscriber;
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import javax.annotation.Nullable;
+
+import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
+
+abstract class CompletableMergeSubscriber implements Subscriber {
+    private static final AtomicReferenceFieldUpdater<CompletableMergeSubscriber, Object> terminalNotificationUpdater =
+            newUpdater(CompletableMergeSubscriber.class, Object.class, "terminalNotification");
+    private static final Object ON_COMPLETE = new Object();
+    private static final Object DELIVERED_DELAYED_ERROR = new Object();
+    @SuppressWarnings("unused")
+    @Nullable
+    private volatile Object terminalNotification;
+    private final Subscriber subscriber;
+    private final CancellableStack dynamicCancellable;
+    private final boolean delayError;
+
+    CompletableMergeSubscriber(Subscriber subscriber, boolean delayError) {
+        this.subscriber = subscriber;
+        this.delayError = delayError;
+        dynamicCancellable = new CancellableStack();
+        subscriber.onSubscribe(dynamicCancellable);
+    }
+
+    @Override
+    public final void onSubscribe(Cancellable cancellable) {
+        dynamicCancellable.add(cancellable);
+    }
+
+    @Override
+    public final void onComplete() {
+        if (onTerminate()) {
+            tryToCompleteSubscriber();
+        }
+    }
+
+    @Override
+    public final void onError(Throwable t) {
+        for (;;) {
+            Object terminalNotification = this.terminalNotification;
+            if (terminalNotification == null) {
+                if (terminalNotificationUpdater.compareAndSet(this, null, t)) {
+                    break;
+                } else if (!delayError) {
+                    // If we are not delaying error notification, and we fail to set the terminal event then that
+                    // means we have already notified the subscriber and should return to avoid duplicate terminal
+                    // notifications.
+                    return;
+                }
+            } else {
+                Throwable tmpT = (Throwable) terminalNotification;
+                tmpT.addSuppressed(t);
+                t = tmpT;
+                break;
+            }
+        }
+
+        // If we are delaying the error then we need to prevent concurrent termination with the subscribe() thread,
+        // and we do this with a two phase atomic set to DELIVERED_DELAYED_ERROR.
+        // If we don't delay the error then we never increase the total completion count, so we don't have to worry
+        // about concurrent invocation.
+        if (!delayError || (onTerminate() &&
+                t == terminalNotificationUpdater.getAndSet(this, DELIVERED_DELAYED_ERROR))) {
+            onError0(t);
+        }
+    }
+
+    final void tryToCompleteSubscriber() {
+        if (terminalNotificationUpdater.compareAndSet(this, null, ON_COMPLETE)) {
+            subscriber.onComplete();
+        } else if (delayError) {
+            // This maybe called from the subscribe() thread and also the Subscriber thread. It is possible the
+            // merge operation already completed successfully in the Subscriber thread, and then the subscribe()
+            // thread observed all merged Completables have completed and so also calls this method.
+            Object maybeThrowable = terminalNotificationUpdater.getAndSet(this, DELIVERED_DELAYED_ERROR);
+            if (maybeThrowable instanceof Throwable) {
+                onError0((Throwable) maybeThrowable);
+            }
+        }
+    }
+
+    private void onError0(Throwable t) {
+        // If we are delaying error, then everything must have terminated by now, and there is no need to cancel
+        // anything. However if we are not delaying error then we should cancel all outstanding work.
+        if (!delayError) {
+            dynamicCancellable.cancel();
+        }
+        subscriber.onError(t);
+    }
+
+    /**
+     * Called when a terminal event is received.
+     *
+     * @return {@code true} if we are done processing after changing state due to receiving a terminal event.
+     */
+    abstract boolean onTerminate();
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MergeCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MergeCompletable.java
@@ -52,18 +52,17 @@ final class MergeCompletable extends AbstractMergeCompletableOperator {
     static final class FixedCountMergeSubscriber extends MergeSubscriber {
         private static final AtomicIntegerFieldUpdater<FixedCountMergeSubscriber> remainingCountUpdater =
                 newUpdater(FixedCountMergeSubscriber.class, "remainingCount");
+        private final int expectedCount;
         private volatile int remainingCount;
 
         FixedCountMergeSubscriber(Subscriber subscriber, int expectedCount, boolean delayError) {
             super(subscriber, delayError);
-            // Subscribe operation must happen before the Subscriber is terminated, so initialization will be visible
-            // in onTerminate.
-            this.remainingCount = expectedCount;
+            this.expectedCount = expectedCount;
         }
 
         @Override
         boolean onTerminate() {
-            return remainingCountUpdater.decrementAndGet(this) == 0;
+            return remainingCountUpdater.incrementAndGet(this) == expectedCount;
         }
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MergeOneCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MergeOneCompletable.java
@@ -15,11 +15,9 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.api.MergeCompletable.FixedCountMergeSubscriber;
-
 import static java.util.Objects.requireNonNull;
 
-final class MergeOneCompletable extends AbstractMergeCompletableOperator {
+final class MergeOneCompletable extends AbstractMergeCompletableOperator<CompletableFixedCountMergeSubscriber> {
     private final Completable onlyOther;
     private final boolean delayError;
 
@@ -30,12 +28,12 @@ final class MergeOneCompletable extends AbstractMergeCompletableOperator {
     }
 
     @Override
-    public MergeSubscriber apply(final Subscriber subscriber) {
-        return new FixedCountMergeSubscriber(subscriber, 2, delayError);
+    public CompletableFixedCountMergeSubscriber apply(final Subscriber subscriber) {
+        return new CompletableFixedCountMergeSubscriber(subscriber, 2, delayError);
     }
 
     @Override
-    void doMerge(final MergeSubscriber subscriber) {
+    void doMerge(final CompletableFixedCountMergeSubscriber subscriber) {
         onlyOther.subscribeInternal(subscriber);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MergeOneCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MergeOneCompletable.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.api.MergeCompletable.FixedCountMergeSubscriber;
+
+import static java.util.Objects.requireNonNull;
+
+final class MergeOneCompletable extends AbstractMergeCompletableOperator {
+    private final Completable onlyOther;
+    private final boolean delayError;
+
+    MergeOneCompletable(boolean delayError, Completable original, Executor executor, Completable other) {
+        super(original, executor);
+        this.delayError = delayError;
+        onlyOther = requireNonNull(other);
+    }
+
+    @Override
+    public MergeSubscriber apply(final Subscriber subscriber) {
+        return new FixedCountMergeSubscriber(subscriber, 2, delayError);
+    }
+
+    @Override
+    void doMerge(final MergeSubscriber subscriber) {
+        onlyOther.subscribeInternal(subscriber);
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MergeCompletableDelayErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MergeCompletableDelayErrorTest.java
@@ -31,7 +31,7 @@ public class MergeCompletableDelayErrorTest {
     private final MergeCompletableTest.CompletableHolder holder = new MergeCompletableTest.CompletableHolder() {
         @Override
         protected Completable createCompletable(Completable[] completables) {
-            return new MergeCompletable(true, completables[0], immediate(),
+            return MergeCompletable.newInstance(true, completables[0], immediate(),
                     copyOfRange(completables, 1, completables.length));
         }
     };

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MergeCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MergeCompletableTest.java
@@ -41,14 +41,16 @@ public class MergeCompletableTest {
     private final CompletableHolder holder = new CompletableHolder() {
         @Override
         protected Completable createCompletable(Completable[] completables) {
-            return new MergeCompletable(false, completables[0], immediate(),
+            return MergeCompletable.newInstance(false, completables[0], immediate(),
                     copyOfRange(completables, 1, completables.length));
         }
     };
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testEmpty() {
-        holder.init(0);
+        TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
+        holder.init(0).listen(subscriber).completeAll();
+        subscriber.awaitOnComplete();
     }
 
     @Test

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/CompletableMergeOneDelayErrorTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/CompletableMergeOneDelayErrorTckTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Completable;
+
+import static io.servicetalk.concurrent.api.Completable.completed;
+
+public class CompletableMergeOneDelayErrorTckTest extends AbstractCompletableOperatorTckTest {
+    @Override
+    protected Completable composeCompletable(Completable completable) {
+        return completable.mergeDelayError(completed());
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/CompletableMergeOneTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/CompletableMergeOneTckTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Completable;
+
+import static io.servicetalk.concurrent.api.Completable.completed;
+
+public class CompletableMergeOneTckTest extends AbstractCompletableOperatorTckTest {
+    @Override
+    protected Completable composeCompletable(Completable completable) {
+        return completable.merge(completed());
+    }
+}


### PR DESCRIPTION
…verride

Motivation:
Completable#merge(Iterable) must iterate before it knows how many
Completables to wait for. The implementation uses two independent
volatile variables for the expected value and current count, which may
result in visibility issues.

Modifications:
- Completable#merge(Iterable) should use the same volatile variable to
manage the count, and avoid data races/visibility issues.
- Add Compleable#merge(Completable) and
Completable#mergeDelayError(Completable) overrides to avoid array
allocation.
- Clean up Compleable#merge implementations to remove unused methods,
and create the optimized implementation depending upon array
cardinality.

Result:
Less data races in Completable#merge(Iterable) and operator overload for
single Completable merge operations.