### PR TITLE
ServiceTalkTestTimeout remove default min timeout limit

### DIFF
--- a/servicetalk-concurrent-internal/src/testFixtures/java/io/servicetalk/concurrent/internal/ServiceTalkTestTimeout.java
+++ b/servicetalk-concurrent-internal/src/testFixtures/java/io/servicetalk/concurrent/internal/ServiceTalkTestTimeout.java
@@ -43,7 +43,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 import static java.lang.Boolean.parseBoolean;
-import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -61,7 +60,7 @@ public final class ServiceTalkTestTimeout extends Timeout {
     }
 
     public ServiceTalkTestTimeout(long timeout, TimeUnit unit) {
-        this(max(timeout, unit.convert(DEFAULT_TIMEOUT_SECONDS, SECONDS)), unit, () -> { });
+        this(timeout, unit, () -> { });
     }
 
     public ServiceTalkTestTimeout(long timeout, TimeUnit unit, Runnable onTimeout) {


### PR DESCRIPTION
Motivation:
During testing/development it is often useful to limit the test value
below the default value. This allows test failures to occur more quickly
when running a sequence of tests, and the developer can then narrow in
on the failing tests and identify patterns. However
ServiceTalkTestTimeout currently enforces a lower bound on the timeout
to the default value (currently 10 seconds per test).

Modifications:
- Remove lower bound in ServiceTalkTestTimeout

Result:
ServiceTalkTestTimeout can set lower timeout values during development.