### PR TITLE
Remove deprecated methods from HTTP request/response types

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractDelegatingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractDelegatingHttpRequest.java
@@ -184,8 +184,8 @@ abstract class AbstractDelegatingHttpRequest implements PayloadInfo, HttpRequest
     }
 
     @Override
-    public boolean onlyEmitsBuffer() {
-        return original.onlyEmitsBuffer();
+    public boolean isGenericTypeBuffer() {
+        return original.isGenericTypeBuffer();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractDelegatingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractDelegatingHttpResponse.java
@@ -56,8 +56,8 @@ abstract class AbstractDelegatingHttpResponse implements HttpResponseMetaData, P
     }
 
     @Override
-    public boolean onlyEmitsBuffer() {
-        return original.onlyEmitsBuffer();
+    public boolean isGenericTypeBuffer() {
+        return original.isGenericTypeBuffer();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
@@ -174,16 +174,6 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     BlockingStreamingHttpRequest transformPayloadBody(UnaryOperator<BlockingIterable<Buffer>> transformer);
 
     /**
-     * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload transformed. Note that the raw objects
-     * of the underlying {@link Iterable} may be exposed. The object types are not guaranteed to be homogeneous.
-     * @deprecated Use {@link #transformPayloadBody(UnaryOperator)}.
-     * @param transformer Responsible for transforming the payload body.
-     * @return {@code this}
-     */
-    @Deprecated
-    BlockingStreamingHttpRequest transformRawPayloadBody(UnaryOperator<BlockingIterable<?>> transformer);
-
-    /**
      * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload transformed to {@link Buffer}s,
      * with access to the trailers.
      * @param trailersTransformer {@link TrailersTransformer} to use for this transform.
@@ -191,17 +181,6 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
      * @return {@code this}
      */
     <T> BlockingStreamingHttpRequest transform(TrailersTransformer<T, Buffer> trailersTransformer);
-
-    /**
-     * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload transformed to {@link Object}s,
-     * with access to the trailers.
-     * @deprecated Use {@link #transform(TrailersTransformer)}.
-     * @param trailersTransformer {@link TrailersTransformer} to use for this transform.
-     * @param <T> The type of state used during the transformation.
-     * @return {@code this}
-     */
-    @Deprecated
-    <T> BlockingStreamingHttpRequest transformRaw(TrailersTransformer<T, Object> trailersTransformer);
 
     /**
      * Translates this {@link BlockingStreamingHttpRequest} to a {@link HttpRequest}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
@@ -171,17 +171,6 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
     BlockingStreamingHttpResponse transformPayloadBody(UnaryOperator<BlockingIterable<Buffer>> transformer);
 
     /**
-     * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload transformed.
-     * @deprecated Use {@link #transformPayloadBody(UnaryOperator)}.
-     * @param transformer A {@link Function} which take as a parameter the existing payload body
-     * {@link BlockingIterable} and returns the new payload body {@link BlockingIterable}. It is assumed the existing
-     * payload body {@link BlockingIterable} will be transformed/consumed or else no more responses may be processed.
-     * @return {@code this}
-     */
-    @Deprecated
-    BlockingStreamingHttpResponse transformRawPayloadBody(UnaryOperator<BlockingIterable<?>> transformer);
-
-    /**
      * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload transformed to {@link Buffer}s,
      * with access to the trailers.
      * @param trailersTransformer {@link TrailersTransformer} to use for this transform.
@@ -189,17 +178,6 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
      * @return {@code this}
      */
     <T> BlockingStreamingHttpResponse transform(TrailersTransformer<T, Buffer> trailersTransformer);
-
-    /**
-     * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload transformed to {@link Object}s,
-     * with access to the trailers.
-     * @deprecated Use {@link #transform(TrailersTransformer)}.
-     * @param trailersTransformer {@link TrailersTransformer} to use for this transform.
-     * @param <T> The type of state used during the transformation.
-     * @return {@code this}
-     */
-    @Deprecated
-    <T> BlockingStreamingHttpResponse transformRaw(TrailersTransformer<T, Object> trailersTransformer);
 
     /**
      * Translates this {@link BlockingStreamingHttpResponse} to a {@link HttpResponse}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
@@ -187,25 +187,9 @@ final class DefaultBlockingStreamingHttpRequest extends AbstractDelegatingHttpRe
         return this;
     }
 
-    @Deprecated
-    @Override
-    public BlockingStreamingHttpRequest transformRawPayloadBody(
-            final UnaryOperator<BlockingIterable<?>> transformer) {
-        original.transformRawPayloadBody(bufferPublisher ->
-                fromIterable(transformer.apply(bufferPublisher.toIterable())));
-        return this;
-    }
-
     @Override
     public <T> BlockingStreamingHttpRequest transform(final TrailersTransformer<T, Buffer> trailersTransformer) {
         original.transform(trailersTransformer);
-        return this;
-    }
-
-    @Deprecated
-    @Override
-    public <T> BlockingStreamingHttpRequest transformRaw(final TrailersTransformer<T, Object> trailersTransformer) {
-        original.transformRaw(trailersTransformer);
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpResponse.java
@@ -88,24 +88,9 @@ final class DefaultBlockingStreamingHttpResponse extends AbstractDelegatingHttpR
         return this;
     }
 
-    @Deprecated
-    @Override
-    public BlockingStreamingHttpResponse transformRawPayloadBody(final UnaryOperator<BlockingIterable<?>> transformer) {
-        original.transformRawPayloadBody(bufferPublisher ->
-                fromIterable(transformer.apply(bufferPublisher.toIterable())));
-        return this;
-    }
-
     @Override
     public <T> BlockingStreamingHttpResponse transform(final TrailersTransformer<T, Buffer> trailersTransformer) {
         original.transform(trailersTransformer);
-        return this;
-    }
-
-    @Deprecated
-    @Override
-    public <T> BlockingStreamingHttpResponse transformRaw(final TrailersTransformer<T, Object> trailersTransformer) {
-        original.transformRaw(trailersTransformer);
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
@@ -237,10 +237,10 @@ final class DefaultHttpRequest extends AbstractDelegatingHttpRequest
         final Publisher<Object> payload;
         if (trailers != null) {
             payload = from(payloadBody, trailers);
-            payloadInfo = new DefaultPayloadInfo(this).setMayHaveTrailers(true);
+            payloadInfo = new DefaultPayloadInfo(this).setMayHaveTrailersAndGenericTypeBuffer(true);
         } else {
             payload = from(payloadBody);
-            payloadInfo = new DefaultPayloadInfo(this).setMayHaveTrailers(false);
+            payloadInfo = new DefaultPayloadInfo(this).setMayHaveTrailersAndGenericTypeBuffer(false);
         }
         return new DefaultStreamingHttpRequest(method(), requestTarget(), version(), headers(), encoding(),
                 original.payloadHolder().allocator(), payload, payloadInfo, original.payloadHolder().headersFactory());

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponse.java
@@ -80,10 +80,10 @@ final class DefaultHttpResponse extends AbstractDelegatingHttpResponse
         final Publisher<Object> payload;
         if (trailers != null) {
             payload = from(payloadBody, trailers);
-            payloadInfo = new DefaultPayloadInfo(this).setMayHaveTrailers(true);
+            payloadInfo = new DefaultPayloadInfo(this).setMayHaveTrailersAndGenericTypeBuffer(true);
         } else {
             payload = from(payloadBody);
-            payloadInfo = new DefaultPayloadInfo(this).setMayHaveTrailers(false);
+            payloadInfo = new DefaultPayloadInfo(this).setMayHaveTrailersAndGenericTypeBuffer(false);
         }
         return new DefaultStreamingHttpResponse(status(), version(), headers(), original.payloadHolder().allocator(),
                 payload, payloadInfo, original.payloadHolder().headersFactory());

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultPayloadInfo.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultPayloadInfo.java
@@ -22,7 +22,7 @@ import static io.servicetalk.http.api.HttpProtocolVersion.h1TrailersSupported;
 final class DefaultPayloadInfo implements PayloadInfo {
     private static final byte SAFE_TO_AGGREGATE = 1;
     private static final byte MAY_HAVE_TRAILERS = 2;
-    private static final byte ONLY_EMIT_BUFFERS = 4;
+    private static final byte GENERIC_TYPE_BUFFER = 4;
 
     private byte flags;
 
@@ -35,7 +35,7 @@ final class DefaultPayloadInfo implements PayloadInfo {
         } else {
             setSafeToAggregate(from.isSafeToAggregate());
             setMayHaveTrailers(from.mayHaveTrailers());
-            setOnlyEmitsBuffer(from.onlyEmitsBuffer());
+            setGenericTypeBuffer(from.isGenericTypeBuffer());
         }
     }
 
@@ -50,8 +50,8 @@ final class DefaultPayloadInfo implements PayloadInfo {
     }
 
     @Override
-    public boolean onlyEmitsBuffer() {
-        return isSet(ONLY_EMIT_BUFFERS);
+    public boolean isGenericTypeBuffer() {
+        return isSet(GENERIC_TYPE_BUFFER);
     }
 
     DefaultPayloadInfo setSafeToAggregate(boolean safeToAggregate) {
@@ -62,8 +62,17 @@ final class DefaultPayloadInfo implements PayloadInfo {
         return set(MAY_HAVE_TRAILERS, mayHaveTrailers);
     }
 
-    DefaultPayloadInfo setOnlyEmitsBuffer(boolean onlyEmitsBuffer) {
-        return set(ONLY_EMIT_BUFFERS, onlyEmitsBuffer);
+    DefaultPayloadInfo setGenericTypeBuffer(boolean genericTypeBuffer) {
+        return set(GENERIC_TYPE_BUFFER, genericTypeBuffer);
+    }
+
+    DefaultPayloadInfo setMayHaveTrailersAndGenericTypeBuffer(boolean mayHaveTrailers) {
+        if (mayHaveTrailers) {
+            flags = (byte) ((flags | MAY_HAVE_TRAILERS) & ~GENERIC_TYPE_BUFFER);
+        } else {
+            flags = (byte) ((flags | GENERIC_TYPE_BUFFER) & ~MAY_HAVE_TRAILERS);
+        }
+        return this;
     }
 
     /**
@@ -86,7 +95,7 @@ final class DefaultPayloadInfo implements PayloadInfo {
      * @return A new {@link PayloadInfo} representing an HTTP message created by a user.
      */
     static DefaultPayloadInfo forUserCreated() {
-        return new DefaultPayloadInfo().setOnlyEmitsBuffer(true);
+        return new DefaultPayloadInfo().setGenericTypeBuffer(true);
     }
 
     private boolean isSet(byte expected) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpRequest.java
@@ -145,12 +145,6 @@ final class DefaultStreamingHttpRequest extends DefaultHttpRequestMetaData
         return payloadHolder.payloadBody();
     }
 
-    @Deprecated
-    @Override
-    public Publisher<Object> payloadBodyAndTrailers() {
-        return payloadHolder.payloadBodyAndTrailers();
-    }
-
     @Override
     public Publisher<Object> messageBody() {
         return payloadHolder.messageBody();
@@ -182,13 +176,6 @@ final class DefaultStreamingHttpRequest extends DefaultHttpRequestMetaData
         return this;
     }
 
-    @Deprecated
-    @Override
-    public StreamingHttpRequest transformRawPayloadBody(UnaryOperator<Publisher<?>> transformer) {
-        payloadHolder.transformRawPayloadBody(transformer);
-        return this;
-    }
-
     @Override
     public StreamingHttpRequest transformMessageBody(final UnaryOperator<Publisher<?>> transformer) {
         payloadHolder.transformMessageBody(transformer);
@@ -198,13 +185,6 @@ final class DefaultStreamingHttpRequest extends DefaultHttpRequestMetaData
     @Override
     public <T> StreamingHttpRequest transform(final TrailersTransformer<T, Buffer> trailersTransformer) {
         payloadHolder.transform(trailersTransformer);
-        return this;
-    }
-
-    @Deprecated
-    @Override
-    public <T> StreamingHttpRequest transformRaw(final TrailersTransformer<T, Object> trailersTransformer) {
-        payloadHolder.transformRaw(trailersTransformer);
         return this;
     }
 
@@ -233,8 +213,8 @@ final class DefaultStreamingHttpRequest extends DefaultHttpRequestMetaData
     }
 
     @Override
-    public boolean onlyEmitsBuffer() {
-        return payloadHolder.onlyEmitsBuffer();
+    public boolean isGenericTypeBuffer() {
+        return payloadHolder.isGenericTypeBuffer();
     }
 
     StreamingHttpPayloadHolder payloadHolder() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpResponse.java
@@ -62,12 +62,6 @@ final class DefaultStreamingHttpResponse extends DefaultHttpResponseMetaData
         return payloadHolder.payloadBody();
     }
 
-    @Deprecated
-    @Override
-    public Publisher<Object> payloadBodyAndTrailers() {
-        return payloadHolder.payloadBodyAndTrailers();
-    }
-
     @Override
     public Publisher<Object> messageBody() {
         return payloadHolder.messageBody();
@@ -99,13 +93,6 @@ final class DefaultStreamingHttpResponse extends DefaultHttpResponseMetaData
         return this;
     }
 
-    @Deprecated
-    @Override
-    public StreamingHttpResponse transformRawPayloadBody(UnaryOperator<Publisher<?>> transformer) {
-        payloadHolder.transformRawPayloadBody(transformer);
-        return this;
-    }
-
     @Override
     public StreamingHttpResponse transformMessageBody(final UnaryOperator<Publisher<?>> transformer) {
         payloadHolder.transformMessageBody(transformer);
@@ -115,13 +102,6 @@ final class DefaultStreamingHttpResponse extends DefaultHttpResponseMetaData
     @Override
     public <T> StreamingHttpResponse transform(final TrailersTransformer<T, Buffer> trailersTransformer) {
         payloadHolder.transform(trailersTransformer);
-        return this;
-    }
-
-    @Deprecated
-    @Override
-    public <T> StreamingHttpResponse transformRaw(final TrailersTransformer<T, Object> trailersTransformer) {
-        payloadHolder.transformRaw(trailersTransformer);
         return this;
     }
 
@@ -150,8 +130,8 @@ final class DefaultStreamingHttpResponse extends DefaultHttpResponseMetaData
     }
 
     @Override
-    public boolean onlyEmitsBuffer() {
-        return payloadHolder.onlyEmitsBuffer();
+    public boolean isGenericTypeBuffer() {
+        return payloadHolder.isGenericTypeBuffer();
     }
 
     StreamingHttpPayloadHolder payloadHolder() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PayloadInfo.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PayloadInfo.java
@@ -42,12 +42,10 @@ interface PayloadInfo {
     boolean mayHaveTrailers();
 
     /**
-     * Returns {@code true} if and only if, the {@link Publisher} associated with this {@link PayloadInfo} will only
-     * emit {@link Buffer}s (independent of trailers).
-     * @deprecated "raw" payload type support will be removed in future releases.
-     * @return {@code true} if and only if, the {@link Publisher} associated with this {@link PayloadInfo} will only
-     * emit {@link Buffer}s (independent of trailers).
+     * Returns {@code true} if and only if, the {@link Publisher} associated with this {@link PayloadInfo} can be
+     * safely cast to {@link Publisher}&lt;{@link Buffer}&gt;
+     * @return {@code true} if and only if, the {@link Publisher} associated with this {@link PayloadInfo} can be
+     * safely cast to {@link Publisher}&lt;{@link Buffer}&gt;
      */
-    @Deprecated
-    boolean onlyEmitsBuffer();
+    boolean isGenericTypeBuffer();
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequest.java
@@ -46,15 +46,6 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
     }
 
     /**
-     * Gets a {@link Publisher} that combines the raw payload body concatenated with the {@link HttpHeaders trailers}.
-     * @deprecated Use {@link #messageBody()}.
-     * @return a {@link Publisher} that combines the raw payload body concatenated with the
-     * {@link HttpHeaders trailers}.
-     */
-    @Deprecated
-    Publisher<Object> payloadBodyAndTrailers();
-
-    /**
      * Get the <a href="https://tools.ietf.org/html/rfc7230#section-3.3">message-body</a> which contains the
      * payload body concatenated with the <a href="https://tools.ietf.org/html/rfc7230#section-4.1.2">trailer</a> (if
      * present).
@@ -134,16 +125,6 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
     StreamingHttpRequest transformPayloadBody(UnaryOperator<Publisher<Buffer>> transformer);
 
     /**
-     * Returns a {@link StreamingHttpRequest} with its underlying payload transformed. Note that the raw objects of the
-     * underlying {@link Publisher} may be exposed. The object types are not guaranteed to be homogeneous.
-     * @deprecated Use {@link #transformPayloadBody(UnaryOperator)}.
-     * @param transformer Responsible for transforming the payload body.
-     * @return {@code this}
-     */
-    @Deprecated
-    StreamingHttpRequest transformRawPayloadBody(UnaryOperator<Publisher<?>> transformer);
-
-    /**
      * Transform the <a href="https://tools.ietf.org/html/rfc7230#section-3.3">message-body</a> which contains the
      * payload body concatenated with the <a href="https://tools.ietf.org/html/rfc7230#section-4.1.2">trailer</a> (if
      * present).
@@ -164,17 +145,6 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
      * @return {@code this}
      */
     <T> StreamingHttpRequest transform(TrailersTransformer<T, Buffer> trailersTransformer);
-
-    /**
-     * Returns a {@link StreamingHttpRequest} with its underlying payload transformed to {@link Object}s,
-     * with access to the trailers.
-     * @deprecated use {@link #transform(TrailersTransformer)}.
-     * @param trailersTransformer {@link TrailersTransformer} to use for this transform.
-     * @param <T> The type of state used during the transformation.
-     * @return {@code this}
-     */
-    @Deprecated
-    <T> StreamingHttpRequest transformRaw(TrailersTransformer<T, Object> trailersTransformer);
 
     /**
      * Translates this {@link StreamingHttpRequest} to a {@link HttpRequest}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpResponse.java
@@ -45,15 +45,6 @@ public interface StreamingHttpResponse extends HttpResponseMetaData {
     }
 
     /**
-     * Gets a {@link Publisher} that combines the raw payload body concatenated with the {@link HttpHeaders trailers}.
-     * @deprecated Use {@link #messageBody()}.
-     * @return a {@link Publisher} that combines the raw payload body concatenated with the
-     * {@link HttpHeaders trailers}.
-     */
-    @Deprecated
-    Publisher<Object> payloadBodyAndTrailers();
-
-    /**
      * Get the <a href="https://tools.ietf.org/html/rfc7230#section-3.3">message-body</a> which contains the
      * payload body concatenated with the <a href="https://tools.ietf.org/html/rfc7230#section-4.1.2">trailer</a> (if
      * present).
@@ -133,16 +124,6 @@ public interface StreamingHttpResponse extends HttpResponseMetaData {
     StreamingHttpResponse transformPayloadBody(UnaryOperator<Publisher<Buffer>> transformer);
 
     /**
-     * Returns a {@link StreamingHttpResponse} with its underlying payload transformed. Note that the raw objects of the
-     * underlying {@link Publisher} may be exposed. The object types are not guaranteed to be homogeneous.
-     * @deprecated Use {@link #transformPayloadBody(UnaryOperator)}.
-     * @param transformer Responsible for transforming the payload body.
-     * @return {@code this}
-     */
-    @Deprecated
-    StreamingHttpResponse transformRawPayloadBody(UnaryOperator<Publisher<?>> transformer);
-
-    /**
      * Transform the <a href="https://tools.ietf.org/html/rfc7230#section-3.3">message-body</a> which contains the
      * payload body concatenated with the <a href="https://tools.ietf.org/html/rfc7230#section-4.1.2">trailer</a> (if
      * present).
@@ -163,17 +144,6 @@ public interface StreamingHttpResponse extends HttpResponseMetaData {
      * @return {@code this}
      */
     <T> StreamingHttpResponse transform(TrailersTransformer<T, Buffer> trailersTransformer);
-
-    /**
-     * Returns a {@link StreamingHttpResponse} with its underlying payload transformed to {@link Object}s,
-     * with access to the trailers.
-     * @deprecated use {@link #transform(TrailersTransformer)}.
-     * @param trailersTransformer {@link TrailersTransformer} to use for this transform.
-     * @param <T> The type of state used during the transformation.
-     * @return {@code this}
-     */
-    @Deprecated
-    <T> StreamingHttpResponse transformRaw(TrailersTransformer<T, Object> trailersTransformer);
 
     /**
      * Translates this {@link StreamingHttpResponse} to a {@link HttpResponse}.

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractConversionTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractConversionTest.java
@@ -75,13 +75,13 @@ abstract class AbstractConversionTest {
     void verifyAggregatedPayloadInfo(final PayloadInfo aggregatedInfo) {
         assertThat("Aggregated request not safe to aggregate.", aggregatedInfo.isSafeToAggregate(), is(true));
         assertThat("Mismatched trailer info.", aggregatedInfo.mayHaveTrailers(), is(payloadInfo.mayHaveTrailers()));
-        assertThat("Mismatched buffer info.", aggregatedInfo.onlyEmitsBuffer(), is(payloadInfo.onlyEmitsBuffer()));
+        assertThat(aggregatedInfo.isGenericTypeBuffer(), is(payloadInfo.isGenericTypeBuffer()));
     }
 
     void verifyPayloadInfo(final PayloadInfo newInfo) {
         assertThat("Mismatched aggregation info.", newInfo.isSafeToAggregate(), is(payloadInfo.isSafeToAggregate()));
         assertThat("Mismatched trailer info.", newInfo.mayHaveTrailers(), is(payloadInfo.mayHaveTrailers()));
-        assertThat("Mismatched buffer info.", newInfo.onlyEmitsBuffer(), is(payloadInfo.onlyEmitsBuffer()));
+        assertThat(newInfo.isGenericTypeBuffer(), is(payloadInfo.isGenericTypeBuffer()));
     }
 
     static class SingleSubscribePublisher extends Publisher<Object> {

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/RequestConversionTests.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/RequestConversionTests.java
@@ -48,7 +48,7 @@ public class RequestConversionTests extends AbstractConversionTest {
         List<Object[]> params = new ArrayList<>();
         params.add(newParam(new DefaultPayloadInfo(), "no-payload-info"));
         params.add(newParam(new DefaultPayloadInfo().setMayHaveTrailers(true), "trailers"));
-        params.add(newParam(new DefaultPayloadInfo().setOnlyEmitsBuffer(true), "only-buffers"));
+        params.add(newParam(new DefaultPayloadInfo().setGenericTypeBuffer(true), "publisher-buffer"));
         params.add(newParam(new DefaultPayloadInfo().setSafeToAggregate(true), "safe-to-aggregate"));
         return params;
     }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/ResponseConversionTests.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/ResponseConversionTests.java
@@ -47,7 +47,7 @@ public class ResponseConversionTests extends AbstractConversionTest {
         List<Object[]> params = new ArrayList<>();
         params.add(newParam(new DefaultPayloadInfo(), "no-payload-info"));
         params.add(newParam(new DefaultPayloadInfo().setMayHaveTrailers(true), "trailers"));
-        params.add(newParam(new DefaultPayloadInfo().setOnlyEmitsBuffer(true), "only-buffers"));
+        params.add(newParam(new DefaultPayloadInfo().setGenericTypeBuffer(true), "publisher-buffer"));
         params.add(newParam(new DefaultPayloadInfo().setSafeToAggregate(true), "safe-to-aggregate"));
         return params;
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
@@ -130,7 +130,6 @@ public class ContentHeadersTest extends AbstractNettyHttpServerTest {
                 new RequestTest(aggregatedRequest(GET), contentLength(), HAVE_EXISTING_CONTENT_LENGTH),
                 new RequestTest(aggregatedRequest(GET), trailers(), HAVE_TRANSFER_ENCODING_CHUNKED),
                 new RequestTest(aggregatedRequestAsStreaming(GET), transform(), HAVE_TRANSFER_ENCODING_CHUNKED),
-                new RequestTest(aggregatedRequestAsStreaming(GET), transformRaw(), HAVE_TRANSFER_ENCODING_CHUNKED),
                 new RequestTest(streamingRequest(GET), defaults(), HAVE_TRANSFER_ENCODING_CHUNKED),
                 new RequestTest(streamingRequest(GET), withoutPayload(), HAVE_TRANSFER_ENCODING_CHUNKED),
 
@@ -180,8 +179,6 @@ public class ContentHeadersTest extends AbstractNettyHttpServerTest {
                 new ResponseTest(aggregatedResponse(OK), GET, trailers(), HAVE_TRANSFER_ENCODING_CHUNKED),
                 new ResponseTest(aggregatedResponse(INTERNAL_SERVER_ERROR), CONNECT, defaults(), HAVE_CONTENT_LENGTH),
                 new ResponseTest(aggregatedResponseAsStreaming(OK), GET, transform(), HAVE_TRANSFER_ENCODING_CHUNKED),
-                new ResponseTest(aggregatedResponseAsStreaming(OK), GET, transformRaw(),
-                        HAVE_TRANSFER_ENCODING_CHUNKED),
                 new ResponseTest(streamingResponse(OK), GET, defaults(), HAVE_TRANSFER_ENCODING_CHUNKED),
                 new ResponseTest(streamingResponse(OK), GET, withoutPayload(), HAVE_TRANSFER_ENCODING_CHUNKED),
 
@@ -300,19 +297,6 @@ public class ContentHeadersTest extends AbstractNettyHttpServerTest {
                 throw new IllegalStateException();
             }
         }, "Transform");
-    }
-
-    private static UnaryOperator<HttpMetaData> transformRaw() {
-        return describe(input -> {
-            if (input instanceof StreamingHttpRequest) {
-                return ((StreamingHttpRequest) input).transformRaw(new StatelessTrailersTransformer<>());
-            } else if (input instanceof StreamingHttpResponse) {
-                return ((StreamingHttpResponse) input).transformRaw(new StatelessTrailersTransformer<>());
-            } else {
-                fail("Unexpected metadata type: " + input.getClass());
-                throw new IllegalStateException();
-            }
-        }, "TransformRaw");
     }
 
     @Test

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentLengthTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentLengthTest.java
@@ -173,14 +173,6 @@ public class ContentLengthTest extends AbstractNettyHttpServerTest {
         setResponseContentLengthAndVerify(response, is("12"));
     }
 
-    @Test
-    public void shouldCalculateResponseContentLengthFromTransformedRawMultipleItemPublisher() throws Exception {
-        StreamingHttpResponse response = newAggregatedResponse().payloadBody("Hello", textSerializer())
-                .toStreamingResponse().transformRawPayloadBody(payload -> payload.map(obj -> (Buffer) obj)
-                        .concat(Publisher.from(" ", "World", "!").map(DEFAULT_RO_ALLOCATOR::fromAscii)));
-        setResponseContentLengthAndVerify(response, is("12"));
-    }
-
     private static HttpRequest newAggregatedRequest() {
         return newAggregatedRequest(GET);
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilterTest.java
@@ -73,7 +73,7 @@ public class ProxyConnectConnectionFactoryFilterTest {
 
     private final FilterableStreamingHttpConnection connection;
     private final TestCompletable connectionClose;
-    private final TestPublisher<Object> payloadBodyAndTrailers;
+    private final TestPublisher<Object> messageBody;
     private final TestSingleSubscriber<FilterableStreamingHttpConnection> subscriber;
 
     public ProxyConnectConnectionFactoryFilterTest() {
@@ -85,7 +85,7 @@ public class ProxyConnectConnectionFactoryFilterTest {
         });
         when(connection.closeAsync()).thenReturn(connectionClose);
 
-        payloadBodyAndTrailers = new TestPublisher.Builder<>().build(subscriber -> {
+        messageBody = new TestPublisher.Builder<>().build(subscriber -> {
             subscriber.onSubscribe(new PublisherSource.Subscription() {
                 @Override
                 public void request(final long n) {
@@ -131,7 +131,7 @@ public class ProxyConnectConnectionFactoryFilterTest {
     private void configureRequestSend() {
         StreamingHttpResponse response = mock(StreamingHttpResponse.class);
         when(response.status()).thenReturn(OK);
-        when(response.messageBody()).thenReturn(payloadBodyAndTrailers);
+        when(response.messageBody()).thenReturn(messageBody);
         when(connection.request(any(), any())).thenReturn(succeeded(response));
     }
 
@@ -174,7 +174,7 @@ public class ProxyConnectConnectionFactoryFilterTest {
     public void nonSuccessfulResponseCode() {
         StreamingHttpResponse response = mock(StreamingHttpResponse.class);
         when(response.status()).thenReturn(INTERNAL_SERVER_ERROR);
-        when(response.messageBody()).thenReturn(payloadBodyAndTrailers);
+        when(response.messageBody()).thenReturn(messageBody);
         when(connection.request(any(), any())).thenReturn(succeeded(response));
 
         configureConnectRequest();
@@ -285,7 +285,7 @@ public class ProxyConnectConnectionFactoryFilterTest {
         verify(connection).connect(any());
         verify(connection).request(any(), any());
         assertThat("CONNECT response payload body was " + (expected ? "was" : "unnecessarily") + " consumed",
-                payloadBodyAndTrailers.isSubscribed(), is(expected));
+                messageBody.isSubscribed(), is(expected));
     }
 
     private void assertConnectionClosed() {


### PR DESCRIPTION
Motivation:
5832d5d65ec26b181fa14ed457eab9864a9ce30b deprecated the following
methods:
- payloadBodyAndTrailers
- transformRawPayloadBody
- transformRaw
These methods can now be removed as alternatives exist.

Modifications:
- Remove the deprecated methods from all http request/response types
- Simplify StreamingHttpPayloadHolder logic which now only expects
  Buffer payload manipulation.
- Remove PayloadInfo#onlyEmitsBuffer methods which are no longer
  relevant.

Result:
Less deprecated methods for HTTP types, more narrow API that is more
representative of what is actually supported (e.g. Buffer type).