### PR TITLE
Github actions remove out of date version comment

### DIFF
--- a/.github/workflows/ci-prb-reports.yml
+++ b/.github/workflows/ci-prb-reports.yml
@@ -22,7 +22,6 @@ jobs:
           # File location set in ci-prb.yml and must be coordinated.
           name: test-results-${{ matrix.os }}-${{ matrix.java }}
       - name: Publish Test Report
-        # v1.0.5
         uses: scacap/action-surefire-report@7a84557836c48d2f522b02d8a84395234f982697
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -37,7 +37,6 @@ jobs:
         run: ./gradlew --parallel --max-workers=4 -PreleaseBuild=true clean check && ./gradlew -PreleaseBuild=true publish
       - name: Publish Test Results
         if: always()
-        # v1.0.5
         uses: scacap/action-surefire-report@7a84557836c48d2f522b02d8a84395234f982697
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -38,7 +38,6 @@ jobs:
         run: ./gradlew --parallel --max-workers=4 clean check && ./gradlew publish
       - name: Publish Test Results
         if: always()
-        # v1.0.5
         uses: scacap/action-surefire-report@7a84557836c48d2f522b02d8a84395234f982697
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Motivation:
The bot updated the action-surefire-report plugin in
c4de9b721a793b9fee4c9f239736e36299098815 and there is an out of date
comment indicating the version.