### PR TITLE
Log when global `IoExecutor` or `Executor` instance gets closed

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DelegatingExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DelegatingExecutor.java
@@ -23,20 +23,31 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * An {@link Executor} that simply delegates all calls to another {@link Executor}.
  */
 public abstract class DelegatingExecutor implements Executor {
 
-    final Executor delegate;
+    private final Executor delegate;
 
     /**
      * New instance.
      *
      * @param delegate {@link Executor} to delegate all calls to.
      */
-    public DelegatingExecutor(final Executor delegate) {
-        this.delegate = delegate;
+    protected DelegatingExecutor(final Executor delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    /**
+     * Returns the delegate {@link Executor} used.
+     *
+     * @return The delegate {@link Executor} used.
+     */
+    protected Executor delegate() {
+        return delegate;
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MergedOffloadPublishExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MergedOffloadPublishExecutor.java
@@ -41,12 +41,12 @@ final class MergedOffloadPublishExecutor extends DelegatingExecutor implements S
         // the Executor. In practice, the Executor passed here should always be self when the SignalOffloaderFactory is
         // an Executor itself.
         assert executor == this;
-        return new PublishOnlySignalOffloader(delegate, fallbackExecutor);
+        return new PublishOnlySignalOffloader(delegate(), fallbackExecutor);
     }
 
     @Override
     public boolean hasThreadAffinity() {
-        return SignalOffloaders.hasThreadAffinity(delegate) && SignalOffloaders.hasThreadAffinity(fallbackExecutor);
+        return SignalOffloaders.hasThreadAffinity(delegate()) && SignalOffloaders.hasThreadAffinity(fallbackExecutor);
     }
 
     private static final class PublishOnlySignalOffloader implements SignalOffloader {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MergedOffloadSubscribeExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MergedOffloadSubscribeExecutor.java
@@ -41,12 +41,12 @@ final class MergedOffloadSubscribeExecutor extends DelegatingExecutor implements
         // the Executor. In practice, the Executor passed here should always be self when the SignalOffloaderFactory is
         // an Executor itself.
         assert executor == this;
-        return new SubscribeOnlySignalOffloader(delegate, fallbackExecutor);
+        return new SubscribeOnlySignalOffloader(delegate(), fallbackExecutor);
     }
 
     @Override
     public boolean hasThreadAffinity() {
-        return SignalOffloaders.hasThreadAffinity(delegate) && SignalOffloaders.hasThreadAffinity(fallbackExecutor);
+        return SignalOffloaders.hasThreadAffinity(delegate()) && SignalOffloaders.hasThreadAffinity(fallbackExecutor);
     }
 
     private static final class SubscribeOnlySignalOffloader implements SignalOffloader {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/GlobalExecutionContext.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/GlobalExecutionContext.java
@@ -23,6 +23,7 @@ import io.servicetalk.transport.api.DefaultExecutionContext;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.IoExecutor;
 
+import io.netty.channel.EventLoopGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,15 +74,15 @@ public final class GlobalExecutionContext {
         }
     }
 
-    private static final class GlobalIoExecutor implements IoExecutor {
+    private static final class GlobalIoExecutor implements EventLoopAwareNettyIoExecutor {
 
         private static final Logger LOGGER = LoggerFactory.getLogger(GlobalIoExecutor.class);
 
         static final String NAME_PREFIX = "servicetalk-global-io-executor";
 
-        private final IoExecutor delegate;
+        private final EventLoopAwareNettyIoExecutor delegate;
 
-        GlobalIoExecutor(final IoExecutor delegate) {
+        GlobalIoExecutor(final EventLoopAwareNettyIoExecutor delegate) {
             this.delegate = delegate;
         }
 
@@ -110,6 +111,26 @@ public final class GlobalExecutionContext {
         @Override
         public boolean isFileDescriptorSocketAddressSupported() {
             return delegate.isFileDescriptorSocketAddressSupported();
+        }
+
+        @Override
+        public boolean isCurrentThreadEventLoop() {
+            return delegate.isCurrentThreadEventLoop();
+        }
+
+        @Override
+        public EventLoopGroup eventLoopGroup() {
+            return delegate.eventLoopGroup();
+        }
+
+        @Override
+        public EventLoopAwareNettyIoExecutor next() {
+            return delegate.next();
+        }
+
+        @Override
+        public Executor asExecutor() {
+            return delegate.asExecutor();
         }
     }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutors.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutors.java
@@ -45,7 +45,7 @@ public final class NettyIoExecutors {
      * @param threadFactory the {@link ThreadFactory} to use.
      * @return The created {@link IoExecutor}
      */
-    public static NettyIoExecutor createIoExecutor(ThreadFactory threadFactory) {
+    public static EventLoopAwareNettyIoExecutor createIoExecutor(ThreadFactory threadFactory) {
         return createIoExecutor(getRuntime().availableProcessors() * 2, threadFactory);
     }
 
@@ -56,7 +56,7 @@ public final class NettyIoExecutors {
      * @param threadFactory the {@link ThreadFactory} to use.
      * @return The created {@link IoExecutor}
      */
-    public static NettyIoExecutor createIoExecutor(int ioThreads, ThreadFactory threadFactory) {
+    public static EventLoopAwareNettyIoExecutor createIoExecutor(int ioThreads, ThreadFactory threadFactory) {
         validateIoThreads(ioThreads);
         return new EventLoopGroupIoExecutor(createEventLoopGroup(ioThreads, threadFactory), true);
     }


### PR DESCRIPTION
Motivation:

Global instances of `IoExecutor` and `Executor` are shared across all client
and server instances by default (unless users provide custom executors).
Closing them may affect all other clients and servers that depend on them.
The only legit way of closing global executors is when everything else that
depends on it is already closed. We should notify users if they close
global instances.

Modifications:

- Wrap global `IoExecutor` and `Executor` instances and log when users
subscribe to their `closeAsync()` or `closeAsyncGracefully()` methods;
- Change `NettyIoExecutors#createIoExecutor` methods return type to
`EventLoopAwareNettyIoExecutor`;

Result:

Users who closed global `IoExecutor` or `Executor` in incorrect order and debug
issues caused by this closure will see a debug message log that will point to
the root cause.