### PR TITLE
HTTP/2 CloseHandler avoid writing after channel closed

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcExecutionStrategy.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcExecutionStrategy.java
@@ -108,4 +108,9 @@ final class DefaultGrpcExecutionStrategy implements GrpcExecutionStrategy {
     public Executor executor() {
         return delegate.executor();
     }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractH2DuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractH2DuplexHandler.java
@@ -70,8 +70,7 @@ abstract class AbstractH2DuplexHandler extends ChannelDuplexHandler {
     }
 
     final void writeTrailers(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-        // For H2 we don't need to notify protocolPayloadEndOutboundSuccess(ctx); the codecs takes care of half-closure
-        closeHandler.protocolPayloadEndOutbound(ctx);
+        closeHandler.protocolPayloadEndOutbound(ctx, promise);
         Http2Headers h2Headers = h1HeadersToH2Headers((HttpHeaders) msg);
         if (h2Headers.isEmpty()) {
             ctx.write(new DefaultHttp2DataFrame(EMPTY_BUFFER, true), promise);
@@ -96,6 +95,7 @@ abstract class AbstractH2DuplexHandler extends ChannelDuplexHandler {
             }
             if (dataFrame.isEndStream()) {
                 ctx.fireChannelRead(headersFactory.newEmptyTrailers());
+                closeHandler.protocolPayloadEndInbound(ctx);
             }
         } finally {
             if (toRelease != null) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -65,6 +65,7 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (msg instanceof HttpRequestMetaData) {
+            closeHandler.protocolPayloadBeginOutbound(ctx);
             HttpRequestMetaData metaData = (HttpRequestMetaData) msg;
             HttpHeaders h1Headers = metaData.headers();
             CharSequence host = h1Headers.getAndRemove(HOST);
@@ -102,6 +103,7 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
             Http2Headers h2Headers = headersFrame.headers();
             final HttpResponseStatus httpStatus;
             if (!readHeaders) {
+                closeHandler.protocolPayloadBeginInbound(ctx);
                 CharSequence status = h2Headers.getAndRemove(STATUS.value());
                 if (status == null) {
                     throw new IllegalArgumentException("a response must have " + STATUS + " header");
@@ -135,6 +137,7 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
                 } else {
                     ctx.fireChannelRead(h2HeadersToH1HeadersClient(h2Headers, null));
                 }
+                closeHandler.protocolPayloadEndInbound(ctx);
             } else if (httpStatus == null) {
                 throw new IllegalArgumentException("a response must have " + STATUS + " header");
             } else {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
@@ -60,6 +60,7 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (msg instanceof HttpResponseMetaData) {
+            closeHandler.protocolPayloadBeginOutbound(ctx);
             HttpResponseMetaData metaData = (HttpResponseMetaData) msg;
             Http2Headers h2Headers = h1HeadersToH2Headers(metaData.headers());
             h2Headers.status(metaData.status().codeAsCharSequence());
@@ -81,6 +82,7 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
             final HttpRequestMethod httpMethod;
             final String path;
             if (!readHeaders) {
+                closeHandler.protocolPayloadBeginInbound(ctx);
                 CharSequence method = h2Headers.getAndRemove(METHOD.value());
                 CharSequence pathSequence = h2Headers.getAndRemove(PATH.value());
                 if (pathSequence == null || method == null) {
@@ -101,6 +103,7 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
                 } else {
                     ctx.fireChannelRead(h2TrailersToH1TrailersServer(h2Headers));
                 }
+                closeHandler.protocolPayloadEndInbound(ctx);
             } else if (httpMethod == null) {
                 throw new IllegalArgumentException("a request must have " + METHOD + " and " +
                         PATH + " headers");

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectEncoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectEncoder.java
@@ -183,15 +183,7 @@ abstract class HttpObjectEncoder<T extends HttpMetaData> extends ChannelOutbound
                 }
             }
         } else if (msg instanceof HttpHeaders) {
-            closeHandler.protocolPayloadEndOutbound(ctx);
-            promise.addListener(f -> {
-                if (f.isSuccess()) {
-                    // Only writes of the last payload that have been successfully written and flushed should emit
-                    // events. A CloseHandler should not get into a completed state on a failed write so that it can
-                    // abort and close the Channel when appropriate.
-                    closeHandler.protocolPayloadEndOutboundSuccess(ctx);
-                }
-            });
+            closeHandler.protocolPayloadEndOutbound(ctx, promise);
             final int oldState = state;
             state = ST_INIT;
             if (oldState == ST_CONTENT_CHUNK) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectEncoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectEncoder.java
@@ -119,6 +119,10 @@ abstract class HttpObjectEncoder<T extends HttpMetaData> extends ChannelOutbound
                 throw new IllegalStateException("unexpected message type: " + simpleClassName(msg));
             }
             T metaData = castMetaData(msg);
+            closeHandler.protocolPayloadBeginOutbound(ctx);
+            if (shouldClose(metaData)) {
+                closeHandler.protocolClosingOutbound(ctx);
+            }
 
             // We prefer a direct allocation here because it is expected the resulted encoded Buffer will be written
             // to a socket. In order to do the write to the socket the memory typically needs to be allocated in direct
@@ -135,10 +139,6 @@ abstract class HttpObjectEncoder<T extends HttpMetaData> extends ChannelOutbound
 
             encodeHeaders(metaData.headers(), byteBuf, stBuf);
             writeShortBE(byteBuf, CRLF_SHORT);
-            closeHandler.protocolPayloadBeginOutbound(ctx);
-            if (shouldClose(metaData)) {
-                closeHandler.protocolClosingOutbound(ctx);
-            }
             headersEncodedSizeAccumulator = HEADERS_WEIGHT_NEW * padSizeForAccumulation(byteBuf.readableBytes()) +
                                             HEADERS_WEIGHT_HISTORICAL * headersEncodedSizeAccumulator;
             ctx.write(byteBuf, promise);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -99,8 +99,8 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -473,14 +473,10 @@ public class HttpRequestEncoderTest {
             fromSource(serverCloseTrigger).toFuture().get();
             Completable write = conn.write(from(request, allocator.fromAscii("Bye"), EmptyHttpHeaders.INSTANCE));
 
-            try {
-                write.toFuture().get();
-                fail("Should not complete normally");
-            } catch (ExecutionException e) {
-                CloseHandler closeHandler = closeHandlerRef.get();
-                assertNotNull(closeHandler);
-                verify(closeHandler, never()).protocolPayloadEndOutbound(any());
-            }
+            assertThrows(ExecutionException.class, () -> write.toFuture().get());
+            CloseHandler closeHandler = closeHandlerRef.get();
+            assertNotNull(closeHandler);
+            verify(closeHandler, never()).protocolPayloadEndOutbound(any(), any());
         }
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NonPipelinedCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NonPipelinedCloseHandler.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+
+import java.util.function.Consumer;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.CHANNEL_CLOSED_INBOUND;
+import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.CHANNEL_CLOSED_OUTBOUND;
+import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.GRACEFUL_USER_CLOSING;
+import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.PROTOCOL_CLOSING_INBOUND;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandler.State.has;
+import static java.util.Objects.requireNonNull;
+
+final class NonPipelinedCloseHandler extends CloseHandler {
+    private static final byte READ = 0x1;
+    private static final byte WRITE = 0x2;
+    private static final byte IN_CLOSED = 0x4;
+    private static final byte OUT_CLOSED = 0x8;
+    private static final byte CLOSED = 0x10;
+    private static final byte GRACEFUL_CLOSE = 0x20;
+    private static final byte IS_CLIENT = 0x40;
+    private static final byte ALL_CLOSED = IN_CLOSED | OUT_CLOSED | CLOSED;
+    private static final byte READ_WRITE = READ | WRITE;
+    private static final byte CLIENT_IN_WRITE = IS_CLIENT | WRITE | IN_CLOSED;
+    private static final byte GRACEFUL_IN_CLOSED = GRACEFUL_CLOSE | IN_CLOSED;
+    private static final byte GRACEFUL_OUT_CLOSED = GRACEFUL_CLOSE | OUT_CLOSED;
+    private byte state;
+    private Consumer<CloseEvent> eventHandler = __ -> { };
+    @Nullable
+    private CloseEvent closeEvent;
+
+    NonPipelinedCloseHandler(boolean isClient) {
+        if (isClient) {
+            state = IS_CLIENT;
+        }
+    }
+
+    @Override
+    public void protocolPayloadBeginInbound(final ChannelHandlerContext ctx) {
+        state = set(state, READ);
+    }
+
+    @Override
+    public void protocolPayloadEndInbound(final ChannelHandlerContext ctx) {
+        state = unset(state, READ);
+        inboundEventCheckClose(ctx.channel());
+    }
+
+    @Override
+    public void protocolPayloadBeginOutbound(final ChannelHandlerContext ctx) {
+        state = set(state, WRITE);
+    }
+
+    @Override
+    public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx, final ChannelPromise promise) {
+        ctx.pipeline().fireUserEventTriggered(OutboundDataEndEvent.INSTANCE);
+        promise.addListener(f -> {
+            state = unset(state, WRITE);
+            outboundEventCheckClose(ctx.channel());
+        });
+    }
+
+    @Override
+    public void protocolClosingInbound(final ChannelHandlerContext ctx) {
+        state = set(state, IN_CLOSED);
+        storeCloseRequestAndEmit(PROTOCOL_CLOSING_INBOUND);
+        inboundEventCheckClose(ctx.channel());
+    }
+
+    @Override
+    public void protocolClosingOutbound(final ChannelHandlerContext ctx) {
+        state = set(state, OUT_CLOSED);
+        storeCloseRequestAndEmit(PROTOCOL_CLOSING_INBOUND);
+        outboundEventCheckClose(ctx.channel());
+    }
+
+    @Override
+    void registerEventHandler(final Channel channel, final Consumer<CloseEvent> eventHandler) {
+        this.eventHandler = requireNonNull(eventHandler);
+    }
+
+    @Override
+    void channelClosedInbound(final ChannelHandlerContext ctx) {
+        state = unset(set(state, IN_CLOSED), READ);
+        storeCloseRequestAndEmit(CHANNEL_CLOSED_INBOUND);
+        inboundEventCheckClose(ctx.channel());
+    }
+
+    @Override
+    void channelClosedOutbound(final ChannelHandlerContext ctx) {
+        state = unset(set(state, OUT_CLOSED), WRITE);
+        storeCloseRequestAndEmit(CHANNEL_CLOSED_OUTBOUND);
+        outboundEventCheckClose(ctx.channel());
+    }
+
+    @Override
+    void closeChannelInbound(final Channel channel) {
+        state = set(state, IN_CLOSED);
+        // todo storeCloseRequestAndEmit ?
+        inboundEventCheckClose(channel);
+    }
+
+    @Override
+    void closeChannelOutbound(final Channel channel) {
+        state = set(state, OUT_CLOSED);
+        // todo storeCloseRequestAndEmit ?
+        outboundEventCheckClose(channel);
+    }
+
+    @Override
+    void gracefulUserClosing(final Channel channel) {
+        state = set(state, GRACEFUL_CLOSE);
+        storeCloseRequestAndEmit(GRACEFUL_USER_CLOSING);
+        if (!isAllSet(state, READ_WRITE)) {
+            closeChannel(channel);
+        }
+    }
+
+    private void inboundEventCheckClose(final Channel channel) {
+        if (isAllSet(state, OUT_CLOSED) || (isAnySet(state, GRACEFUL_IN_CLOSED) && !isAllSet(state, WRITE))) {
+            closeChannel(channel);
+        } else if (isAllSet(state, CLIENT_IN_WRITE)) {
+            // If a client inbound has closed while writing we abort the write because we can't be sure if the write
+            // will ever complete or receive any additional feedback form the server.
+            state = unset(state, WRITE);
+            channel.pipeline().fireUserEventTriggered(AbortWritesEvent.INSTANCE);
+        }
+    }
+
+    private void outboundEventCheckClose(final Channel channel) {
+        if (isAllSet(state, IN_CLOSED) || (isAnySet(state, GRACEFUL_OUT_CLOSED) && !isAllSet(state, READ))) {
+            closeChannel(channel);
+        }
+    }
+
+    private void storeCloseRequestAndEmit(final CloseEvent event) {
+        if (this.closeEvent == null) {
+            this.closeEvent = event;
+        }
+        eventHandler.accept(event);
+    }
+
+    private void closeChannel(final Channel channel) {
+        if (!has(state, CLOSED)) {
+            state = set(state, ALL_CLOSED);
+            channel.close();
+        }
+    }
+
+    private static byte set(byte state, byte flags) {
+        return (byte) (state | flags);
+    }
+
+    private static byte unset(byte state, byte flags) {
+        return (byte) (state & ~flags);
+    }
+
+    private static boolean isAllSet(byte state, byte flags) {
+        return (state & flags) == flags;
+    }
+
+    private static boolean isAnySet(byte state, byte flags) {
+        return (state & flags) != 0;
+    }
+}

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NonPipelinedCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NonPipelinedCloseHandler.java
@@ -26,6 +26,7 @@ import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.CH
 import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.CHANNEL_CLOSED_OUTBOUND;
 import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.GRACEFUL_USER_CLOSING;
 import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.PROTOCOL_CLOSING_INBOUND;
+import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.PROTOCOL_CLOSING_OUTBOUND;
 import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandler.State.has;
 import static java.util.Objects.requireNonNull;
 
@@ -88,7 +89,7 @@ final class NonPipelinedCloseHandler extends CloseHandler {
     @Override
     public void protocolClosingOutbound(final ChannelHandlerContext ctx) {
         state = set(state, OUT_CLOSED);
-        storeCloseRequestAndEmit(PROTOCOL_CLOSING_INBOUND);
+        storeCloseRequestAndEmit(PROTOCOL_CLOSING_OUTBOUND);
         outboundEventCheckClose(ctx.channel());
     }
 
@@ -129,7 +130,7 @@ final class NonPipelinedCloseHandler extends CloseHandler {
     void gracefulUserClosing(final Channel channel) {
         state = set(state, GRACEFUL_CLOSE);
         storeCloseRequestAndEmit(GRACEFUL_USER_CLOSING);
-        if (!isAllSet(state, READ_WRITE)) {
+        if (!isAnySet(state, READ_WRITE)) {
             closeChannel(channel);
         }
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
@@ -185,12 +185,10 @@ class RequestResponseCloseHandler extends CloseHandler {
             ctx.pipeline().fireUserEventTriggered(OutboundDataEndEvent.INSTANCE);
         }
         promise.addListener(f -> {
-            if (f.isSuccess()) {
-                state = unset(state, WRITE);
-                final CloseEvent evt = this.closeEvent;
-                if (evt != null) {
-                    closeChannelHalfOrFullyOnPayloadEnd(ctx.channel(), evt, false);
-                }
+            state = unset(state, WRITE);
+            final CloseEvent evt = this.closeEvent;
+            if (evt != null) {
+                closeChannelHalfOrFullyOnPayloadEnd(ctx.channel(), evt, false);
             }
         });
     }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
@@ -78,12 +78,7 @@ abstract class AbstractSslCloseNotifyAlertHandlingTest {
                             closeHandler.protocolPayloadBeginOutbound(ctx);
                         }
                         if (END.equals(msg)) {
-                            closeHandler.protocolPayloadEndOutbound(ctx);
-                            promise.addListener(f -> {
-                                if (f.isSuccess()) {
-                                    closeHandler.protocolPayloadEndOutboundSuccess(ctx);
-                                }
-                            });
+                            closeHandler.protocolPayloadEndOutbound(ctx, promise);
                         }
                         ctx.write(msg, promise);
                     }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NonPipelinedCloseHandlerTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NonPipelinedCloseHandlerTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.EventLoop;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.util.concurrent.EventExecutor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.CHANNEL_CLOSED_INBOUND;
+import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.CHANNEL_CLOSED_OUTBOUND;
+import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.GRACEFUL_USER_CLOSING;
+import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.PROTOCOL_CLOSING_INBOUND;
+import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.PROTOCOL_CLOSING_OUTBOUND;
+import static io.servicetalk.transport.netty.internal.NonPipelinedCloseHandlerTest.Events.CI;
+import static io.servicetalk.transport.netty.internal.NonPipelinedCloseHandlerTest.Events.CO;
+import static io.servicetalk.transport.netty.internal.NonPipelinedCloseHandlerTest.Events.FC;
+import static io.servicetalk.transport.netty.internal.NonPipelinedCloseHandlerTest.Events.IB;
+import static io.servicetalk.transport.netty.internal.NonPipelinedCloseHandlerTest.Events.IC;
+import static io.servicetalk.transport.netty.internal.NonPipelinedCloseHandlerTest.Events.IE;
+import static io.servicetalk.transport.netty.internal.NonPipelinedCloseHandlerTest.Events.IS;
+import static io.servicetalk.transport.netty.internal.NonPipelinedCloseHandlerTest.Events.OB;
+import static io.servicetalk.transport.netty.internal.NonPipelinedCloseHandlerTest.Events.OC;
+import static io.servicetalk.transport.netty.internal.NonPipelinedCloseHandlerTest.Events.OE;
+import static io.servicetalk.transport.netty.internal.NonPipelinedCloseHandlerTest.Events.OS;
+import static io.servicetalk.transport.netty.internal.NonPipelinedCloseHandlerTest.Events.UC;
+import static io.servicetalk.transport.netty.internal.NonPipelinedCloseHandlerTest.ExpectEvent.CCI;
+import static io.servicetalk.transport.netty.internal.NonPipelinedCloseHandlerTest.ExpectEvent.CCO;
+import static io.servicetalk.transport.netty.internal.NonPipelinedCloseHandlerTest.ExpectEvent.GUC;
+import static io.servicetalk.transport.netty.internal.NonPipelinedCloseHandlerTest.ExpectEvent.NIL;
+import static io.servicetalk.transport.netty.internal.NonPipelinedCloseHandlerTest.ExpectEvent.PCI;
+import static io.servicetalk.transport.netty.internal.NonPipelinedCloseHandlerTest.ExpectEvent.PCO;
+import static java.util.Arrays.asList;
+import static java.util.Objects.hash;
+import static java.util.stream.Collectors.toSet;
+import static junit.framework.TestCase.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+public class NonPipelinedCloseHandlerTest {
+    private final ChannelHandlerContext ctx;
+    private final Channel channel;
+    private final CloseHandler h;
+    private final AtomicBoolean closed = new AtomicBoolean();
+    private final List<Events> events;
+    private final ExpectEvent expectEvent;
+    @Nullable
+    private CloseEvent observedEvent;
+
+    protected enum Events {
+        IB, IE, IC, // emit Input Begin/End/Closing
+        OB, OE, OC, // emit Output Begin/End/Closing
+        IS, OS,     // emit Input/Output Socket closed
+        UC,         // emit User Closing
+        FC,         // Full-Close
+        CI, CO,     // emit Inbound/Outbound close (read cancellation, write subscriber termination)
+    }
+
+    protected enum ExpectEvent {
+        NIL(null), // No event, not closed
+        PCO(PROTOCOL_CLOSING_OUTBOUND),
+        PCI(PROTOCOL_CLOSING_INBOUND),
+        GUC(GRACEFUL_USER_CLOSING),
+        CCO(CHANNEL_CLOSED_OUTBOUND),
+        CCI(CHANNEL_CLOSED_INBOUND);
+
+        @Nullable
+        private final CloseEvent ce;
+
+        ExpectEvent(@Nullable CloseEvent c) {
+            this.ce = c;
+        }
+    }
+
+    public NonPipelinedCloseHandlerTest(boolean client, final List<Events> events, final ExpectEvent expectEvent,
+                                        final String desc, final String location) {
+        h = new NonPipelinedCloseHandler(client);
+        this.events = events;
+        this.expectEvent = expectEvent;
+        ctx = mock(ChannelHandlerContext.class);
+        channel = mock(SocketChannel.class, "[id: 0xmocked, L:mocked - R:mocked]");
+        when(ctx.channel()).thenReturn(channel);
+        when(ctx.newPromise()).thenReturn(new DefaultChannelPromise(channel));
+        when(channel.newPromise()).thenReturn(new DefaultChannelPromise(channel));
+
+        EventExecutor exec = mock(EventExecutor.class);
+        when(ctx.executor()).thenReturn(exec);
+        when(exec.inEventLoop()).thenReturn(true);
+        EventLoop loop = mock(EventLoop.class);
+        when(channel.eventLoop()).thenReturn(loop);
+        when(loop.inEventLoop()).thenReturn(true);
+        ChannelPipeline pipeline = mock(ChannelPipeline.class);
+        when(ctx.pipeline()).thenReturn(pipeline);
+        when(channel.pipeline()).thenReturn(pipeline);
+        ChannelFuture future = mock(ChannelFuture.class);
+        when(channel.close()).then(__ -> {
+            closed.set(true);
+            return future;
+        });
+        h.registerEventHandler(channel, e -> {
+            if (observedEvent == null) {
+                observedEvent = e;
+            }
+        });
+    }
+
+    @Parameterized.Parameters(name = "{index}. {3} - {0} {1} = {2}")
+    public static Collection<Object[]> data() {
+        StackTraceElement se = Thread.currentThread().getStackTrace()[1];
+        List<Object[]> params = asList(new Object[][] {
+                {true, e(OB, OE, IB, IE), NIL, "sequential, no close"},
+                {true, e(OB, IB, OE, IE), NIL, "interleaved, no close"},
+                {true, e(OB, CI, OE, FC), NIL, "inbound close while writing"},
+                {true, e(OB, UC, OE, FC), GUC, "user close while writing"},
+                {true, e(OB, IC, OE, FC), PCI, "protocol inbound close while writing"},
+                {true, e(OB, IS, OE, FC), CCI, "channel inbound close while writing"},
+                {true, e(OB, IS, OS, FC), CCI, "channel inbound & outbound close while writing"},
+                {true, e(OB, CO, FC), NIL, "outbound close while writing"},
+                {true, e(OB, OC, FC), PCO, "protocol outbound close while writing"},
+                {true, e(OB, OS, FC), CCO, "channel outbound close while writing"},
+                {true, e(OB, IB, CI, OE, FC), NIL, "inbound close while writing & reading"},
+                {true, e(OB, IB, UC, OE, IE, FC), GUC, "user close while writing & reading"},
+                {true, e(OB, IB, IC, OE, FC), PCI, "protocol inbound close while writing & reading"},
+                {true, e(OB, IB, IS, OE, FC), CCI, "channel inbound close while writing & reading"},
+                {true, e(OB, IB, IS, OS, FC), CCI, "channel inbound & outbound close while writing & reading"},
+                {true, e(OB, IB, IC, OC, FC), PCI, "protocol inbound & outbound close while writing & reading"},
+                {true, e(OB, IB, CO, IE, FC), NIL, "outbound close while writing & reading"},
+                {true, e(OB, IB, OC, IE, FC), PCO, "protocol outbound close while writing & reading"},
+                {true, e(OB, IB, OS, IE, FC), CCO, "channel outbound close while writing & reading"},
+                {true, e(OB, IB, OS, IS, FC), CCO, "channel outbound & inbound close while writing & reading"},
+                {true, e(OB, IB, OC, IC, FC), PCO, "protocol outbound & inbound close while writing & reading"},
+                {true, e(OB, OE, IB, IE, CO, FC), NIL, "outbound close while idle"},
+                {true, e(OB, OE, IB, IE, OS, FC), CCO, "channel outbound close while idle"},
+                {true, e(OB, OE, IB, IE, CI, FC), NIL, "inbound close while idle"},
+                {true, e(OB, OE, IB, IE, IS, FC), CCI, "channel inbound close while idle"},
+                {true, e(OB, OE, IB, IE, UC, FC), GUC, "user close while idle"},
+                {true, e(OB, OE, IB, IE, IC), PCI, "protocol inbound close while idle"},
+                {true, e(OB, OE, IB, IE, OC), PCO, "protocol outbound close while idle"},
+                {false, e(IB, IE, OB, OE), NIL, "sequential, no close"},
+                {false, e(IB, OB, IE, OE), NIL, "interleaved, no close"},
+                {false, e(IB, CO, IE, FC), NIL, "outbound close while reading"},
+                {false, e(IB, UC, IE, FC), GUC, "user close while reading"},
+                {false, e(IB, OC, IE, FC), PCO, "protocol outbound close while reading"},
+                {false, e(IB, OS, IE, FC), CCO, "channel outbound close while reading"},
+                {false, e(IB, OS, IS, FC), CCO, "channel outbound & inbound close while reading"},
+                {false, e(IB, CI, FC), NIL, "inbound close while reading"},
+                {false, e(IB, IC, FC), PCI, "protocol inbound close while reading"},
+                {false, e(IB, IS, FC), CCI, "channel inbound close while reading"},
+                {false, e(IB, OB, CO, IE, FC), NIL, "outbound close while reading & writing"},
+                {false, e(IB, OB, UC, IE, OE, FC), GUC, "user close while reading & writing"},
+                {false, e(IB, OB, OC, IE, FC), PCO, "protocol outbound close while reading & writing"},
+                {false, e(IB, OB, OS, IE, FC), CCO, "channel outbound close while reading & writing"},
+                {false, e(IB, OB, OS, IS, FC), CCO, "channel outbound & inbound close while reading & writing"},
+                {false, e(IB, OB, OC, IC, FC), PCO, "protocol outbound & inbound close while reading & writing"},
+                {false, e(IB, OB, CI, OE, FC), NIL, "inbound close while reading & writing"},
+                {false, e(IB, OB, IC, OE, FC), PCI, "protocol inbound close while reading & writing"},
+                {false, e(IB, OB, IS, OE, FC), CCI, "channel inbound close while reading & writing"},
+                {false, e(IB, OB, IS, OS, FC), CCI, "channel inbound & outbound close while reading & writing"},
+                {false, e(IB, OB, IC, OC, FC), PCI, "protocol inbound & outbound close while reading & writing"},
+                {false, e(IB, IE, OB, OE, CO, FC), NIL, "outbound close while idle"},
+                {false, e(IB, IE, OB, OE, OS, FC), CCO, "channel outbound close while idle"},
+                {false, e(IB, IE, OB, OE, CI, FC), NIL, "inbound close while idle"},
+                {false, e(IB, IE, OB, OE, IS, FC), CCI, "channel inbound close while idle"},
+                {false, e(IB, IE, OB, OE, UC), GUC, "user close while idle"},
+                {false, e(IB, IE, OB, OE, IC), PCI, "protocol inbound close while idle"},
+                {false, e(IB, IE, OB, OE, OC), PCO, "protocol outbound close while idle"},
+        });
+        String fileName = se.getFileName();
+        int offset = se.getLineNumber() + 3; // Lines between `se` and first parameter
+        for (int i = 0; i < params.size(); i++) { // Appends param location as last entry
+            Object[] o = params.get(i);
+            params.set(i, new Object[]{o[0], o[1], o[2], o[3], fileName + ":" + (offset + i)});
+        }
+        Set<Integer> uniques = params.stream().map(objs -> hash(objs[0], objs[1], objs[2])).collect(toSet());
+        assertEquals("Duplicate test scenario?", uniques.size(), params.size());
+        return params;
+    }
+
+    @Test
+    public void simulate() {
+        for (Events event : events) {
+            switch (event) {
+                case IB:
+                    assertNotClosed();
+                    h.protocolPayloadBeginInbound(ctx);
+                    break;
+                case IE:
+                    assertNotClosed();
+                    h.protocolPayloadEndInbound(ctx);
+                    break;
+                case IC:
+                    h.protocolClosingInbound(ctx);
+                    break;
+                case OB:
+                    assertNotClosed();
+                    h.protocolPayloadBeginOutbound(ctx);
+                    break;
+                case OE:
+                    assertNotClosed();
+                    ChannelPromise promise = ctx.newPromise();
+                    promise.trySuccess();
+                    h.protocolPayloadEndOutbound(ctx, promise);
+                    break;
+                case OC:
+                    h.protocolClosingOutbound(ctx);
+                    break;
+                case IS:
+                    h.channelClosedInbound(ctx);
+                    break;
+                case OS:
+                    h.channelClosedOutbound(ctx);
+                    break;
+                case UC:
+                    h.gracefulUserClosing(channel);
+                    break;
+                case FC:
+                    verify(channel).close();
+                    break;
+                case CI:
+                    h.closeChannelInbound(channel);
+                    break;
+                case CO:
+                    h.closeChannelOutbound(channel);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown: " + event);
+            }
+        }
+        assertThat("Expected CloseEvent", observedEvent, equalTo(expectEvent.ce));
+    }
+
+    private void assertNotClosed() {
+        assertFalse("Channel Closed - testcase invalid or bug?", closed.get());
+    }
+
+    private static List<Events> e(Events... args) {
+        return asList(args);
+    }
+}

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandlerTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandlerTest.java
@@ -368,8 +368,7 @@ public class RequestResponseCloseHandlerTest {
                 }
                 return scc;
             });
-            h = (RequestResponseCloseHandler) spy(mode == C ? forPipelinedRequestResponse(true, channel.config()) :
-                    forPipelinedRequestResponse(false, channel.config()));
+            h = (RequestResponseCloseHandler) spy(forPipelinedRequestResponse(mode == C, channel.config()));
             h.registerEventHandler(channel, e -> {
                 if (observedEvent == null) {
                     LOGGER.debug("Emitted: {}", e);


### PR DESCRIPTION
Motivation:
HTTP/2 child channels currently use a static CloseHandler instance which
will immediately close the connection upon detecting inbound channel
closing. This event may occur as a result of an exception being thrown
in error code, which may then write data (e.g. error code in response
trailers). Using the static CloseHandler may result in writing a stream
reset frame followed by subsequent data/headers frames which violates
the HTTP/2 protocol.

Modifications:
- Introduce a CloseHandler implementation that can be used in scenarios
  that don't require half-closure or DuplexChannel types. This
  CloseHandler can be used for HTTP/2 to delay any pending close
  operations until after any pending writes complete.

Result:
No more HTTP/2 protocol violations due to writing RST_STREAM frame
before data/headers frames due to error recovery.