### PR TITLE
Correctly use `emptyAsyncCloseable()`

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLBHttpConnectionFactory.java
@@ -42,7 +42,7 @@ import static java.util.Objects.requireNonNull;
 
 abstract class AbstractLBHttpConnectionFactory<ResolvedAddress>
         implements ConnectionFactory<ResolvedAddress, LoadBalancedStreamingHttpConnection> {
-    private final ListenableAsyncCloseable close = emptyAsyncCloseable();
+
     @Nullable
     final StreamingHttpConnectionFilterFactory connectionFilterFunction;
     final ReadOnlyHttpClientConfig config;
@@ -68,6 +68,8 @@ abstract class AbstractLBHttpConnectionFactory<ResolvedAddress>
         this.strategyInfluencer = strategyInfluencer;
         filterableConnectionFactory = connectionFactoryFilter.create(
                 new ConnectionFactory<ResolvedAddress, FilterableStreamingHttpConnection>() {
+                    private final ListenableAsyncCloseable close = emptyAsyncCloseable();
+
                     @Override
                     public Single<FilterableStreamingHttpConnection> newConnection(
                             final ResolvedAddress ra, @Nullable final TransportObserver observer) {


### PR DESCRIPTION
Motivation:

1. `AbstractLBHttpConnectionFactory` shares a single instance of
`emptyAsyncCloseable()` between all `ConnectionFactory` instances.
Each should have its own `emptyAsyncCloseable()`.
2. `DefaultPartitionedHttpClientBuilder#NoopPartitionClient`
implements `ListenableAsyncCloseable`, but does not use
`emptyAsyncCloseable()`.

Modifications:

- Create a new instance of `emptyAsyncCloseable()` for each
`ConnectionFactory` in `AbstractLBHttpConnectionFactory`;
- Create a new instance of `emptyAsyncCloseable()` for each
`DefaultPartitionedHttpClientBuilder#NoopPartitionClient`;

Result:

Correct use of `emptyAsyncCloseable()` in all
`ListenableAsyncCloseable` implementations.