### PR TITLE
Identify retryable `Http2Exception`(s) generated by netty

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
@@ -33,6 +33,7 @@ import io.servicetalk.transport.api.ConnectionObserver.ReadObserver;
 import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
 import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
 import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.RetryableException;
 import io.servicetalk.transport.api.TransportObserver;
 
 import io.netty.channel.Channel;
@@ -43,7 +44,6 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http2.Http2Exception.StreamException;
 import io.netty.handler.codec.http2.Http2StreamChannel;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -141,7 +141,7 @@ public class StreamObserverTest {
         }
     }
 
-    @Ignore("https://github.com/apple/servicetalk/issues/1264")
+    // @Ignore("https://github.com/apple/servicetalk/issues/1264")
     @Test
     public void maxActiveStreamsViolationError() throws Exception {
         CountDownLatch maxConcurrentStreamsValueSetToOne = new CountDownLatch(1);
@@ -163,6 +163,7 @@ public class StreamObserverTest {
             ExecutionException e = assertThrows(ExecutionException.class,
                     () -> connection.request(connection.get("/second")).toFuture().get());
             assertThat(e.getCause(), instanceOf(Http2Exception.class));
+            assertThat(e.getCause(), instanceOf(RetryableException.class));
             assertThat(e.getCause().getCause(), instanceOf(StreamException.class));
 
             verify(clientMultiplexedObserver, times(2)).onNewStream();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
@@ -44,6 +44,7 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http2.Http2Exception.StreamException;
 import io.netty.handler.codec.http2.Http2StreamChannel;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -141,7 +142,7 @@ public class StreamObserverTest {
         }
     }
 
-    // @Ignore("https://github.com/apple/servicetalk/issues/1264")
+    @Ignore("https://github.com/apple/servicetalk/issues/1264")
     @Test
     public void maxActiveStreamsViolationError() throws Exception {
         CountDownLatch maxConcurrentStreamsValueSetToOne = new CountDownLatch(1);


### PR DESCRIPTION
Motivation:

HTTP/2 codec may throw an exception when it creates a stream in some cases:
- When there is a concurrency between closing the parent h2 connection and
creating a new stream;
- When stream IDs are exhausted for this endpoint;
- When maximum active streams violated for this endpoint;
In all this cases it's safe to retry the request because we do not start
writing it on the wire. When parent connection is closing concurrently, we
won't hit this error again because it will be marked as "closing" and LB
won't select this connection again.

Modification:

- Wrap `Http2Exception`(s) with `Http2Error.REFUSED_STREAM` as retryable;
- Wrap `Http2NoMoreStreamIdsException` as retryable;

Result:

`HttpClient` will automatically retry recoverable HTTP/2 exceptions.