### PR TITLE
Make `AsyncContext` visible from `TransportObserver#onNewConnection()`

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,13 +66,12 @@ final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpC
         // We disable auto read by default so we can handle stuff in the ConnectionFilter before we accept any content.
         // In case ALPN negotiates h2, h2 connection MUST enable auto read for its Channel.
         return TcpConnector.connect(null, resolvedAddress, roTcpClientConfig, false,
-                executionContext, channel -> createConnection(channel, observer));
+                executionContext, this::createConnection, observer);
     }
 
     private Single<FilterableStreamingHttpConnection> createConnection(
-            final Channel channel, final TransportObserver observer) {
+            final Channel channel, final ConnectionObserver connectionObserver) {
         final ReadOnlyTcpClientConfig tcpConfig = this.config.tcpConfig();
-        final ConnectionObserver connectionObserver = observer.onNewConnection();
         return new AlpnChannelSingle(channel,
                 new TcpClientChannelInitializer(tcpConfig, connectionObserver), false).flatMap(protocol -> {
             switch (protocol) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnServerContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnServerContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,11 +60,8 @@ final class AlpnServerContext {
         // We disable auto read by default so we can handle stuff in the ConnectionFilter before we accept any content.
         // In case ALPN negotiates h2, h2 connection MUST enable auto read for its Channel.
         return TcpServerBinder.bind(listenAddress, tcpConfig, false, executionContext, connectionAcceptor,
-                channel -> {
-                    final ConnectionObserver connectionObserver = tcpConfig.transportObserver().onNewConnection();
-                    return initChannel(listenAddress, channel, config, executionContext, service,
-                            drainRequestPayloadBody, connectionObserver);
-                },
+                (channel, connectionObserver) -> initChannel(listenAddress, channel, config, executionContext, service,
+                        drainRequestPayloadBody, connectionObserver),
                 serverConnection -> {
                     // Start processing requests on http/1.1 connection:
                     if (serverConnection instanceof NettyHttpServerConnection) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,12 +89,9 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
         final ReadOnlyTcpServerConfig tcpServerConfig = config.tcpConfig();
         // Auto read is required for h2
         return TcpServerBinder.bind(listenAddress, tcpServerConfig, true, executionContext, connectionAcceptor,
-                channel -> {
-                    final ConnectionObserver connectionObserver = tcpServerConfig.transportObserver().onNewConnection();
-                    return initChannel(listenAddress, channel, executionContext, config,
-                            new TcpServerChannelInitializer(tcpServerConfig, connectionObserver), service,
-                            drainRequestPayloadBody, connectionObserver);
-                },
+                (channel, connectionObserver) -> initChannel(listenAddress, channel, executionContext, config,
+                        new TcpServerChannelInitializer(tcpServerConfig, connectionObserver), service,
+                        drainRequestPayloadBody, connectionObserver),
                 serverConnection -> { /* nothing to do as h2 uses auto read on the parent channel */ })
                 .map(delegate -> {
                     LOGGER.debug("Started HTTP/2 server with prior-knowledge for address {}", delegate.listenAddress());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,12 +124,9 @@ final class NettyHttpServer {
         final ReadOnlyTcpServerConfig tcpServerConfig = config.tcpConfig();
         // We disable auto read so we can handle stuff in the ConnectionFilter before we accept any content.
         return TcpServerBinder.bind(address, tcpServerConfig, false, executionContext, connectionAcceptor,
-                channel -> {
-                    final ConnectionObserver connectionObserver = tcpServerConfig.transportObserver().onNewConnection();
-                    return initChannel(channel, executionContext, config,
-                            new TcpServerChannelInitializer(tcpServerConfig, connectionObserver), service,
-                            drainRequestPayloadBody, connectionObserver);
-                },
+                (channel, connectionObserver) -> initChannel(channel, executionContext, config,
+                        new TcpServerChannelInitializer(tcpServerConfig, connectionObserver), service,
+                        drainRequestPayloadBody, connectionObserver),
                 serverConnection -> serverConnection.process(true))
                 .map(delegate -> {
                     LOGGER.debug("Started HTTP/1.1 server for address {}.", delegate.listenAddress());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,11 +44,10 @@ final class StreamingConnectionFactory {
             final ReadOnlyHttpClientConfig roConfig, final TransportObserver observer) {
         // We disable auto read so we can handle stuff in the ConnectionFilter before we accept any content.
         return TcpConnector.connect(null, resolvedAddress, roConfig.tcpConfig(), false, executionContext,
-                channel -> {
-                    final ConnectionObserver connectionObserver = observer.onNewConnection();
-                    return createConnection(channel, executionContext, roConfig, new TcpClientChannelInitializer(
-                            roConfig.tcpConfig(), connectionObserver, roConfig.hasProxy()), connectionObserver);
-                });
+                (channel, connectionObserver) -> createConnection(channel, executionContext, roConfig,
+                        new TcpClientChannelInitializer(roConfig.tcpConfig(), connectionObserver, roConfig.hasProxy()),
+                        connectionObserver),
+                observer);
     }
 
     static Single<? extends DefaultNettyConnection<Object, Object>> createConnection(final Channel channel,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -225,8 +225,16 @@ public abstract class AbstractNettyHttpServerTest {
         return sslEnabled;
     }
 
-    ServerContext serverContext() {
+    final ServerContext serverContext() {
         return serverContext;
+    }
+
+    final StreamingHttpClient streamingHttpClient() {
+        return httpClient;
+    }
+
+    final StreamingHttpConnection streamingHttpConnection() {
+        return httpConnection;
     }
 
     void protocol(HttpProtocolConfig protocol) {
@@ -269,15 +277,11 @@ public abstract class AbstractNettyHttpServerTest {
         assertThat(actualPayload, is(expectedPayload));
     }
 
-    Publisher<Buffer> getChunkPublisherFromStrings(final String... texts) {
-        return Publisher.from(texts).map(this::getChunkFromString);
+    static Publisher<Buffer> getChunkPublisherFromStrings(final String... texts) {
+        return Publisher.from(texts).map(AbstractNettyHttpServerTest::getChunkFromString);
     }
 
-    StreamingHttpConnection streamingHttpConnection() {
-        return httpConnection;
-    }
-
-    Buffer getChunkFromString(final String text) {
+    static Buffer getChunkFromString(final String text) {
         return DEFAULT_ALLOCATOR.fromAscii(text);
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
@@ -41,7 +41,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 
 import static io.servicetalk.concurrent.api.AsyncContextMap.Key.newKey;
@@ -154,7 +154,7 @@ public class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServ
 
     private static final class AsyncContextCaptureTransportObserver implements TransportObserver {
 
-        private final Map<String, String> storageMap = new ConcurrentSkipListMap<>();
+        private final Map<String, String> storageMap = new ConcurrentHashMap<>();
         private final AsyncContextMap.Key<String> key;
 
         AsyncContextCaptureTransportObserver(AsyncContextMap.Key<String> key) {
@@ -167,6 +167,8 @@ public class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServ
 
         @Override
         public ConnectionObserver onNewConnection() {
+            // Use String.valueOf(...) here and in all other callbacks to prevent passing `null` value to the
+            // ConcurrentHashMap which does not allow `null` values:
             storageMap.put("onNewConnection", valueOf(AsyncContext.get(key)));
             return new AsyncContextCaptureConnectionObserver();
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
@@ -59,9 +59,9 @@ import static io.servicetalk.http.netty.TestServiceStreaming.SVC_THROW_ERROR;
 import static java.lang.String.valueOf;
 import static java.util.Collections.unmodifiableMap;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThrows;
 
 @RunWith(Parameterized.class)
@@ -145,7 +145,7 @@ public class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServ
 
     private static void assertMap(Map<String, String> map, String expected) {
         Set<Map.Entry<String, String>> entries = map.entrySet();
-        assertThat("No entries in the map", entries, hasSize(greaterThan(0)));
+        assertThat("No entries in the map", entries, not(empty()));
         for (Map.Entry<String, String> entry : entries) {
             assertThat("Unexpected value for \"" + entry.getKey() + "\" callback",
                     entry.getValue(), equalTo(expected));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.api.AsyncContext;
+import io.servicetalk.concurrent.api.AsyncContextMap;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.ConnectionInfo;
+import io.servicetalk.transport.api.ConnectionObserver;
+import io.servicetalk.transport.api.ConnectionObserver.DataObserver;
+import io.servicetalk.transport.api.ConnectionObserver.MultiplexedObserver;
+import io.servicetalk.transport.api.ConnectionObserver.ReadObserver;
+import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
+import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
+import io.servicetalk.transport.api.TransportObserver;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopSecurityHandshakeObserver;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ExecutionException;
+
+import static io.servicetalk.concurrent.api.AsyncContextMap.Key.newKey;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
+import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED;
+import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED_SERVER;
+import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ECHO;
+import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ERROR_BEFORE_READ;
+import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ERROR_DURING_READ;
+import static io.servicetalk.http.netty.TestServiceStreaming.SVC_NO_CONTENT_AFTER_READ;
+import static io.servicetalk.http.netty.TestServiceStreaming.SVC_THROW_ERROR;
+import static java.lang.String.valueOf;
+import static java.util.Collections.unmodifiableMap;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThrows;
+
+@RunWith(Parameterized.class)
+public class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest {
+
+    private static final AsyncContextMap.Key<String> CLIENT_KEY = newKey("client");
+    private static final String CLIENT_VALUE = "client_value";
+
+    private final AsyncContextCaptureTransportObserver clientObserver =
+            new AsyncContextCaptureTransportObserver(CLIENT_KEY);
+    private final HttpProtocol protocol;
+
+    public HttpTransportObserverAsyncContextTest(HttpProtocol protocol) {
+        super(CACHED, CACHED_SERVER);
+        this.protocol = protocol;
+        protocol(protocol.config);
+        transportObserver(clientObserver, NoopTransportObserver.INSTANCE);
+    }
+
+    @Parameters(name = "protocol={0}")
+    public static HttpProtocol[] data() {
+        return HttpProtocol.values();
+    }
+
+    @Before
+    public void setupContext() {
+        AsyncContext.put(CLIENT_KEY, CLIENT_VALUE);
+    }
+
+    @Test
+    public void echoRequestResponse() throws Exception {
+        String requestContent = "request_content";
+        testRequestResponse(newRequest(SVC_ECHO), OK, requestContent.length());
+    }
+
+    @Test
+    public void clientErrorWrite() {
+        StreamingHttpClient client = streamingHttpClient();
+        assertThrows(ExecutionException.class, () -> client.request(client.post(SVC_NO_CONTENT_AFTER_READ)
+                .payloadBody(Publisher.failed(DELIBERATE_EXCEPTION)))
+                .toFuture().get());
+        assertMap(clientObserver.storageMap(), CLIENT_VALUE);
+    }
+
+    @Test
+    public void serverHandlerError() throws Exception {
+        testRequestResponse(newRequest(SVC_THROW_ERROR), INTERNAL_SERVER_ERROR, 0);
+    }
+
+    @Test
+    public void serverErrorBeforeRead() throws Exception {
+        testServerReadError(SVC_ERROR_BEFORE_READ);
+    }
+
+    @Test
+    public void serverErrorDuringRead() throws Exception {
+        testServerReadError(SVC_ERROR_DURING_READ);
+    }
+
+    private StreamingHttpRequest newRequest(String path) {
+        String requestContent = "request_content";
+        return streamingHttpClient().post(path)
+                .addHeader(CONTENT_LENGTH, valueOf(requestContent.length()))
+                .payloadBody(getChunkPublisherFromStrings(requestContent));
+    }
+
+    private void testRequestResponse(StreamingHttpRequest request, HttpResponseStatus expectedStatus,
+                                     int expectedResponseLength) throws Exception {
+        StreamingHttpResponse response = streamingHttpClient().request(request).toFuture().get();
+        assertResponse(response, protocol.version, expectedStatus, expectedResponseLength);
+        assertMap(clientObserver.storageMap(), CLIENT_VALUE);
+    }
+
+    private void testServerReadError(String path) throws Exception {
+        StreamingHttpResponse response = streamingHttpClient().request(newRequest(path))
+                .toFuture().get();
+        assertResponse(response, protocol.version, OK);
+        assertThrows(ExecutionException.class, () -> response.payloadBody().ignoreElements().toFuture().get());
+        assertMap(clientObserver.storageMap(), CLIENT_VALUE);
+    }
+
+    private static void assertMap(Map<String, String> map, String expected) {
+        Set<Map.Entry<String, String>> entries = map.entrySet();
+        assertThat("No entries in the map", entries, hasSize(greaterThan(0)));
+        for (Map.Entry<String, String> entry : entries) {
+            assertThat("Unexpected value for \"" + entry.getKey() + "\" callback",
+                    entry.getValue(), equalTo(expected));
+        }
+    }
+
+    private static final class AsyncContextCaptureTransportObserver implements TransportObserver {
+
+        private final Map<String, String> storageMap = new ConcurrentSkipListMap<>();
+        private final AsyncContextMap.Key<String> key;
+
+        AsyncContextCaptureTransportObserver(AsyncContextMap.Key<String> key) {
+            this.key = key;
+        }
+
+        Map<String, String> storageMap() {
+            return unmodifiableMap(storageMap);
+        }
+
+        @Override
+        public ConnectionObserver onNewConnection() {
+            storageMap.put("onNewConnection", valueOf(AsyncContext.get(key)));
+            return new AsyncContextCaptureConnectionObserver();
+        }
+
+        private class AsyncContextCaptureConnectionObserver implements ConnectionObserver {
+
+            @Override
+            public void onDataRead(final int size) {
+                // AsyncContext is unknown at this point because this event is triggered by network
+            }
+
+            @Override
+            public void onDataWrite(final int size) {
+                // AsyncContext is unknown at this point because protocols can write multiple requests concurrently
+            }
+
+            @Override
+            public void onFlush() {
+                // AsyncContext is unknown at this point because protocols can flush multiple requests concurrently
+            }
+
+            @Override
+            public SecurityHandshakeObserver onSecurityHandshake() {
+                // AsyncContext is unknown at this point because this event is triggered by network
+                return NoopSecurityHandshakeObserver.INSTANCE;
+            }
+
+            @Override
+            public DataObserver connectionEstablished(final ConnectionInfo info) {
+                // AsyncContext is unknown at this point because this event is triggered by network
+                return new AsyncContextCaptureDataObserver();
+            }
+
+            @Override
+            public MultiplexedObserver multiplexedConnectionEstablished(final ConnectionInfo info) {
+                // AsyncContext is unknown at this point because this event is triggered by network
+                return new AsyncContextCaptureMultiplexedObserver();
+            }
+
+            @Override
+            public void connectionClosed(final Throwable error) {
+                // AsyncContext is unknown at this point because this event is triggered by network
+            }
+
+            @Override
+            public void connectionClosed() {
+                // AsyncContext may be unknown at this point if the closure is initiated by the transport
+            }
+        }
+
+        private class AsyncContextCaptureMultiplexedObserver implements MultiplexedObserver {
+
+            @Override
+            public StreamObserver onNewStream() {
+                storageMap.put("onNewStream", valueOf(AsyncContext.get(key)));
+                return new AsyncContextCaptureStreamObserver();
+            }
+        }
+
+        private class AsyncContextCaptureStreamObserver implements StreamObserver {
+
+            @Override
+            public DataObserver streamEstablished() {
+                storageMap.put("streamEstablished", valueOf(AsyncContext.get(key)));
+                return new AsyncContextCaptureDataObserver();
+            }
+
+            @Override
+            public void streamClosed(final Throwable error) {
+                // AsyncContext may be unknown at this point if the closure is initiated by the transport
+            }
+
+            @Override
+            public void streamClosed() {
+                // AsyncContext may be unknown at this point if the closure is initiated by the transport
+            }
+        }
+
+        private class AsyncContextCaptureDataObserver implements DataObserver {
+
+            @Override
+            public ReadObserver onNewRead() {
+                storageMap.put("onNewRead", valueOf(AsyncContext.get(key)));
+                return new AsyncContextCaptureReadObserver();
+            }
+
+            @Override
+            public WriteObserver onNewWrite() {
+                storageMap.put("onNewWrite", valueOf(AsyncContext.get(key)));
+                return new AsyncContextCaptureWriteObserver();
+            }
+        }
+
+        private class AsyncContextCaptureReadObserver implements ReadObserver {
+
+            @Override
+            public void requestedToRead(final long n) {
+                storageMap.put("requestedToRead", valueOf(AsyncContext.get(key)));
+            }
+
+            @Override
+            public void itemRead() {
+                storageMap.put("itemRead", valueOf(AsyncContext.get(key)));
+            }
+
+            @Override
+            public void readFailed(final Throwable cause) {
+                storageMap.put("readFailed", valueOf(AsyncContext.get(key)));
+            }
+
+            @Override
+            public void readComplete() {
+                storageMap.put("readComplete", valueOf(AsyncContext.get(key)));
+            }
+
+            @Override
+            public void readCancelled() {
+                storageMap.put("readCancelled", valueOf(AsyncContext.get(key)));
+            }
+        }
+
+        private class AsyncContextCaptureWriteObserver implements WriteObserver {
+
+            @Override
+            public void requestedToWrite(final long n) {
+                storageMap.put("requestedToWrite", valueOf(AsyncContext.get(key)));
+            }
+
+            @Override
+            public void itemReceived() {
+                storageMap.put("itemReceived", valueOf(AsyncContext.get(key)));
+            }
+
+            @Override
+            public void onFlushRequest() {
+                storageMap.put("onFlushRequest", valueOf(AsyncContext.get(key)));
+            }
+
+            // For the following callbacks AsyncContext is unknown because protocols can write multiple requests
+            // concurrently. Users should use other callbacks above to retrieve the request context and keep it in a
+            // class local variable.
+            @Override
+            public void itemWritten() {
+            }
+
+            @Override
+            public void writeFailed(final Throwable cause) {
+            }
+
+            @Override
+            public void writeComplete() {
+            }
+
+            @Override
+            public void writeCancelled() {
+            }
+        }
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TestServiceStreaming.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TestServiceStreaming.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import java.util.function.Function;
 
 import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
@@ -50,6 +51,7 @@ final class TestServiceStreaming implements StreamingHttpService {
     static final String SVC_LARGE_LAST = "/largeLast";
     static final String SVC_TEST_PUBLISHER = "/testPublisher";
     static final String SVC_NO_CONTENT = "/noContent";
+    static final String SVC_NO_CONTENT_AFTER_READ = "/noContentAfterRead";
     static final String SVC_ROT13 = "/rot13";
     static final String SVC_THROW_ERROR = "/throwError";
     static final String SVC_SINGLE_ERROR = "/singleError";
@@ -92,6 +94,8 @@ final class TestServiceStreaming implements StreamingHttpService {
             case SVC_NO_CONTENT:
                 response = newNoContentResponse(req, factory);
                 break;
+            case SVC_NO_CONTENT_AFTER_READ:
+                return req.payloadBody().ignoreElements().concat(succeeded(newNoContentResponse(req, factory)));
             case SVC_ROT13:
                 response = newRot13Response(req, factory);
                 break;
@@ -109,7 +113,7 @@ final class TestServiceStreaming implements StreamingHttpService {
             default:
                 response = newNotFoundResponse(req, factory);
         }
-        return Single.succeeded(response);
+        return succeeded(response);
     }
 
     private static StreamingHttpResponse newEchoResponse(final StreamingHttpRequest req,

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpConnectorTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpConnectorTest.java
@@ -21,7 +21,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.transport.api.ConnectionInfo.Protocol;
 import io.servicetalk.transport.netty.internal.DefaultNettyConnection;
 import io.servicetalk.transport.netty.internal.NettyConnection;
-import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -95,7 +95,7 @@ public final class TcpConnectorTest extends AbstractTcpServerTest {
 
         NettyConnection<Buffer, Buffer> connection = TcpConnector.<NettyConnection<Buffer, Buffer>>connect(null,
                 serverContext.listenAddress(), new TcpClientConfig().asReadOnly(emptyList()), false,
-                CLIENT_CTX, channel -> DefaultNettyConnection.initChannel(channel,
+                CLIENT_CTX, (channel, connectionObserver) -> DefaultNettyConnection.initChannel(channel,
                         CLIENT_CTX.bufferAllocator(), CLIENT_CTX.executor(), o -> true,
                         UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, defaultFlushStrategy(), null, channel2 -> {
                             channel2.pipeline().addLast(new ChannelInboundHandlerAdapter() {
@@ -111,8 +111,8 @@ public final class TcpConnectorTest extends AbstractTcpServerTest {
                                     ctx.fireChannelActive();
                                 }
                             });
-                        }, CLIENT_CTX.executionStrategy(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, true))
-                .toFuture().get();
+                        }, CLIENT_CTX.executionStrategy(), mock(Protocol.class), connectionObserver, true),
+                NoopTransportObserver.INSTANCE).toFuture().get();
         connection.closeAsync().toFuture().get();
 
         registeredLatch.await();


### PR DESCRIPTION
Motivation:

Users who want to correlate `TransportObserver#onNewConnection()` events with
the request object may use `AsyncContext` to propagate correlation key.
However, `AsyncContext` is not visible from `TransportObserver#onNewConnection()`
because it runs from IO-thread. It's also important to invoke
`TransportObserver#onNewConnection()` callback earlier on the client-side.

Modifications:

- Trigger `TransportObserver#onNewConnection()` as soon as someone subscribes to
`TcpConnector#connect` single on the client-side to get access to the caller's
thread `AsyncContext`;
- Trigger `TransportObserver#onNewConnection()` at the beginning of `initChannel`
on the server-side for consistency with the client-side;
- Update internal classes and tests to use new API;
- Add tests to verify `AsyncContext` is visible for expected callbacks;

Result:

`AsyncContext` is visible from `TransportObserver#onNewConnection()` on the
client-side.