### PR TITLE
`HttpCookiePair` impls should treat name and value case-sensitively

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpCookiePair.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpCookiePair.java
@@ -15,8 +15,6 @@
  */
 package io.servicetalk.http.api;
 
-import static io.servicetalk.buffer.api.CharSequences.caseInsensitiveHashCode;
-import static io.servicetalk.buffer.api.CharSequences.contentEqualsIgnoreCase;
 import static io.servicetalk.buffer.api.CharSequences.indexOf;
 import static io.servicetalk.http.api.HeaderUtils.validateCookieNameAndValue;
 
@@ -135,18 +133,18 @@ public final class DefaultHttpCookiePair implements HttpCookiePair {
             return false;
         }
         final HttpCookiePair rhs = (HttpCookiePair) o;
-        return contentEqualsIgnoreCase(name, rhs.name()) && contentEqualsIgnoreCase(value, rhs.value());
+        return name.equals(rhs.name()) && value.equals(rhs.value());
     }
 
     @Override
     public int hashCode() {
-        int hash = 31 + caseInsensitiveHashCode(name);
-        hash = 31 * hash + caseInsensitiveHashCode(value);
+        int hash = 31 + name.hashCode();
+        hash = 31 * hash + value.hashCode();
         return hash;
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "[" + name + "]";
+        return getClass().getSimpleName() + '[' + name + ']';
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
@@ -194,12 +194,11 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                             value = setCookieString.subSequence(begin, i);
                             // Increment by 3 because we are skipping DQUOTE SEMI SP
                             i += 3;
-                            begin = i;
                         } else {
                             isWrapped = true;
                             ++i;
-                            begin = i;
                         }
+                        begin = i;
                     } else if (value == null) {
                         throw new IllegalArgumentException("unexpected quote at index: " + i);
                     }
@@ -426,14 +425,15 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
         // if equals(a) == equals(b) then a.hasCode() == b.hashCode()
         // [1] https://tools.ietf.org/html/rfc6265#section-5.1.3
         // [2] https://tools.ietf.org/html/rfc6265#section-5.1.4
-        return contentEqualsIgnoreCase(name, rhs.name()) &&
+        return name.equals(rhs.name()) && value.equals(rhs.value()) &&
                 contentEqualsIgnoreCase(domain, rhs.domain()) &&
                 Objects.equals(path, rhs.path());
     }
 
     @Override
     public int hashCode() {
-        int hash = 31 + caseInsensitiveHashCode(name);
+        int hash = 31 + name.hashCode();
+        hash = 31 * hash + value.hashCode();
         if (domain != null) {
             hash = 31 * hash + caseInsensitiveHashCode(domain);
         }
@@ -445,7 +445,7 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "[" + name + "]";
+        return getClass().getSimpleName() + '[' + name + ']';
     }
 
     private enum ParseState {

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpCookiePairTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpCookiePairTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+public class DefaultHttpCookiePairTest {
+
+    @Test
+    public void testEqual() {
+        assertThat(new DefaultHttpCookiePair("foo", "bar"),
+                is(new DefaultHttpCookiePair("foo", "bar")));
+        assertThat(new DefaultHttpCookiePair("foo", "bar").hashCode(),
+                is(new DefaultHttpCookiePair("foo", "bar").hashCode()));
+
+        // isWrapped attribute is ignored:
+        assertThat(new DefaultHttpCookiePair("foo", "bar", true),
+                is(new DefaultHttpCookiePair("foo", "bar", false)));
+        assertThat(new DefaultHttpCookiePair("foo", "bar", true).hashCode(),
+                is(new DefaultHttpCookiePair("foo", "bar", false).hashCode()));
+    }
+
+    @Test
+    public void testNotEqual() {
+        // Name is case-sensitive:
+        assertThat(new DefaultHttpCookiePair("foo", "bar"),
+                is(not(new DefaultHttpCookiePair("Foo", "bar"))));
+        assertThat(new DefaultHttpCookiePair("foo", "bar").hashCode(),
+                is(not(new DefaultHttpCookiePair("Foo", "bar").hashCode())));
+
+        assertThat(new DefaultHttpCookiePair("foo", "bar", true),
+                is(not(new DefaultHttpCookiePair("foO", "bar", true))));
+        assertThat(new DefaultHttpCookiePair("foo", "bar", true).hashCode(),
+                is(not(new DefaultHttpCookiePair("foO", "bar", true).hashCode())));
+
+        // Value is case-sensitive:
+        assertThat(new DefaultHttpCookiePair("foo", "bar"),
+                is(not(new DefaultHttpCookiePair("foo", "Bar"))));
+        assertThat(new DefaultHttpCookiePair("foo", "bar").hashCode(),
+                is(not(new DefaultHttpCookiePair("foo", "Bar").hashCode())));
+
+        assertThat(new DefaultHttpCookiePair("foo", "bar", false),
+                is(not(new DefaultHttpCookiePair("foo", "baR", false))));
+        assertThat(new DefaultHttpCookiePair("foo", "bar", false),
+                is(not(new DefaultHttpCookiePair("foo", "baR", false).hashCode())));
+    }
+}

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpSetCookieTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpSetCookieTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import org.junit.Test;
+
+import static io.servicetalk.http.api.HttpSetCookie.SameSite.Lax;
+import static io.servicetalk.http.api.HttpSetCookie.SameSite.None;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+public class DefaultHttpSetCookieTest {
+
+    @Test
+    public void testEqual() {
+        assertThat(new DefaultHttpSetCookie("foo", "bar"),
+                is(new DefaultHttpSetCookie("foo", "bar")));
+        assertThat(new DefaultHttpSetCookie("foo", "bar").hashCode(),
+                is(new DefaultHttpSetCookie("foo", "bar").hashCode()));
+
+        // Domain is case-insensitive, other attributes are ignored:
+        assertThat(new DefaultHttpSetCookie("foo", "bar", "/", "servicetalk.io", null, 1L, None, true, false, true),
+                is(new DefaultHttpSetCookie("foo", "bar", "/", "ServiceTalk.io", null, 2L, Lax, false, true, false)));
+        assertThat(new DefaultHttpSetCookie("foo", "bar", "/", "servicetalk.io", null, 1L, None, true, false, true)
+                        .hashCode(),
+                is(new DefaultHttpSetCookie("foo", "bar", "/", "ServiceTalk.io", null, 2L, Lax, false, true, false)
+                        .hashCode()));
+    }
+
+    @Test
+    public void testNotEqual() {
+        // Name is case-sensitive:
+        assertThat(new DefaultHttpSetCookie("foo", "bar"),
+                is(not(new DefaultHttpSetCookie("Foo", "bar"))));
+        assertThat(new DefaultHttpSetCookie("foo", "bar").hashCode(),
+                is(not(new DefaultHttpSetCookie("Foo", "bar").hashCode())));
+
+        // Value is case-sensitive:
+        assertThat(new DefaultHttpSetCookie("foo", "bar"),
+                is(not(new DefaultHttpSetCookie("foo", "Bar"))));
+        assertThat(new DefaultHttpSetCookie("foo", "bar").hashCode(),
+                is(not(new DefaultHttpSetCookie("foo", "Bar").hashCode())));
+
+        // Path is case-sensitive:
+        assertThat(new DefaultHttpSetCookie("foo", "bar", "/path", "servicetalk.io",
+                        null, 1L, None, true, false, true),
+                is(not(new DefaultHttpSetCookie("foo", "bar", "/Path", "servicetalk.io",
+                        null, 1L, None, true, false, true))));
+        assertThat(new DefaultHttpSetCookie("foo", "bar", "/path", "servicetalk.io",
+                        null, 1L, None, true, false, true).hashCode(),
+                is(not(new DefaultHttpSetCookie("foo", "bar", "/Path", "servicetalk.io",
+                        null, 1L, None, true, false, true).hashCode())));
+
+        // Domain doesn't match:
+        assertThat(new DefaultHttpSetCookie("foo", "bar", "/path", "servicetalk.io",
+                        null, 1L, None, true, false, true),
+                is(not(new DefaultHttpSetCookie("foo", "bar", "/path", "docs.servicetalk.io",
+                        null, 1L, None, true, false, true))));
+        assertThat(new DefaultHttpSetCookie("foo", "bar", "/path", "servicetalk.io",
+                        null, 1L, None, true, false, true).hashCode(),
+                is(not(new DefaultHttpSetCookie("foo", "bar", "/path", "docs.servicetalk.io",
+                        null, 1L, None, true, false, true).hashCode())));
+    }
+}


### PR DESCRIPTION
Motivation:

RFC6265 implicitly defines that cookie names are case-sensitive. All
browsers treat cookie names as case-sensitive, see [1, 2].
Cookie values are always case-sensitive.

1. https://stackoverflow.com/questions/11311893/is-the-name-of-a-cookie-case-sensitive
2. https://github.com/playframework/playframework/issues/2241

Modifications:

- Change `equals` and `hashCode` impl of `DefaultHttpCookiePair` to compare
cookie name and value case-sensitively;
- Change `equals` and `hashCode` impl of `DefaultHttpSetCookie` to compare
cookie name case-sensitively, also include cookie value;
- Add tests to verify changes;

Result:

`HttpCookiePair` implementations correctly implement `equals` and `hashCode`.