### PR TITLE
DefaultHttpCookiePair#parseCookiePair more strict overflow detection

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpCookiePair.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpCookiePair.java
@@ -85,10 +85,12 @@ public final class DefaultHttpCookiePair implements HttpCookiePair {
         return parseCookiePair0(sequence, nameStart, nameLength, valueEnd < 0 ? sequence.length() : valueEnd);
     }
 
-    static HttpCookiePair parseCookiePair0(final CharSequence sequence, int nameStart, int nameLength, int valueEnd) {
+    private static HttpCookiePair parseCookiePair0(final CharSequence sequence, int nameStart, int nameLength,
+                                                   int valueEnd) {
         final int valueStart = nameStart + nameLength + 1;
         if (valueEnd <= valueStart || valueStart < 0) {
-            throw new IllegalArgumentException("unexpected format of cookie pair, empty value");
+            throw new IllegalArgumentException("value indexes are invalid. valueStart: " + valueStart
+                    + " valueEnd: " + valueEnd);
         }
         if (sequence.charAt(valueStart) == '"' && sequence.charAt(valueEnd - 1) == '"') {
             if (valueEnd - 2 <= valueStart) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpCookiePair.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpCookiePair.java
@@ -87,7 +87,7 @@ public final class DefaultHttpCookiePair implements HttpCookiePair {
 
     static HttpCookiePair parseCookiePair0(final CharSequence sequence, int nameStart, int nameLength, int valueEnd) {
         final int valueStart = nameStart + nameLength + 1;
-        if (valueEnd - 1 < valueStart) {
+        if (valueEnd <= valueStart || valueStart < 0) {
             throw new IllegalArgumentException("unexpected format of cookie pair, empty value");
         }
         if (sequence.charAt(valueStart) == '"' && sequence.charAt(valueEnd - 1) == '"') {


### PR DESCRIPTION
Motivation:
DefaultHttpCookiePair#parseCookiePair doesn't check for overflow when
calculating the value starting index.

Modifications:
- Check for overflow when calculating overflow index.

Result:
More robust overflow detection in DefaultHttpCookiePair#parseCookiePair.