### PR TITLE
Debug-log when `RoundRobinLoadBalancer` closes connections to inactive addresses

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -346,7 +346,7 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
         void markInactive() {
             @SuppressWarnings("unchecked")
             final List<C> toRemove = connectionsUpdater.getAndSet(this, CLOSED_LIST);
-            LOGGER.debug("Closing {} connections gracefully to inactive address {}", toRemove.size(), address);
+            LOGGER.debug("Closing {} connection(s) gracefully to inactive address: {}", toRemove.size(), address);
             for (C conn : toRemove) {
                 conn.closeAsyncGracefully().subscribe();
             }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -346,6 +346,7 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
         void markInactive() {
             @SuppressWarnings("unchecked")
             final List<C> toRemove = connectionsUpdater.getAndSet(this, CLOSED_LIST);
+            LOGGER.debug("Closing {} connections gracefully to inactive address {}", toRemove.size(), address);
             for (C conn : toRemove) {
                 conn.closeAsyncGracefully().subscribe();
             }


### PR DESCRIPTION
Motivation:

When RRLB receives an inactive event from `ServiceDiscoverer`, it initiates
graceful closure of all connections to the host that became inactive. Give
some visibility to this logic.

Modifications:

- Add `DEBUG` log statement when RRLB closes connections to inactive host;

Result:

Users can debug when RRLB initiates connection closure.