### PR TITLE
DefaultHttpCookiePair#parseCookiePair public -> package private 

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpCookiePair.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpCookiePair.java
@@ -64,7 +64,7 @@ public final class DefaultHttpCookiePair implements HttpCookiePair {
      * <a href="https://tools.ietf.org/html/rfc6265#section-4.1.1">cookie-pair</a> in {@code sequence}.
      * @return a {@link HttpCookiePair} parsed from {@code sequence}.
      */
-    public static HttpCookiePair parseCookiePair(final CharSequence sequence, int nameStart, int valueEnd) {
+    static HttpCookiePair parseCookiePair(final CharSequence sequence, int nameStart, int valueEnd) {
         return parseCookiePair(sequence, nameStart, indexOf(sequence, '=', nameStart) - nameStart, valueEnd);
     }
 
@@ -80,8 +80,7 @@ public final class DefaultHttpCookiePair implements HttpCookiePair {
      * <a href="https://tools.ietf.org/html/rfc6265#section-4.1.1">cookie-pair</a> in {@code sequence}.
      * @return a {@link HttpCookiePair} parsed from {@code sequence}.
      */
-    public static HttpCookiePair parseCookiePair(final CharSequence sequence, int nameStart, int nameLength,
-                                                 int valueEnd) {
+    static HttpCookiePair parseCookiePair(final CharSequence sequence, int nameStart, int nameLength, int valueEnd) {
         return parseCookiePair0(sequence, nameStart, nameLength, valueEnd < 0 ? sequence.length() : valueEnd);
     }
 


### PR DESCRIPTION
Motivation:
DefaultHttpCookiePair#parseCookiePair methods are currently public, but
users are unlikely to interact directly with these APIs and are instead
encouraged to interact with HttpCookiePair objects via the HttpHeaders
API.

Modifications:
- Make DefaultHttpCookiePair#parseCookiePair methods package private

Result:
Less public API surface that isn't necessary and duplicates capabilities
provided by other public APIs.