### PR TITLE
Wrap all netty's HTTP/2 related exceptions with `IOException`

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -285,7 +285,8 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                                     parentContext.sslSession(),
                                     parentContext.nettyChannel().config(),
                                     streamObserver,
-                                    true);
+                                    true,
+                                    Http2Exception::wrapIfNecessary);
 
                     // In h2 a stream is 1 to 1 with a request/response life cycle. This means there is no concept of
                     // pipelining on a stream so we can use the non-pipelined connection which is more light weight.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -54,6 +54,7 @@ import static io.servicetalk.concurrent.api.Processors.newCompletableProcessor;
 import static io.servicetalk.concurrent.api.Processors.newSingleProcessor;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
+import static io.servicetalk.http.netty.Http2Exception.wrapIfNecessary;
 import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.assignConnectionError;
 import static io.servicetalk.transport.netty.internal.NettyIoExecutors.fromNettyEventLoop;
 import static io.servicetalk.transport.netty.internal.NettyPipelineSslUtils.extractSslSessionAndReport;
@@ -219,6 +220,7 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
 
         @Override
         public final void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            cause = wrapIfNecessary(cause);
             if (observer != NoopConnectionObserver.INSTANCE) {
                 assignConnectionError(ctx.channel(), cause);
             }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -173,7 +173,8 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                                                 connection.sslSession(),
                                                 channel.config(),
                                                 streamObserver,
-                                                false);
+                                                false,
+                                                Http2Exception::wrapIfNecessary);
 
                                 // ServiceTalk HTTP service handler
                                 new NettyHttpServerConnection(streamConnection, service,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
@@ -16,7 +16,6 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.http.api.HttpHeaders;
-import io.servicetalk.transport.api.RetryableException;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
@@ -174,20 +173,5 @@ final class H2ToStH1Utils {
             http2Headers.add(h1Entry.getKey().toString().toLowerCase(), h1Entry.getValue());
         }
         return http2Headers;
-    }
-
-    /**
-     * <a href="https://tools.ietf.org/html/rfc7540#section-8.1.4">REFUSED_STREAM</a> is always retryable.
-     */
-    static final class H2StreamRefusedException extends H2StreamResetException implements RetryableException {
-        H2StreamRefusedException(String message) {
-            super(message);
-        }
-    }
-
-    static class H2StreamResetException extends RuntimeException {
-        H2StreamResetException(String message) {
-            super(message);
-        }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/Http2Exception.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/Http2Exception.java
@@ -20,9 +20,9 @@ import io.servicetalk.transport.api.RetryableException;
 import java.io.IOException;
 
 /**
- * An exception that indicates <a href="https://tools.ietf.org/html/rfc7540">HTTP/2</a> protocol error.
+ * An exception that indicates <a href="https://tools.ietf.org/html/rfc7540#section-5.4">HTTP/2 error</a>.
  */
-public class Http2Exception extends IOException {
+class Http2Exception extends IOException {
     private static final long serialVersionUID = 745695232431963628L;
 
     Http2Exception(final String message) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/Http2Exception.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/Http2Exception.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.transport.api.RetryableException;
+
+import java.io.IOException;
+
+/**
+ * An exception that indicates <a href="https://tools.ietf.org/html/rfc7540">HTTP/2</a> protocol error.
+ */
+public class Http2Exception extends IOException {
+    private static final long serialVersionUID = 745695232431963628L;
+
+    Http2Exception(final String message) {
+        super(message);
+    }
+
+    Http2Exception(final Throwable cause) {
+        super(cause);
+    }
+
+    static Throwable wrapIfNecessary(final Throwable cause) {
+        if (cause instanceof io.netty.handler.codec.http2.Http2Exception) {
+            return new StacklessHttp2Exception((io.netty.handler.codec.http2.Http2Exception) cause);
+        }
+        if (cause instanceof io.netty.handler.codec.http2.Http2FrameStreamException) {
+            return new StacklessHttp2Exception((io.netty.handler.codec.http2.Http2FrameStreamException) cause);
+        }
+        return cause;
+    }
+
+    private static final class StacklessHttp2Exception extends Http2Exception {
+        private static final long serialVersionUID = 7794465950455688900L;
+
+        StacklessHttp2Exception(io.netty.handler.codec.http2.Http2Exception cause) {
+            super(cause);
+        }
+
+        StacklessHttp2Exception(io.netty.handler.codec.http2.Http2FrameStreamException cause) {
+            super(cause);
+        }
+
+        @Override
+        public Throwable fillInStackTrace() {
+            // This is a wrapping exception class that always has an original cause and does not require stack trace.
+            return this;
+        }
+    }
+
+    /**
+     * <a href="https://tools.ietf.org/html/rfc7540#section-8.1.4">REFUSED_STREAM</a> is always retryable.
+     */
+    static final class H2StreamRefusedException extends H2StreamResetException implements RetryableException {
+        private static final long serialVersionUID = 615309480184187428L;
+
+        H2StreamRefusedException(String message) {
+            super(message);
+        }
+    }
+
+    static class H2StreamResetException extends Http2Exception {
+        private static final long serialVersionUID = -2000223857660046560L;
+
+        H2StreamResetException(String message) {
+            super(message);
+        }
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
@@ -23,7 +23,7 @@ import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpServiceFilter;
-import io.servicetalk.http.netty.H2ToStH1Utils.H2StreamResetException;
+import io.servicetalk.http.netty.Http2Exception.H2StreamResetException;
 import io.servicetalk.transport.api.ConnectionInfo;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ConnectionObserver.DataObserver;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
@@ -162,15 +162,16 @@ public class StreamObserverTest {
 
             ExecutionException e = assertThrows(ExecutionException.class,
                     () -> connection.request(connection.get("/second")).toFuture().get());
-            assertThat(e.getCause(), instanceOf(StreamException.class));
+            assertThat(e.getCause(), instanceOf(Http2Exception.class));
+            assertThat(e.getCause().getCause(), instanceOf(StreamException.class));
 
             verify(clientMultiplexedObserver, times(2)).onNewStream();
             verify(clientStreamObserver, times(2)).streamEstablished();
             verify(clientDataObserver, times(2)).onNewRead();
             verify(clientDataObserver, times(2)).onNewWrite();
             verify(clientReadObserver).readCancelled();
-            verify(clientWriteObserver).writeFailed(e.getCause());
-            verify(clientStreamObserver, await()).streamClosed(e.getCause());
+            verify(clientWriteObserver).writeFailed(e.getCause().getCause());
+            verify(clientStreamObserver, await()).streamClosed(e.getCause().getCause());
         }
         verify(clientStreamObserver, await()).streamClosed();
         verify(clientConnectionObserver).connectionClosed();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
@@ -170,8 +170,8 @@ public class StreamObserverTest {
             verify(clientDataObserver, times(2)).onNewRead();
             verify(clientDataObserver, times(2)).onNewWrite();
             verify(clientReadObserver).readCancelled();
-            verify(clientWriteObserver).writeFailed(e.getCause().getCause());
-            verify(clientStreamObserver, await()).streamClosed(e.getCause().getCause());
+            verify(clientWriteObserver).writeFailed(e.getCause());
+            verify(clientStreamObserver, await()).streamClosed(e.getCause());
         }
         verify(clientStreamObserver, await()).streamClosed();
         verify(clientConnectionObserver).connectionClosed();

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -397,7 +397,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
             protected void handleSubscribe(Subscriber completableSubscriber) {
                 final WriteObserver writeObserver = DefaultNettyConnection.this.dataObserver.onNewWrite();
                 WriteStreamSubscriber subscriber = new WriteStreamSubscriber(channel(), demandEstimatorSupplier.get(),
-                        completableSubscriber, closeHandler, writeObserver);
+                        completableSubscriber, closeHandler, writeObserver, enrichProtocolError);
                 if (failIfWriteActive(subscriber, completableSubscriber)) {
                     toSource(composeFlushes(channel(), write, flushStrategySupplier.get(), writeObserver))
                             .subscribe(subscriber);

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -64,6 +64,7 @@ import java.net.SocketOption;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
@@ -84,6 +85,7 @@ import static io.servicetalk.transport.netty.internal.NettyPipelineSslUtils.extr
 import static io.servicetalk.transport.netty.internal.SocketOptionUtils.getOption;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
+import static java.util.function.UnaryOperator.identity;
 
 /**
  * Implementation of {@link NettyConnection} backed by a netty {@link Channel}.
@@ -136,13 +138,15 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     private final ChannelConfig parentChannelConfig;
     private volatile DataObserver dataObserver;
     private final boolean isClient;
+    private final UnaryOperator<Throwable> enrichProtocolError;
 
     private DefaultNettyConnection(Channel channel, BufferAllocator allocator, Executor executor,
                                    Predicate<Read> terminalPredicate, CloseHandler closeHandler,
                                    FlushStrategy flushStrategy, @Nullable Long idleTimeoutMs,
                                    ExecutionStrategy executionStrategy, Protocol protocol,
                                    @Nullable SSLSession sslSession, @Nullable ChannelConfig parentChannelConfig,
-                                   DataObserver dataObserver, boolean isClient) {
+                                   DataObserver dataObserver, boolean isClient,
+                                   UnaryOperator<Throwable> enrichProtocolError) {
         super(channel, executor);
         nettyChannelPublisher = new NettyChannelPublisher<>(channel, terminalPredicate, closeHandler);
         this.readPublisher = registerReadObserver(nettyChannelPublisher.recoverWith(this::enrichErrorPublisher));
@@ -183,6 +187,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
         this.protocol = requireNonNull(protocol);
         this.dataObserver = dataObserver;
         this.isClient = isClient;
+        this.enrichProtocolError = requireNonNull(enrichProtocolError);
     }
 
     /**
@@ -202,6 +207,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
      * @param parentChannelConfig {@link ChannelConfig} of the parent {@link Channel} to query {@link SocketOption}s.
      * @param streamObserver {@link StreamObserver} to report internal events.
      * @param isClient tells if this {@link Channel} is for the client.
+     * @param enrichProtocolError enriches protocol-specific {@link Throwable}s.
      * @param <Read> Type of objects read from the {@link NettyConnection}.
      * @param <Write> Type of objects written to the {@link NettyConnection}.
      * @return A {@link Single} that completes with a {@link DefaultNettyConnection} after the channel is activated and
@@ -211,10 +217,11 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
             Channel channel, BufferAllocator allocator, Executor executor, Predicate<Read> terminalPredicate,
             CloseHandler closeHandler, FlushStrategy flushStrategy, @Nullable Long idleTimeoutMs,
             ExecutionStrategy executionStrategy, Protocol protocol, @Nullable SSLSession sslSession,
-            @Nullable ChannelConfig parentChannelConfig, StreamObserver streamObserver, boolean isClient) {
+            @Nullable ChannelConfig parentChannelConfig, StreamObserver streamObserver, boolean isClient,
+            UnaryOperator<Throwable> enrichProtocolError) {
         DefaultNettyConnection<Read, Write> connection = new DefaultNettyConnection<>(channel, allocator, executor,
                 terminalPredicate, closeHandler, flushStrategy, idleTimeoutMs, executionStrategy, protocol,
-                sslSession, parentChannelConfig, streamObserver.streamEstablished(), isClient);
+                sslSession, parentChannelConfig, streamObserver.streamEstablished(), isClient, enrichProtocolError);
         channel.pipeline().addLast(new NettyToStChannelInboundHandler<>(connection, null,
                 null, false, NoopConnectionObserver.INSTANCE));
         return connection;
@@ -257,7 +264,8 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
                     delayedCancellable = new DelayedCancellable();
                     DefaultNettyConnection<Read, Write> connection = new DefaultNettyConnection<>(channel, allocator,
                             executor, terminalPredicate, closeHandler, flushStrategy, idleTimeoutMs,
-                            executionStrategy, protocol, null, null, NoopDataObserver.INSTANCE, isClient);
+                            executionStrategy, protocol, null, null, NoopDataObserver.INSTANCE, isClient,
+                            identity());
                     channel.attr(CHANNEL_CLOSEABLE_KEY).set(connection);
                     // We need the NettyToStChannelInboundHandler to be last in the pipeline. We accomplish that by
                     // calling the ChannelInitializer before we do addLast for the NettyToStChannelInboundHandler.
@@ -337,7 +345,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     }
 
     private Throwable enrichError(final Throwable t) {
-        final Throwable throwable;
+        Throwable throwable;
         if (t instanceof AbortedFirstWrite) {
             final Throwable cause = t.getCause();
             if (closeReason != null) {
@@ -350,6 +358,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
         } else {
             throwable = wrapIfReasonIsKnown(t);
         }
+        throwable = enrichProtocolError.apply(throwable);
         transportError.onSuccess(throwable);
         return throwable;
     }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberFutureListenersTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberFutureListenersTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
+import static java.util.function.UnaryOperator.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -74,7 +75,7 @@ public class WriteStreamSubscriberFutureListenersTest {
         WriteDemandEstimator estimator = WriteDemandEstimators.newDefaultEstimator();
         TestCompletableSubscriber completableSubscriber = new TestCompletableSubscriber();
         subscriber = new WriteStreamSubscriber(channel, estimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity());
         TestSubscription subscription = new TestSubscription();
         subscriber.onSubscribe(subscription);
         assertThat("No items requested.", subscription.requested(), greaterThan(0L));
@@ -178,7 +179,7 @@ public class WriteStreamSubscriberFutureListenersTest {
         WriteDemandEstimator estimator = WriteDemandEstimators.newDefaultEstimator();
         TestCompletableSubscriber completableSubscriber = new TestCompletableSubscriber();
         WriteStreamSubscriber subscriber = new WriteStreamSubscriber(mockChannel, estimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity());
         subscriber.onNext(1);
         verifyListenerInvokedWithSuccess(listeners.take());
         subscriber.onNext(2);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberOutOfEventloopTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberOutOfEventloopTest.java
@@ -29,6 +29,7 @@ import static io.servicetalk.concurrent.api.Processors.newCompletableProcessor;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
+import static java.util.function.UnaryOperator.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
@@ -45,7 +46,7 @@ public class WriteStreamSubscriberOutOfEventloopTest extends AbstractOutOfEventl
         CompletableSource.Subscriber completableSubscriber = mock(CompletableSource.Subscriber.class);
         WriteDemandEstimator demandEstimator = mock(WriteDemandEstimator.class);
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity());
     }
 
     @Test
@@ -103,7 +104,7 @@ public class WriteStreamSubscriberOutOfEventloopTest extends AbstractOutOfEventl
         };
         WriteDemandEstimator demandEstimator = mock(WriteDemandEstimator.class);
         this.subscriber = new WriteStreamSubscriber(channel, demandEstimator, subscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity());
 
         this.subscriber.onNext(1);
         this.subscriber.onError(DELIBERATE_EXCEPTION);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberTest.java
@@ -25,6 +25,7 @@ import java.nio.channels.ClosedChannelException;
 
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
+import static java.util.function.UnaryOperator.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
@@ -50,7 +51,7 @@ public class WriteStreamSubscriberTest extends AbstractWriteTest {
         super.setUp();
         closeHandler = mock(CloseHandler.class);
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber, closeHandler,
-                NoopWriteObserver.INSTANCE);
+                NoopWriteObserver.INSTANCE, identity());
         subscription = mock(Subscription.class);
         when(demandEstimator.estimateRequestN(anyLong())).thenReturn(1L);
         subscriber.onSubscribe(subscription);
@@ -105,7 +106,7 @@ public class WriteStreamSubscriberTest extends AbstractWriteTest {
     @Test
     public void testCancelBeforeOnSubscribe() {
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity());
         subscription = mock(Subscription.class);
         subscriber.cancel();
         subscriber.onSubscribe(subscription);
@@ -124,7 +125,7 @@ public class WriteStreamSubscriberTest extends AbstractWriteTest {
     public void testRequestMoreBeforeOnSubscribe() {
         reset(completableSubscriber);
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity());
         subscriber.channelWritable();
         subscription = mock(Subscription.class);
         subscriber.onSubscribe(subscription);


### PR DESCRIPTION
Motivation:

Netty's `Http2Exception` and `Http2FrameStreamException` extend `Exception`
instead of `IOException`. `IOException` provide better user-experience for
interception of HTTP/2 errors and more compatible with exception handling
logic in other libraries.

Modifications:

- Create a new `io.servicetalk.http.netty.Http2Exception` class that extends
`IOException`;
- Wrap all netty's HTTP/2 related exceptions with this new type;
- Change pre-existing `H2StreamRefusedException` and `H2StreamResetException`
to also extend the new type;
- Include streamId in `H2StreamRefusedException` and `H2StreamResetException`
exception messages;
- Update tests that expect netty exception types;

Result:

All HTTP/2 related exceptions extend `IOException`.