### PR TITLE
Do not fail HTTP/2 single-frame messages with zero content-length

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -188,7 +188,7 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
                 throw new IllegalArgumentException("content-length (" + contentLength +
                         ") header is not expected for status code " + statusCode + " in response to " + method.name() +
                         " request");
-            } else if (fullResponse && !HEAD.equals(method)) {
+            } else if (fullResponse && contentLength > 0 && !HEAD.equals(method)) {
                 handleUnexpectedContentLength();
             }
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
@@ -143,7 +143,7 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
                     } else {
                         h2Headers.add(TRANSFER_ENCODING, CHUNKED);
                     }
-                } else if (fullRequest) {
+                } else if (fullRequest && contentLength > 0) {
                     handleUnexpectedContentLength();
                 }
             } else if (contentLength >= 0) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractH2DuplexHandlerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractH2DuplexHandlerTest.java
@@ -316,6 +316,22 @@ public class AbstractH2DuplexHandlerTest {
     }
 
     @Test
+    public void singleHeadersFrameWithZeroContentLength() {
+        variant.writeOutbound(channel);
+
+        Http2Headers headers = variant.setHeaders(new DefaultHttp2Headers());
+        headers.setInt(CONTENT_LENGTH, 0);
+        channel.writeInbound(new DefaultHttp2HeadersFrame(headers, true));
+
+        HttpMetaData metaData = channel.readInbound();
+        assertThat(metaData.headers().get(CONTENT_LENGTH), contentEqualTo(valueOf(0)));
+
+        HttpHeaders trailers = channel.readInbound();
+        assertThat(trailers.isEmpty(), is(true));
+        assertThat(channel.inboundMessages(), is(empty()));
+    }
+
+    @Test
     public void lessThanActual() {
         invalidContentLength(3, "hello", false);
     }


### PR DESCRIPTION
Motivation:

HTTP/2 allows sending a request/response message in a single `HEADERS`
frame with `END_STREAM` flag if it doesn't have payload body. Those
messages may contain `content-length: 0` header. However,
`AbstractH2DuplexHandler` mistakenly rejects them as malformed.

Modifications:

- `H2ToStH1ClientDuplexHandler` and `H2ToStH1ServerDuplexHandler` shoudl
throw unexpected `content-length` exception for single-frame
request/response only if its `content-length` header value is greater
than zero;
- Add test to verify this scenario;

Result:

`AbstractH2DuplexHandler` allows single-frame HTTP/2 messages with zero
content-length header value.