### PR TITLE
Make sure our `Uri` parsers correctly handle malformed authorities

### DIFF
--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpAuthorityFormUriTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpAuthorityFormUriTest.java
@@ -90,6 +90,11 @@ public class HttpAuthorityFormUriTest {
         new HttpAuthorityFormUri("[::1]:8080foo");
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedAuthority() {
+        new HttpAuthorityFormUri("blah@apple.com:80@apple.com");
+    }
+
     @Test
     public void encodeTouchesAllComponents() {
         verifyEncodeDecode("www.foo bar.com:8080", "www.foo%20bar.com:8080");

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/Uri3986Test.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/Uri3986Test.java
@@ -82,6 +82,11 @@ public class Uri3986Test {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void portNegative() {
+        new Uri3986("http://foo.com:-1");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void portInvalidAtEnd() {
         new Uri3986("http://foo.com:6553a");
     }
@@ -93,7 +98,7 @@ public class Uri3986Test {
 
     @Test(expected = IllegalArgumentException.class)
     public void portInvalidMiddle() {
-        new Uri3986("http://foo.com:1ab");
+        new Uri3986("http://foo.com:1ab2");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -114,6 +119,11 @@ public class Uri3986Test {
     @Test(expected = IllegalArgumentException.class)
     public void duplicateUserInfo() {
         new Uri3986("http://foo@bar@apple.com");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedAuthority() {
+        new Uri3986("http://blah@apple.com:80@apple.com");
     }
 
     @Test


### PR DESCRIPTION
Motivation:

AHC recently was exposed to CVE-2020-13956 [1] incorrectly handling
malformed authority component. They fixed it in [2]. Let's make sure
ST doesn't have the same issue.

Modifications:

- Add tests for our `Uri` impls for the same case as [2];

Result:

Confidence that our `Uri` impls correctly handle malformed authority
component.

1. https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13956
2. https://github.com/apache/httpcomponents-client/commit/e628b4c5c464c2fa346385596cc78e035a91a62e