### PR TITLE
Add MDC ThreadContextMap conflict check on ST default provider

### DIFF
--- a/servicetalk-log4j2-mdc-utils/gradle/checkstyle/suppressions.xml
+++ b/servicetalk-log4j2-mdc-utils/gradle/checkstyle/suppressions.xml
@@ -19,6 +19,8 @@
     "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
-  <suppress checks="IllegalInstantiationOfString"
-            files="io[\\/]servicetalk[\\/]log4j2[\\/]dc[\\/]utils[\\/]ServiceTalkThreadContextMap.java"/>
+  <suppress id="ConsolePrint"
+            files="io[\\/]servicetalk[\\/]log4j2[\\/]mdc[\\/]utils[\\/]ServiceTalkThreadContextMap.java"/>
+  <suppress checks="LineLength"
+            files="io[\\/]servicetalk[\\/]log4j2[\\/]mdc[\\/]utils[\\/]ServiceTalkThreadContextMap.java"/>
 </suppressions>

--- a/servicetalk-log4j2-mdc/src/main/java/io/servicetalk/log4j2/mdc/DefaultServiceTalkThreadContextMap.java
+++ b/servicetalk-log4j2-mdc/src/main/java/io/servicetalk/log4j2/mdc/DefaultServiceTalkThreadContextMap.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.log4j2.mdc;
+
+import io.servicetalk.log4j2.mdc.utils.ServiceTalkThreadContextMap;
+
+/**
+ * Empty subclass to differentiate uses of MDC.
+ */
+public class DefaultServiceTalkThreadContextMap extends ServiceTalkThreadContextMap {
+}

--- a/servicetalk-log4j2-mdc/src/main/java/io/servicetalk/log4j2/mdc/package-info.java
+++ b/servicetalk-log4j2-mdc/src/main/java/io/servicetalk/log4j2/mdc/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.log4j2.mdc;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-log4j2-mdc/src/main/resources/META-INF/log4j-provider.properties
+++ b/servicetalk-log4j2-mdc/src/main/resources/META-INF/log4j-provider.properties
@@ -16,4 +16,4 @@
 
 LoggerContextFactory=org.apache.logging.log4j.core.impl.Log4jContextFactory
 Log4jAPIVersion=2.6.0
-ThreadContextMap=io.servicetalk.log4j2.mdc.utils.ServiceTalkThreadContextMap
+ThreadContextMap=io.servicetalk.log4j2.mdc.DefaultServiceTalkThreadContextMap


### PR DESCRIPTION
**Motivation**:

When multiple MDC providers are available in the cp, then unless the user specifies one through a system property, we can't know which one will be used. 

**Modifications**:

Add conflict check on ST's default provider, to detect presence of the other provider, and throw an exception.

**Result**:

Fast fail for common conflicts in the class path.

**Example output**:
```
Detected multiple ServiceTalk MDC adapters in classpath. The [io.servicetalk.log4j2.mdc.DefaultServiceTalkThreadContextMap, io.servicetalk.opentracing.log4j2.ServiceTalkTracingThreadContextMap] MDC adapters should not be loaded at the same time. Please exclude one from your dependencies.
ERROR StatusLogger Unable to locate or load configured ThreadContextMap io.servicetalk.opentracing.log4j2.ServiceTalkTracingThreadContextMap
 java.lang.IllegalStateException: log4j2.threadContextMap is not set to io.servicetalk.opentracing.log4j2.ServiceTalkTracingThreadContextMap. There is no way to determine which ThreadContextMap has precedence for MDC storage and behavior is therefore undefined.
	at io.servicetalk.log4j2.mdc.utils.ServiceTalkThreadContextMap.detectPossibleConflicts(ServiceTalkThreadContextMap.java:82)
	at io.servicetalk.log4j2.mdc.utils.ServiceTalkThreadContextMap.<init>(ServiceTalkThreadContextMap.java:58)
	at io.servicetalk.opentracing.log4j2.ServiceTalkTracingThreadContextMap.<init>(ServiceTalkTracingThreadContextMap.java:44)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at java.base/java.lang.Class.newInstance(Class.java:584)
	at org.apache.logging.log4j.spi.ThreadContextMapFactory.createThreadContextMap(ThreadContextMapFactory.java:106)
	at org.apache.logging.log4j.ThreadContext.init(ThreadContext.java:224)
	at org.apache.logging.log4j.ThreadContext.<clinit>(ThreadContext.java:202)
	at org.apache.logging.log4j.core.impl.ContextDataInjectorFactory.createDefaultInjector(ContextDataInjectorFactory.java:87)
	at org.apache.logging.log4j.core.impl.ContextDataInjectorFactory.createInjector(ContextDataInjectorFactory.java:71)
	at org.apache.logging.log4j.core.lookup.ContextMapLookup.<init>(ContextMapLookup.java:34)
	at org.apache.logging.log4j.core.lookup.Interpolator.<init>(Interpolator.java:126)
	at org.apache.logging.log4j.core.config.AbstractConfiguration.<init>(AbstractConfiguration.java:129)
	at org.apache.logging.log4j.core.config.NullConfiguration.<init>(NullConfiguration.java:32)
	at org.apache.logging.log4j.core.LoggerContext.<clinit>(LoggerContext.java:88)
	at org.apache.logging.log4j.core.selector.ClassLoaderContextSelector.createContext(ClassLoaderContextSelector.java:249)
	at org.apache.logging.log4j.core.selector.ClassLoaderContextSelector.locateContext(ClassLoaderContextSelector.java:213)
	at org.apache.logging.log4j.core.selector.ClassLoaderContextSelector.getContext(ClassLoaderContextSelector.java:137)
	at org.apache.logging.log4j.core.selector.ClassLoaderContextSelector.getContext(ClassLoaderContextSelector.java:124)
	at org.apache.logging.log4j.core.selector.ClassLoaderContextSelector.getContext(ClassLoaderContextSelector.java:118)
	at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:150)
	at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:47)
	at org.apache.logging.log4j.LogManager.getContext(LogManager.java:194)
	at org.apache.logging.log4j.LogManager.getLogger(LogManager.java:597)
	at Test.<clinit>(Test.java:12)
```
