### PR TITLE
Completable#merge(Publisher) subscriber concurrency updates

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableMergeWithPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableMergeWithPublisher.java
@@ -241,8 +241,7 @@ final class CompletableMergeWithPublisher<T> extends AbstractNoHandleSubscribePu
                     // No need to acquire lock if the Completable has terminated, there will be no concurrency.
                     offloadedSubscriber.onNext(t);
                     break;
-                } else if (stateUpdater.compareAndSet(this, currState,
-                        (newState = setState(currState, IN_ON_NEXT)))) {
+                } else if (stateUpdater.compareAndSet(this, currState, (newState = setState(currState, IN_ON_NEXT)))) {
                     try {
                         offloadedSubscriber.onNext(t);
                     } finally {


### PR DESCRIPTION
Motivation:
CompletableMergeWithPublisher currently uses an atomic counter to
control when the downstream subscriber should be terminated, and also a
ConcurrentTerminalSubscriber to protect the downstream subscriber from
concurrent invocation. These two concurrency controls can be merged into
a single atomic variable to reduce the number of atomic operations.

Modifications:
- Remove ConcurrentTerminalSubscriber from
  CompletableMergeWithPublisher. The counter only needs to track two
  completion events which can be represented as a bitmask which permits
  immediate error propagation but requires both complete events.
- onNext can now avoid locking/unlocking if the completable has
  terminated because there will be no concurrency.

Result:
Optimized concurrency control in Completable#merge(Publisher).