### PR TITLE
Fix broken encoding when publisher has no content

### DIFF
--- a/servicetalk-encoding-api/src/main/java/io/servicetalk/encoding/api/AbstractZipContentCodec.java
+++ b/servicetalk-encoding-api/src/main/java/io/servicetalk/encoding/api/AbstractZipContentCodec.java
@@ -105,10 +105,10 @@ abstract class AbstractZipContentCodec extends AbstractContentCodec {
                 .concat(succeeded(END_OF_STREAM))
                 .liftSync(subscriber -> new PublisherSource.Subscriber<Buffer>() {
 
-                    final SwappableBufferOutputStream stream = new SwappableBufferOutputStream();
+                    private final SwappableBufferOutputStream stream = new SwappableBufferOutputStream();
 
                     @Nullable
-                    DeflaterOutputStream output;
+                    private DeflaterOutputStream output;
 
                     private boolean headerWritten;
 
@@ -570,12 +570,9 @@ abstract class AbstractZipContentCodec extends AbstractContentCodec {
         }
     }
 
-    static class SwappableBufferOutputStream extends OutputStream {
+    private static class SwappableBufferOutputStream extends OutputStream {
         @Nullable
         private Buffer buffer;
-
-        SwappableBufferOutputStream() {
-        }
 
         private void swap(final Buffer buffer) {
             this.buffer = requireNonNull(buffer);
@@ -600,7 +597,7 @@ abstract class AbstractZipContentCodec extends AbstractContentCodec {
         }
     }
 
-    static final class BufferBoundedInputStream extends InputStream {
+    private static final class BufferBoundedInputStream extends InputStream {
         private final Buffer buffer;
         private int count;
 

--- a/servicetalk-encoding-api/src/main/java/io/servicetalk/encoding/api/AbstractZipContentCodec.java
+++ b/servicetalk-encoding-api/src/main/java/io/servicetalk/encoding/api/AbstractZipContentCodec.java
@@ -138,11 +138,18 @@ abstract class AbstractZipContentCodec extends AbstractContentCodec {
                         // +1 for the encoding footer (ie. END_OF_STREAM)
                         try {
                             if (next == END_OF_STREAM) {
-                                // ZIP footer is 10 bytes
-                                Buffer dst = allocator.newBuffer(10);
-                                stream.swap(dst);
-                                output.finish();
+                                Buffer dst;
+                                if (!headerWritten) {
+                                    // Empty publisher will not produce any items other than the END_OF_STREAM
+                                    // so we need to keep the header & footer in the same chunk and deliver downstream.
+                                    dst = stream.buffer;
+                                } else {
+                                    // ZIP footer is 10 bytes
+                                    dst = allocator.newBuffer(10);
+                                    stream.swap(dst);
+                                }
 
+                                output.finish();
                                 subscriber.onNext(dst);
                                 return;
                             }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpServiceFilter.java
@@ -34,6 +34,8 @@ import static io.servicetalk.http.api.HeaderUtils.hasContentEncoding;
 import static io.servicetalk.http.api.HeaderUtils.identifyContentEncodingOrNullIfIdentity;
 import static io.servicetalk.http.api.HeaderUtils.setContentEncoding;
 import static io.servicetalk.http.api.HttpHeaderNames.ACCEPT_ENCODING;
+import static io.servicetalk.http.api.HttpRequestMethod.CONNECT;
+import static io.servicetalk.http.api.HttpRequestMethod.HEAD;
 import static java.util.Collections.emptyList;
 
 /**
@@ -106,7 +108,8 @@ public final class ContentCodingHttpServiceFilter
                         }
 
                         return super.handle(ctx, request, responseFactory).map(response -> {
-                            encodePayloadContentIfAvailable(request.headers(), responseCodings, response, allocator);
+                            encodePayloadContentIfAvailable(request.headers(), request.method(), request.version(),
+                                    responseCodings, response, allocator);
                             return response;
                         });
                     } catch (UnsupportedContentEncodingException cause) {
@@ -126,10 +129,16 @@ public final class ContentCodingHttpServiceFilter
     }
 
     private static void encodePayloadContentIfAvailable(final HttpHeaders requestHeaders,
+                                                        final HttpRequestMethod method,
+                                                        final HttpProtocolVersion version,
                                                         final List<ContentCodec> supportedEncodings,
                                                         final StreamingHttpResponse response,
                                                         final BufferAllocator allocator) {
         if (supportedEncodings.isEmpty() || hasContentEncoding(response.headers())) {
+            return;
+        }
+
+        if (isPassThrough(method, version, response)) {
             return;
         }
 
@@ -138,6 +147,30 @@ public final class ContentCodingHttpServiceFilter
             setContentEncoding(response.headers(), coding.name());
             response.transformPayloadBody(bufferPublisher -> coding.encode(bufferPublisher, allocator));
         }
+    }
+
+    private static boolean isPassThrough(final HttpRequestMethod method, final HttpProtocolVersion version,
+                                      final StreamingHttpResponse response) {
+        // see. https://tools.ietf.org/html/rfc7230#section-3.3.3
+        // The length of a message body is determined by one of the following
+        //         (in order of precedence):
+        //
+        // 1.  Any response to a HEAD request and any response with a 1xx
+        //         (Informational), 204 (No Content), or 304 (Not Modified) status
+        // code is always terminated by the first empty line after the
+        // header fields, regardless of the header fields present in the
+        // message, and thus cannot contain a message body.
+        //
+        // 2.  Any 2xx (Successful) response to a CONNECT request implies that
+        // the connection will become a tunnel immediately after the empty
+        // line that concludes the header fields.  A client MUST ignore any
+        // Content-Length or Transfer-Encoding header fields received in
+        // such a message.
+        // ...
+
+        int code = response.status().code();
+        return code < 200 || code == 204 || code == 304 ||
+                (method == HEAD || (method == CONNECT && code == 200));
     }
 
     @Nullable

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BaseContentCodingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BaseContentCodingTest.java
@@ -134,7 +134,7 @@ public abstract class BaseContentCodingTest {
 
         public String toString() {
             if (list.isEmpty()) {
-                return "identity";
+                return identity().name().toString();
             }
 
             StringBuilder b = new StringBuilder();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkContentCodingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkContentCodingTest.java
@@ -226,7 +226,7 @@ public class ServiceTalkContentCodingTest extends BaseContentCodingTest {
     protected void assertResponse(final StreamingHttpResponse response) throws Throwable {
         verifyNoErrors();
 
-        assertResponseHeaders(response.headers().get(CONTENT_ENCODING, "identity").toString());
+        assertResponseHeaders(response.headers().get(CONTENT_ENCODING, identity().name()).toString());
 
         String responsePayload = response.payloadBody(textDeserializer()).collect(StringBuilder::new,
                 StringBuilder::append).toFuture().get().toString();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkContentCodingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkContentCodingTest.java
@@ -198,7 +198,7 @@ public class ServiceTalkContentCodingTest extends BaseContentCodingTest {
         verifyNoErrors();
     }
 
-    private void verifyNoErrors() throws Throwable {
+    protected void verifyNoErrors() throws Throwable {
         if (!errors.isEmpty()) {
             throw errors.get(0);
         }
@@ -223,7 +223,7 @@ public class ServiceTalkContentCodingTest extends BaseContentCodingTest {
                 .payloadBody(from(payloadAsString((byte) 'a')), textSerializer())).toFuture().get());
     }
 
-    private void assertResponse(final StreamingHttpResponse response) throws Throwable {
+    protected void assertResponse(final StreamingHttpResponse response) throws Throwable {
         verifyNoErrors();
 
         assertResponseHeaders(response.headers().get(CONTENT_ENCODING, "identity").toString());
@@ -269,12 +269,11 @@ public class ServiceTalkContentCodingTest extends BaseContentCodingTest {
         }
     }
 
-    static ServerContext newServiceTalkServer(final Scenario scenario, final List<Throwable> errors)
+    private ServerContext newServiceTalkServer(final Scenario scenario, final List<Throwable> errors)
             throws Exception {
         HttpServerBuilder httpServerBuilder = HttpServers.forAddress(localAddress(0));
 
-        StreamingHttpService service = (ctx, request, responseFactory) -> succeeded(responseFactory.ok()
-                .payloadBody(from(payloadAsString((byte) 'b')), textSerializer()));
+        StreamingHttpService service = (ctx, request, responseFactory) -> succeeded(buildResponse(responseFactory));
 
         StreamingHttpServiceFilterFactory filterFactory = REQ_FILTER.apply(scenario, errors);
 
@@ -284,6 +283,10 @@ public class ServiceTalkContentCodingTest extends BaseContentCodingTest {
                         scenario.serverSupported))
                 .appendServiceFilter(filterFactory)
                 .listenStreamingAndAwait(service);
+    }
+
+    protected StreamingHttpResponse buildResponse(final StreamingHttpResponseFactory responseFactory) {
+        return responseFactory.ok().payloadBody(from(payloadAsString((byte) 'b')), textSerializer());
     }
 
     static BlockingHttpClient newServiceTalkClient(final HostAndPort hostAndPort, final Scenario scenario,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkEmptyContentCodingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkEmptyContentCodingTest.java
@@ -21,6 +21,7 @@ import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import static io.servicetalk.encoding.api.ContentCodings.identity;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_ENCODING;
 
 @RunWith(Parameterized.class)
@@ -35,7 +36,7 @@ public class ServiceTalkEmptyContentCodingTest extends ServiceTalkContentCodingT
     protected void assertResponse(final StreamingHttpResponse response) throws Throwable {
         verifyNoErrors();
 
-        assertResponseHeaders(response.headers().get(CONTENT_ENCODING, "identity").toString());
+        assertResponseHeaders(response.headers().get(CONTENT_ENCODING, identity().name()).toString());
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkEmptyContentCodingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkEmptyContentCodingTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_ENCODING;
+
+@RunWith(Parameterized.class)
+public class ServiceTalkEmptyContentCodingTest extends ServiceTalkContentCodingTest {
+
+    public ServiceTalkEmptyContentCodingTest(final HttpProtocol protocol, final Codings serverCodings,
+                                             final Codings clientCodings, final Compression compression,
+                                             final boolean valid) {
+        super(protocol, serverCodings, clientCodings, compression, valid);
+    }
+
+    protected void assertResponse(final StreamingHttpResponse response) throws Throwable {
+        verifyNoErrors();
+
+        assertResponseHeaders(response.headers().get(CONTENT_ENCODING, "identity").toString());
+    }
+
+    @Override
+    protected StreamingHttpResponse buildResponse(final StreamingHttpResponseFactory responseFactory) {
+        return responseFactory.ok();
+    }
+}


### PR DESCRIPTION
**Motivation**:

When a payload publisher on the response flow is not emitting any items, the encoder will not emit the header, thus a client will not be able to decode the response.

**Modifications**:

Make sure the header is emitted even for empty publishers.
Extra checks where added to skip encoding & headers when the request doesn't support body-messages.
 
**Result**:

Clients will be able to decode correctly encoded response payload, even when empty.
