### PR TITLE
HttpRequestMetaData query string empty value parsing fix

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpQuery.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpQuery.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.http.api;
 
+import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -280,18 +281,9 @@ final class HttpQuery implements Iterable<Map.Entry<String, String>> {
             }
             final String value = listIterator.next();
             assert key != null;
-            return new Entry<String, String>() {
-
-                @Override
-                public String getKey() {
-                    return key;
-                }
-
-                @Override
-                public String getValue() {
-                    return value;
-                }
-
+            // Make new references for key/value as otherwise if references are not processed sequentially/individually
+            // (e.g. added to a collection) references in earlier entries will be overwritten to point to later entries.
+            return new SimpleEntry<String, String>(key, value) {
                 @Override
                 public String setValue(final String value) {
                     throw new UnsupportedOperationException();

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/UriUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/UriUtils.java
@@ -248,11 +248,15 @@ final class UriUtils {
     private static void addQueryParam(final String s, final int nameStart, int valueStart, final int valueEnd,
                                       final Charset charset, final Map<String, List<String>> params,
                                       final BiFunction<String, Charset, String> decoder) {
+        final String value;
+        final String name;
         if (valueStart <= nameStart) {
-            valueStart = valueEnd + 1;
+            name = decoder.apply(s.substring(nameStart, valueEnd), charset);
+            value = "";
+        } else {
+            name = decoder.apply(s.substring(nameStart, valueStart - 1), charset);
+            value = decoder.apply(s.substring(valueStart, valueEnd), charset);
         }
-        final String name = decoder.apply(s.substring(nameStart, valueStart - 1), charset);
-        final String value = decoder.apply(s.substring(valueStart, valueEnd), charset);
         final List<String> values = params.computeIfAbsent(name, k -> new ArrayList<>(1)); // Often there's only 1 value
         values.add(value);
     }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
@@ -679,8 +679,7 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
 
         List<Entry<String, String>> entries = iteratorAsList(fixture.queryParameters().iterator());
         assertThat(entries, hasSize(1));
-        assertEquals("bar", entries.get(0).getKey());
-        assertEquals("", entries.get(0).getValue());
+        assertEntry(entries.get(0), "bar", "");
     }
 
     @Test
@@ -691,7 +690,7 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
     }
 
     private void testTwoEmptyQueryParams(String v1, String v2) {
-        String rawQuery = "bar" + (v1.isEmpty() ? "" : "=" + v1) + "&baz" + (v2.isEmpty() ? "" : "=" + v2);
+        String rawQuery = "bar" + queryValue(v1) + "&baz" + queryValue(v2);
         String requestTarget = "/foo?" + rawQuery;
         createFixture(requestTarget);
         assertEquals(requestTarget, fixture.requestTarget());
@@ -708,10 +707,8 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
 
         List<Entry<String, String>> entries = iteratorAsList(fixture.queryParameters().iterator());
         assertThat(entries, hasSize(2));
-        assertEquals("bar", entries.get(0).getKey());
-        assertEquals(v1, entries.get(0).getValue());
-        assertEquals("baz", entries.get(1).getKey());
-        assertEquals(v2, entries.get(1).getValue());
+        assertEntry(entries.get(0), "bar", v1);
+        assertEntry(entries.get(1), "baz", v2);
     }
 
     @Test
@@ -727,8 +724,7 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
     }
 
     private void testThreeEmptyQueryParams(String v1, String v2, String v3) {
-        String rawQuery = "bar" + (v1.isEmpty() ? "" : "=" + v1) + "&baz" + (v2.isEmpty() ? "" : "=" + v2) +
-                "&zap" + (v3.isEmpty() ? "" : "=" + v3);
+        String rawQuery = "bar" + queryValue(v1) + "&baz" + queryValue(v2) + "&zap" + queryValue(v3);
         String requestTarget = "/foo?" + rawQuery;
         createFixture(requestTarget);
         assertEquals(requestTarget, fixture.requestTarget());
@@ -747,12 +743,9 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
 
         List<Entry<String, String>> entries = iteratorAsList(fixture.queryParameters().iterator());
         assertThat(entries, hasSize(3));
-        assertEquals("bar", entries.get(0).getKey());
-        assertEquals(v1, entries.get(0).getValue());
-        assertEquals("baz", entries.get(1).getKey());
-        assertEquals(v2, entries.get(1).getValue());
-        assertEquals("zap", entries.get(2).getKey());
-        assertEquals(v3, entries.get(2).getValue());
+        assertEntry(entries.get(0), "bar", v1);
+        assertEntry(entries.get(1), "baz", v2);
+        assertEntry(entries.get(2), "zap", v3);
     }
 
     @Test
@@ -882,8 +875,15 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
 
     private static void assertNext(Iterator<Entry<String, String>> itr, String key, String value) {
         assertTrue(itr.hasNext());
-        Entry<String, String> next = itr.next();
+        assertEntry(itr.next(), key, value);
+    }
+
+    private static void assertEntry(Entry<String, String> next, String key, String value) {
         assertEquals(key, next.getKey());
         assertEquals(value, next.getValue());
+    }
+
+    private static String queryValue(String v) {
+        return v.isEmpty() ? "" : "=" + v;
     }
 }


### PR DESCRIPTION
Motivation:
HttpRequestMetaData#queryParameter(String) could incounter index out of
bounds conditions if an empty value was the last entry in the query
string.

Modifications:
- Fix indexing for name/value start/end indexes and add tests for empty
  values.

Result:
No more index out of bounds for
HttpRequestMetaData#queryParameter(String).