### PR TITLE
Allow HEAD requests with content-length header over HTTP/2

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractH2DuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractH2DuplexHandler.java
@@ -168,7 +168,7 @@ abstract class AbstractH2DuplexHandler extends ChannelDuplexHandler {
         }
     }
 
-    private void handleUnexpectedContentLength() {
+    final void handleUnexpectedContentLength() {
         final String msg = "Expected content-length " + contentLength + " not equal to the actual length " +
                 seenContentLength +
                 ". Malformed request/response according to https://tools.ietf.org/html/rfc7540#section-8.1.2.6.";

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -43,6 +43,7 @@ import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.api.HttpRequestMethod.CONNECT;
+import static io.servicetalk.http.api.HttpRequestMethod.HEAD;
 import static io.servicetalk.http.api.HttpResponseMetaDataFactory.newResponseMetaData;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATIONAL_1XX;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h1HeadersToH2Headers;
@@ -135,7 +136,14 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
                 if (httpStatus != null) {
                     fireFullResponse(ctx, h2Headers, httpStatus);
                 } else {
-                    validateContentLengthMatch();
+                    if (!HEAD.equals(method)) {
+                        // https://tools.ietf.org/html/rfc7230#section-3.3
+                        // Responses to the HEAD request method (Section 4.3.2 of [RFC7231]) never include a message
+                        // body because the associated response header fields (e.g., Transfer-Encoding, Content-Length,
+                        // etc.), if present, indicate only what their values would have been if the request method had
+                        // been GET (Section 4.3.1 of [RFC7231]).
+                        validateContentLengthMatch();
+                    }
                     ctx.fireChannelRead(h2HeadersToH1HeadersClient(h2Headers, null, false));
                 }
                 closeHandler.protocolPayloadEndInbound(ctx);
@@ -180,6 +188,8 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
                 throw new IllegalArgumentException("content-length (" + contentLength +
                         ") header is not expected for status code " + statusCode + " in response to " + method.name() +
                         " request");
+            } else if (fullResponse && !HEAD.equals(method)) {
+                handleUnexpectedContentLength();
             }
         }
         return new NettyH2HeadersToHttpHeaders(h2Headers, headersFactory.validateCookies());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
@@ -143,6 +143,8 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
                     } else {
                         h2Headers.add(TRANSFER_ENCODING, CHUNKED);
                     }
+                } else if (fullRequest) {
+                    handleUnexpectedContentLength();
                 }
             } else if (contentLength >= 0) {
                 throw new IllegalArgumentException("content-length (" + contentLength +


### PR DESCRIPTION
Motivation:

Responses to the HEAD request method (Section 4.3.2 of [RFC7231]) never
include a message body because the associated response header fields
(e.g., Transfer-Encoding, Content-Length, etc.), if present, indicate
only what their values would have been if the request method had been
GET (Section 4.3.1 of [RFC7231]).

All other requests and responses should fail if the `content-length`
header is present when there is only a single `HEADERS` frame with
`END_STREAM` flag.

https://tools.ietf.org/html/rfc7230#section-3.3

Modifications:

- Adjust `H2ToStH1ClientDuplexHandler` to allow receiving responses to
`HEAD` requests with `content-length` header;
- Fail any other request or response with `content-length` header when
it consist of only a single `HEADERS` frame with `END_STREAM` flag;
- Add tests for described use-cases;

Result:

`HEAD` requests may receive a response with `content-length` header,
other single-frame messages should not have `content-length` header,
unless it's an exceptional case.