### PR TITLE
Remove `content-length` when `transfer-encoding: chunked` is present

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -671,12 +671,19 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
             return null;
         }
 
+        final long contentLength = contentLength();
         if (isContentAlwaysEmpty(message)) {
             removeTransferEncodingChunked(message.headers());
             return State.SKIP_CONTROL_CHARS;
         } else if (isTransferEncodingChunked(message.headers())) {
+            if (contentLength >= 0L && HTTP_1_1.equals(message.version())) {
+                // Remove the received content-length header(s), keep only "transfer-encoding: chunked"
+                // See https://tools.ietf.org/html/rfc7230#section-3.3.3, item 3.
+                message.headers().remove(CONTENT_LENGTH);
+                this.contentLength = Long.MIN_VALUE;
+            }
             return State.READ_CHUNK_SIZE;
-        } else if (contentLength() >= 0) {
+        } else if (contentLength >= 0L) {
             return State.READ_FIXED_LENGTH_CONTENT;
         } else {
             return State.READ_VARIABLE_LENGTH_CONTENT;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseEncoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseEncoder.java
@@ -109,11 +109,12 @@ final class HttpResponseEncoder extends HttpObjectEncoder<HttpResponseMetaData> 
         // - this is the rough equivalent of what is done in Netty in terms of sequencing. Instead of trying to
         // iterate a decoded list it makes some assumptions about the base class ordering of events.
         HttpRequestMethod method = methodQueue.poll();
+
+        HttpHeaders headers = msg.headers();
         if (isAlwaysEmpty) {
             final HttpResponseStatus status = msg.status();
             if (status.statusClass() == INFORMATIONAL_1XX || status.code() == NO_CONTENT.code()) {
 
-                HttpHeaders headers = msg.headers();
                 // Stripping Content-Length:
                 // See https://tools.ietf.org/html/rfc7230#section-3.3.2
                 headers.remove(CONTENT_LENGTH);
@@ -122,11 +123,15 @@ final class HttpResponseEncoder extends HttpObjectEncoder<HttpResponseMetaData> 
                 // See https://tools.ietf.org/html/rfc7230#section-3.3.1
                 headers.remove(TRANSFER_ENCODING);
             }
-        } else if (method != null && CONNECT.name().equals(method.name())
-                && msg.status().statusClass() == SUCCESSFUL_2XX) {
+        } else if (CONNECT.equals(method) && msg.status().statusClass() == SUCCESSFUL_2XX) {
+
+            // Stripping Content-Length:
+            // See https://tools.ietf.org/html/rfc7230#section-3.3.2
+            headers.remove(CONTENT_LENGTH);
+
             // Stripping Transfer-Encoding:
             // See https://tools.ietf.org/html/rfc7230#section-3.3.1
-            msg.headers().remove(TRANSFER_ENCODING);
+            headers.remove(TRANSFER_ENCODING);
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -411,6 +411,22 @@ abstract class HttpObjectDecoderTest {
     }
 
     @Test
+    public void chunkedWithContentLength() {
+        int chunkSize = 128;
+        int chunkedContentLength = 2 + 2 + chunkSize + 2 + 5;
+        writeMsg(startLineForContent() + "\r\n" +
+                "Host: servicetalk.io" + "\r\n" +
+                "Connection: keep-alive" + "\r\n" +
+                "Content-Length: " + chunkedContentLength + "\r\n" +
+                "Transfer-Encoding: chunked" + "\r\n" + "\r\n");
+        writeChunk(chunkSize);
+        writeLastChunk();
+        HttpMetaData metaData = validateWithContent(-chunkSize, false);
+        assertThat("Unexpected content-length header(s)",
+                metaData.headers().valuesIterator(CONTENT_LENGTH).hasNext(), is(false));
+    }
+
+    @Test
     public void chunkedNoTrailersMultipleLargeContent() {
         int chunkSize = 4096;
         int numChunks = 5;


### PR DESCRIPTION
Motivation:

If a message is received with both a Transfer-Encoding and a
Content-Length header field, the Transfer-Encoding overrides the
Content-Length.  Such a message might indicate an attempt to
perform request smuggling (Section 9.5) or response splitting
(Section 9.4) and ought to be handled as an error.  A sender MUST
remove the received Content-Length field prior to forwarding such
a message downstream.

See https://tools.ietf.org/html/rfc7230#section-3.3.3

Modifications:

- Remove `content-length` header when `transfer-encoding: chunked`
is present in incoming (`HttpObjectDecoder`) and outgoing
(`HttpObjectEncoder`) messages;
- Add tests to verify the behavior;

Result:

HTTP/1.1 codec follow RFC7230 3.3.3 item 3: removes Content-Length
header when "Transfer-Encoding: chunked" is present.