### PR TITLE
Improve CharSequences#split to support trim and min copies

### DIFF
--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
@@ -239,12 +239,10 @@ public final class CharSequences {
             }
         }
 
-        if (startIndex != -1) {
-            if ((input.length() - startIndex) > 0) {
-                result.add(subsequence(isAscii, input, startIndex, input.length()));
-            } else {
-                result.add(isAscii ? newAsciiString("") : "");
-            }
+        if ((input.length() - startIndex) > 0) {
+            result.add(subsequence(isAscii, input, startIndex, input.length()));
+        } else {
+            result.add(isAscii ? EMPTY_ASCII_BUFFER : "");
         }
 
         return result;
@@ -271,7 +269,7 @@ public final class CharSequences {
                 if (endIndex > startIndex) {
                     result.add(subsequence(isAscii, input, startIndex, endIndex));
                 } else {
-                    result.add(isAscii ? newAsciiString("") : "");
+                    result.add(isAscii ? EMPTY_ASCII_BUFFER : "");
                 }
 
                 startIndex = i + 1;
@@ -284,7 +282,7 @@ public final class CharSequences {
             if ((input.length() - startIndex) > 0) {
                 result.add(subsequence(isAscii, input, startIndex, endIndex));
             } else {
-                result.add(isAscii ? newAsciiString("") : "");
+                result.add(isAscii ? EMPTY_ASCII_BUFFER : "");
             }
         }
 

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
@@ -221,48 +221,60 @@ public final class CharSequences {
             return emptyList();
         }
 
-        List<CharSequence> result = new ArrayList<>();
+        boolean isAscii = isAsciiString(input);
+        List<CharSequence> result = new ArrayList<>(4);
 
-        int startIndex = trim ? -1 : 0;
+        int startIndex = 0;
         int endIndex = -1;
 
-        for (int i = 0; i < input.length(); i++) {
-            char c = input.charAt(i);
-            if (!trim) {
-                endIndex = i;
-            } else if (c != ' ' && c != delimiter) {
-                endIndex = i + 1;
-            }
-
-            if (startIndex == -1 && c != ' ' && c != delimiter) {
-                startIndex = i;
-            } else if (c == delimiter) {
-                if (startIndex != -1 && endIndex != -1 && (i - startIndex) > 0) {
-                    result.add(subsequence(input, startIndex, endIndex));
+        if (trim) {
+            startIndex = -1;
+            for (int i = 0; i < input.length(); i++) {
+                char c = input.charAt(i);
+                if (c != ' ' && c != delimiter) {
+                    endIndex = i + 1;
                 }
 
-                if (!trim) {
-                    startIndex = i + 1;
-                } else {
+                if (startIndex == -1 && c != ' ' && c != delimiter) {
+                    startIndex = i;
+                } else if (c == delimiter) {
+                    if (endIndex > startIndex) {
+                        result.add(subsequence(isAscii, input, startIndex, endIndex));
+                    } else {
+                        result.add(isAscii ? newAsciiString("") : "");
+                    }
+
                     startIndex = -1;
                     endIndex = -1;
                 }
             }
-        }
+        } else {
+            for (int i = 0; i < input.length(); i++) {
+                char c = input.charAt(i);
+                endIndex = i;
 
-        if (!trim) {
+                if (c == delimiter) {
+                    if (endIndex >= startIndex) {
+                        result.add(subsequence(isAscii, input, startIndex, endIndex));
+                    }
+
+                    startIndex = i + 1;
+                }
+            }
+
             endIndex = input.length();
         }
 
         if (startIndex != -1 && endIndex != -1 && (input.length() - startIndex) > 0) {
-            result.add(subsequence(input, startIndex, endIndex));
+            result.add(subsequence(isAscii, input, startIndex, endIndex));
         }
 
         return result;
     }
 
-    private static CharSequence subsequence(final CharSequence input, final int start, final int end) {
-        if (isAsciiString(input)) {
+    private static CharSequence subsequence(final boolean isAscii, final CharSequence input,
+                                            final int start, final int end) {
+        if (isAscii) {
             return newAsciiString(((AsciiBuffer) input).unwrap().copy(start, end - start));
         } else {
             return input.subSequence(start, end);

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
@@ -83,7 +83,6 @@ public class CharSequencesTest {
     }
 
     private static void splitWithTrim(Function<String, ? extends CharSequence> f) {
-        // System.out.println(split(" gzip  ,  deflate  ", ',', true));
         assertThat(split(f.apply(" ,      "), ',', true),
                 contains(f.apply(""), f.apply("")));
         assertThat(split(f.apply(" ,      ,"), ',', true),

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.buffer.api;
+
+import org.junit.Test;
+
+import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
+import static io.servicetalk.buffer.api.CharSequences.split;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+
+public class CharSequencesTest {
+
+    // Common strings
+    public static final String GZIP = "gzip";
+    public static final CharSequence GZIP_ASCII = newAsciiString(GZIP);
+    public static final String DEFLATE = "deflate";
+    public static final CharSequence DEFLATE_ASCII = newAsciiString(DEFLATE);
+    public static final String COMPRESS = "compress";
+    public static final CharSequence COMPRESS_ASCII = newAsciiString(COMPRESS);
+
+    @Test
+    public void splitString() {
+        assertThat(split(" ,      ", ',', false), contains(" ", "      "));
+        assertThat(split(" ,      ,", ',', false), contains(" ", "      "));
+        assertThat(split(" gzip  ,  deflate  ", ',', false), contains(" gzip  ", "  deflate  "));
+        assertThat(split(" gzip  ,  deflate  ,", ',', false), contains(" gzip  ", "  deflate  "));
+        assertThat(split("gzip, deflate", ',', false), contains(GZIP, " deflate"));
+        assertThat(split("gzip , deflate", ',', false), contains("gzip ", " deflate"));
+        assertThat(split("gzip ,  deflate", ',', false), contains("gzip ", "  deflate"));
+        assertThat(split(" gzip, deflate", ',', false), contains(" gzip", " deflate"));
+        assertThat(split(GZIP, ',', false), contains(GZIP));
+        assertThat(split("gzip,", ',', false), contains(GZIP));
+        assertThat(split("gzip,deflate,compress", ',', false), contains(GZIP, DEFLATE, COMPRESS));
+        assertThat(split("gzip,,compress", ',', false), contains(GZIP, COMPRESS));
+        assertThat(split("gzip, ,compress", ',', false), contains(GZIP, " ", COMPRESS));
+        assertThat(split("gzip , , compress", ',', false), contains("gzip ", " ", " compress"));
+        assertThat(split("gzip , white space word , compress", ',', false),
+                contains("gzip ", " white space word ", " compress"));
+    }
+
+    @Test
+    public void splitStringWithTrim() {
+        assertThat(split(" ,      ", ',', true), empty());
+        assertThat(split(" ,      ,", ',', true), empty());
+        assertThat(split(" gzip  ,  deflate  ", ',', true), contains(GZIP, DEFLATE));
+        assertThat(split(" gzip  ,  deflate  ,", ',', true), contains(GZIP, DEFLATE));
+        assertThat(split("gzip, deflate", ',', true), contains(GZIP, DEFLATE));
+        assertThat(split("gzip , deflate", ',', true), contains(GZIP, DEFLATE));
+        assertThat(split("gzip ,  deflate", ',', true), contains(GZIP, DEFLATE));
+        assertThat(split(" gzip, deflate", ',', true), contains(GZIP, DEFLATE));
+        assertThat(split(GZIP, ',', true), contains(GZIP));
+        assertThat(split("gzip,", ',', true), contains(GZIP));
+        assertThat(split("gzip,deflate,compress", ',', true), contains(GZIP, DEFLATE, COMPRESS));
+        assertThat(split("gzip,,compress", ',', true), contains(GZIP, COMPRESS));
+        assertThat(split("gzip, ,compress", ',', true), contains(GZIP, COMPRESS));
+        assertThat(split("gzip , , compress", ',', true), contains(GZIP, COMPRESS));
+        assertThat(split(",, , ", ',', true), empty());
+        assertThat(split("gzip , white space word , compress", ',', true),
+                contains("gzip", "white space word", "compress"));
+    }
+
+    @Test
+    public void splitAsciiString() {
+        assertThat(split(newAsciiString(" ,      "), ',', false),
+                contains(newAsciiString(" "), newAsciiString("      ")));
+        assertThat(split(newAsciiString(" ,      ,"), ',', false),
+                contains(newAsciiString(" "), newAsciiString("      ")));
+        assertThat(split(newAsciiString(" gzip  ,  deflate  "), ',', false),
+                contains(newAsciiString(" gzip  "), newAsciiString("  deflate  ")));
+        assertThat(split(newAsciiString(" gzip  ,  deflate  ,"), ',', false),
+                contains(newAsciiString(" gzip  "), newAsciiString("  deflate  ")));
+        assertThat(split(newAsciiString("gzip, deflate"), ',', false),
+                contains(GZIP_ASCII, newAsciiString(" deflate")));
+        assertThat(split(newAsciiString("gzip , deflate"), ',', false),
+                contains(newAsciiString("gzip "), newAsciiString(" deflate")));
+        assertThat(split(newAsciiString("gzip ,  deflate"), ',', false),
+                contains(newAsciiString("gzip "), newAsciiString("  deflate")));
+        assertThat(split(newAsciiString(" gzip, deflate"), ',', false),
+                contains(newAsciiString(" gzip"), newAsciiString(" deflate")));
+        assertThat(split(GZIP_ASCII, ',', false), contains(GZIP_ASCII));
+        assertThat(split(newAsciiString("gzip,"), ',', false), contains(GZIP_ASCII));
+        assertThat(split(newAsciiString("gzip,deflate,compress"), ',', false),
+                contains(GZIP_ASCII, DEFLATE_ASCII, COMPRESS_ASCII));
+        assertThat(split(newAsciiString("gzip,,compress"), ',', false),
+                contains(GZIP_ASCII, COMPRESS_ASCII));
+        assertThat(split(newAsciiString("gzip, ,compress"), ',', false),
+                contains(GZIP_ASCII, newAsciiString(" "), COMPRESS_ASCII));
+        assertThat(split(newAsciiString("gzip , , compress"), ',', false),
+                contains(newAsciiString("gzip "), newAsciiString(" "), newAsciiString(" compress")));
+    }
+
+    @Test
+    public void splitAsciiStringWithTrim() {
+        assertThat(split(newAsciiString(" ,      "), ',', true), empty());
+        assertThat(split(newAsciiString(" ,      ,"), ',', true), empty());
+        assertThat(split(newAsciiString(" gzip  ,  deflate  "), ',', true),
+                contains(GZIP_ASCII, DEFLATE_ASCII));
+        assertThat(split(newAsciiString(" gzip  ,  deflate  ,"), ',', true),
+                contains(GZIP_ASCII, DEFLATE_ASCII));
+        assertThat(split(newAsciiString("gzip, deflate"), ',', true),
+                contains(GZIP_ASCII, DEFLATE_ASCII));
+        assertThat(split(newAsciiString("gzip , deflate"), ',', true),
+                contains(GZIP_ASCII, DEFLATE_ASCII));
+        assertThat(split(newAsciiString("gzip ,  deflate"), ',', true),
+                contains(GZIP_ASCII, DEFLATE_ASCII));
+        assertThat(split(newAsciiString(" gzip, deflate"), ',', true),
+                contains(GZIP_ASCII, DEFLATE_ASCII));
+        assertThat(split(GZIP_ASCII, ',', true), contains(GZIP_ASCII));
+        assertThat(split(newAsciiString("gzip,"), ',', true), contains(GZIP_ASCII));
+        assertThat(split(newAsciiString("gzip,deflate,compress"), ',', true),
+                contains(GZIP_ASCII, DEFLATE_ASCII, COMPRESS_ASCII));
+        assertThat(split(newAsciiString("gzip,,compress"), ',', true),
+                contains(GZIP_ASCII, COMPRESS_ASCII));
+        assertThat(split(newAsciiString("gzip, ,compress"), ',', true),
+                contains(GZIP_ASCII, COMPRESS_ASCII));
+        assertThat(split(newAsciiString("gzip , , compress"), ',', true),
+                contains(GZIP_ASCII, COMPRESS_ASCII));
+        assertThat(split(newAsciiString(",, , "), ',', true), empty());
+    }
+}

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
@@ -21,11 +21,11 @@ import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.buffer.api.CharSequences.split;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
 
 public class CharSequencesTest {
 
     // Common strings
+    public static final CharSequence EMPTY_ASCII = newAsciiString("");
     public static final String GZIP = "gzip";
     public static final CharSequence GZIP_ASCII = newAsciiString(GZIP);
     public static final String DEFLATE = "deflate";
@@ -46,17 +46,29 @@ public class CharSequencesTest {
         assertThat(split(GZIP, ',', false), contains(GZIP));
         assertThat(split("gzip,", ',', false), contains(GZIP));
         assertThat(split("gzip,deflate,compress", ',', false), contains(GZIP, DEFLATE, COMPRESS));
-        assertThat(split("gzip,,compress", ',', false), contains(GZIP, COMPRESS));
+        assertThat(split("gzip,,compress", ',', false), contains(GZIP, "", COMPRESS));
         assertThat(split("gzip, ,compress", ',', false), contains(GZIP, " ", COMPRESS));
         assertThat(split("gzip , , compress", ',', false), contains("gzip ", " ", " compress"));
         assertThat(split("gzip , white space word , compress", ',', false),
                 contains("gzip ", " white space word ", " compress"));
+        assertThat(split("gzip compress", ' ', false),
+                contains("gzip", "compress"));
+        assertThat(split("gzip     compress", ' ', false),
+                contains("gzip", "", "", "", "", "compress"));
+        assertThat(split("gzip     compress", ' ', false),
+                contains("gzip", "", "", "", "", "compress"));
+        assertThat(split(" gzip     compress ", ' ', false),
+                contains("", "gzip", "", "", "", "", "compress"));
+        assertThat(split("gzip,,,,,compress", ',', false),
+                contains("gzip", "", "", "", "", "compress"));
+        assertThat(split(",gzip,,,,,compress,", ',', false),
+                contains("", "gzip", "", "", "", "", "compress"));
     }
 
     @Test
     public void splitStringWithTrim() {
-        assertThat(split(" ,      ", ',', true), empty());
-        assertThat(split(" ,      ,", ',', true), empty());
+        assertThat(split(" ,      ", ',', true), contains(""));
+        assertThat(split(" ,      ,", ',', true), contains("", ""));
         assertThat(split(" gzip  ,  deflate  ", ',', true), contains(GZIP, DEFLATE));
         assertThat(split(" gzip  ,  deflate  ,", ',', true), contains(GZIP, DEFLATE));
         assertThat(split("gzip, deflate", ',', true), contains(GZIP, DEFLATE));
@@ -66,12 +78,22 @@ public class CharSequencesTest {
         assertThat(split(GZIP, ',', true), contains(GZIP));
         assertThat(split("gzip,", ',', true), contains(GZIP));
         assertThat(split("gzip,deflate,compress", ',', true), contains(GZIP, DEFLATE, COMPRESS));
-        assertThat(split("gzip,,compress", ',', true), contains(GZIP, COMPRESS));
-        assertThat(split("gzip, ,compress", ',', true), contains(GZIP, COMPRESS));
-        assertThat(split("gzip , , compress", ',', true), contains(GZIP, COMPRESS));
-        assertThat(split(",, , ", ',', true), empty());
+        assertThat(split("gzip,,compress", ',', true), contains(GZIP, "", COMPRESS));
+        assertThat(split("gzip, ,compress", ',', true), contains(GZIP, "", COMPRESS));
+        assertThat(split("gzip , , compress", ',', true), contains(GZIP, "", COMPRESS));
+        assertThat(split(",, , ", ',', true), contains("", "", ""));
         assertThat(split("gzip , white space word , compress", ',', true),
                 contains("gzip", "white space word", "compress"));
+        assertThat(split("gzip compress", ' ', true),
+                contains("gzip", "compress"));
+        assertThat(split("gzip     compress", ' ', true),
+                contains("gzip", "", "", "", "", "compress"));
+        assertThat(split(" gzip     compress ", ' ', true),
+                contains("", "gzip", "", "", "", "", "compress"));
+        assertThat(split("gzip,,,,,compress", ',', true),
+                contains("gzip", "", "", "", "", "compress"));
+        assertThat(split(",gzip,,,,,compress,", ',', true),
+                contains("", "gzip", "", "", "", "", "compress"));
     }
 
     @Test
@@ -97,17 +119,21 @@ public class CharSequencesTest {
         assertThat(split(newAsciiString("gzip,deflate,compress"), ',', false),
                 contains(GZIP_ASCII, DEFLATE_ASCII, COMPRESS_ASCII));
         assertThat(split(newAsciiString("gzip,,compress"), ',', false),
-                contains(GZIP_ASCII, COMPRESS_ASCII));
+                contains(GZIP_ASCII, newAsciiString(""), COMPRESS_ASCII));
         assertThat(split(newAsciiString("gzip, ,compress"), ',', false),
                 contains(GZIP_ASCII, newAsciiString(" "), COMPRESS_ASCII));
         assertThat(split(newAsciiString("gzip , , compress"), ',', false),
                 contains(newAsciiString("gzip "), newAsciiString(" "), newAsciiString(" compress")));
+        assertThat(split(newAsciiString(" gzip  ,  deflate  ,  "), ',', false),
+                contains(newAsciiString(" gzip  "), newAsciiString("  deflate  "),
+                        newAsciiString("  ")));
     }
 
     @Test
     public void splitAsciiStringWithTrim() {
-        assertThat(split(newAsciiString(" ,      "), ',', true), empty());
-        assertThat(split(newAsciiString(" ,      ,"), ',', true), empty());
+        assertThat(split(newAsciiString(" ,      "), ',', true), contains(EMPTY_ASCII));
+        assertThat(split(newAsciiString(" ,      ,"), ',', true),
+                contains(EMPTY_ASCII, EMPTY_ASCII));
         assertThat(split(newAsciiString(" gzip  ,  deflate  "), ',', true),
                 contains(GZIP_ASCII, DEFLATE_ASCII));
         assertThat(split(newAsciiString(" gzip  ,  deflate  ,"), ',', true),
@@ -125,11 +151,14 @@ public class CharSequencesTest {
         assertThat(split(newAsciiString("gzip,deflate,compress"), ',', true),
                 contains(GZIP_ASCII, DEFLATE_ASCII, COMPRESS_ASCII));
         assertThat(split(newAsciiString("gzip,,compress"), ',', true),
-                contains(GZIP_ASCII, COMPRESS_ASCII));
+                contains(GZIP_ASCII, EMPTY_ASCII, COMPRESS_ASCII));
         assertThat(split(newAsciiString("gzip, ,compress"), ',', true),
-                contains(GZIP_ASCII, COMPRESS_ASCII));
+                contains(GZIP_ASCII, EMPTY_ASCII, COMPRESS_ASCII));
         assertThat(split(newAsciiString("gzip , , compress"), ',', true),
-                contains(GZIP_ASCII, COMPRESS_ASCII));
-        assertThat(split(newAsciiString(",, , "), ',', true), empty());
+                contains(GZIP_ASCII, EMPTY_ASCII, COMPRESS_ASCII));
+        assertThat(split(newAsciiString(",, , "), ',', true),
+                contains(EMPTY_ASCII, EMPTY_ASCII, EMPTY_ASCII));
+        assertThat(split(newAsciiString(" gzip  ,  deflate  , "), ',', true),
+                contains(GZIP_ASCII, DEFLATE_ASCII));
     }
 }

--- a/servicetalk-encoding-api-internal/src/main/java/io/servicetalk/encoding/api/internal/HeaderUtils.java
+++ b/servicetalk-encoding-api-internal/src/main/java/io/servicetalk/encoding/api/internal/HeaderUtils.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.buffer.api.CharSequences.split;
 import static io.servicetalk.encoding.api.ContentCodings.identity;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
@@ -104,7 +105,7 @@ public final class HeaderUtils {
         }
 
         List<ContentCodec> knownEncodings = new ArrayList<>();
-        List<CharSequence> acceptEncodingValues = CharSequences.split(acceptEncodingHeaderValue, ',');
+        List<CharSequence> acceptEncodingValues = split(acceptEncodingHeaderValue, ',', true);
         for (CharSequence val : acceptEncodingValues) {
             ContentCodec enc = encodingFor(allowedEncodings, val);
             if (enc != null) {

--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -35,6 +35,7 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
+  testImplementation testFixtures(project(":servicetalk-buffer-api"))
   testImplementation project(":servicetalk-concurrent-api-internal")
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-encoding-api-internal")

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcMessageEncodingTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcMessageEncodingTest.java
@@ -58,6 +58,7 @@ import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.InflaterInputStream;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static io.grpc.internal.GrpcUtil.MESSAGE_ACCEPT_ENCODING;
@@ -212,11 +213,7 @@ public class GrpcMessageEncodingTest {
                                 .get(MESSAGE_ACCEPT_ENCODING, "NOT_PRESENT").toString().split(","))
                                     .map((String::trim)).collect(toList());
 
-                        final List<String> expectedReqAcceptedEncodings = clientSupportedEncodings.stream()
-                                                .filter((enc) -> enc != identity())
-                                                .map((ContentCodec::name))
-                                                .map((CharSequence::toString))
-                                                .collect(toList());
+                        final List<String> expectedReqAcceptedEncodings = encodingsAsStrings(clientSupportedEncodings);
 
                         assertTrue("Request encoding should be present in the request headers",
                                 contentEquals(reqEncoding.name(), request.headers().get(MESSAGE_ENCODING, "identity")));
@@ -247,11 +244,7 @@ public class GrpcMessageEncodingTest {
                             .get(MESSAGE_ACCEPT_ENCODING, "NOT_PRESENT").toString().split(","))
                             .map((String::trim)).collect(toList());
 
-                    final List<String> expectedRespAcceptedEncodings = serverSupportedEncodings.stream()
-                                    .filter((enc) -> enc != identity())
-                                    .map((ContentCodec::name))
-                                    .map((CharSequence::toString))
-                                    .collect(toList());
+                    final List<String> expectedRespAcceptedEncodings = encodingsAsStrings(serverSupportedEncodings);
 
                     if (!expectedRespAcceptedEncodings.isEmpty() && !actualRespAcceptedEncodings.isEmpty()) {
                         assertEquals(expectedRespAcceptedEncodings, actualRespAcceptedEncodings);
@@ -478,6 +471,15 @@ public class GrpcMessageEncodingTest {
 
     private static void assertGrpcStatusException(GrpcStatusException grpcStatusException) {
         assertThat(grpcStatusException.status().code(), is(GrpcStatusCode.UNIMPLEMENTED));
+    }
+
+    @Nonnull
+    private static List<String> encodingsAsStrings(final List<ContentCodec> supportedEncodings) {
+        return supportedEncodings.stream()
+                .filter(enc -> enc != identity())
+                .map(ContentCodec::name)
+                .map(CharSequence::toString)
+                .collect(toList());
     }
 
     static class TestEncodingScenario {

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcMessageEncodingTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcMessageEncodingTest.java
@@ -211,7 +211,7 @@ public class GrpcMessageEncodingTest {
 
                         final List<String> actualReqAcceptedEncodings = stream(request.headers()
                                 .get(MESSAGE_ACCEPT_ENCODING, "NOT_PRESENT").toString().split(","))
-                                    .map((String::trim)).collect(toList());
+                                    .map(String::trim).collect(toList());
 
                         final List<String> expectedReqAcceptedEncodings = encodingsAsStrings(clientSupportedEncodings);
 
@@ -227,7 +227,7 @@ public class GrpcMessageEncodingTest {
 
                     return super.handle(ctx, request, responseFactory).map((response -> {
                         try {
-                            _handle(clientSupportedEncodings, serverSupportedEncodings, response);
+                            handle0(clientSupportedEncodings, serverSupportedEncodings, response);
                         } catch (Throwable t) {
                             errors.add(t);
                             throw t;
@@ -237,7 +237,7 @@ public class GrpcMessageEncodingTest {
                     }));
                 }
 
-                private void _handle(final List<ContentCodec> clientSupportedEncodings,
+                private void handle0(final List<ContentCodec> clientSupportedEncodings,
                                      final List<ContentCodec> serverSupportedEncodings,
                                      final StreamingHttpResponse response) {
                     final List<String> actualRespAcceptedEncodings = stream(response.headers()

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcMessageEncodingTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcMessageEncodingTest.java
@@ -49,9 +49,10 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPInputStream;
@@ -64,6 +65,7 @@ import static io.grpc.internal.GrpcUtil.MESSAGE_ENCODING;
 import static io.servicetalk.buffer.api.Buffer.asInputStream;
 import static io.servicetalk.buffer.api.Buffer.asOutputStream;
 import static io.servicetalk.buffer.api.CharSequences.contentEquals;
+import static io.servicetalk.buffer.api.Matchers.contentEqualTo;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
@@ -84,7 +86,6 @@ import static java.lang.String.valueOf;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 import static java.util.Collections.disjoint;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static java.util.zip.GZIPInputStream.GZIP_MAGIC;
@@ -92,7 +93,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.internal.util.io.IOUtil.closeQuietly;
@@ -168,13 +168,13 @@ public class GrpcMessageEncodingTest {
         }
     };
 
-    private static final Function<TestEncodingScenario, StreamingHttpServiceFilterFactory> REQ_RESP_VERIFIER = (options)
-                        -> new StreamingHttpServiceFilterFactory() {
+    private static final BiFunction<TestEncodingScenario, List<Throwable>, StreamingHttpServiceFilterFactory>
+            REQ_RESP_VERIFIER = (options, errors) -> new StreamingHttpServiceFilterFactory() {
         @Override
         public StreamingHttpServiceFilter create(final StreamingHttpService service) {
             return new StreamingHttpServiceFilter(service) {
-                @Override
 
+                @Override
                 public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
                                                             final StreamingHttpRequest request,
                                                             final StreamingHttpResponseFactory responseFactory) {
@@ -183,7 +183,6 @@ public class GrpcMessageEncodingTest {
                     final List<ContentCodec> serverSupportedEncodings = options.serverSupported;
 
                     try {
-
                         request.transformPayloadBody(bufferPublisher -> bufferPublisher.map((buffer -> {
                             try {
                                 byte compressedFlag = buffer.getByte(0);
@@ -203,7 +202,7 @@ public class GrpcMessageEncodingTest {
 
                                 assertEquals(reqEncoding != identity() ? 1 : 0, compressedFlag);
                             } catch (Throwable t) {
-                                t.printStackTrace();
+                                errors.add(t);
                                 throw t;
                             }
                             return buffer;
@@ -213,9 +212,7 @@ public class GrpcMessageEncodingTest {
                                 .get(MESSAGE_ACCEPT_ENCODING, "NOT_PRESENT").toString().split(","))
                                     .map((String::trim)).collect(toList());
 
-                        final List<String> expectedReqAcceptedEncodings = (clientSupportedEncodings == null) ?
-                                        emptyList() :
-                                        clientSupportedEncodings.stream()
+                        final List<String> expectedReqAcceptedEncodings = clientSupportedEncodings.stream()
                                                 .filter((enc) -> enc != identity())
                                                 .map((ContentCodec::name))
                                                 .map((CharSequence::toString))
@@ -227,89 +224,91 @@ public class GrpcMessageEncodingTest {
                             assertEquals(expectedReqAcceptedEncodings, actualReqAcceptedEncodings);
                         }
                     } catch (Throwable t) {
-                        t.printStackTrace();
+                        errors.add(t);
                         throw t;
                     }
 
                     return super.handle(ctx, request, responseFactory).map((response -> {
                         try {
-                            final List<String> actualRespAcceptedEncodings = stream(response.headers()
-                                    .get(MESSAGE_ACCEPT_ENCODING, "NOT_PRESENT").toString().split(","))
-                                    .map((String::trim)).collect(toList());
-
-                            final List<String> expectedRespAcceptedEncodings = (serverSupportedEncodings == null) ?
-                                    emptyList() :
-                                    serverSupportedEncodings.stream()
-                                            .filter((enc) -> enc != identity())
-                                            .map((ContentCodec::name))
-                                            .map((CharSequence::toString))
-                                            .collect(toList());
-
-                            if (!expectedRespAcceptedEncodings.isEmpty() && !actualRespAcceptedEncodings.isEmpty()) {
-                                assertEquals(expectedRespAcceptedEncodings, actualRespAcceptedEncodings);
-                            }
-
-                            final String respEncName = response.headers()
-                                    .get(MESSAGE_ENCODING, "identity").toString();
-
-                            if (clientSupportedEncodings == null) {
-                                assertEquals(identity().name().toString(), respEncName);
-                            } else if (serverSupportedEncodings == null) {
-                                assertEquals(identity().name().toString(), respEncName);
-                            } else {
-                                if (disjoint(serverSupportedEncodings, clientSupportedEncodings)) {
-                                    assertEquals(identity().name().toString(), respEncName);
-                                } else {
-                                    assertNotNull("Response encoding not in the client supported list " +
-                                                    "[" + clientSupportedEncodings + "]",
-                                            encodingFor(clientSupportedEncodings, valueOf(response.headers()
-                                                    .get(MESSAGE_ENCODING, "identity"))));
-
-                                    assertNotNull("Response encoding not in the server supported list " +
-                                                    "[" + serverSupportedEncodings + "]",
-                                            encodingFor(serverSupportedEncodings, valueOf(response.headers()
-                                            .get(MESSAGE_ENCODING, "identity"))));
-                                }
-                            }
-
-                            response.transformPayloadBody(bufferPublisher -> bufferPublisher.map((buffer -> {
-                                try {
-                                    final ContentCodec respEnc =
-                                            encodingFor(clientSupportedEncodings == null ? asList(identity()) :
-                                                    clientSupportedEncodings, valueOf(response.headers()
-                                                    .get(MESSAGE_ENCODING, "identity")));
-
-                                    if (buffer.readableBytes() > 0) {
-                                        byte compressedFlag = buffer.getByte(0);
-                                        assertEquals(respEnc != identity() ? 1 : 0, compressedFlag);
-
-                                        if (respEnc == gzipDefault() || respEnc.name().equals(CUSTOM_ENCODING.name())) {
-                                            int actualHeader = buffer.getShortLE(5) & 0xFFFF;
-                                            assertEquals(GZIP_MAGIC, actualHeader);
-                                        }
-
-                                        if (respEnc != identity()) {
-                                            assertTrue("Compressed content length should be less than the original " +
-                                                    "payload size", buffer.readableBytes() < PAYLOAD_SIZE);
-                                        } else {
-                                            assertTrue("Uncompressed content length should be more than the original " +
-                                                            "payload size " + buffer.readableBytes(),
-                                                    buffer.readableBytes() > PAYLOAD_SIZE);
-                                        }
-                                    }
-                                } catch (Throwable t) {
-                                    t.printStackTrace();
-                                    throw t;
-                                }
-                                return buffer;
-                            })));
+                            _handle(clientSupportedEncodings, serverSupportedEncodings, response);
                         } catch (Throwable t) {
-                            t.printStackTrace();
+                            errors.add(t);
                             throw t;
                         }
 
                         return response;
                     }));
+                }
+
+                private void _handle(final List<ContentCodec> clientSupportedEncodings,
+                                     final List<ContentCodec> serverSupportedEncodings,
+                                     final StreamingHttpResponse response) {
+                    final List<String> actualRespAcceptedEncodings = stream(response.headers()
+                            .get(MESSAGE_ACCEPT_ENCODING, "NOT_PRESENT").toString().split(","))
+                            .map((String::trim)).collect(toList());
+
+                    final List<String> expectedRespAcceptedEncodings = serverSupportedEncodings.stream()
+                                    .filter((enc) -> enc != identity())
+                                    .map((ContentCodec::name))
+                                    .map((CharSequence::toString))
+                                    .collect(toList());
+
+                    if (!expectedRespAcceptedEncodings.isEmpty() && !actualRespAcceptedEncodings.isEmpty()) {
+                        assertEquals(expectedRespAcceptedEncodings, actualRespAcceptedEncodings);
+                    }
+
+                    final String respEncName = response.headers()
+                            .get(MESSAGE_ENCODING, "identity").toString();
+
+                    if (clientSupportedEncodings.isEmpty() || serverSupportedEncodings.isEmpty()) {
+                        assertThat(identity().name(), contentEqualTo(respEncName));
+                    } else {
+                        if (disjoint(serverSupportedEncodings, clientSupportedEncodings)) {
+                            assertEquals(identity().name().toString(), respEncName);
+                        } else {
+                            ContentCodec expected = identity();
+                            for (ContentCodec codec : clientSupportedEncodings) {
+                                if (serverSupportedEncodings.contains(codec)) {
+                                    expected = codec;
+                                    break;
+                                }
+                            }
+
+                            assertEquals(expected, encodingFor(clientSupportedEncodings, response.headers()
+                                    .get(MESSAGE_ENCODING, identity().name())));
+                        }
+                    }
+
+                    response.transformPayloadBody(bufferPublisher -> bufferPublisher.map((buffer -> {
+                        try {
+                            final ContentCodec respEnc =
+                                    encodingFor(clientSupportedEncodings, valueOf(response.headers()
+                                            .get(MESSAGE_ENCODING, "identity")));
+
+                            if (buffer.readableBytes() > 0) {
+                                byte compressedFlag = buffer.getByte(0);
+                                assertEquals(respEnc != identity() ? 1 : 0, compressedFlag);
+
+                                if (respEnc == gzipDefault() || respEnc.name().equals(CUSTOM_ENCODING.name())) {
+                                    int actualHeader = buffer.getShortLE(5) & 0xFFFF;
+                                    assertEquals(GZIP_MAGIC, actualHeader);
+                                }
+
+                                if (respEnc != identity()) {
+                                    assertTrue("Compressed content length should be less than the original " +
+                                            "payload size", buffer.readableBytes() < PAYLOAD_SIZE);
+                                } else {
+                                    assertTrue("Uncompressed content length should be more than the original " +
+                                                    "payload size " + buffer.readableBytes(),
+                                            buffer.readableBytes() > PAYLOAD_SIZE);
+                                }
+                            }
+                        } catch (Throwable t) {
+                            errors.add(t);
+                            throw t;
+                        }
+                        return buffer;
+                    })));
                 }
             };
         }
@@ -359,6 +358,7 @@ public class GrpcMessageEncodingTest {
     private final TesterClient client;
     private final ContentCodec requestEncoding;
     private final boolean expectedSuccess;
+    private final List<Throwable> errors = Collections.synchronizedList(new ArrayList<>());
 
     public GrpcMessageEncodingTest(final List<ContentCodec> serverSupportedCodings,
                                    final List<ContentCodec> clientSupportedCodings,
@@ -395,6 +395,7 @@ public class GrpcMessageEncodingTest {
                 {singletonList(gzipDefault()), asList(gzipDefault(), identity()), identity(), true},
                 {singletonList(gzipDefault()), asList(gzipDefault(), identity()), identity(), true},
                 {singletonList(gzipDefault()), asList(gzipDefault(), identity()), gzipDefault(), true},
+                {singletonList(gzipDefault()), asList(deflateDefault(), gzipDefault()), gzipDefault(), true},
                 {null, asList(gzipDefault(), identity()), gzipDefault(), false},
                 {null, asList(gzipDefault(), deflateDefault(), identity()), deflateDefault(), false},
                 {null, asList(gzipDefault(), identity()), identity(), true},
@@ -413,14 +414,9 @@ public class GrpcMessageEncodingTest {
 
     private ServerContext listenAndAwait(final TestEncodingScenario encodingOptions) throws Exception {
 
-        StreamingHttpServiceFilterFactory filterFactory = REQ_RESP_VERIFIER.apply(encodingOptions);
-        if (encodingOptions.serverSupported == null) {
-            return grpcServerBuilder.appendHttpServiceFilter(filterFactory)
-                    .listenAndAwait(new ServiceFactory(new TesterServiceImpl()));
-        } else {
-            return grpcServerBuilder.appendHttpServiceFilter(filterFactory)
-                    .listenAndAwait(new ServiceFactory(new TesterServiceImpl(), encodingOptions.serverSupported));
-        }
+        StreamingHttpServiceFilterFactory filterFactory = REQ_RESP_VERIFIER.apply(encodingOptions, errors);
+        return grpcServerBuilder.appendHttpServiceFilter(filterFactory)
+                .listenAndAwait(new ServiceFactory(new TesterServiceImpl(), encodingOptions.serverSupported));
     }
 
     private TesterClient newClient(@Nullable final List<ContentCodec> supportedCodings) {
@@ -431,11 +427,19 @@ public class GrpcMessageEncodingTest {
     }
 
     @Test
-    public void test() throws ExecutionException, InterruptedException {
+    public void test() throws Throwable {
         if (expectedSuccess) {
             assertSuccessful(requestEncoding);
         } else {
             assertUnimplemented(requestEncoding);
+        }
+
+        verifyNoErrors();
+    }
+
+    private void verifyNoErrors() throws Throwable {
+        if (!errors.isEmpty()) {
+            throw errors.get(0);
         }
     }
 
@@ -478,17 +482,15 @@ public class GrpcMessageEncodingTest {
 
     static class TestEncodingScenario {
         final ContentCodec requestEncoding;
-        @Nullable
         final List<ContentCodec> clientSupported;
-        @Nullable
         final List<ContentCodec> serverSupported;
 
         TestEncodingScenario(final ContentCodec requestEncoding,
-                             final List<ContentCodec> clientSupported,
-                             final List<ContentCodec> serverSupported) {
+                             @Nullable final List<ContentCodec> clientSupported,
+                             @Nullable final List<ContentCodec> serverSupported) {
             this.requestEncoding = requestEncoding;
-            this.clientSupported = clientSupported;
-            this.serverSupported = serverSupported;
+            this.clientSupported = clientSupported == null ? singletonList(identity()) : clientSupported;
+            this.serverSupported = serverSupported == null ? singletonList(identity()) : serverSupported;
         }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/CharSequences.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/CharSequences.java
@@ -133,7 +133,7 @@ public final class CharSequences {
      * @return a {@link List} of {@link CharSequence} subsequences of the input with the separated values
      */
     public static List<CharSequence> split(final CharSequence input, final char delimiter) {
-        return io.servicetalk.buffer.api.CharSequences.split(input, delimiter);
+        return io.servicetalk.buffer.api.CharSequences.split(input, delimiter, false);
     }
 
     /**


### PR DESCRIPTION
**Motivation**:

CharSequences#split needed some improvements to avoid extra allocations for trimming (externally) and conversion to String due to calls to subsequence.

**Modifications**:

This PR improves the helper to support trimming individual tokens without additional allocations, and also better utilizes AsciiBuffer internals to avoid unnecessary conversions.

**Result**:

API can now handle representations that contain whitespaces in between delimiters.

Fixes: https://github.com/apple/servicetalk/issues/1216