### PR TITLE
Avoid incorrectly throwing `QueueFullException` from `PublisherAsBlockingIterable`

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterable.java
@@ -215,8 +215,7 @@ final class PublisherAsBlockingIterable<T> implements BlockingIterable<T> {
         }
 
         private void requestMoreIfRequired() {
-            final int onNextQueued = onNextQueuedUpdater.decrementAndGet(this);
-            assert onNextQueued >= 0;
+            onNextQueuedUpdater.decrementAndGet(this);
             if (--itemsToNextRequest == 0) {
                 itemsToNextRequest = requestN;
                 subscription.request(itemsToNextRequest);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterableTest.java
@@ -375,12 +375,20 @@ public final class PublisherAsBlockingIterableTest {
         source.onNext(1);
         // Since, we have not consumed any item, we should not be requesting more.
         assertThat(subscription.requested(), is((long) 2));
-        verifyNextIs(iterator, 1); // Take next item, queue is half full, we should now be requesting more.
+        // Check the next item, it should be dequeued and prepared for the next().
+        assertThat("Item expected but not found.", iterator.hasNext(), is(true));
+        // Queue is half full, we should now be requesting more.
         assertThat(subscription.requested(), is((long) 3));
+        // Deliver all requested items.
         source.onNext(2, 3);
+        // Now take already dequeued item.
+        assertThat("Unexpected item found.", iterator.next(), is(1));
+        // Verify all other items.
         verifyNextIs(iterator, 2);
         verifyNextIs(iterator, 3);
         assertThat(subscription.requested(), is((long) 5));
+        source.onComplete();
+        assertThat("Item not expected but found.", iterator.hasNext(), is(false));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

`PublisherAsBlockingIterable` uses an intermediate queue to keep the received
items from the `Publisher` until users consume them. However, `onNextQueued`
counter is updated when users consume `next()` item, but it's actually removed
from the queue inside `hasNext()`. As the result, `QueueFullException` is
generated when the queue is still able to fit one more element.

Modifications:

- Removed unnecessary `maxBufferedItems` internal variable;
- Update `onNextQueued` counter together with `itemsToNextRequest` counter
inside `hasNext()`;
- Enhance
`PublisherAsBlockingIterableTest#replenishingRequestedShouldHonourQueueContents()`
test to account for this use-case;

Result:

`PublisherAsBlockingIterable` correctly updates `onNextQueued` counter.