### PR TITLE
Fix search feature for javadoc website

### DIFF
--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -85,7 +85,7 @@ popd
 echo "Docs website generated, see ./$DOCS_FOLDER"
 
 echo "Generate javadoc"
-./gradlew --no-daemon javadocAll
+./gradlew --no-daemon clean javadocAll
 echo "Javadoc generated, see ./$JAVADOC_FOLDER"
 ``
 if ( ! git remote get-url docs ); then

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/ExecutorRule.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/ExecutorRule.java
@@ -47,7 +47,7 @@ public final class ExecutorRule<E extends Executor> extends ExternalResource {
 
     /**
      * Create an {@link ExecutorRule} with a {@link TestExecutor}.
-     * <p></p>
+     * <p>
      * {@link #executor()} will return the {@link TestExecutor} to allow controlling the executor in tests.
      *
      * @return a new {@link ExecutorRule}.

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkRootPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkRootPlugin.groovy
@@ -43,6 +43,12 @@ final class ServiceTalkRootPlugin extends ServiceTalkCorePlugin {
         description = "Consolidate sub-project's Javadoc into a single location"
         group = "documentation"
         destinationDir = file("$buildDir/javadoc")
+        // Disable module directories to avoid "undefined" sub-folder bug in JDK11. See:
+        // - https://stackoverflow.com/questions/53732632/gradle-javadoc-search-redirects-to-undefined-url
+        // - https://bugs.openjdk.java.net/browse/JDK-8215291
+        if (JavaVersion.current().isJava11()) {
+          options.addBooleanOption('-no-module-directories', true)
+        }
 
         gradle.projectsEvaluated {
           subprojects.findAll {!it.name.contains("examples") &&
@@ -52,6 +58,7 @@ final class ServiceTalkRootPlugin extends ServiceTalkCorePlugin {
               classpath += javadocTask.classpath
               excludes += javadocTask.excludes
               includes += javadocTask.includes
+              dependsOn javadocTask
             }
           }
         }


### PR DESCRIPTION
Motivation:

When users use search features of the javadoc website, they are redirected
to the broken link. This is due to the bug in JDK:
https://bugs.openjdk.java.net/browse/JDK-8215291

Modifications:

- Add `-no-module-directories` option for `javadocAll` task to workaround
the bug for JDK11;
- `javadocAll` task should depend on `javadoc` taks from each submodule;
-  `publish-docs.sh` should clean the project before generating javadoc;

Result:

Search feature works for javadoc website.