### PR TITLE
URL fix for JAX-RS API documentation

### DIFF
--- a/servicetalk-data-jackson-jersey/docs/modules/ROOT/pages/index.adoc
+++ b/servicetalk-data-jackson-jersey/docs/modules/ROOT/pages/index.adoc
@@ -11,7 +11,7 @@ CAUTION: This serializer can not currently be used with Server-Sent Events (SSE)
 
 If you have configured a Jackson `ObjectMapper` and want to use it with this module, you need to provide it to the
 JAX-RS runtime as
-a https://jax-rs.github.io/apidocs/2.1/index.html?javax/ws/rs/ext/ContextResolver.html[`ContextResolver`].
+a https://eclipse-ee4j.github.io/jaxrs-api/apidocs/2.1.6/javax/ws/rs/ext/ContextResolver.html[`ContextResolver`].
 To help with this, `ServiceTalkJacksonSerializerFeature` provides a helper method named `contextResolverFor` that
 can build a `ContextResolver<JacksonSerializationProvider>` from an `ObjectMapper` instance.
 
@@ -20,7 +20,7 @@ It is up to the user to properly register this `ContextResolver` with their appl
 == Using a custom JacksonSerializationProvider
 
 Like with `ObjectMapper`, if you want to use a custom `ServiceTalkJacksonSerializerFeature` you need to provide it as
-a https://jax-rs.github.io/apidocs/2.1/index.html?javax/ws/rs/ext/ContextResolver.html[`ContextResolver`].
+a https://eclipse-ee4j.github.io/jaxrs-api/apidocs/2.1.6/javax/ws/rs/ext/ContextResolver.html[`ContextResolver`].
 `ServiceTalkJacksonSerializerFeature` provides a helper method named `contextResolverFor` that
 can build a `ContextResolver<JacksonSerializationProvider>` from an `ServiceTalkJacksonSerializerFeature` instance.
 


### PR DESCRIPTION
Motivation:
The public URL for the JAX-RS 2.1.X API documentation has moved to the Eclipse Jakarta EE
site. This has broken links to the documentation in the published ServiceTalk.io site and
prevents successful validation of generated site documentation for local builds.

Modifications:
The broken URL is updated to match the current published location for JAX-RS API
documentation.

Result:
Validation succeeds for local documentation builds and the link is no longer broken.