### PR TITLE
[Single|Completable] to Publisher and Publisher#scanWith offloading a…

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableToPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableToPublisher.java
@@ -74,21 +74,21 @@ final class CompletableToPublisher<T> extends AbstractNoHandleSubscribePublisher
 
         @Override
         public void onComplete() {
-            if (terminatedUpdater.getAndSet(this, 1) == 0) {
+            if (terminatedUpdater.compareAndSet(this, 0, 1)) {
                 subscriber.onComplete();
             }
         }
 
         @Override
         public void onError(Throwable t) {
-            if (terminatedUpdater.getAndSet(this, 1) == 0) {
+            if (terminatedUpdater.compareAndSet(this, 0, 1)) {
                 subscriber.onError(t);
             }
         }
 
         @Override
         public void request(long n) {
-            if (!isRequestNValid(n) && terminatedUpdater.getAndSet(this, 1) == 0) {
+            if (!isRequestNValid(n) && terminatedUpdater.compareAndSet(this, 0, 1)) {
                 // We have not offloaded the Subscriber as we generally emit to the Subscriber from the Completable
                 // Subscriber methods which is correctly offloaded. This is the only case where we invoke the
                 // Subscriber directly, hence we explicitly offload.


### PR DESCRIPTION
…nd async context fixes

Motivation:
[Single|Completable] to Publisher and Publisher#scanWith operators may
emit to the Subscriber directly from the Subscription thread. In these
cases both the AsyncContext and Offloading needs to be properly
initialized before execution. Also the offloading creation needs to be
deferred so that it is only done if the associated Subscriber will be
terminated, otherwise resources may leak (e.g. threads in the thread
based offloader).

Modifications:
- OnSubscribeIgnoringSubscriberForOffloading#offloadWithDummyOnSubscribe
should also require AsyncContext parameters so it is clear that both
offloading and async context must be configured.
- Publisher#scanWith should use the offloadWithDummyOnSubscribe method
and avoid pre-allocating the offloaded subscriber because the offloaded
subscriber is only terminated if signals are emitted from the
Subscription thread, and if it isn't terminated resources (e.g. threads)
may leak.

Result:
More correct offloading and async context usage.