### PR TITLE
Update import for `H2StreamResetException`

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ResponseCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ResponseCancelTest.java
@@ -28,7 +28,7 @@ import io.servicetalk.http.api.StreamingHttpRequester;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpServiceFilter;
-import io.servicetalk.http.netty.H2ToStH1Utils.H2StreamResetException;
+import io.servicetalk.http.netty.Http2Exception.H2StreamResetException;
 import io.servicetalk.transport.api.TransportObserver;
 
 import org.junit.Test;


### PR DESCRIPTION
Motivation:

`H2StreamResetException` was moved in #1304, but used old location in #1307.
Those PRs were merged concurrently without updating the import.

Modifications:

- Update import for `H2StreamResetException` in `H2ResponseCancelTest`;

Result:

Build does not fail.