### PR TITLE
Mark `H2ProtocolConfigBuilder#enableFrameLogging(String)` as deprecated

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
@@ -78,9 +78,11 @@ public final class H2ProtocolConfigBuilder {
     /**
      * Enables a logger for HTTP/2 frames.
      *
+     * @deprecated Use {@link #enableFrameLogging(String, LogLevel, BooleanSupplier)} instead.
      * @param loggerName provides the logger to log HTTP/2 frames.
      * @return {@code this}
      */
+    @Deprecated
     public H2ProtocolConfigBuilder enableFrameLogging(final String loggerName) {
         return enableFrameLogging(loggerName, TRACE, () -> false);
     }


### PR DESCRIPTION
Motivation:

We introduced
`H2ProtocolConfigBuilder#enableFrameLogging(String, LogLevel, BooleanSupplier)`
a few releases ago but forgot to mark the original
`H2ProtocolConfigBuilder#enableFrameLogging(String)` as deprecated.

Modifications:

- Mark `H2ProtocolConfigBuilder#enableFrameLogging(String)` as deprecated;

Result:

`H2ProtocolConfigBuilder#enableFrameLogging(String)` is marked as deprecated and
prepared to be removed in future releases.