### PR TITLE
Examples for HTTP and gRPC compression

### DIFF
--- a/docs/generation/README.adoc
+++ b/docs/generation/README.adoc
@@ -22,7 +22,7 @@ maintained in the https://github.com/apple/servicetalk[upstream project].
 * Source code links in the docs link to files locally.
 * Validates the generated HTML and checks for dangling links.
 
-This allows to preview local doc changes made to upstream projects.
+This allows previewing of local doc changes made to upstream projects.
 
 [source,shell]
 ----

--- a/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
@@ -1,6 +1,7 @@
 
 * xref:{page-version}@servicetalk-examples::http/index.adoc[HTTP]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#HelloWorld[Hello World]
+** xref:{page-version}@servicetalk-examples::http/index.adoc#Compression[Compression]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#Serialization[Serialization]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#JAXRS[JAX-RS]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#MetaData[MetaData]

--- a/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
@@ -11,5 +11,6 @@
 ** xref:{page-version}@servicetalk-examples::http/service-composition.adoc[Service Composition]
 * xref:{page-version}@servicetalk-examples::grpc/index.adoc[gRPC]
 ** xref:{page-version}@servicetalk-examples::grpc/index.adoc#HelloWorld[Hello World]
+** xref:{page-version}@servicetalk-examples::grpc/index.adoc#Compression[Compression]
 ** xref:{page-version}@servicetalk-examples::grpc/index.adoc#route-guide[Route Guide]
 ** xref:{page-version}@servicetalk-examples::grpc/index.adoc#protoc-options[Protoc Options]

--- a/servicetalk-examples/docs/modules/ROOT/pages/grpc/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/grpc/index.adoc
@@ -75,6 +75,15 @@ xref:{page-version}@servicetalk::programming-paradigms.adoc#asynchronous-and-str
 `recordRoute` API that uses the
 xref:{page-version}@servicetalk::programming-paradigms.adoc#asynchronous-and-streaming[bi-directional streaming programming paradigm].
 
+[#Compression]
+== Compression
+
+Extends the async "Hello World" example to demonstrate compression of the response body.
+
+* link:{source-root}/servicetalk-examples/grpc/compression/src/main/java/io/servicetalk/examples/grpc/compression/async/CompressionExampleServer.java[CompressionExampleServer] - Waits for hello request from the client and responds with a compressed greeting response.
+* link:{source-root}/servicetalk-examples/grpc/compression/src/main/java/io/servicetalk/examples/grpc/compression/async/CompressionExampleClient.java[CompressionExampleClient] - Sends a hello request to the server and receives a compressed greeting response.
+
+
 [#protoc-options]
 == Protoc Options
 

--- a/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
@@ -67,6 +67,18 @@ receives the response payload body as a blocking iterable stream of buffers.
 client that sends a `GET` request to the specified URL in absolute-form and receives the response payload body as a
 blocking iterable stream of buffers.
 
+[#Compression]
+== Compression
+
+Extends the async "Hello World" example to demonstrate content encoding compression filters. No separate example is
+needed for the other API variants as the usage of content encoding filters is the same for all API styles.
+
+* link:{source-root}/servicetalk-examples/http/compression/src/main/java/io/servicetalk/examples/http/compression/CompressionFilterExampleServer.java[CompressionFilterExampleServer] - a server that demonstrates 
+the asynchronous API and responds with a simple `Hello World!` response body, optionally customized for a specific name for `POST` requests, as a `text/plain`.
+* link:{source-root}/servicetalk-examples/http/compression/src/main/java/io/servicetalk/examples/http/compression/CompressionFilterExampleClient.java[CompressionFilterExampleClient.java] - a client that
+sends a `POST` request containing a name to the link:{source-root}/servicetalk-examples/http/compression/src/main/java/io/servicetalk/examples/http/compression/CompressionFilterExampleServer.java[server] and 
+receives a response greeting the posted name as a single content.
+
 [#Serialization]
 == Serialization
 
@@ -132,7 +144,7 @@ This example demonstrates how client and server can be configured to do mutual a
 Using the following classes:
 
 - link:{source-root}/servicetalk-examples/http/mutual-tls/src/main/java/io/servicetalk/examples/http/mutualtls/HttpServerMutualTLS.java[HttpServerMutualTLS] - A server that sets the trust manager and key manager, and requires client authentication.
-- link:{source-root}/servicetalk-examples/http/mutual-tls/src/main/java/io/servicetalk/examples/http/mutualtls/HttpServerMutualTLS.java[HttpClientMutualTLS] - A client that sets the trust manager and key manager.
+- link:{source-root}/servicetalk-examples/http/mutual-tls/src/main/java/io/servicetalk/examples/http/mutualtls/HttpClientMutualTLS.java[HttpClientMutualTLS] - A client that sets the trust manager and key manager.
 
 NOTE: This example uses the link:#blocking-aggregated[blocking + aggregated] API, as the TLS/SSL configuration API is
 the same across all the HTTP APIs.

--- a/servicetalk-examples/grpc/compression/README.adoc
+++ b/servicetalk-examples/grpc/compression/README.adoc
@@ -1,0 +1,3 @@
+== ServiceTalk gRPC Compression Example
+
+Extends "Hello World" ServiceTalk gRPC example to demonstrate compression of request and response bodies.

--- a/servicetalk-examples/grpc/compression/build.gradle
+++ b/servicetalk-examples/grpc/compression/build.gradle
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+buildscript {
+  dependencies {
+    classpath "com.google.protobuf:protobuf-gradle-plugin:$protobufGradlePluginVersion"
+  }
+}
+
+apply plugin: "java"
+apply plugin: "com.google.protobuf"
+apply from: "../../gradle/idea.gradle"
+
+dependencies {
+  implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-grpc-netty")
+  implementation project(":servicetalk-grpc-protoc")
+  implementation project(":servicetalk-grpc-protobuf")
+
+  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+}
+
+protobuf {
+  protoc {
+    artifact = "com.google.protobuf:protoc:$protobufVersion"
+  }
+  plugins {
+    servicetalk_grpc {
+      //// Users are expected to use "artifact" instead of "path". we use "path"
+      //// only because we want to use the gradle project local version of the plugin
+      // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
+      path = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
+                  "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+    }
+  }
+  generateProtoTasks {
+    all().each { task ->
+      task.plugins {
+        servicetalk_grpc {
+          // Need to tell protobuf-gradle-plugin to output in the correct directory if all generated
+          // code for a single proto goes to a single file (e.g. "java_multiple_files = false" in the .proto).
+          outputSubDir = "java"
+        }
+      }
+    }
+  }
+  generatedFilesBaseDir = "$buildDir/generated/sources/proto"
+}
+
+// The following setting must be omitted in users projects and is necessary here
+// only because we want to use the locally built version of the plugin
+afterEvaluate {
+  generateProto.dependsOn(":servicetalk-grpc-protoc:buildExecutable")
+}

--- a/servicetalk-examples/grpc/compression/src/main/java/io/servicetalk/examples/grpc/compression/CompressionExampleClient.java
+++ b/servicetalk-examples/grpc/compression/src/main/java/io/servicetalk/examples/grpc/compression/CompressionExampleClient.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.grpc.compression;
+
+import io.servicetalk.encoding.api.ContentCodec;
+import io.servicetalk.encoding.api.ContentCodings;
+import io.servicetalk.grpc.netty.GrpcClients;
+
+import io.grpc.examples.compression.Greeter;
+import io.grpc.examples.compression.Greeter.ClientFactory;
+import io.grpc.examples.compression.Greeter.GreeterClient;
+import io.grpc.examples.compression.HelloRequest;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Extends the async "Hello World" example to include support for compression of the server response.
+ */
+public final class CompressionExampleClient {
+
+    /**
+     * Encodings supported in preferred order.
+     */
+    private static final List<ContentCodec> PREFERRED_ENCODINGS =
+            Collections.unmodifiableList(Arrays.asList(
+                    ContentCodings.gzipDefault(),
+                    ContentCodings.deflateDefault(),
+                    ContentCodings.identity()
+            ));
+
+    /**
+     * Metadata that, when provided to a sayHello, will cause the request to be compressed.
+     */
+    private static final Greeter.SayHelloMetadata COMPRESS_REQUEST = new Greeter.SayHelloMetadata(ContentCodings.gzipDefault());
+
+    public static void main(String... args) throws Exception {
+        try (GreeterClient client = GrpcClients.forAddress("localhost", 8080).build(new ClientFactory()
+                // Requests will include 'Message-Accept-Encoding' HTTP header to inform the server which encodings we support.
+                .supportedMessageCodings(PREFERRED_ENCODINGS))) {
+            // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
+            // before the response has been processed. This isn't typical usage for a streaming API but is useful for
+            // demonstration purposes.
+            CountDownLatch responseProcessedLatch = new CountDownLatch(2);
+
+            // This request is sent with the request being uncompressed. The response may
+            // be compressed because the ClientFactory will include the encodings we
+            // support as a request header.
+            client.sayHello(HelloRequest.newBuilder().setName("Foo").build())
+                    .afterFinally(responseProcessedLatch::countDown)
+                    .subscribe(System.out::println);
+
+            // This request uses a different overload of the "sayHello" method that allows
+            // providing request metadata and we use it to request compression of the
+            // request.
+            client.sayHello(COMPRESS_REQUEST, HelloRequest.newBuilder().setName("Foo").build())
+                    .afterFinally(responseProcessedLatch::countDown)
+                    .subscribe(System.out::println);
+
+            responseProcessedLatch.await();
+        }
+    }
+}

--- a/servicetalk-examples/grpc/compression/src/main/java/io/servicetalk/examples/grpc/compression/CompressionExampleServer.java
+++ b/servicetalk-examples/grpc/compression/src/main/java/io/servicetalk/examples/grpc/compression/CompressionExampleServer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.grpc.compression;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.encoding.api.ContentCodec;
+import io.servicetalk.encoding.api.ContentCodings;
+import io.servicetalk.grpc.api.GrpcServiceContext;
+import io.servicetalk.grpc.netty.GrpcServers;
+
+import io.grpc.examples.compression.Greeter.GreeterService;
+import io.grpc.examples.compression.Greeter.ServiceFactory;
+import io.grpc.examples.compression.HelloReply;
+import io.grpc.examples.compression.HelloRequest;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+
+/**
+ * A simple extension of the gRPC "Hello World" example which demonstrates
+ * compression of the request and response bodies.
+ */
+public class CompressionExampleServer {
+
+    /**
+     * Supported encodings in preferred order. These will be matched against the list of encodings provided by the
+     * client to choose a mutually agreeable encoding.
+     */
+    private static final List<ContentCodec> SUPPORTED_ENCODINGS =
+            Collections.unmodifiableList(Arrays.asList(
+                    // For the purposes of this example we disable GZip for the response compression and use the
+                    // client's second choice (deflate) to demonstrate that negotiation of compression algorithm is
+                    // handled correctly.
+                    /* ContentCodings.gzipDefault(), */
+                    ContentCodings.deflateDefault(),
+                    ContentCodings.identity()
+            ));
+
+    public static void main(String... args) throws Exception {
+        GrpcServers.forPort(8080)
+                // Create a ServiceFactory that includes the encodings supported for requests and the preferred
+                // encodings for responses. Responses will automatically be compressed if the request includes
+                // a mutually agreeable compression encoding that the client indicates they will accept and that the
+                // server supports. Requests using unsupported encodings receive an error response in the "grpc-status".
+                .listenAndAwait(new ServiceFactory(new MyGreeterService(), SUPPORTED_ENCODINGS))
+                .awaitShutdown();
+    }
+
+    private static final class MyGreeterService implements GreeterService {
+
+        @Override
+        public Single<HelloReply> sayHello(final GrpcServiceContext ctx, final HelloRequest request) {
+            return succeeded(HelloReply.newBuilder().setMessage("Hello " + request.getName()).build());
+        }
+    }
+}

--- a/servicetalk-examples/grpc/compression/src/main/java/io/servicetalk/examples/grpc/compression/package-info.java
+++ b/servicetalk-examples/grpc/compression/src/main/java/io/servicetalk/examples/grpc/compression/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.grpc.compression;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-examples/grpc/compression/src/main/proto/compression.proto
+++ b/servicetalk-examples/grpc/compression/src/main/proto/compression.proto
@@ -1,0 +1,38 @@
+// Copyright 2015 The gRPC Authors
+// Copyright 2021 Apple Inc. and the ServiceTalk project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.compression";
+option java_outer_classname = "CompressionExampleProto";
+option objc_class_prefix = "HLW";
+
+package compression;
+
+// The greeting service definition.
+service Greeter {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+    string message = 1;
+}

--- a/servicetalk-examples/grpc/compression/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/grpc/compression/src/main/resources/log4j2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="info">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d %30t [%-5level] %-30logger{1} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <!-- Prints server start and shutdown -->
+    <Logger name="io.servicetalk.http.netty.H2ServerParentConnectionContext" level="DEBUG"/>
+
+    <!-- Prints default subscriber errors-->
+    <Logger name="io.servicetalk.concurrent.api" level="DEBUG"/>
+
+    <!-- Use `-Dservicetalk.logger.level=DEBUG` to change the root logger level via command line  -->
+    <Root level="${sys:servicetalk.logger.level:-INFO}">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/servicetalk-examples/http/compression/build.gradle
+++ b/servicetalk-examples/http/compression/build.gradle
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: "java"
+apply from: "../../gradle/idea.gradle"
+
+dependencies {
+  implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-http-netty")
+
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+}

--- a/servicetalk-examples/http/compression/src/main/java/io/servicetalk/examples/http/compression/CompressionFilterExampleClient.java
+++ b/servicetalk-examples/http/compression/src/main/java/io/servicetalk/examples/http/compression/CompressionFilterExampleClient.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.compression;
+
+import io.servicetalk.encoding.api.ContentCodec;
+import io.servicetalk.encoding.api.ContentCodings;
+import io.servicetalk.http.api.ContentCodingHttpRequesterFilter;
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.http.netty.HttpClients;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static io.servicetalk.http.api.HttpSerializationProviders.textDeserializer;
+import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
+
+/**
+ * Extends the async "Hello World" example to include compression of the request
+ * and response bodies.
+ */
+public final class CompressionFilterExampleClient {
+
+    /**
+     * Encodings in preferred order.
+     */
+    private static final List<ContentCodec> PREFERRED_ENCODINGS =
+            Collections.unmodifiableList(Arrays.asList(
+                    ContentCodings.gzipDefault(),
+                    ContentCodings.deflateDefault(),
+                    ContentCodings.identity()
+            ));
+
+    public static void main(String... args) throws Exception {
+        try (HttpClient client = HttpClients.forSingleAddress("localhost", 8080)
+                // Adds filter that provides compression for the request body when a request sets the encoding.
+                // Also sets the accept encoding header for the server's response.
+                .appendClientFilter(new ContentCodingHttpRequesterFilter(PREFERRED_ENCODINGS))
+                .build()) {
+            // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
+            // before the response has been processed. This isn't typical usage for a streaming API but is useful for
+            // demonstration purposes.
+            CountDownLatch responseProcessedLatch = new CountDownLatch(2);
+
+            // Make a request with an uncompressed payload.
+            HttpRequest request = client.post("/sayHello")
+                    // Request will be sent with no compression, which has the same effect as setting encoding to identity
+                    // .encoding(ContentCodings.identity())
+                    .payloadBody("George", textSerializer());
+            client.request(request)
+                    .afterFinally(responseProcessedLatch::countDown)
+                    .subscribe(resp -> {
+                        System.out.println(resp.toString((name, value) -> value));
+                        System.out.println(resp.payloadBody(textDeserializer()));
+                    });
+
+            // Make a request with an gzip compressed payload.
+            request = client.post("/sayHello")
+                    // Encode the request using gzip.
+                    .encoding(ContentCodings.gzipDefault())
+                    .payloadBody("Gracie", textSerializer());
+            client.request(request)
+                    .afterFinally(responseProcessedLatch::countDown)
+                    .subscribe(resp -> {
+                        System.out.println(resp.toString((name, value) -> value));
+                        System.out.println(resp.payloadBody(textDeserializer()));
+                    });
+
+            responseProcessedLatch.await();
+        }
+    }
+}

--- a/servicetalk-examples/http/compression/src/main/java/io/servicetalk/examples/http/compression/CompressionFilterExampleServer.java
+++ b/servicetalk-examples/http/compression/src/main/java/io/servicetalk/examples/http/compression/CompressionFilterExampleServer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.compression;
+
+import io.servicetalk.encoding.api.ContentCodec;
+import io.servicetalk.encoding.api.ContentCodings;
+import io.servicetalk.http.api.ContentCodingHttpServiceFilter;
+import io.servicetalk.http.netty.HttpServers;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.api.HttpSerializationProviders.textDeserializer;
+import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
+
+/**
+ * Extends the async "Hello World" sample to add support for compression of
+ * request and response payload bodies.
+ */
+public final class CompressionFilterExampleServer {
+
+    /**
+     * Supported encodings for the request. Requests using unsupported encodings will receive an HTTP 415
+     * "Unsupported Media Type" response.
+     */
+    private static final List<ContentCodec> SUPPORTED_REQ_ENCODINGS =
+            Collections.unmodifiableList(Arrays.asList(
+                    ContentCodings.gzipDefault(),
+                    ContentCodings.deflateDefault(),
+                    ContentCodings.identity()
+            ));
+
+     /**
+     * Supported encodings for the response in preferred order. These will be matched against the list of encodings
+      * provided by the client to choose a mutually agreeable encoding.
+     */
+    private static final List<ContentCodec> SUPPORTED_RESP_ENCODINGS =
+             Collections.unmodifiableList(Arrays.asList(
+                     // For the purposes of this example we disable GZip for the response compression and use the client's second
+                     // choice (deflate) to demonstrate that negotiation of compression algorithm is handled correctly.
+                     /* ContentCodings.gzipDefault(), */
+                     ContentCodings.deflateDefault(),
+                     ContentCodings.identity()
+             ));
+
+    public static void main(String... args) throws Exception {
+        HttpServers.forPort(8080)
+                // Adds a content coding service filter that includes the encodings supported for requests and the
+                // preferred encodings for responses. Responses will automatically be compressed if the request includes
+                // a mutually agreeable compression encoding that the client indicates they will accept and that the
+                // server supports.
+                .appendServiceFilter(new ContentCodingHttpServiceFilter(SUPPORTED_REQ_ENCODINGS, SUPPORTED_RESP_ENCODINGS))
+                .listenAndAwait((ctx, request, responseFactory) -> {
+                        String who = request.payloadBody(textDeserializer());
+                        return succeeded(responseFactory.ok().payloadBody("Hello " + who +  "!", textSerializer()));
+                })
+                .awaitShutdown();
+    }
+}

--- a/servicetalk-examples/http/compression/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/compression/src/main/resources/log4j2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="info">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d %30t [%-5level] %-30logger{1} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <!-- Prints server start and shutdown -->
+    <Logger name="io.servicetalk.http.netty.NettyHttpServer" level="DEBUG"/>
+
+    <!-- Prints default subscriber errors-->
+    <Logger name="io.servicetalk.concurrent.api" level="DEBUG"/>
+
+    <!-- Use `-Dservicetalk.logger.level=DEBUG` to change the root logger level via command line  -->
+    <Root level="${sys:servicetalk.logger.level:-INFO}">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/settings.gradle
+++ b/settings.gradle
@@ -40,6 +40,7 @@ include "servicetalk-annotations",
         "servicetalk-examples:grpc:helloworld",
         "servicetalk-examples:grpc:routeguide",
         "servicetalk-examples:grpc:protoc-options",
+        "servicetalk-examples:grpc:compression",
         "servicetalk-examples:http:helloworld",
         "servicetalk-examples:http:mutual-tls",
         "servicetalk-examples:http:http2",
@@ -88,6 +89,7 @@ include "servicetalk-annotations",
 project(":servicetalk-examples:grpc:helloworld").name = "servicetalk-examples-grpc-helloworld"
 project(":servicetalk-examples:grpc:routeguide").name = "servicetalk-examples-grpc-routeguide"
 project(":servicetalk-examples:grpc:protoc-options").name = "servicetalk-examples-grpc-protoc-options"
+project(":servicetalk-examples:grpc:compression").name = "servicetalk-examples-grpc-compression"
 project(":servicetalk-examples:http:http2").name = "servicetalk-examples-http-http2"
 project(":servicetalk-examples:http:helloworld").name = "servicetalk-examples-http-helloworld"
 project(":servicetalk-examples:http:jaxrs").name = "servicetalk-examples-http-jaxrs"

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,6 +48,7 @@ include "servicetalk-annotations",
         "servicetalk-examples:http:serialization",
         "servicetalk-examples:http:service-composition",
         "servicetalk-examples:http:uds",
+        "servicetalk-examples:http:compression",
         "servicetalk-gradle-plugin-internal",
         "servicetalk-grpc-api",
         "servicetalk-grpc-netty",
@@ -95,3 +96,4 @@ project(":servicetalk-examples:http:serialization").name = "servicetalk-examples
 project(":servicetalk-examples:http:service-composition").name = "servicetalk-examples-http-service-composition"
 project(":servicetalk-examples:http:uds").name = "servicetalk-examples-http-uds"
 project(":servicetalk-examples:http:mutual-tls").name = "servicetalk-examples-http-mutual-tls"
+project(":servicetalk-examples:http:compression").name = "servicetalk-examples-http-compression"


### PR DESCRIPTION
Motivation:
Provide an example demonstrating use of the content encoding compression features.

Modifications:
- A new HTTP example, Compression
- Additional documentation

Result:
No further need to reference test code to understand how to use compression features.