### PR TITLE
Add Netty epoll dependency for linux-aarch64

### DIFF
--- a/servicetalk-opentracing-zipkin-publisher/build.gradle
+++ b/servicetalk-opentracing-zipkin-publisher/build.gradle
@@ -33,8 +33,6 @@ dependencies {
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
   implementation "io.netty:netty-codec:$nettyVersion"
   implementation "io.netty:netty-transport:$nettyVersion"
-  implementation "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
-  implementation "io.netty:netty-transport-native-kqueue:$nettyVersion:osx-x86_64"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))

--- a/servicetalk-tcp-netty-internal/build.gradle
+++ b/servicetalk-tcp-netty-internal/build.gradle
@@ -43,6 +43,7 @@ dependencies {
   testFixturesImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
+  testFixturesImplementation "io.netty:netty-transport-native-epoll:$nettyVersion:linux-aarch_64"
   testFixturesImplementation "io.netty:netty-transport-native-kqueue:$nettyVersion:osx-x86_64"
   testFixturesImplementation "junit:junit:$junitVersion"
   testFixturesImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -30,6 +30,7 @@ dependencies {
   implementation project(":servicetalk-utils-internal")
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
   implementation "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
+  implementation "io.netty:netty-transport-native-epoll:$nettyVersion:linux-aarch_64"
   implementation "io.netty:netty-transport-native-kqueue:$nettyVersion:osx-x86_64"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/servicetalk-transport-netty/build.gradle
+++ b/servicetalk-transport-netty/build.gradle
@@ -25,6 +25,4 @@ dependencies {
   implementation project(":servicetalk-transport-netty-internal")
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
   implementation "io.netty:netty-common:$nettyVersion"
-  implementation "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
-  implementation "io.netty:netty-transport-native-kqueue:$nettyVersion:osx-x86_64"
 }


### PR DESCRIPTION
Motivation:
ServiceTalk includes implementation dependendencies on Netty's native
modules so users will get runtime dependencies for free. We don't yet
include the linux-aarch64 dependency for epoll.

Modifications:
- add the epoll linux-aarch64 dependency
- remove redundant native dependencies from packages that will bring in
  the dependencies transitively

Result:
linux-aarch64 linux use cases get native epoll transport for free.