### PR TITLE
Don't close entire HTTP/2 connection when request is cancelled

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcServiceContext.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcServiceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package io.servicetalk.grpc.api;
 
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.encoding.api.ContentCodec;
-import io.servicetalk.http.api.HttpConnectionContext.HttpProtocol;
+import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.transport.api.ConnectionContext;
 
@@ -100,9 +100,9 @@ final class DefaultGrpcServiceContext extends DefaultGrpcMetadata implements Grp
     }
 
     private static final class DefaultGrpcProtocol implements GrpcProtocol {
-        private final HttpProtocol httpProtocol;
+        private final HttpProtocolVersion httpProtocol;
 
-        private DefaultGrpcProtocol(final HttpProtocol httpProtocol) {
+        private DefaultGrpcProtocol(final HttpProtocolVersion httpProtocol) {
             this.httpProtocol = requireNonNull(httpProtocol);
         }
 
@@ -112,7 +112,7 @@ final class DefaultGrpcServiceContext extends DefaultGrpcMetadata implements Grp
         }
 
         @Override
-        public HttpProtocol httpProtocol() {
+        public HttpProtocolVersion httpProtocol() {
             return httpProtocol;
         }
     }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceContext.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package io.servicetalk.grpc.api;
 
 import io.servicetalk.encoding.api.ContentCodec;
-import io.servicetalk.http.api.HttpConnectionContext.HttpProtocol;
+import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.transport.api.ConnectionContext;
 
 import java.util.List;
@@ -41,6 +41,6 @@ public interface GrpcServiceContext extends ConnectionContext, GrpcMetadata {
 
     interface GrpcProtocol extends Protocol {
 
-        HttpProtocol httpProtocol();
+        HttpProtocolVersion httpProtocol();
     }
 }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcServiceContextProtocolTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcServiceContextProtocolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,8 @@ import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTesterService;
 import io.servicetalk.grpc.netty.TesterProto.Tester.ClientFactory;
 import io.servicetalk.grpc.netty.TesterProto.Tester.ServiceFactory;
 import io.servicetalk.grpc.netty.TesterProto.Tester.TesterService;
-import io.servicetalk.http.api.HttpConnectionContext.HttpProtocol;
 import io.servicetalk.http.api.HttpProtocolConfig;
+import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.transport.api.ServerContext;
 
 import org.junit.After;
@@ -68,7 +68,7 @@ public class GrpcServiceContextProtocolTest {
     private final ServerContext serverContext;
     private final BlockingTesterClient client;
 
-    public GrpcServiceContextProtocolTest(HttpProtocol httpProtocol, boolean streamingService) throws Exception {
+    public GrpcServiceContextProtocolTest(HttpProtocolVersion httpProtocol, boolean streamingService) throws Exception {
         expectedValue = "gRPC over " + httpProtocol;
 
         serverContext = GrpcServers.forAddress(localAddress(0))
@@ -87,11 +87,11 @@ public class GrpcServiceContextProtocolTest {
         return new Object[][]{{HTTP_2_0, true}, {HTTP_2_0, false}, {HTTP_1_1, true}, {HTTP_1_1, false}};
     }
 
-    private static HttpProtocolConfig protocolConfig(HttpProtocol httpProtocol) {
-        if (httpProtocol == HTTP_2_0) {
+    private static HttpProtocolConfig protocolConfig(HttpProtocolVersion httpProtocol) {
+        if (HTTP_2_0.equals(httpProtocol)) {
             return h2Default();
         }
-        if (httpProtocol == HTTP_1_1) {
+        if (HTTP_1_1.equals(httpProtocol)) {
             return h1Default();
         }
         throw new IllegalArgumentException("Unknown httpProtocol: " + httpProtocol);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpConnectionContext.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpConnectionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ public class DelegatingHttpConnectionContext extends DelegatingConnectionContext
     }
 
     @Override
-    public HttpProtocol protocol() {
+    public HttpProtocolVersion protocol() {
         return delegate.protocol();
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServiceContext.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServiceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ public class DelegatingHttpServiceContext extends HttpServiceContext {
     }
 
     @Override
-    public HttpProtocol protocol() {
+    public HttpProtocolVersion protocol() {
         return delegate.protocol();
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnectionContext.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnectionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,11 +26,5 @@ public interface HttpConnectionContext extends ConnectionContext {
     HttpExecutionContext executionContext();
 
     @Override
-    HttpProtocol protocol();
-
-    /**
-     * Provides information about the HTTP protocol.
-     */
-    interface HttpProtocol extends Protocol {
-    }
+    HttpProtocolVersion protocol();
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpProtocolVersion.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpProtocolVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.Buffer;
-import io.servicetalk.http.api.HttpConnectionContext.HttpProtocol;
+import io.servicetalk.transport.api.ConnectionInfo.Protocol;
 
 import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.PREFER_HEAP_RO_ALLOCATOR;
 import static io.servicetalk.http.api.BufferUtils.writeReadOnlyBuffer;
@@ -24,7 +24,7 @@ import static io.servicetalk.http.api.BufferUtils.writeReadOnlyBuffer;
 /**
  * HTTP <a href="https://tools.ietf.org/html/rfc7230.html#section-2.6">protocol versioning</a>.
  */
-public final class HttpProtocolVersion implements HttpProtocol {
+public final class HttpProtocolVersion implements Protocol {
     /**
      * HTTP/1.1 version described in <a href="https://tools.ietf.org/html/rfc7230">RFC 7230</a>.
      */

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestHttpServiceContext.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestHttpServiceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ public class TestHttpServiceContext extends HttpServiceContext {
     }
 
     @Override
-    public HttpProtocol protocol() {
+    public HttpProtocolVersion protocol() {
         return HTTP_1_0;
     }
 

--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ dependencies {
   testImplementation project(":servicetalk-data-jackson")
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-utils-internal")
+  testImplementation project(":servicetalk-concurrent-api-test")
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation "io.netty:netty-transport-native-unix-common:$nettyVersion"
   testImplementation "io.netty:netty-tcnative-boringssl-static:$tcnativeVersion"

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultNettyHttpConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultNettyHttpConnectionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpConnectionContext;
 import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.transport.api.DelegatingConnectionContext;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;
@@ -47,8 +48,8 @@ final class DefaultNettyHttpConnectionContext extends DelegatingConnectionContex
     }
 
     @Override
-    public HttpProtocol protocol() {
-        return (HttpProtocol) nettyConnectionContext.protocol();
+    public HttpProtocolVersion protocol() {
+        return (HttpProtocolVersion) nettyConnectionContext.protocol();
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import io.servicetalk.http.api.HttpEventKey;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpHeadersFactory;
+import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
@@ -353,7 +354,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
         }
 
         @Override
-        public HttpProtocol protocol() {
+        public HttpProtocolVersion protocol() {
             return parentContext.protocol();
         }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import io.servicetalk.http.api.DefaultHttpExecutionContext;
 import io.servicetalk.http.api.HttpConnectionContext;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.FlushStrategyHolder;
@@ -133,7 +134,7 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
     }
 
     @Override
-    public HttpProtocol protocol() {
+    public HttpProtocolVersion protocol() {
         return HTTP_2_0;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -431,8 +431,8 @@ final class NettyHttpServer {
         }
 
         @Override
-        public HttpProtocol protocol() {
-            return (HttpProtocol) connection.protocol();
+        public HttpProtocolVersion protocol() {
+            return (HttpProtocolVersion) connection.protocol();
         }
 
         @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ResponseCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ResponseCancelTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.client.api.DelegatingConnectionFactory;
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.FilterableStreamingHttpConnection;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.ReservedStreamingHttpConnection;
+import io.servicetalk.http.api.StreamingHttpConnection;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequestFactory;
+import io.servicetalk.http.api.StreamingHttpRequester;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.http.netty.H2ToStH1Utils.H2StreamResetException;
+import io.servicetalk.transport.api.TransportObserver;
+
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.concurrent.api.Single.defer;
+import static io.servicetalk.concurrent.api.Single.failed;
+import static io.servicetalk.concurrent.api.test.Verifiers.stepVerifier;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
+import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED;
+import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED_SERVER;
+import static io.servicetalk.http.netty.HttpProtocol.HTTP_2;
+import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ECHO;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+public class H2ResponseCancelTest extends AbstractNettyHttpServerTest {
+
+    private static final String PARAM = "param";
+
+    private final CountDownLatch firstRequestReceivedLatch = new CountDownLatch(1);
+    private final CountDownLatch secondRequestReceivedLatch = new CountDownLatch(1);
+
+    private final CountDownLatch firstResponseLatch = new CountDownLatch(1);
+    private final CountDownLatch secondResponseLatch = new CountDownLatch(1);
+
+    private final AtomicInteger newConnectionsCounter = new AtomicInteger();
+
+    public H2ResponseCancelTest() {
+        super(CACHED, CACHED_SERVER);
+        protocol(HTTP_2.config);
+        serviceFilterFactory(service -> new StreamingHttpServiceFilter(service) {
+            @Override
+            public Single<StreamingHttpResponse> handle(HttpServiceContext ctx, StreamingHttpRequest request,
+                                                        StreamingHttpResponseFactory responseFactory) {
+                try {
+                    if ("first".equals(request.queryParameter(PARAM))) {
+                        firstRequestReceivedLatch.countDown();
+                        firstResponseLatch.await();
+                    }
+                    if ("second".equals(request.queryParameter(PARAM))) {
+                        secondRequestReceivedLatch.countDown();
+                        secondResponseLatch.await();
+                    }
+                    if ("close".equals(request.queryParameter(PARAM))) {
+                        ctx.closeAsync().toFuture().get();
+                    }
+                } catch (Exception e) {
+                    return failed(e);
+                }
+                return delegate().handle(ctx, request, responseFactory);
+            }
+        });
+        connectionFactoryFilter(factory -> new DelegatingConnectionFactory<InetSocketAddress,
+                FilterableStreamingHttpConnection>(factory) {
+            @Override
+            public Single<FilterableStreamingHttpConnection> newConnection(InetSocketAddress inetSocketAddress,
+                                                                           @Nullable TransportObserver observer) {
+                return defer(() -> {
+                    newConnectionsCounter.incrementAndGet();
+                    return delegate().newConnection(inetSocketAddress, observer);
+                });
+            }
+        });
+    }
+
+    @Test
+    public void testClient() throws Exception {
+        // Release existing connection to avoid creating unexpected number of new h2 connections because of randomness
+        // in RRLB (it may randomly pick the reserved connection until all attempts are taken).
+        ((ReservedStreamingHttpConnection) streamingHttpConnection()).releaseAsync().toFuture().get();
+
+        int connectionsBefore = newConnectionsCounter.get();
+        requestCancellationResetsStreamButNotParentConnection(streamingHttpClient());
+        int connectionsAfter = newConnectionsCounter.get();
+        assertThat("Client unexpectedly created more connections instead of reusing the existing one",
+                connectionsAfter - connectionsBefore, is(0));
+    }
+
+    @Test
+    public void testConnection() throws Exception {
+        StreamingHttpConnection connection = streamingHttpConnection();
+        AtomicBoolean connectionClosed = new AtomicBoolean();
+        connection.onClose().whenFinally(() -> connectionClosed.set(true)).subscribe();
+
+        requestCancellationResetsStreamButNotParentConnection(connection);
+        assertThat("Connection closed unexpectedly", connectionClosed.get(), is(false));
+    }
+
+    @Test
+    public void testServerClosesStreamNotConnection() throws Exception {
+        StreamingHttpConnection connection = streamingHttpConnection();
+        AtomicBoolean connectionClosed = new AtomicBoolean();
+        connection.onClose().whenFinally(() -> connectionClosed.set(true)).subscribe();
+
+        ExecutionException e = assertThrows(ExecutionException.class,
+                () -> makeRequest(newRequest(connection, "close")));
+        assertThat(e.getCause(), instanceOf(H2StreamResetException.class));
+
+        // Mak sure we can use the same connection for future requests:
+        assertResponse(makeRequest(newRequest(connection, "ok")), HTTP_2_0, OK, "ok");
+        assertThat("Connection closed unexpectedly", connectionClosed.get(), is(false));
+    }
+
+    private void requestCancellationResetsStreamButNotParentConnection(StreamingHttpRequester requester)
+            throws Exception {
+
+        BlockingQueue<StreamingHttpResponse> responses = new LinkedBlockingDeque<>();
+        requester.request(defaultStrategy(), newRequest(requester, "first")).subscribe(responses::add);
+        firstRequestReceivedLatch.await();
+
+        AtomicReference<Cancellable> cancellable = new AtomicReference<>();
+        stepVerifier(requester.request(defaultStrategy(), newRequest(requester, "second"))
+                        .whenOnSuccess(responses::add)) // Add response to the queue to verify that we never receive it
+                .expectCancellableConsumed(cancellable::set)
+                .then(() -> {
+                    try {
+                        secondRequestReceivedLatch.await();
+                        cancellable.get().cancel(); // If I use thenCancel() the current then(Runnable) does not run
+                    } catch (InterruptedException e) {
+                        // ignore
+                    }
+                })
+                .expectError()
+                // .thenCancel()
+                .verify();
+
+        assertThat("Unexpected responses", responses, hasSize(0));
+        firstResponseLatch.countDown();
+
+        assertResponse(responses.take(), HTTP_2_0, OK, "first");
+        // Mak sure we can use the same connection for future requests:
+        assertResponse(makeRequest(newRequest(requester, "third")), HTTP_2_0, OK, "third");
+    }
+
+    private static StreamingHttpRequest newRequest(StreamingHttpRequestFactory requestFactory, String param) {
+        return requestFactory.post(SVC_ECHO)
+                .addQueryParameter(PARAM, param)
+                .payloadBody(from(param), textSerializer());
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ResponseCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ResponseCancelTest.java
@@ -56,7 +56,7 @@ import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupp
 import static io.servicetalk.http.netty.HttpProtocol.HTTP_2;
 import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ECHO;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
@@ -121,7 +121,7 @@ public class H2ResponseCancelTest extends AbstractNettyHttpServerTest {
         requestCancellationResetsStreamButNotParentConnection(streamingHttpClient());
         int connectionsAfter = newConnectionsCounter.get();
         assertThat("Client unexpectedly created more connections instead of reusing the existing one",
-                connectionsAfter - connectionsBefore, is(0));
+                connectionsAfter, is(connectionsBefore));
     }
 
     @Test
@@ -172,11 +172,11 @@ public class H2ResponseCancelTest extends AbstractNettyHttpServerTest {
                 // .thenCancel()
                 .verify();
 
-        assertThat("Unexpected responses", responses, hasSize(0));
+        assertThat("Unexpected responses", responses, is(empty()));
         firstResponseLatch.countDown();
 
         assertResponse(responses.take(), HTTP_2_0, OK, "first");
-        // Mak sure we can use the same connection for future requests:
+        // Make sure we can use the same connection for future requests:
         assertResponse(makeRequest(newRequest(requester, "third")), HTTP_2_0, OK, "third");
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionContextProtocolTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionContextProtocolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package io.servicetalk.http.netty;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.BlockingHttpConnection;
-import io.servicetalk.http.api.HttpConnectionContext.HttpProtocol;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpServerBuilder;
@@ -61,7 +60,7 @@ public class HttpConnectionContextProtocolTest {
 
         final HttpProtocolConfig[] protocols;
         final boolean secure;
-        final HttpProtocol expectedProtocol;
+        final HttpProtocolVersion expectedProtocol;
 
         Config(HttpProtocolConfig[] protocols, boolean secure, HttpProtocolVersion expectedProtocol) {
             this.protocols = protocols;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProtocol.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,11 @@ import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h2;
+import static io.servicetalk.logging.api.LogLevel.TRACE;
 
 enum HttpProtocol {
     HTTP_1(h1Default(), HTTP_1_1),
-    HTTP_2(h2().enableFrameLogging("servicetalk-tests-h2-frame-logger").build(), HTTP_2_0);
+    HTTP_2(h2().enableFrameLogging("servicetalk-tests-h2-frame-logger", TRACE, () -> true).build(), HTTP_2_0);
 
     final HttpProtocolConfig config;
     final HttpProtocolVersion version;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseCancelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,9 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 import java.net.InetSocketAddress;
 import java.nio.channels.ClosedChannelException;
@@ -50,14 +53,13 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseabl
 import static io.servicetalk.concurrent.api.Processors.newSingleProcessor;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
-import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
-import static io.servicetalk.http.netty.HttpServers.forAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
+@RunWith(Parameterized.class)
 public class ResponseCancelTest {
 
     private final BlockingQueue<Processor<HttpResponse, HttpResponse>> serverResponses;
@@ -70,17 +72,19 @@ public class ResponseCancelTest {
     @Rule
     public final Timeout timeout = new ServiceTalkTestTimeout();
 
-    public ResponseCancelTest() throws Exception {
+    public ResponseCancelTest(HttpProtocol protocol) throws Exception {
         serverResponses = new LinkedBlockingQueue<>();
         delayedClientCancels = new LinkedBlockingQueue<>();
         delayedClientTermination = new LinkedBlockingQueue<>();
-        ctx = forAddress(localAddress(0))
+        ctx = HttpServers.forAddress(localAddress(0))
+                .protocols(protocol.config)
                 .listenAndAwait((__, ___, factory) -> {
                     Processor<HttpResponse, HttpResponse> resp = newSingleProcessor();
                     serverResponses.add(resp);
                     return fromSource(resp);
                 });
-        client = forSingleAddress(serverHostAndPort(ctx))
+        client = HttpClients.forSingleAddress(serverHostAndPort(ctx))
+                .protocols(protocol.config)
                 .appendConnectionFilter(connection -> new StreamingHttpConnectionFilter(connection) {
                     @Override
                     public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
@@ -106,6 +110,11 @@ public class ResponseCancelTest {
                 })
                 .appendConnectionFactoryFilter(original -> new CountingConnectionFactory(original, connectionCount))
                 .build();
+    }
+
+    @Parameters(name = "protocol={0}")
+    public static HttpProtocol[] data() {
+        return HttpProtocol.values();
     }
 
     @After


### PR DESCRIPTION
Motivation:

`LoadBalancedStreamingHttpClient` pessimistically assumes the connection
that serves a request should be closed on request cancellation. However,
in case of HTTP/2 it closes the parent TCP connection instead of a stream
(because stream is not accessible from the connection API). It also fails
all other in-flight requests on the same connection.

Modifications:

- In case of HTTP/2 and above mark request as finished instead of closing
the connection when cancellation happens;
- Test that request cancellation doesn't close parent TCP connection for
HTTP/2 protocol;
- Change `HttpConnectionContext#protocol()` to return `HttpProtocolVersion`;
- Change `GrpcConnectionContext.GrpcProtocol` to return `HttpProtocolVersion`;

Result:

HTTP/2 request cancellation doesn't close the TCP connection.