### PR TITLE
OnSubscribeIgnoringSubscriberForOffloading empty subscription usage

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableToPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableToPublisher.java
@@ -22,7 +22,7 @@ import io.servicetalk.concurrent.internal.SignalOffloader;
 
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
-import static io.servicetalk.concurrent.api.OnSubscribeIgnoringSubscriberForOffloading.offloadWithDummyOnSubscribe;
+import static io.servicetalk.concurrent.api.OnSubscribeIgnoringSubscriberForOffloading.offloadSubscriber;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
@@ -48,6 +48,7 @@ final class CompletableToPublisher<T> extends AbstractNoHandleSubscribePublisher
 
     private static final class ConversionSubscriber<T> extends SequentialCancellable
             implements CompletableSource.Subscriber, Subscription {
+        @SuppressWarnings("rawtypes")
         private static final AtomicIntegerFieldUpdater<ConversionSubscriber> terminatedUpdater =
                 newUpdater(ConversionSubscriber.class, "terminated");
         private final Subscriber<? super T> subscriber;
@@ -86,7 +87,7 @@ final class CompletableToPublisher<T> extends AbstractNoHandleSubscribePublisher
                 // We have not offloaded the Subscriber as we generally emit to the Subscriber from the Completable
                 // Subscriber methods which is correctly offloaded. This is the only case where we invoke the
                 // Subscriber directly, hence we explicitly offload.
-                Subscriber<? super T> offloaded = offloadWithDummyOnSubscribe(signalOffloader, subscriber);
+                Subscriber<? super T> offloaded = offloadSubscriber(signalOffloader, subscriber);
                 try {
                     // offloadSubscriber before cancellation so that signalOffloader does not exit on seeing a cancel.
                     cancel();

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableToPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableToPublisher.java
@@ -22,7 +22,7 @@ import io.servicetalk.concurrent.internal.SignalOffloader;
 
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
-import static io.servicetalk.concurrent.api.OnSubscribeIgnoringSubscriberForOffloading.offloadSubscriber;
+import static io.servicetalk.concurrent.api.OnSubscribeIgnoringSubscriberForOffloading.offloadWithDummyOnSubscribe;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
@@ -87,7 +87,7 @@ final class CompletableToPublisher<T> extends AbstractNoHandleSubscribePublisher
                 // We have not offloaded the Subscriber as we generally emit to the Subscriber from the Completable
                 // Subscriber methods which is correctly offloaded. This is the only case where we invoke the
                 // Subscriber directly, hence we explicitly offload.
-                Subscriber<? super T> offloaded = offloadSubscriber(signalOffloader, subscriber);
+                Subscriber<? super T> offloaded = offloadWithDummyOnSubscribe(signalOffloader, subscriber);
                 try {
                     // offloadSubscriber before cancellation so that signalOffloader does not exit on seeing a cancel.
                     cancel();

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/OnSubscribeIgnoringSubscriberForOffloading.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/OnSubscribeIgnoringSubscriberForOffloading.java
@@ -50,7 +50,7 @@ final class OnSubscribeIgnoringSubscriberForOffloading<T> implements PublisherSo
         original.onComplete();
     }
 
-    static <T> PublisherSource.Subscriber<? super T> offloadSubscriber(
+    static <T> PublisherSource.Subscriber<? super T> offloadWithDummyOnSubscribe(
             SignalOffloader offloader, PublisherSource.Subscriber<? super T> original) {
         OnSubscribeIgnoringSubscriberForOffloading<T> subscriber =
                 new OnSubscribeIgnoringSubscriberForOffloading<>(original);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/OnSubscribeIgnoringSubscriberForOffloading.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/OnSubscribeIgnoringSubscriberForOffloading.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.internal.SignalOffloader;
 
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.internal.EmptySubscriptions.newEmptySubscription;
+import static io.servicetalk.concurrent.internal.EmptySubscriptions.EMPTY_SUBSCRIPTION;
 
 final class OnSubscribeIgnoringSubscriberForOffloading<T> implements PublisherSource.Subscriber<T> {
 
@@ -50,7 +50,7 @@ final class OnSubscribeIgnoringSubscriberForOffloading<T> implements PublisherSo
         original.onComplete();
     }
 
-    static <T> PublisherSource.Subscriber<? super T> offloadWithDummyOnSubscribe(
+    static <T> PublisherSource.Subscriber<? super T> offloadSubscriber(
             SignalOffloader offloader, PublisherSource.Subscriber<? super T> original) {
         OnSubscribeIgnoringSubscriberForOffloading<T> subscriber =
                 new OnSubscribeIgnoringSubscriberForOffloading<>(original);
@@ -59,7 +59,7 @@ final class OnSubscribeIgnoringSubscriberForOffloading<T> implements PublisherSo
         // already, so we send an onSubscribe to the offloaded Subscriber which ignores this signal but makes
         // the signalOffloader does not see spec violation (onError without onSubscribe) for the offloaded
         // subscriber.
-        toReturn.onSubscribe(newEmptySubscription(subscriber));
+        toReturn.onSubscribe(EMPTY_SUBSCRIPTION);
         return toReturn;
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleToPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleToPublisher.java
@@ -23,7 +23,7 @@ import io.servicetalk.concurrent.internal.SignalOffloader;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.OnSubscribeIgnoringSubscriberForOffloading.offloadWithDummyOnSubscribe;
+import static io.servicetalk.concurrent.api.OnSubscribeIgnoringSubscriberForOffloading.offloadSubscriber;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
@@ -53,7 +53,7 @@ final class SingleToPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
         private static final int STATE_REQUESTED = 1;
         private static final int STATE_AWAITING_REQUESTED = 2;
         private static final int STATE_TERMINATED = 3;
-
+        @SuppressWarnings("rawtypes")
         private static final AtomicIntegerFieldUpdater<ConversionSubscriber> stateUpdater =
                 newUpdater(ConversionSubscriber.class, "state");
         private final Subscriber<? super T> subscriber;
@@ -109,7 +109,7 @@ final class SingleToPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
                         // We have not offloaded the Subscriber as we generally emit to the Subscriber from the
                         // Single Subscriber methods which is correctly offloaded. This is the case where we invoke the
                         // Subscriber directly, hence we explicitly offload.
-                        terminateSuccessfully(result, offloadWithDummyOnSubscribe(signalOffloader, subscriber));
+                        terminateSuccessfully(result, offloadSubscriber(signalOffloader, subscriber));
                         return;
                     } else if (cState == STATE_IDLE &&
                             stateUpdater.compareAndSet(this, STATE_IDLE, STATE_REQUESTED)) {
@@ -120,7 +120,7 @@ final class SingleToPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
                 }
             } else {
                 if (stateUpdater.getAndSet(this, STATE_TERMINATED) != STATE_TERMINATED) {
-                    Subscriber<? super T> offloaded = offloadWithDummyOnSubscribe(signalOffloader, this.subscriber);
+                    Subscriber<? super T> offloaded = offloadSubscriber(signalOffloader, this.subscriber);
                     try {
                         // offloadSubscriber before cancellation so that signalOffloader does not exit on seeing a
                         // cancel.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleToPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleToPublisher.java
@@ -23,7 +23,7 @@ import io.servicetalk.concurrent.internal.SignalOffloader;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.OnSubscribeIgnoringSubscriberForOffloading.offloadSubscriber;
+import static io.servicetalk.concurrent.api.OnSubscribeIgnoringSubscriberForOffloading.offloadWithDummyOnSubscribe;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
@@ -109,7 +109,7 @@ final class SingleToPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
                         // We have not offloaded the Subscriber as we generally emit to the Subscriber from the
                         // Single Subscriber methods which is correctly offloaded. This is the case where we invoke the
                         // Subscriber directly, hence we explicitly offload.
-                        terminateSuccessfully(result, offloadSubscriber(signalOffloader, subscriber));
+                        terminateSuccessfully(result, offloadWithDummyOnSubscribe(signalOffloader, subscriber));
                         return;
                     } else if (cState == STATE_IDLE &&
                             stateUpdater.compareAndSet(this, STATE_IDLE, STATE_REQUESTED)) {
@@ -120,7 +120,7 @@ final class SingleToPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
                 }
             } else {
                 if (stateUpdater.getAndSet(this, STATE_TERMINATED) != STATE_TERMINATED) {
-                    Subscriber<? super T> offloaded = offloadSubscriber(signalOffloader, this.subscriber);
+                    Subscriber<? super T> offloaded = offloadWithDummyOnSubscribe(signalOffloader, this.subscriber);
                     try {
                         // offloadSubscriber before cancellation so that signalOffloader does not exit on seeing a
                         // cancel.


### PR DESCRIPTION
Motivation:
93165f04398085600a628e5af9d5de625b37aa2f made a change to ensure invalid
requestN demand is propagated to the associated Subscriber. However
OnSubscribeIgnoringSubscriberForOffloading#offloadWithDummyOnSubscribe
is used in such a way that a terminal event will already be delivered
and demand is validated externally. This usage is so the offloader has
the expected onSubscribe method invoked, but the Subscription will not
actually be used. The usage can therefore be simplified to use
EMPTY_SUBSCRIPTION and avoid potential for duplicate terminal delivery
to the Subscriber.

Modifications:
- OnSubscribeIgnoringSubscriberForOffloading#offloadWithDummyOnSubscribe
  to use EMPTY_SUBSCRIPTION.

Result:
Avoid potential for duplicate terminal event delivery in
OnSubscribeIgnoringSubscriberForOffloading.