### PR TITLE
Add PayloadWriter#close(Throwable)

### DIFF
--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectableBufferOutputStreamTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectableBufferOutputStreamTest.java
@@ -228,7 +228,9 @@ public class ConnectableBufferOutputStreamTest {
         }
 
         assertThat(subscriber.takeOnNext(), is(buf(1)));
-        subscriber.awaitOnComplete();
+        // The subscriber has cancelled, we shouldn't force complete the subscriber and give the illusion we
+        // successfully completed writing all data and closed the PayloadWriter.
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         cbos.close(); // should be idempotent
 
         // Make sure the Subscription thread isn't blocked.
@@ -249,7 +251,9 @@ public class ConnectableBufferOutputStreamTest {
             verifyCheckedRunnableException(e, IOException.class);
         }
 
-        subscriber.awaitOnComplete();
+        // The subscriber has cancelled, we shouldn't force complete the subscriber and give the illusion we
+        // successfully completed writing all data and closed the PayloadWriter.
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         cbos.close(); // should be idempotent
 
         // Make sure the Subscription thread isn't blocked.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectableBufferOutputStreamTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectableBufferOutputStreamTest.java
@@ -46,6 +46,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.PREFER_HEAP_ALLOCATOR;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.api.internal.ConnectablePayloadWriterTest.assertNoTerminal;
 import static io.servicetalk.concurrent.api.internal.ConnectablePayloadWriterTest.toRunnable;
 import static io.servicetalk.concurrent.api.internal.ConnectablePayloadWriterTest.verifyCheckedRunnableException;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -228,9 +229,7 @@ public class ConnectableBufferOutputStreamTest {
         }
 
         assertThat(subscriber.takeOnNext(), is(buf(1)));
-        // The subscriber has cancelled, we shouldn't force complete the subscriber and give the illusion we
-        // successfully completed writing all data and closed the PayloadWriter.
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
+        assertNoTerminal(subscriber);
         cbos.close(); // should be idempotent
 
         // Make sure the Subscription thread isn't blocked.
@@ -251,9 +250,7 @@ public class ConnectableBufferOutputStreamTest {
             verifyCheckedRunnableException(e, IOException.class);
         }
 
-        // The subscriber has cancelled, we shouldn't force complete the subscriber and give the illusion we
-        // successfully completed writing all data and closed the PayloadWriter.
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
+        assertNoTerminal(subscriber);
         cbos.close(); // should be idempotent
 
         // Make sure the Subscription thread isn't blocked.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectablePayloadWriterTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectablePayloadWriterTest.java
@@ -224,9 +224,7 @@ public class ConnectablePayloadWriterTest {
         }
 
         assertThat(subscriber.takeOnNext(), is("foo"));
-        // The subscriber has cancelled, we shouldn't force complete the subscriber and give the illusion we
-        // successfully completed writing all data and closed the PayloadWriter.
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
+        assertNoTerminal(subscriber);
         cpw.close(); // should be idempotent
 
         // Make sure the Subscription thread isn't blocked.
@@ -248,14 +246,18 @@ public class ConnectablePayloadWriterTest {
         }
 
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        // The subscriber has cancelled, we shouldn't force complete the subscriber and give the illusion we
-        // successfully completed writing all data and closed the PayloadWriter.
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
+        assertNoTerminal(subscriber);
         cpw.close(); // should be idempotent
 
         // Make sure the Subscription thread isn't blocked.
         subscriber.awaitSubscription().request(1);
         subscriber.awaitSubscription().cancel();
+    }
+
+    static void assertNoTerminal(TestPublisherSubscriber<?> subscriber) {
+        // We cancelled the subscription, this shouldn't force complete the subscriber and give the illusion we
+        // successfully completed writing all data and closed the PayloadWriter.
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectablePayloadWriterTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectablePayloadWriterTest.java
@@ -224,7 +224,9 @@ public class ConnectablePayloadWriterTest {
         }
 
         assertThat(subscriber.takeOnNext(), is("foo"));
-        subscriber.awaitOnComplete();
+        // The subscriber has cancelled, we shouldn't force complete the subscriber and give the illusion we
+        // successfully completed writing all data and closed the PayloadWriter.
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         cpw.close(); // should be idempotent
 
         // Make sure the Subscription thread isn't blocked.
@@ -246,7 +248,9 @@ public class ConnectablePayloadWriterTest {
         }
 
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
-        subscriber.awaitOnComplete();
+        // The subscriber has cancelled, we shouldn't force complete the subscriber and give the illusion we
+        // successfully completed writing all data and closed the PayloadWriter.
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         cpw.close(); // should be idempotent
 
         // Make sure the Subscription thread isn't blocked.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouteConversions.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouteConversions.java
@@ -127,6 +127,11 @@ final class GrpcRouteConversions {
                             }
 
                             @Override
+                            public void close(final Throwable cause) throws IOException {
+                                connectablePayloadWriter.close(cause);
+                            }
+
+                            @Override
                             public void close() throws IOException {
                                 connectablePayloadWriter.close();
                             }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouteConversions.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouteConversions.java
@@ -127,13 +127,13 @@ final class GrpcRouteConversions {
                             }
 
                             @Override
-                            public void close(final Throwable cause) throws IOException {
-                                connectablePayloadWriter.close(cause);
+                            public void close() throws IOException {
+                                connectablePayloadWriter.close();
                             }
 
                             @Override
-                            public void close() throws IOException {
-                                connectablePayloadWriter.close();
+                            public void close(final Throwable cause) throws IOException {
+                                connectablePayloadWriter.close(cause);
                             }
 
                             @Override

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -692,13 +692,13 @@ final class GrpcRouter {
         }
 
         @Override
-        public void close(final Throwable cause) throws IOException {
-            payloadWriter.close(cause);
+        public void close() throws IOException {
+            payloadWriter.close();
         }
 
         @Override
-        public void close() throws IOException {
-            payloadWriter.close();
+        public void close(final Throwable cause) throws IOException {
+            payloadWriter.close(cause);
         }
 
         @Override

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -692,6 +692,11 @@ final class GrpcRouter {
         }
 
         @Override
+        public void close(final Throwable cause) throws IOException {
+            payloadWriter.close(cause);
+        }
+
+        @Override
         public void close() throws IOException {
             payloadWriter.close();
         }

--- a/servicetalk-grpc-protobuf/src/main/java/io/servicetalk/grpc/protobuf/ProtoBufSerializationProviderBuilder.java
+++ b/servicetalk-grpc-protobuf/src/main/java/io/servicetalk/grpc/protobuf/ProtoBufSerializationProviderBuilder.java
@@ -240,13 +240,13 @@ public final class ProtoBufSerializationProviderBuilder {
                 }
 
                 @Override
-                public void close(final Throwable cause) throws IOException {
-                    payloadWriter.close(cause);
+                public void close() throws IOException {
+                    payloadWriter.close();
                 }
 
                 @Override
-                public void close() throws IOException {
-                    payloadWriter.close();
+                public void close(final Throwable cause) throws IOException {
+                    payloadWriter.close(cause);
                 }
 
                 @Override

--- a/servicetalk-grpc-protobuf/src/main/java/io/servicetalk/grpc/protobuf/ProtoBufSerializationProviderBuilder.java
+++ b/servicetalk-grpc-protobuf/src/main/java/io/servicetalk/grpc/protobuf/ProtoBufSerializationProviderBuilder.java
@@ -240,6 +240,11 @@ public final class ProtoBufSerializationProviderBuilder {
                 }
 
                 @Override
+                public void close(final Throwable cause) throws IOException {
+                    payloadWriter.close(cause);
+                }
+
+                @Override
                 public void close() throws IOException {
                     payloadWriter.close();
                 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
@@ -90,7 +90,6 @@ final class BlockingStreamingToStreamingService extends AbstractServiceAdapterHo
                             HttpHeaders headers = metaData.headers();
                             boolean addTrailers = isTransferEncodingChunked(headers);
                             if (!addTrailers && !HTTP_1_0.equals(metaData.version()) && !hasContentLength(headers) &&
-                                    !hasContentLength(headers) &&
                                     // HEAD responses MUST never carry a payload, adding chunked makes no sense and
                                     // breaks our HttpResponseDecoder
                                     !HEAD.equals(request.method())) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.CompletableSource.Processor;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.SingleSource.Subscriber;
@@ -41,6 +42,7 @@ import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
 import static io.servicetalk.http.api.HttpExecutionStrategies.OFFLOAD_RECEIVE_META_STRATEGY;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_0;
 import static io.servicetalk.http.api.HttpRequestMethod.HEAD;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.StreamingHttpResponses.newTransportResponse;
@@ -73,12 +75,9 @@ final class BlockingStreamingToStreamingService extends AbstractServiceAdapterHo
                     return;
                 }
 
-                // This exists to help users with error propagation. If the user closes the payloadWriter and they throw
-                // (e.g. try-with-resources) this processor is merged with the payloadWriter Publisher so the error will
-                // still be propagated.
                 final Processor exceptionProcessor = newCompletableProcessor();
                 final BufferHttpPayloadWriter payloadWriter = new BufferHttpPayloadWriter(
-                        ctx.headersFactory().newTrailers());
+                        ctx.headersFactory().newTrailers(), exceptionProcessor);
                 DefaultBlockingStreamingHttpServerResponse response = null;
                 try {
                     final Consumer<HttpResponseMetaData> sendMeta = (metaData) -> {
@@ -89,8 +88,8 @@ final class BlockingStreamingToStreamingService extends AbstractServiceAdapterHo
                             // Content-Length header field can provide the anticipated size.
                             // https://tools.ietf.org/html/rfc7230#section-3.3.2
                             HttpHeaders headers = metaData.headers();
-                            boolean addTrailers = metaData.version().major() > 1 || isTransferEncodingChunked(headers);
-                            if (!addTrailers && metaData.version().major() == 1 && metaData.version().minor() > 0 &&
+                            boolean addTrailers = isTransferEncodingChunked(headers);
+                            if (!addTrailers && !HTTP_1_0.equals(metaData.version()) && !hasContentLength(headers) &&
                                     !hasContentLength(headers) &&
                                     // HEAD responses MUST never carry a payload, adding chunked makes no sense and
                                     // breaks our HttpResponseDecoder
@@ -129,11 +128,6 @@ final class BlockingStreamingToStreamingService extends AbstractServiceAdapterHo
                             ctx.headersFactory().newHeaders(), payloadWriter,
                             ctx.executionContext().bufferAllocator(), sendMeta);
                     original.handle(ctx, request.toBlockingStreamingRequest(), response);
-
-                    // The user code has returned successfully, complete the processor so the response stream can
-                    // complete. If the user handles the request asynchronously (e.g. on another thread) they are
-                    // responsible for closing the payloadWriter.
-                    exceptionProcessor.onComplete();
                 } catch (Throwable cause) {
                     tiCancellable.setDone(cause);
                     if (response == null || response.markMetaSent()) {
@@ -168,10 +162,12 @@ final class BlockingStreamingToStreamingService extends AbstractServiceAdapterHo
 
     private static final class BufferHttpPayloadWriter implements HttpPayloadWriter<Buffer> {
         private final ConnectablePayloadWriter<Buffer> payloadWriter = new ConnectablePayloadWriter<>();
+        private final CompletableSource.Subscriber subscriber;
         private final HttpHeaders trailers;
 
-        BufferHttpPayloadWriter(final HttpHeaders trailers) {
+        BufferHttpPayloadWriter(final HttpHeaders trailers, final CompletableSource.Subscriber subscriber) {
             this.trailers = trailers;
+            this.subscriber = subscriber;
         }
 
         @Override
@@ -186,12 +182,20 @@ final class BlockingStreamingToStreamingService extends AbstractServiceAdapterHo
 
         @Override
         public void close() throws IOException {
-            payloadWriter.close();
+            try {
+                payloadWriter.close();
+            } finally {
+                subscriber.onComplete();
+            }
         }
 
         @Override
         public void close(final Throwable cause) throws IOException {
-            payloadWriter.close(cause);
+            try {
+                payloadWriter.close(cause);
+            } finally {
+                subscriber.onError(cause);
+            }
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
@@ -180,11 +180,6 @@ final class BlockingStreamingToStreamingService extends AbstractServiceAdapterHo
         }
 
         @Override
-        public void close(final Throwable cause) throws IOException {
-            payloadWriter.close(cause);
-        }
-
-        @Override
         public void flush() throws IOException {
             payloadWriter.flush();
         }
@@ -192,6 +187,11 @@ final class BlockingStreamingToStreamingService extends AbstractServiceAdapterHo
         @Override
         public void close() throws IOException {
             payloadWriter.close();
+        }
+
+        @Override
+        public void close(final Throwable cause) throws IOException {
+            payloadWriter.close(cause);
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingToBufferHttpPayloadWriter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingToBufferHttpPayloadWriter.java
@@ -42,6 +42,11 @@ abstract class DelegatingToBufferHttpPayloadWriter<T> implements HttpPayloadWrit
     }
 
     @Override
+    public void close(Throwable cause) throws IOException {
+        delegate.close(cause);
+    }
+
+    @Override
     public HttpHeaders trailers() {
         return delegate.trailers();
     }

--- a/servicetalk-oio-api/src/main/java/io/servicetalk/oio/api/PayloadWriter.java
+++ b/servicetalk-oio-api/src/main/java/io/servicetalk/oio/api/PayloadWriter.java
@@ -35,4 +35,20 @@ public interface PayloadWriter<T> extends Closeable, Flushable {
      * closed.
      */
     void write(T t) throws IOException;
+
+    /**
+     * Closes this stream and releases any system resources associated
+     * with it. If the stream is already closed then invoking this
+     * method has no effect.
+     *
+     * <p> As noted in {@link AutoCloseable#close()}, cases where the
+     * close may fail require careful attention. It is strongly advised
+     * to relinquish the underlying resources and to internally
+     * <em>mark</em> the {@code Closeable} as closed, prior to throwing
+     * the {@code IOException}.
+     *
+     * @param cause Indicate the close is a result of a failure.
+     * @throws IOException if an I/O error occurs
+     */
+    void close(Throwable cause) throws IOException;
 }

--- a/servicetalk-oio-api/src/main/java/io/servicetalk/oio/api/PayloadWriter.java
+++ b/servicetalk-oio-api/src/main/java/io/servicetalk/oio/api/PayloadWriter.java
@@ -37,18 +37,14 @@ public interface PayloadWriter<T> extends Closeable, Flushable {
     void write(T t) throws IOException;
 
     /**
-     * Closes this stream and releases any system resources associated
-     * with it. If the stream is already closed then invoking this
-     * method has no effect.
-     *
-     * <p> As noted in {@link AutoCloseable#close()}, cases where the
-     * close may fail require careful attention. It is strongly advised
-     * to relinquish the underlying resources and to internally
-     * <em>mark</em> the {@code Closeable} as closed, prior to throwing
-     * the {@code IOException}.
+     * Reclaims any resources associated with this {@link PayloadWriter} and propagates {@code cause} to downstream
+     * consumers. Subsequent calls to {@link #write(Object)} are expected to fail.
+     * <p>
+     * This method shares the same characteristics as {@link #close()}, and care must be taken to clean up resources
+     * and propagate the {@code cause} before throwing.
      *
      * @param cause Indicate the close is a result of a failure.
-     * @throws IOException if an I/O error occurs
+     * @throws IOException if an input/output error occurs.
      */
     void close(Throwable cause) throws IOException;
 }

--- a/servicetalk-oio-api/src/main/java/io/servicetalk/oio/api/PayloadWriter.java
+++ b/servicetalk-oio-api/src/main/java/io/servicetalk/oio/api/PayloadWriter.java
@@ -37,11 +37,15 @@ public interface PayloadWriter<T> extends Closeable, Flushable {
     void write(T t) throws IOException;
 
     /**
-     * Reclaims any resources associated with this {@link PayloadWriter} and propagates {@code cause} to downstream
-     * consumers. Subsequent calls to {@link #write(Object)} are expected to fail.
-     * <p>
-     * This method shares the same characteristics as {@link #close()}, and care must be taken to clean up resources
-     * and propagate the {@code cause} before throwing.
+     * This method shares the same characteristics as {@link #close()} but propagates {@code cause} to downstream
+     * consumer instead of propagating "successful" completion. Here are notable characteristics shared with
+     * {@link #close()}:
+     * <ul>
+     *     <li>Resources are reclaimed</li>
+     *     <li>This method is idempotent</li>
+     *     <li>Subsequent calls to {@link #write(Object)} are expected to fail</li>
+     *     <li>Before any exception is thrown, all resources must be reclaimed and {@code cause} propagated</li>
+     * </ul>
      *
      * @param cause Indicate the close is a result of a failure.
      * @throws IOException if an input/output error occurs.


### PR DESCRIPTION
Motivation:
In some scenarios the PayloadWriter wraps a Subscriber (e.g.
ConnectablePayloadWriter), and the close may occur as a result of an
error that needs to be propagated to the Subscriber.

Modifications:
- Add close(Throwable) to the PayloadWriter API
- ConnectablePayloadWriter calls subscriber.onError(cause) for the
close(Throwable) method
- BlockingStreamingToStreamingService to use close(Throwable) for more
robust cleanup

Result:
PayloadWriter use cases can close while indicating the error reason.