### PR TITLE
gRPC Server allow drop of request trailers

### DIFF
--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -54,7 +54,7 @@ final class DefaultGrpcServerBuilder extends GrpcServerBuilder implements Server
             .executionStrategy(defaultStrategy());
 
     DefaultGrpcServerBuilder(final HttpServerBuilder httpServerBuilder) {
-        this.httpServerBuilder = httpServerBuilder.protocols(h2Default());
+        this.httpServerBuilder = httpServerBuilder.protocols(h2Default()).allowDropRequestTrailers(true);
     }
 
     @Override


### PR DESCRIPTION
Motivation:
The
[gRPC protocol](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests)
does not use request trailers. This means the server is allowed to drop
trailers if any are present. This may provide a performance benefit as
request transformation operations do not have to worry about preserving
trailers.

Modifications:
- DefaultGrpcServerBuilder to use the allowDropRequestTrailers(true)
  method.

Result:
gRPC Server is allowed to drop the request trailers, requiring less work
to preserve trailers (which don't exist) through request transform
operations.