### PR TITLE
Infer HttpVersion in requests/responses based upon protocol selection

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLBHttpConnectionFactory.java
@@ -25,6 +25,7 @@ import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategyInfluencer;
+import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.transport.api.ConnectionContext;
@@ -46,7 +47,7 @@ abstract class AbstractLBHttpConnectionFactory<ResolvedAddress>
     final StreamingHttpConnectionFilterFactory connectionFilterFunction;
     final ReadOnlyHttpClientConfig config;
     final HttpExecutionContext executionContext;
-    final StreamingHttpRequestResponseFactory reqRespFactory;
+    final Function<HttpProtocolVersion, StreamingHttpRequestResponseFactory> reqRespFactoryFunc;
     final HttpExecutionStrategyInfluencer strategyInfluencer;
     final ConnectionFactory<ResolvedAddress, FilterableStreamingHttpConnection> filterableConnectionFactory;
     private final Function<FilterableStreamingHttpConnection,
@@ -55,7 +56,7 @@ abstract class AbstractLBHttpConnectionFactory<ResolvedAddress>
     AbstractLBHttpConnectionFactory(
             final ReadOnlyHttpClientConfig config, final HttpExecutionContext executionContext,
             @Nullable final StreamingHttpConnectionFilterFactory connectionFilterFunction,
-            final StreamingHttpRequestResponseFactory reqRespFactory,
+            final Function<HttpProtocolVersion, StreamingHttpRequestResponseFactory> reqRespFactoryFunc,
             final HttpExecutionStrategyInfluencer strategyInfluencer,
             final ConnectionFactoryFilter<ResolvedAddress, FilterableStreamingHttpConnection> connectionFactoryFilter,
             final Function<FilterableStreamingHttpConnection,
@@ -63,7 +64,7 @@ abstract class AbstractLBHttpConnectionFactory<ResolvedAddress>
         this.connectionFilterFunction = connectionFilterFunction;
         this.config = requireNonNull(config);
         this.executionContext = requireNonNull(executionContext);
-        this.reqRespFactory = requireNonNull(reqRespFactory);
+        this.reqRespFactoryFunc = requireNonNull(reqRespFactoryFunc);
         this.strategyInfluencer = strategyInfluencer;
         filterableConnectionFactory = connectionFactoryFilter.create(
                 new ConnectionFactory<ResolvedAddress, FilterableStreamingHttpConnection>() {
@@ -88,7 +89,7 @@ abstract class AbstractLBHttpConnectionFactory<ResolvedAddress>
                     public Completable closeAsyncGracefully() {
                         return close.closeAsyncGracefully();
                     }
-        });
+                });
         this.protocolBinding = protocolBinding;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnIds.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnIds.java
@@ -27,12 +27,12 @@ package io.servicetalk.http.netty;
 final class AlpnIds {
 
     /**
-     * {@code "http/1.1"}: HTTP version 1.1
+     * <a href="https://tools.ietf.org/html/rfc7301#section-6">http/1.1</a>: HTTP version 1.1
      */
     static final String HTTP_1_1 = "http/1.1";
 
     /**
-     * {@code "h2"}: HTTP version 2
+     * <a href="https://tools.ietf.org/html/rfc7540#section-3.1">h2</a>: HTTP version 2.
      */
     static final String HTTP_2 = "h2";
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultBlockingStreamingHttpResponseFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultBlockingStreamingHttpResponseFactory.java
@@ -19,24 +19,26 @@ import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.http.api.BlockingStreamingHttpResponse;
 import io.servicetalk.http.api.BlockingStreamingHttpResponseFactory;
 import io.servicetalk.http.api.HttpHeadersFactory;
+import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.http.api.StreamingHttpResponses;
-
-import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 
 final class DefaultBlockingStreamingHttpResponseFactory implements BlockingStreamingHttpResponseFactory {
     private final HttpHeadersFactory headersFactory;
     private final BufferAllocator allocator;
+    private final HttpProtocolVersion version;
 
     DefaultBlockingStreamingHttpResponseFactory(final HttpHeadersFactory headersFactory,
-                                                final BufferAllocator allocator) {
+                                                final BufferAllocator allocator,
+                                                final HttpProtocolVersion version) {
         this.headersFactory = headersFactory;
         this.allocator = allocator;
+        this.version = version;
     }
 
     @Override
     public BlockingStreamingHttpResponse newResponse(final HttpResponseStatus status) {
-        return StreamingHttpResponses.newResponse(status, HTTP_1_1, headersFactory.newHeaders(),
+        return StreamingHttpResponses.newResponse(status, version, headersFactory.newHeaders(),
                 allocator, headersFactory).toBlockingStreamingResponse();
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpResponseFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpResponseFactory.java
@@ -17,26 +17,29 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.http.api.HttpHeadersFactory;
+import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpResponse;
 import io.servicetalk.http.api.HttpResponseFactory;
 import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.http.api.StreamingHttpResponses;
 
 import static io.servicetalk.concurrent.internal.FutureUtils.awaitResult;
-import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 
 final class DefaultHttpResponseFactory implements HttpResponseFactory {
     private final HttpHeadersFactory headersFactory;
     private final BufferAllocator allocator;
+    private final HttpProtocolVersion version;
 
-    DefaultHttpResponseFactory(final HttpHeadersFactory headersFactory, final BufferAllocator allocator) {
+    DefaultHttpResponseFactory(final HttpHeadersFactory headersFactory, final BufferAllocator allocator,
+                               final HttpProtocolVersion version) {
         this.headersFactory = headersFactory;
         this.allocator = allocator;
+        this.version = version;
     }
 
     @Override
     public HttpResponse newResponse(final HttpResponseStatus status) {
-        return awaitResult(StreamingHttpResponses.newResponse(status, HTTP_1_1, headersFactory.newHeaders(), allocator,
+        return awaitResult(StreamingHttpResponses.newResponse(status, version, headersFactory.newHeaders(), allocator,
                 headersFactory).toResponse().toFuture());
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -70,6 +70,7 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseabl
 import static io.servicetalk.concurrent.api.AsyncCloseables.toListenableAsyncCloseable;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverCompleteFromSource;
+import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.defaultReqRespFactory;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -118,7 +119,8 @@ final class DefaultMultiAddressUrlHttpClientBuilder
 
             FilterableStreamingHttpClient urlClient = closeables.prepend(
                     new StreamingUrlHttpClient(buildContext.executionContext, clientFactory, keyFactory,
-                            buildContext.reqRespFactory));
+                            defaultReqRespFactory(buildContext.httpConfig().asReadOnly(),
+                                    buildContext.executionContext.bufferAllocator())));
 
             // Need to wrap the top level client (group) in order for non-relative redirects to work
             urlClient = maxRedirects <= 0 ? urlClient :

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -68,8 +68,10 @@ import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.failed;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.SD_RETRY_STRATEGY_INIT_DURATION;
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.SD_RETRY_STRATEGY_JITTER;
+import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.defaultReqRespFactory;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 
@@ -117,7 +119,9 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
 
         DefaultPartitionedStreamingHttpClientFilter<U, R> partitionedClient =
                 new DefaultPartitionedStreamingHttpClientFilter<>(psdEvents, serviceDiscoveryMaxQueueSize,
-                        clientFactory, partitionAttributesBuilderFactory, buildContext.reqRespFactory,
+                        clientFactory, partitionAttributesBuilderFactory,
+                        defaultReqRespFactory(buildContext.httpConfig().asReadOnly(),
+                                buildContext.executionContext.bufferAllocator()),
                         buildContext.executionContext, partitionMapFactory);
         return new FilterableClientToClient(partitionedClient, buildContext.executionContext.executionStrategy(),
                 buildContext.builder.buildStrategyInfluencerForClient(
@@ -221,7 +225,8 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
 
         @Override
         public StreamingHttpResponseFactory httpResponseFactory() {
-            return new DefaultStreamingHttpResponseFactory(DefaultHttpHeadersFactory.INSTANCE, DEFAULT_ALLOCATOR);
+            return new DefaultStreamingHttpResponseFactory(DefaultHttpHeadersFactory.INSTANCE, DEFAULT_ALLOCATOR,
+                    HTTP_1_1);
         }
 
         @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -32,7 +32,6 @@ import io.servicetalk.client.api.partition.UnknownPartitionException;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.http.api.DefaultHttpHeadersFactory;
 import io.servicetalk.http.api.DefaultServiceDiscoveryRetryStrategy;
 import io.servicetalk.http.api.FilterableReservedStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
@@ -64,11 +63,9 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.failed;
-import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.SD_RETRY_STRATEGY_INIT_DURATION;
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.SD_RETRY_STRATEGY_JITTER;
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.defaultReqRespFactory;
@@ -132,7 +129,7 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
                                                                                  FilterableStreamingHttpClient {
 
         private static final Function<PartitionAttributes, FilterableStreamingHttpClient> PARTITION_CLOSED = pa ->
-                new NoopPartitionClient(new ClosedPartitionException(pa, "Partition closed "));
+                new NoopPartitionClient(new ClosedPartitionException(pa, "Partition closed"));
         private static final Function<PartitionAttributes, FilterableStreamingHttpClient> PARTITION_UNKNOWN = pa ->
                 new NoopPartitionClient(new UnknownPartitionException(pa, "Partition unknown"));
 
@@ -225,8 +222,7 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
 
         @Override
         public StreamingHttpResponseFactory httpResponseFactory() {
-            return new DefaultStreamingHttpResponseFactory(DefaultHttpHeadersFactory.INSTANCE, DEFAULT_ALLOCATOR,
-                    HTTP_1_1);
+            throw ex;
         }
 
         @Override
@@ -247,7 +243,7 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
 
         @Override
         public StreamingHttpRequest newRequest(final HttpRequestMethod method, final String requestTarget) {
-            throw new UnsupportedOperationException("Noop partition client should not be used.");
+            throw ex;
         }
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -38,8 +38,10 @@ import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpExecutionStrategyInfluencer;
+import io.servicetalk.http.api.HttpHeadersFactory;
 import io.servicetalk.http.api.HttpLoadBalancerFactory;
 import io.servicetalk.http.api.HttpProtocolConfig;
+import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.MultiAddressHttpClientFilterFactory;
 import io.servicetalk.http.api.ServiceDiscoveryRetryStrategy;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
@@ -90,6 +92,10 @@ import static java.util.function.Function.identity;
  * @param <R> the type of address after resolution (resolved address)
  */
 final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHttpClientBuilder<U, R> {
+    /**
+     * https://tools.ietf.org/html/rfc7540#section-3.1
+     */
+    private static final String H2_ALPN_ID = "h2";
     static final Duration SD_RETRY_STRATEGY_INIT_DURATION = ofSeconds(10);
     static final Duration SD_RETRY_STRATEGY_JITTER = ofSeconds(5);
     @Nullable
@@ -215,7 +221,6 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
     static final class HttpClientBuildContext<U, R> {
         final DefaultSingleAddressHttpClientBuilder<U, R> builder;
         final HttpExecutionContext executionContext;
-        final StreamingHttpRequestResponseFactory reqRespFactory;
         private final ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer;
         private final SdStatusCompletable sdStatus;
         @Nullable
@@ -223,12 +228,10 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
 
         HttpClientBuildContext(
                 final DefaultSingleAddressHttpClientBuilder<U, R> builder, final HttpExecutionContext executionContext,
-                final StreamingHttpRequestResponseFactory reqRespFactory,
                 final ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> sd, final SdStatusCompletable sdStatus,
                 @Nullable final U proxyAddress) {
             this.builder = builder;
             this.executionContext = executionContext;
-            this.reqRespFactory = reqRespFactory;
             this.serviceDiscoverer = sd;
             this.sdStatus = sdStatus;
             this.proxyAddress = proxyAddress;
@@ -237,6 +240,10 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
         U address() {
             assert builder.address != null : "Attempted to buildStreaming with an unknown address";
             return proxyAddress != null ? proxyAddress : builder.address;
+        }
+
+        HttpClientConfig httpConfig() {
+            return builder.config;
         }
 
         StreamingHttpClient build() {
@@ -250,8 +257,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
     }
 
     private static <U, R> StreamingHttpClient buildStreaming(final HttpClientBuildContext<U, R> ctx) {
-        final ReadOnlyHttpClientConfig roConfig = ctx.builder.config.asReadOnly();
-
+        final ReadOnlyHttpClientConfig roConfig = ctx.httpConfig().asReadOnly();
         if (roConfig.h2Config() != null && roConfig.hasProxy()) {
             throw new IllegalStateException("Proxying is not yet supported with HTTP/2");
         }
@@ -259,11 +265,8 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
         // Track resources that potentially need to be closed when an exception is thrown during buildStreaming
         final CompositeCloseable closeOnException = newCompositeCloseable();
         try {
-
             final Publisher<ServiceDiscovererEvent<R>> sdEvents =
                     ctx.serviceDiscoverer.discover(ctx.address()).flatMapConcatIterable(identity());
-
-            final StreamingHttpRequestResponseFactory reqRespFactory = ctx.reqRespFactory;
 
             ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> connectionFactoryFilter =
                     ctx.builder.connectionFactoryFilter;
@@ -278,19 +281,52 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
             final HttpExecutionStrategy executionStrategy = ctx.executionContext.executionStrategy();
             // closed by the LoadBalancer
             final ConnectionFactory<R, LoadBalancedStreamingHttpConnection> connectionFactory;
+            final StreamingHttpRequestResponseFactory reqRespFactory;
             if (roConfig.isH2PriorKnowledge()) {
+                H2ProtocolConfig h2Config = roConfig.h2Config();
+                assert h2Config != null;
                 connectionFactory = new H2LBHttpConnectionFactory<>(roConfig, ctx.executionContext,
-                        ctx.builder.connectionFilterFactory, reqRespFactory,
+                        ctx.builder.connectionFilterFactory,
+                        (reqRespFactory =
+                                new DefaultStreamingHttpRequestResponseFactory(ctx.executionContext.bufferAllocator(),
+                                        h2Config.headersFactory(), HTTP_2_0)),
                         ctx.builder.influencerChainBuilder.buildForConnectionFactory(executionStrategy),
                         connectionFactoryFilter, ctx.builder.loadBalancerFactory::toLoadBalancedConnection);
             } else if (roConfig.tcpConfig().isAlpnConfigured()) {
+                H1ProtocolConfig h1Config = roConfig.h1Config();
+                H2ProtocolConfig h2Config = roConfig.h2Config();
                 connectionFactory = new AlpnLBHttpConnectionFactory<>(roConfig, ctx.executionContext,
-                        ctx.builder.connectionFilterFactory, reqRespFactory,
+                        ctx.builder.connectionFilterFactory,
+                        new AlpnReqRespFactoryFunc(ctx.executionContext.bufferAllocator(),
+                                h1Config == null ? null : h1Config.headersFactory(),
+                                h2Config == null ? null : h2Config.headersFactory()),
                         ctx.builder.influencerChainBuilder.buildForConnectionFactory(executionStrategy),
                         connectionFactoryFilter, ctx.builder.loadBalancerFactory::toLoadBalancedConnection);
+                // The client can't know which protocol will be negotiated, so just default to the preferred protocol
+                // and pay additional conversion costs if we don't get our preference.
+                String preferredAlpnProtocol = roConfig.tcpConfig().preferredAlpnProtocol();
+                if (H2_ALPN_ID.equals(preferredAlpnProtocol)) {
+                    if (h2Config == null) {
+                        throw new IllegalStateException("h2 is preferred alpn protocol, but the h2 config is null");
+                    }
+                    reqRespFactory = new DefaultStreamingHttpRequestResponseFactory(
+                            ctx.executionContext.bufferAllocator(), h2Config.headersFactory(), HTTP_2_0);
+                } else { // just fall back to h1, all other protocols should convert to/from it.
+                    if (h1Config == null) {
+                        throw new IllegalStateException(preferredAlpnProtocol +
+                                " is preferred alpn protocol, but the h1 config is null");
+                    }
+                    reqRespFactory = new DefaultStreamingHttpRequestResponseFactory(
+                            ctx.executionContext.bufferAllocator(), h1Config.headersFactory(), HTTP_1_1);
+                }
             } else {
+                H1ProtocolConfig h1Config = roConfig.h1Config();
+                assert h1Config != null;
                 connectionFactory = new PipelinedLBHttpConnectionFactory<>(roConfig, ctx.executionContext,
-                        ctx.builder.connectionFilterFactory, reqRespFactory,
+                        ctx.builder.connectionFilterFactory,
+                        (reqRespFactory =
+                                new DefaultStreamingHttpRequestResponseFactory(ctx.executionContext.bufferAllocator(),
+                                        h1Config.headersFactory(), HTTP_1_1)),
                         ctx.builder.influencerChainBuilder.buildForConnectionFactory(executionStrategy),
                         connectionFactoryFilter, ctx.builder.loadBalancerFactory::toLoadBalancedConnection);
             }
@@ -326,6 +362,37 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
         }
     }
 
+    static StreamingHttpRequestResponseFactory defaultReqRespFactory(ReadOnlyHttpClientConfig roConfig,
+                                                                     BufferAllocator allocator) {
+        if (roConfig.isH2PriorKnowledge()) {
+            H2ProtocolConfig h2Config = roConfig.h2Config();
+            assert h2Config != null;
+            return new DefaultStreamingHttpRequestResponseFactory(allocator, h2Config.headersFactory(), HTTP_2_0);
+        } else if (roConfig.tcpConfig().isAlpnConfigured()) {
+            H1ProtocolConfig h1Config = roConfig.h1Config();
+            H2ProtocolConfig h2Config = roConfig.h2Config();
+            // The client can't know which protocol will be negotiated, so just default to the preferred protocol
+            // and pay additional conversion costs if we don't get our preference.
+            String preferredAlpnProtocol = roConfig.tcpConfig().preferredAlpnProtocol();
+            if (H2_ALPN_ID.equals(preferredAlpnProtocol)) {
+                if (h2Config == null) {
+                    throw new IllegalStateException("h2 is preferred alpn protocol, but the h2 config is null");
+                }
+                return new DefaultStreamingHttpRequestResponseFactory(allocator, h2Config.headersFactory(), HTTP_2_0);
+            } else { // just fall back to h1, all other protocols should convert to/from it.
+                if (h1Config == null) {
+                    throw new IllegalStateException(preferredAlpnProtocol +
+                            " is preferred alpn protocol, but the h1 config is null");
+                }
+                return new DefaultStreamingHttpRequestResponseFactory(allocator, h1Config.headersFactory(), HTTP_1_1);
+            }
+        } else {
+            H1ProtocolConfig h1Config = roConfig.h1Config();
+            assert h1Config != null;
+            return new DefaultStreamingHttpRequestResponseFactory(allocator, h1Config.headersFactory(), HTTP_1_1);
+        }
+    }
+
     private static StreamingHttpClientFilterFactory appendFilter(
             @Nullable final StreamingHttpClientFilterFactory currClientFilterFactory,
             final StreamingHttpClientFilterFactory appendClientFilterFactory) {
@@ -354,16 +421,6 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
     private HttpClientBuildContext<U, R> buildContext0(@Nullable U address) {
         final DefaultSingleAddressHttpClientBuilder<U, R> clonedBuilder = address == null ? copy() : copy(address);
         final HttpExecutionContext exec = clonedBuilder.executionContextBuilder.build();
-        final StreamingHttpRequestResponseFactory reqRespFactory;
-        if (clonedBuilder.config.isH2PriorKnowledge()) {
-            assert clonedBuilder.config.protocolConfigs().h2Config() != null;
-            reqRespFactory = new DefaultStreamingHttpRequestResponseFactory(exec.bufferAllocator(),
-                    clonedBuilder.config.protocolConfigs().h2Config().headersFactory(), HTTP_2_0);
-        } else {
-            assert clonedBuilder.config.protocolConfigs().h1Config() != null;
-            reqRespFactory = new DefaultStreamingHttpRequestResponseFactory(exec.bufferAllocator(),
-                    clonedBuilder.config.protocolConfigs().h1Config().headersFactory(), HTTP_1_1);
-        }
         final SdStatusCompletable sdStatus = new SdStatusCompletable();
         ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> sd =
                 new RetryingServiceDiscoverer<>(new StatusAwareServiceDiscoverer<>(serviceDiscoverer, sdStatus),
@@ -371,7 +428,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
                                 DefaultServiceDiscoveryRetryStrategy.Builder.<R>withDefaults(exec.executor(),
                                         SD_RETRY_STRATEGY_INIT_DURATION, SD_RETRY_STRATEGY_JITTER).build() :
                                 serviceDiscovererRetryStrategy);
-        return new HttpClientBuildContext<>(clonedBuilder, exec, reqRespFactory, sd, sdStatus, proxyAddress);
+        return new HttpClientBuildContext<>(clonedBuilder, exec, sd, sdStatus, proxyAddress);
     }
 
     private AbsoluteAddressHttpRequesterFilter proxyAbsoluteAddressFilterFactory() {
@@ -681,6 +738,61 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
         @Override
         public Completable closeAsyncGracefully() {
             return delegate.closeAsyncGracefully();
+        }
+    }
+
+    private static final class AlpnReqRespFactoryFunc implements
+                                                  Function<HttpProtocolVersion, StreamingHttpRequestResponseFactory> {
+        private final BufferAllocator allocator;
+        @Nullable
+        private final HttpHeadersFactory h1HeadersFactory;
+        @Nullable
+        private final HttpHeadersFactory h2HeadersFactory;
+        @Nullable
+        private StreamingHttpRequestResponseFactory h1Factory;
+        @Nullable
+        private StreamingHttpRequestResponseFactory h2Factory;
+
+        AlpnReqRespFactoryFunc(final BufferAllocator allocator, @Nullable final HttpHeadersFactory h1HeadersFactory,
+                               @Nullable final HttpHeadersFactory h2HeadersFactory) {
+            this.allocator = allocator;
+            this.h1HeadersFactory = h1HeadersFactory;
+            this.h2HeadersFactory = h2HeadersFactory;
+        }
+
+        @Override
+        public StreamingHttpRequestResponseFactory apply(final HttpProtocolVersion version) {
+            if (version == HTTP_1_1) {
+                if (h1Factory == null) { // its OK if we race and re-initialize the instance.
+                    h1Factory = new DefaultStreamingHttpRequestResponseFactory(allocator,
+                            headersFactory(h1HeadersFactory, HTTP_1_1), HTTP_1_1);
+                }
+                return h1Factory;
+            } else if (version == HTTP_2_0) {
+                if (h2Factory == null) { // its OK if we race and re-initialize the instance.
+                    h2Factory = new DefaultStreamingHttpRequestResponseFactory(allocator,
+                            headersFactory(h2HeadersFactory, HTTP_2_0), HTTP_2_0);
+                }
+                return h2Factory;
+            } else if (version.major() <= 1) {
+                // client doesn't generate HTTP_1_0 requests, no need to cache.
+                return new DefaultStreamingHttpRequestResponseFactory(allocator,
+                        headersFactory(h1HeadersFactory, version), version);
+            } else if (version.major() == 2) {
+                return new DefaultStreamingHttpRequestResponseFactory(allocator,
+                        headersFactory(h2HeadersFactory, version), version);
+            } else {
+                throw new IllegalArgumentException("unsupported protocol: " + version);
+            }
+        }
+
+        private static HttpHeadersFactory headersFactory(@Nullable HttpHeadersFactory factory,
+                                                         HttpProtocolVersion version) {
+            if (factory == null) {
+                throw new IllegalStateException("HeadersFactory config not found for selected protocol: "
+                        + version);
+            }
+            return factory;
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultStreamingHttpResponseFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultStreamingHttpResponseFactory.java
@@ -17,25 +17,27 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.http.api.HttpHeadersFactory;
+import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpResponses;
 
-import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
-
 final class DefaultStreamingHttpResponseFactory implements StreamingHttpResponseFactory {
     private final HttpHeadersFactory headersFactory;
     private final BufferAllocator allocator;
+    private final HttpProtocolVersion version;
 
-    DefaultStreamingHttpResponseFactory(HttpHeadersFactory headersFactory, BufferAllocator allocator) {
+    DefaultStreamingHttpResponseFactory(HttpHeadersFactory headersFactory, BufferAllocator allocator,
+                                        HttpProtocolVersion version) {
         this.headersFactory = headersFactory;
         this.allocator = allocator;
+        this.version = version;
     }
 
     @Override
     public StreamingHttpResponse newResponse(final HttpResponseStatus status) {
-        return StreamingHttpResponses.newResponse(status, HTTP_1_1, headersFactory.newHeaders(),
+        return StreamingHttpResponses.newResponse(status, version, headersFactory.newHeaders(),
                 allocator, headersFactory);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import static io.netty.handler.codec.http2.Http2CodecUtil.SMALLEST_MAX_CONCURRENT_STREAMS;
 import static io.servicetalk.client.api.internal.ReservableRequestConcurrencyControllers.newController;
 import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 
 final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpConnectionFactory<ResolvedAddress> {
     H2LBHttpConnectionFactory(
@@ -46,7 +47,7 @@ final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpCon
             final ConnectionFactoryFilter<ResolvedAddress, FilterableStreamingHttpConnection> connectionFactoryFilter,
             final Function<FilterableStreamingHttpConnection,
                     FilterableStreamingHttpLoadBalancedConnection> protocolBinding) {
-        super(config, executionContext, connectionFilterFunction, reqRespFactory, strategyInfluencer,
+        super(config, executionContext, connectionFilterFunction, version -> reqRespFactory, strategyInfluencer,
                 connectionFactoryFilter, protocolBinding);
     }
 
@@ -60,7 +61,7 @@ final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpCon
         return TcpConnector.connect(null, resolvedAddress, roTcpClientConfig, true, executionContext,
                 (channel, connectionObserver) -> H2ClientParentConnectionContext.initChannel(channel,
                         executionContext.bufferAllocator(), executionContext.executor(),
-                        config.h2Config(), reqRespFactory, roTcpClientConfig.flushStrategy(),
+                        config.h2Config(), reqRespFactoryFunc.apply(HTTP_2_0), roTcpClientConfig.flushStrategy(),
                         roTcpClientConfig.idleTimeoutMs(), executionContext.executionStrategy(),
                         new TcpClientChannelInitializer(roTcpClientConfig, connectionObserver).andThen(
                                 new H2ClientParentChannelInitializer(config.h2Config())), connectionObserver),

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -174,9 +174,8 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                                                 Http2Exception::wrapIfNecessary);
 
                                 // ServiceTalk HTTP service handler
-                                new NettyHttpServerConnection(streamConnection, service,
-                                        executionStrategy, h2ServerConfig.headersFactory(),
-                                        drainRequestPayloadBody).process(false);
+                                new NettyHttpServerConnection(streamConnection, service, executionStrategy, HTTP_2_0,
+                                        h2ServerConfig.headersFactory(), drainRequestPayloadBody).process(false);
                             }
                     }).init(channel);
                 } catch (Throwable cause) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -22,7 +22,6 @@ import io.servicetalk.http.api.HttpHeadersFactory;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.HttpResponseStatus;
-import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
 import io.servicetalk.transport.netty.internal.CloseHandler;
 
@@ -44,8 +43,8 @@ import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.api.HttpRequestMethod.CONNECT;
+import static io.servicetalk.http.api.HttpResponseMetaDataFactory.newResponseMetaData;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATIONAL_1XX;
-import static io.servicetalk.http.api.StreamingHttpResponses.newResponse;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h1HeadersToH2Headers;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h2HeadersSanitizeForH1;
 import static io.servicetalk.http.netty.HeaderUtils.canAddResponseTransferEncodingProtocol;
@@ -139,9 +138,8 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
             } else if (httpStatus == null) {
                 throw new IllegalArgumentException("a response must have " + STATUS + " header");
             } else {
-                StreamingHttpResponse response = newResponse(httpStatus, HTTP_2_0,
-                        h2HeadersToH1HeadersClient(h2Headers, httpStatus), allocator, headersFactory);
-                ctx.fireChannelRead(response);
+                ctx.fireChannelRead(
+                        newResponseMetaData(HTTP_2_0, httpStatus, h2HeadersToH1HeadersClient(h2Headers, httpStatus)));
             }
         } else if (msg instanceof Http2DataFrame) {
             readDataFrame(ctx, msg);
@@ -156,9 +154,8 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
         if (shouldAddZeroContentLength(httpStatus.code(), method)) {
             h2Headers.set(CONTENT_LENGTH, ZERO);
         }
-        StreamingHttpResponse response = newResponse(httpStatus, HTTP_2_0,
-                h2HeadersToH1HeadersClient(h2Headers, httpStatus), allocator, headersFactory);
-        ctx.fireChannelRead(response);
+        ctx.fireChannelRead(
+                newResponseMetaData(HTTP_2_0, httpStatus, h2HeadersToH1HeadersClient(h2Headers, httpStatus)));
         ctx.fireChannelRead(headersFactory.newEmptyTrailers());
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestEncoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestEncoder.java
@@ -38,6 +38,7 @@ import io.servicetalk.transport.netty.internal.CloseHandler;
 import java.util.Queue;
 
 import static io.netty.handler.codec.http.HttpConstants.SP;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
 import static java.util.Objects.requireNonNull;
 
@@ -139,7 +140,9 @@ final class HttpRequestEncoder extends HttpObjectEncoder<HttpRequestMetaData> {
             }
         }
 
-        message.version().writeTo(stBuffer);
+        // It is possible for the user to generate a request with a non-http/1.x version (e.g. ALPN prefers h2), and
+        // if this happens just force http/1.1 to avoid generating an invalid request.
+        (message.version().major() == 1 ? message.version() : HTTP_1_1).writeTo(stBuffer);
         stBuffer.writeShort(CRLF_SHORT);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -162,7 +162,7 @@ final class NettyHttpServer {
                 initializer.andThen(getChannelInitializer(getByteBufAllocator(httpExecutionContext.bufferAllocator()),
                         h1Config, closeHandler)), httpExecutionContext.executionStrategy(), HTTP_1_1, observer, false)
                 .map(conn -> new NettyHttpServerConnection(conn, service, httpExecutionContext.executionStrategy(),
-                        h1Config.headersFactory(), drainRequestPayloadBody)), HTTP_1_1, channel);
+                        HTTP_1_1, h1Config.headersFactory(), drainRequestPayloadBody)), HTTP_1_1, channel);
     }
 
     private static ChannelInitializer getChannelInitializer(final ByteBufAllocator alloc, final H1ProtocolConfig config,
@@ -234,14 +234,16 @@ final class NettyHttpServer {
         NettyHttpServerConnection(final NettyConnection<Object, Object> connection,
                                   final StreamingHttpService service,
                                   final HttpExecutionStrategy strategy,
+                                  final HttpProtocolVersion version,
                                   final HttpHeadersFactory headersFactory,
                                   final boolean drainRequestPayloadBody) {
             super(headersFactory,
-                    new DefaultHttpResponseFactory(headersFactory, connection.executionContext().bufferAllocator()),
+                    new DefaultHttpResponseFactory(headersFactory, connection.executionContext().bufferAllocator(),
+                            version),
                     new DefaultStreamingHttpResponseFactory(headersFactory,
-                            connection.executionContext().bufferAllocator()),
+                            connection.executionContext().bufferAllocator(), version),
                     new DefaultBlockingStreamingHttpResponseFactory(headersFactory,
-                            connection.executionContext().bufferAllocator()));
+                            connection.executionContext().bufferAllocator(), version));
             this.connection = connection;
             this.headersFactory = headersFactory;
             executionContext = new DefaultHttpExecutionContext(connection.executionContext().bufferAllocator(),

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
@@ -32,6 +32,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.client.api.internal.ReservableRequestConcurrencyControllers.newController;
 import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.netty.StreamingConnectionFactory.buildStreaming;
 
 final class PipelinedLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpConnectionFactory<ResolvedAddress> {
@@ -43,7 +44,7 @@ final class PipelinedLBHttpConnectionFactory<ResolvedAddress> extends AbstractLB
             final ConnectionFactoryFilter<ResolvedAddress, FilterableStreamingHttpConnection> connectionFactoryFilter,
             final Function<FilterableStreamingHttpConnection,
                     FilterableStreamingHttpLoadBalancedConnection> protocolBinding) {
-        super(config, executionContext, connectionFilterFunction, reqRespFactory, strategyInfluencer,
+        super(config, executionContext, connectionFilterFunction, version -> reqRespFactory, strategyInfluencer,
                 connectionFactoryFilter, protocolBinding);
     }
 
@@ -53,7 +54,7 @@ final class PipelinedLBHttpConnectionFactory<ResolvedAddress> extends AbstractLB
         assert config.h1Config() != null;
         return buildStreaming(executionContext, resolvedAddress, config, observer)
                 .map(conn -> new PipelinedStreamingHttpConnection(conn, config.h1Config(), executionContext,
-                        reqRespFactory));
+                        reqRespFactoryFunc.apply(HTTP_1_1)));
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
@@ -110,7 +110,7 @@ public class AlpnClientAndServerTest {
                 {singletonList(HTTP_1_1), asList(HTTP_2, HTTP_1_1), HttpProtocolVersion.HTTP_1_1, null},
                 {singletonList(HTTP_1_1), asList(HTTP_1_1, HTTP_2), HttpProtocolVersion.HTTP_1_1, null},
                 {singletonList(HTTP_1_1), singletonList(HTTP_2), null, ClosedChannelException.class},
-                {singletonList(HTTP_1_1), singletonList(HTTP_1_1), HttpProtocolVersion.HTTP_1_1, null},
+                {singletonList(HTTP_1_1), singletonList(HTTP_1_1), HttpProtocolVersion.HTTP_1_1, null}
         });
     }
 
@@ -165,7 +165,7 @@ public class AlpnClientAndServerTest {
     }
 
     @Test
-    public void testAlpn() throws Exception {
+    public void testAlpnConnection() throws Exception {
         if (expectedExceptionType != null) {
             assertThrows(expectedExceptionType, () -> client.request(client.get("/")));
             return;
@@ -175,18 +175,30 @@ public class AlpnClientAndServerTest {
             assertThat(connection.connectionContext().protocol(), is(expectedProtocol));
             assertThat(connection.connectionContext().sslSession(), is(notNullValue()));
 
-            HttpResponse response = connection.request(client.get("/"));
-            assertThat(response.version(), is(expectedProtocol));
-            assertThat(response.status(), is(OK));
-            assertThat(response.payloadBody(textDeserializer()), is(PAYLOAD_BODY));
-
-            HttpServiceContext serviceCtx = serviceContext.take();
-            assertThat(serviceCtx.protocol(), is(expectedProtocol));
-            assertThat(serviceCtx.sslSession(), is(notNullValue()));
-            assertThat(requestVersion.take(), is(expectedProtocol));
-
-            assertThat(serviceContext, is(empty()));
-            assertThat(requestVersion, is(empty()));
+            assertResponseAndServiceContext(connection.request(client.get("/")));
         }
+    }
+
+    @Test
+    public void testAlpnClient() throws Exception {
+        if (expectedExceptionType != null) {
+            assertThrows(expectedExceptionType, () -> client.request(client.get("/")));
+        } else {
+            assertResponseAndServiceContext(client.request(client.get("/")));
+        }
+    }
+
+    private void assertResponseAndServiceContext(HttpResponse response) throws Exception {
+        assertThat(response.version(), is(expectedProtocol));
+        assertThat(response.status(), is(OK));
+        assertThat(response.payloadBody(textDeserializer()), is(PAYLOAD_BODY));
+
+        HttpServiceContext serviceCtx = serviceContext.take();
+        assertThat(serviceCtx.protocol(), is(expectedProtocol));
+        assertThat(serviceCtx.sslSession(), is(notNullValue()));
+        assertThat(requestVersion.take(), is(expectedProtocol));
+
+        assertThat(serviceContext, is(empty()));
+        assertThat(requestVersion, is(empty()));
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
@@ -110,7 +110,7 @@ public class AlpnClientAndServerTest {
                 {singletonList(HTTP_1_1), asList(HTTP_2, HTTP_1_1), HttpProtocolVersion.HTTP_1_1, null},
                 {singletonList(HTTP_1_1), asList(HTTP_1_1, HTTP_2), HttpProtocolVersion.HTTP_1_1, null},
                 {singletonList(HTTP_1_1), singletonList(HTTP_2), null, ClosedChannelException.class},
-                {singletonList(HTTP_1_1), singletonList(HTTP_1_1), HttpProtocolVersion.HTTP_1_1, null}
+                {singletonList(HTTP_1_1), singletonList(HTTP_1_1), HttpProtocolVersion.HTTP_1_1, null},
         });
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseFactoryStatusCodeTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseFactoryStatusCodeTest.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.buffer.netty.BufferAllocators;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.http.api.BlockingStreamingHttpResponse;
 import io.servicetalk.http.api.BlockingStreamingHttpResponseFactory;
@@ -37,7 +36,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.http.api.DefaultHttpHeadersFactory.INSTANCE;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
@@ -57,7 +58,7 @@ public class HttpResponseFactoryStatusCodeTest {
     @Test
     public void testStatusCode() {
         final HttpResponseFactory httpResponseFactory =
-                new DefaultHttpResponseFactory(INSTANCE, BufferAllocators.DEFAULT_ALLOCATOR);
+                new DefaultHttpResponseFactory(INSTANCE, DEFAULT_ALLOCATOR, HTTP_1_1);
 
         List<HttpResponseStatus> actualStatuses =
                 buildHttpStatuses(httpResponseFactory, HttpResponseFactory.class, HttpResponse.class);
@@ -69,7 +70,7 @@ public class HttpResponseFactoryStatusCodeTest {
     public void testBlockingStatusCode() {
 
         final BlockingStreamingHttpResponseFactory blockingStreamingHttpResponseFactory =
-                new DefaultBlockingStreamingHttpResponseFactory(INSTANCE, BufferAllocators.DEFAULT_ALLOCATOR);
+                new DefaultBlockingStreamingHttpResponseFactory(INSTANCE, DEFAULT_ALLOCATOR, HTTP_1_1);
 
         List<HttpResponseStatus> actualStatuses =
                 buildHttpStatuses(blockingStreamingHttpResponseFactory,
@@ -82,7 +83,7 @@ public class HttpResponseFactoryStatusCodeTest {
     public void testStreamingStatusCode() {
 
         final StreamingHttpResponseFactory streamingHttpResponseFactory =
-                new DefaultStreamingHttpResponseFactory(INSTANCE, BufferAllocators.DEFAULT_ALLOCATOR);
+                new DefaultStreamingHttpResponseFactory(INSTANCE, DEFAULT_ALLOCATOR, HTTP_1_1);
 
         List<HttpResponseStatus> actualStatuses =
                 buildHttpStatuses(streamingHttpResponseFactory,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
@@ -48,6 +48,7 @@ import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
 import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
 import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
 import static io.servicetalk.http.netty.NettyHttpServer.initChannel;
 import static io.servicetalk.transport.netty.internal.NettyIoExecutors.fromNettyEventLoop;
@@ -62,7 +63,7 @@ import static org.hamcrest.Matchers.is;
 public class ServerRespondsOnClosingTest {
 
     private static final HttpResponseFactory RESPONSE_FACTORY = new DefaultHttpResponseFactory(
-            DefaultHttpHeadersFactory.INSTANCE, DEFAULT_ALLOCATOR);
+            DefaultHttpHeadersFactory.INSTANCE, DEFAULT_ALLOCATOR, HTTP_1_1);
     private static final String RESPONSE_PAYLOAD_BODY = "Hello World";
 
     @Rule

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractReadOnlyTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractReadOnlyTcpConfig.java
@@ -44,15 +44,16 @@ abstract class AbstractReadOnlyTcpConfig<SecurityConfig, ReadOnlyView> {
     private final FlushStrategy flushStrategy;
     @Nullable
     private final UserDataLoggerConfig wireLoggerConfig;
-    private final boolean alpnConfigured;
+    @Nullable
+    private final String preferredAlpnProtocol;
 
     protected AbstractReadOnlyTcpConfig(final AbstractTcpConfig<SecurityConfig, ReadOnlyView> from,
-                                        final boolean alpnConfigured) {
+                                        @Nullable final String preferredAlpnProtocol) {
         options = from.options() == null ? emptyMap() : unmodifiableMap(new HashMap<>(from.options()));
         idleTimeoutMs = from.idleTimeoutMs();
         flushStrategy = from.flushStrategy();
         wireLoggerConfig = from.wireLoggerConfig();
-        this.alpnConfigured = alpnConfigured;
+        this.preferredAlpnProtocol = preferredAlpnProtocol;
     }
 
     /**
@@ -102,7 +103,17 @@ abstract class AbstractReadOnlyTcpConfig<SecurityConfig, ReadOnlyView> {
      * configured
      */
     public boolean isAlpnConfigured() {
-        return alpnConfigured;
+        return preferredAlpnProtocol != null;
+    }
+
+    /**
+     * Get the preferred ALPN protocol. If a protocol sensitive decision must be made without knowing which protocol is
+     * negotiated (e.g. at the client level) this protocol can be used as a best guess.
+     * @return the preferred ALPN protocol.
+     */
+    @Nullable
+    public String preferredAlpnProtocol() {
+        return preferredAlpnProtocol;
     }
 
     /**

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpClientConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpClientConfig.java
@@ -44,7 +44,7 @@ public final class ReadOnlyTcpClientConfig
      * @param from Source to copy from.
      */
     ReadOnlyTcpClientConfig(final TcpClientConfig from, final List<String> supportedAlpnProtocols) {
-        super(from, !supportedAlpnProtocols.isEmpty());
+        super(from, supportedAlpnProtocols.isEmpty() ? null : supportedAlpnProtocols.get(0));
         final ReadOnlyClientSecurityConfig securityConfig = from.securityConfig();
         if (securityConfig != null) {
             sslContext = forClient(securityConfig, supportedAlpnProtocols);

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
@@ -49,7 +49,7 @@ public final class ReadOnlyTcpServerConfig
      * @param from Source to copy from.
      */
     ReadOnlyTcpServerConfig(final TcpServerConfig from, final List<String> supportedAlpnProtocols) {
-        super(from, !supportedAlpnProtocols.isEmpty());
+        super(from, supportedAlpnProtocols.isEmpty() ? null : supportedAlpnProtocols.get(0));
         final TransportObserver transportObserver = from.transportObserver();
         this.transportObserver = transportObserver == NoopTransportObserver.INSTANCE ? transportObserver :
                 asSafeObserver(transportObserver);


### PR DESCRIPTION
Motivation:
HTTP/1.x protocol requires the version is included in the request and
response. When generating requests/response objects in the application
we tend to default to HTTP_1_1 despite the protocol and user
preferences. This may result in additional conversions and confusion
when using version accessors.

Modifications:
- For request/response factories that can derive the real version from
  the transport they should use the real version
- For use cases that don't know which protocol will be used (e.g. Client
  where h1, h2, etc. is requested) use the version most preferred
locally. Worst case additional conversions will be required if the
preferred protocol isn't used.

Result:
HttpVersion in request/response objects will be more accurate and less
conversions will be required.