### PR TITLE
Add additional tests for checking correct validation of HTTP headers

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -286,6 +286,31 @@ abstract class HttpObjectDecoderTest {
     }
 
     @Test
+    public void whitespaceHeaderName() {
+        testBadHeaderName(" ");
+        testBadHeaderName("  ");
+        testBadHeaderName("\t");
+        testBadHeaderName("\t\t");
+    }
+
+    @Test
+    public void embededWhitespaceHeaderName() {
+        testBadHeaderName("content length");
+        testBadHeaderName("content\tlength");
+    }
+
+    @Test
+    public void trailingWhitespaceHeaderName() {
+        testBadHeaderName("content-length ");
+        testBadHeaderName("content-length\t");
+    }
+
+    private void testBadHeaderName(String badHeader) {
+        assertDecoderException(startLine() + "\r\n" +
+                badHeader + ": 3" + "\r\n" + "\r\n", "Invalid header name");
+    }
+
+    @Test
     public void headerNameWithControlChar() {
         assertDecoderExceptionWithCause(startLine() + "\r\n" +
                 "H\0st: servicetalk.io" + "\r\n" + "\r\n", "Invalid header name");


### PR DESCRIPTION
Motiviation:
The existing tests for HTTP header validation do not cover some important header cases.
While adding the missing tests does not reveal any faults in the current header validation
it is important to include the tests for regression checking purposes.

Modification:
Additional tests for more invalid HTTP header cases are added as well as additional
documentation.

Result:
Regressions in HTTP header validation would be more likely detected.