### PR TITLE
Some filters won't be executed on retry/repeat

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/SingleRequestOrResponseApiTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/SingleRequestOrResponseApiTest.java
@@ -55,6 +55,7 @@ import java.util.stream.IntStream;
 
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Publisher.fromIterable;
+import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.grpc.api.GrpcStatusCode.INVALID_ARGUMENT;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -97,8 +98,10 @@ public class SingleRequestOrResponseApiTest {
                                                                     StreamingHttpRequest request) {
                         // Change path to send the request to the route API that expects only a single request item
                         // and generates requested number of response items:
-                        request.requestTarget(BlockingTestResponseStreamRpc.PATH);
-                        return super.request(delegate, strategy, request);
+                        return defer(() -> {
+                            request.requestTarget(BlockingTestResponseStreamRpc.PATH);
+                            return delegate.request(strategy, request).subscribeShareContext();
+                        });
                     }
                 });
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbsoluteAddressHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbsoluteAddressHttpRequesterFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbsoluteAddressHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbsoluteAddressHttpRequesterFilter.java
@@ -29,6 +29,7 @@ import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequester;
 import io.servicetalk.http.api.StreamingHttpResponse;
 
+import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.http.utils.HttpRequestUriUtils.getEffectiveRequestUri;
 import static java.util.Objects.requireNonNull;
 
@@ -86,8 +87,10 @@ final class AbsoluteAddressHttpRequesterFilter implements StreamingHttpClientFil
     private Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                   final HttpExecutionStrategy strategy,
                                                   final StreamingHttpRequest request) {
-        final String effectiveRequestUri = getEffectiveRequestUri(request, scheme, authority, false);
-        request.requestTarget(effectiveRequestUri);
-        return delegate.request(strategy, request);
+        return defer(() -> {
+            final String effectiveRequestUri = getEffectiveRequestUri(request, scheme, authority, false);
+            request.requestTarget(effectiveRequestUri);
+            return delegate.request(strategy, request).subscribeShareContext();
+        });
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -42,6 +42,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpApiConversions.isSafeToAggregate;
 import static io.servicetalk.http.api.HttpApiConversions.mayHaveTrailers;
@@ -99,20 +100,22 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
     @Override
     public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
                                                  final StreamingHttpRequest request) {
-        Publisher<Object> flatRequest;
-        // See https://tools.ietf.org/html/rfc7230#section-3.3.3
-        if (canAddRequestContentLength(request)) {
-            flatRequest = setRequestContentLength(request);
-        } else {
-            flatRequest = Publisher.<Object>from(request).concat(request.payloadBodyAndTrailers());
-            if (!mayHaveTrailers(request)) {
-                flatRequest = flatRequest.concat(succeeded(EmptyHttpHeaders.INSTANCE));
+        return defer(() -> {
+            Publisher<Object> flatRequest;
+            // See https://tools.ietf.org/html/rfc7230#section-3.3.3
+            if (canAddRequestContentLength(request)) {
+                flatRequest = setRequestContentLength(request);
+            } else {
+                flatRequest = Publisher.<Object>from(request).concat(request.payloadBodyAndTrailers());
+                if (!mayHaveTrailers(request)) {
+                    flatRequest = flatRequest.concat(succeeded(EmptyHttpHeaders.INSTANCE));
+                }
+                addRequestTransferEncodingIfNecessary(request);
             }
-            addRequestTransferEncodingIfNecessary(request);
-        }
 
-        return strategy.invokeClient(executionContext.executor(), flatRequest, determineFlushStrategyForApi(request),
-                this);
+            return strategy.invokeClient(executionContext.executor(), flatRequest, determineFlushStrategyForApi(request),
+                    this).subscribeShareContext();
+        });
     }
 
     @Nullable

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -113,8 +113,8 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
                 addRequestTransferEncodingIfNecessary(request);
             }
 
-            return strategy.invokeClient(executionContext.executor(), flatRequest, determineFlushStrategyForApi(request),
-                    this).subscribeShareContext();
+            return strategy.invokeClient(executionContext.executor(), flatRequest,
+                    determineFlushStrategyForApi(request), this).subscribeShareContext();
         });
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilter.java
@@ -30,6 +30,7 @@ import io.servicetalk.http.api.StreamingHttpRequester;
 import io.servicetalk.http.api.StreamingHttpResponse;
 
 import static io.netty.util.NetUtil.isValidIpV6Address;
+import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.http.api.CharSequences.newAsciiString;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_0;
@@ -84,10 +85,12 @@ final class HostHeaderHttpRequesterFilter implements StreamingHttpClientFilterFa
     private Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                   final HttpExecutionStrategy strategy,
                                                   final StreamingHttpRequest request) {
-        // "Host" header is not required for HTTP/1.0
-        if (!HTTP_1_0.equals(request.version()) && !request.headers().contains(HOST)) {
-            request.setHeader(HOST, fallbackHost);
-        }
-        return delegate.request(strategy, request);
+        return defer(() -> {
+            // "Host" header is not required for HTTP/1.0
+            if (!HTTP_1_0.equals(request.version()) && !request.headers().contains(HOST)) {
+                request.setHeader(HOST, fallbackHost);
+            }
+            return delegate.request(strategy, request).subscribeShareContext();
+        });
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbsoluteAddressHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbsoluteAddressHttpRequesterFilterTest.java
@@ -15,8 +15,7 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.buffer.api.BufferAllocator;
-import io.servicetalk.buffer.netty.BufferAllocators;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.http.api.DefaultHttpHeadersFactory;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.HttpHeadersFactory;
@@ -25,42 +24,53 @@ import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequests;
+import io.servicetalk.http.api.StreamingHttpResponse;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AbsoluteAddressHttpRequesterFilterTest {
 
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+
     @Mock
     private FilterableStreamingHttpClient delegate;
-    private final BufferAllocator allocator = BufferAllocators.DEFAULT_ALLOCATOR;
+    @Mock
+    private StreamingHttpResponse response;
     private final HttpHeadersFactory headersFactory = new DefaultHttpHeadersFactory(false, false);
     private final StreamingHttpRequest request = StreamingHttpRequests.newRequest(HttpRequestMethod.GET, "",
-            HttpProtocolVersion.HTTP_1_1, headersFactory.newHeaders(), allocator, headersFactory);
+            HttpProtocolVersion.HTTP_1_1, headersFactory.newHeaders(), DEFAULT_ALLOCATOR, headersFactory);
     private final ArgumentCaptor<StreamingHttpRequest> requestCapture =
             ArgumentCaptor.forClass(StreamingHttpRequest.class);
     private StreamingHttpClientFilter filter;
 
     @Before
     public void setup() {
+        when(delegate.request(any(), any())).thenReturn(succeeded(response));
         filter = new AbsoluteAddressHttpRequesterFilter("http", "host:80").create(delegate);
     }
 
     @Test
-    public void shouldAddAuthorityToOriginFormRequestTarget() {
+    public void shouldAddAuthorityToOriginFormRequestTarget() throws Exception {
         request.requestTarget("/path?query");
-        filter.request(noOffloadsStrategy(), request);
+        filter.request(noOffloadsStrategy(), request).toFuture().get();
         verify(delegate).request(any(), requestCapture.capture());
 
         final StreamingHttpRequest capturedRequest = requestCapture.getValue();
@@ -68,9 +78,9 @@ public class AbsoluteAddressHttpRequesterFilterTest {
     }
 
     @Test
-    public void shouldNotAddAuthorityToAbsoluteFormRequestTarget() {
+    public void shouldNotAddAuthorityToAbsoluteFormRequestTarget() throws Exception {
         request.requestTarget("https://otherhost:443/otherpath?otherQuery");
-        filter.request(noOffloadsStrategy(), request);
+        filter.request(noOffloadsStrategy(), request).toFuture().get();
         verify(delegate).request(any(), requestCapture.capture());
 
         final StreamingHttpRequest capturedRequest = requestCapture.getValue();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbsoluteAddressHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbsoluteAddressHttpRequesterFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Motivation:

`HostHeaderHttpRequesterFilter`, `AbsoluteAddressHttpRequesterFilter`,
and `AbstractStreamingHttpConnection` modify the request outside of the
asynchronous execution chain. In case of repeat or retry, if the
`request`'s state was reset or a new `request` was created, we loose
the state applied by those classes.

Modifications:

- Use `Single.defer` operator in all these cases to execute the logic
for each retry/repeat operation;

Result:

Filters logic always applied on each retry/repeat.