### PR TITLE
Avoid "Maximum active streams violated for this endpoint" at the client level

### DIFF
--- a/servicetalk-http-netty/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-http-netty/gradle/spotbugs/main-exclusions.xml
@@ -22,4 +22,13 @@
     <Method name="equals"/>
     <Bug pattern="EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS"/>
   </Match>
+
+  <!-- False-positive alerts, the invoked methods have side-effect -->
+  <Match>
+    <Or>
+      <Class name="io.servicetalk.http.netty.StreamingHttpRequestWithContext"/>
+      <Class name="io.servicetalk.http.netty.AbsoluteAddressHttpRequesterFilter"/>
+    </Or>
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -29,6 +29,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.SubscribableSingle;
 import io.servicetalk.concurrent.internal.DelayedCancellable;
 import io.servicetalk.concurrent.internal.SequentialCancellable;
+import io.servicetalk.concurrent.internal.ThrowableUtils;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpConnectionContext;
 import io.servicetalk.http.api.HttpEventKey;
@@ -41,6 +42,7 @@ import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.netty.LoadBalancedStreamingHttpClient.OwnedRunnable;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ConnectionObserver.MultiplexedObserver;
 import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
@@ -68,6 +70,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.SocketAddress;
 import java.net.SocketOption;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
@@ -78,6 +81,7 @@ import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.HeaderUtils.LAST_CHUNK_PREDICATE;
@@ -239,24 +243,58 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                     final StreamObserver observer = multiplexedObserver.onNewStream();
                     final Promise<Http2StreamChannel> promise;
                     final SequentialCancellable sequentialCancellable;
+                    Runnable ownedRunnable = null;
                     try {
                         final EventExecutor e = parentContext.nettyChannel().eventLoop();
                         promise = e.newPromise();
+                        // Take ownership of the Runnable associated with the request (if any) before we start opening
+                        // a new stream. If we move this action to childChannelActive, the
+                        // LoadBalancedStreamingHttpClient may prematurely mark the request as finished before netty
+                        // marks the stream as inactive. This code is responsible for running this Runnable in case of
+                        // any errors or stream closure.
+                        if (StreamingHttpRequestWithContext.class.equals(request.getClass())) {
+                            OwnedRunnable runnable = ((StreamingHttpRequestWithContext) request).runnable();
+                            if (runnable.own()) {
+                                ownedRunnable = runnable;
+                            } else {
+                                // The request is already cancelled and the cancel signal will eventually propagate
+                                // here. No need to try to open a stream, we can just fail fast:
+                                final Throwable cause = StacklessCancellationException.newInstance(this.getClass(),
+                                        "handleSubscribe");
+                                observer.streamClosed(cause);
+                                deliverErrorFromSource(subscriber, cause);
+                                return;
+                            }
+                        }   // Else user wrapped the request object => Runnable will always be owned by originator
                         bs.open(promise);
                         sequentialCancellable = new SequentialCancellable(() -> promise.cancel(true));
                     } catch (Throwable cause) {
+                        if (ownedRunnable != null) {
+                            ownedRunnable.run();
+                        }
                         observer.streamClosed(cause);
                         deliverErrorFromSource(subscriber, cause);
                         return;
                     }
-                    subscriber.onSubscribe(sequentialCancellable);
+
+                    try {
+                        subscriber.onSubscribe(sequentialCancellable);
+                    } catch (Throwable cause) {
+                        if (ownedRunnable != null) {
+                            ownedRunnable.run();
+                        }
+                        handleExceptionFromOnSubscribe(subscriber, cause);
+                        return;
+                    }
+
+                    final Runnable onCloseRunnable = ownedRunnable;
                     if (promise.isDone()) {
                         childChannelActive(promise, subscriber, sequentialCancellable, strategy, request, observer,
-                                allowDropTrailersReadFromTransport);
+                                allowDropTrailersReadFromTransport, onCloseRunnable);
                     } else {
                         promise.addListener((FutureListener<Http2StreamChannel>) future -> childChannelActive(
                                 future, subscriber, sequentialCancellable, strategy, request, observer,
-                                allowDropTrailersReadFromTransport));
+                                allowDropTrailersReadFromTransport, onCloseRunnable));
                     }
                 }
             };
@@ -268,13 +306,17 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                                         HttpExecutionStrategy strategy,
                                         StreamingHttpRequest request,
                                         StreamObserver streamObserver,
-                                        boolean allowDropTrailersReadFromTransport) {
+                                        boolean allowDropTrailersReadFromTransport,
+                                        @Nullable Runnable onCloseRunnable) {
             final SingleSource<StreamingHttpResponse> responseSingle;
             Throwable futureCause = future.cause(); // assume this doesn't throw
             if (futureCause == null) {
                 Http2StreamChannel streamChannel = null;
                 try {
                     streamChannel = future.getNow();
+                    if (onCloseRunnable != null) {
+                        streamChannel.closeFuture().addListener(f -> onCloseRunnable.run());
+                    }
                     parentContext.trackActiveStream(streamChannel);
 
                     final CloseHandler closeHandler = forNonPipelined(true, streamChannel.config());
@@ -310,6 +352,11 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                             unexpected.addSuppressed(cause);
                             LOGGER.warn("Unexpected exception while handling the original cause", unexpected);
                         }
+                    } else {
+                        streamObserver.streamClosed(cause);
+                        if (onCloseRunnable != null) {
+                            onCloseRunnable.run();
+                        }
                     }
                     subscriber.onError(cause);
                     return;
@@ -331,6 +378,10 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                     }
                 });
             } else {
+                streamObserver.streamClosed(futureCause);
+                if (onCloseRunnable != null) {
+                    onCloseRunnable.run();
+                }
                 subscriber.onError(futureCause);
             }
         }
@@ -445,6 +496,23 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
             if (completedUpdater.compareAndSet(this, 0, 1)) {
                 channel.writeAndFlush(Http2SettingsAckFrame.INSTANCE);
             }
+        }
+    }
+
+    private static final class StacklessCancellationException extends CancellationException {
+        private static final long serialVersionUID = 3235852873427231209L;
+
+        private StacklessCancellationException() { }
+
+        // Override fillInStackTrace() so we not populate the backtrace via a native call and so leak the
+        // Classloader.
+        @Override
+        public Throwable fillInStackTrace() {
+            return this;
+        }
+
+        static StacklessCancellationException newInstance(Class<?> clazz, String method) {
+            return ThrowableUtils.unknownStackTrace(new StacklessCancellationException(), clazz, method);
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingHttpRequestWithContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingHttpRequestWithContext.java
@@ -205,12 +205,6 @@ final class StreamingHttpRequestWithContext implements StreamingHttpRequest {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-    public Publisher<Object> payloadBodyAndTrailers() {
-        return delegate.payloadBodyAndTrailers();
-    }
-
-    @Override
     public Publisher<Object> messageBody() {
         return delegate.messageBody();
     }
@@ -249,13 +243,6 @@ final class StreamingHttpRequestWithContext implements StreamingHttpRequest {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-    public StreamingHttpRequest transformRawPayloadBody(final UnaryOperator<Publisher<?>> transformer) {
-        delegate.transformRawPayloadBody(transformer);
-        return this;
-    }
-
-    @Override
     public StreamingHttpRequest transformMessageBody(final UnaryOperator<Publisher<?>> transformer) {
         delegate.transformMessageBody(transformer);
         return this;
@@ -264,13 +251,6 @@ final class StreamingHttpRequestWithContext implements StreamingHttpRequest {
     @Override
     public <T> StreamingHttpRequest transform(final TrailersTransformer<T, Buffer> trailersTransformer) {
         delegate.transform(trailersTransformer);
-        return this;
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
-    public <T> StreamingHttpRequest transformRaw(final TrailersTransformer<T, Object> trailersTransformer) {
-        delegate.transformRaw(trailersTransformer);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingHttpRequestWithContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingHttpRequestWithContext.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.encoding.api.ContentCodec;
+import io.servicetalk.http.api.BlockingStreamingHttpRequest;
+import io.servicetalk.http.api.HttpCookiePair;
+import io.servicetalk.http.api.HttpDeserializer;
+import io.servicetalk.http.api.HttpHeaders;
+import io.servicetalk.http.api.HttpProtocolVersion;
+import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.http.api.HttpRequestMethod;
+import io.servicetalk.http.api.HttpSerializer;
+import io.servicetalk.http.api.HttpSetCookie;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.TrailersTransformer;
+import io.servicetalk.http.netty.LoadBalancedStreamingHttpClient.OwnedRunnable;
+import io.servicetalk.transport.api.HostAndPort;
+
+import java.nio.charset.Charset;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import javax.annotation.Nullable;
+
+final class StreamingHttpRequestWithContext implements StreamingHttpRequest {
+
+    private final StreamingHttpRequest delegate;
+    private final OwnedRunnable runnable;
+
+    StreamingHttpRequestWithContext(final StreamingHttpRequest delegate, final OwnedRunnable runnable) {
+        this.delegate = delegate;
+        this.runnable = runnable;
+    }
+
+    OwnedRunnable runnable() {
+        return runnable;
+    }
+
+    @Override
+    public HttpProtocolVersion version() {
+        return delegate.version();
+    }
+
+    @Override
+    public HttpHeaders headers() {
+        return delegate.headers();
+    }
+
+    @Nullable
+    @Override
+    public ContentCodec encoding() {
+        return delegate.encoding();
+    }
+
+    @Override
+    public String toString(final BiFunction<? super CharSequence, ? super CharSequence, CharSequence> headerFilter) {
+        return delegate.toString(headerFilter);
+    }
+
+    @Override
+    public HttpRequestMethod method() {
+        return delegate.method();
+    }
+
+    @Override
+    public String requestTarget() {
+        return delegate.requestTarget();
+    }
+
+    @Override
+    public String requestTarget(final Charset encoding) {
+        return delegate.requestTarget(encoding);
+    }
+
+    @Nullable
+    @Override
+    public String scheme() {
+        return delegate.scheme();
+    }
+
+    @Nullable
+    @Override
+    public String userInfo() {
+        return delegate.userInfo();
+    }
+
+    @Nullable
+    @Override
+    public String host() {
+        return delegate.host();
+    }
+
+    @Override
+    public int port() {
+        return delegate.port();
+    }
+
+    @Override
+    public String rawPath() {
+        return delegate.rawPath();
+    }
+
+    @Override
+    public String path() {
+        return delegate.path();
+    }
+
+    @Nullable
+    @Override
+    public String rawQuery() {
+        return delegate.rawQuery();
+    }
+
+    @Nullable
+    @Override
+    public String query() {
+        return delegate.query();
+    }
+
+    @Nullable
+    @Override
+    public String queryParameter(final String key) {
+        return delegate.queryParameter(key);
+    }
+
+    @Override
+    public Iterable<Map.Entry<String, String>> queryParameters() {
+        return delegate.queryParameters();
+    }
+
+    @Override
+    public Iterable<String> queryParameters(final String key) {
+        return delegate.queryParameters(key);
+    }
+
+    @Override
+    public Iterator<String> queryParametersIterator(final String key) {
+        return delegate.queryParametersIterator(key);
+    }
+
+    @Override
+    public Set<String> queryParametersKeys() {
+        return delegate.queryParametersKeys();
+    }
+
+    @Override
+    public boolean hasQueryParameter(final String key) {
+        return delegate.hasQueryParameter(key);
+    }
+
+    @Override
+    public boolean hasQueryParameter(final String key, final String value) {
+        return delegate.hasQueryParameter(key, value);
+    }
+
+    @Override
+    public int queryParametersSize() {
+        return delegate.queryParametersSize();
+    }
+
+    @Override
+    public boolean removeQueryParameters(final String key) {
+        return delegate.removeQueryParameters(key);
+    }
+
+    @Override
+    public boolean removeQueryParameters(final String key, final String value) {
+        return delegate.removeQueryParameters(key, value);
+    }
+
+    @Nullable
+    @Override
+    public HostAndPort effectiveHostAndPort() {
+        return delegate.effectiveHostAndPort();
+    }
+
+    @Override
+    public Publisher<Buffer> payloadBody() {
+        return delegate.payloadBody();
+    }
+
+    @Override
+    public <T> Publisher<T> payloadBody(final HttpDeserializer<T> deserializer) {
+        return delegate.payloadBody(deserializer);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public Publisher<Object> payloadBodyAndTrailers() {
+        return delegate.payloadBodyAndTrailers();
+    }
+
+    @Override
+    public Publisher<Object> messageBody() {
+        return delegate.messageBody();
+    }
+
+    @Override
+    public StreamingHttpRequest payloadBody(final Publisher<Buffer> payloadBody) {
+        delegate.payloadBody(payloadBody);
+        return this;
+    }
+
+    @Override
+    public <T> StreamingHttpRequest payloadBody(final Publisher<T> payloadBody, final HttpSerializer<T> serializer) {
+        delegate.payloadBody(payloadBody, serializer);
+        return this;
+    }
+
+    @Override
+    public <T> StreamingHttpRequest transformPayloadBody(final Function<Publisher<Buffer>, Publisher<T>> transformer,
+                                                         final HttpSerializer<T> serializer) {
+        delegate.transformPayloadBody(transformer, serializer);
+        return this;
+    }
+
+    @Override
+    public <T, R> StreamingHttpRequest transformPayloadBody(final Function<Publisher<T>, Publisher<R>> transformer,
+                                                            final HttpDeserializer<T> deserializer,
+                                                            final HttpSerializer<R> serializer) {
+        delegate.transformPayloadBody(transformer, deserializer, serializer);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest transformPayloadBody(final UnaryOperator<Publisher<Buffer>> transformer) {
+        delegate.transformPayloadBody(transformer);
+        return this;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public StreamingHttpRequest transformRawPayloadBody(final UnaryOperator<Publisher<?>> transformer) {
+        delegate.transformRawPayloadBody(transformer);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest transformMessageBody(final UnaryOperator<Publisher<?>> transformer) {
+        delegate.transformMessageBody(transformer);
+        return this;
+    }
+
+    @Override
+    public <T> StreamingHttpRequest transform(final TrailersTransformer<T, Buffer> trailersTransformer) {
+        delegate.transform(trailersTransformer);
+        return this;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public <T> StreamingHttpRequest transformRaw(final TrailersTransformer<T, Object> trailersTransformer) {
+        delegate.transformRaw(trailersTransformer);
+        return this;
+    }
+
+    @Override
+    public Single<HttpRequest> toRequest() {
+        return delegate.toRequest();
+    }
+
+    @Override
+    public BlockingStreamingHttpRequest toBlockingStreamingRequest() {
+        return delegate.toBlockingStreamingRequest();
+    }
+
+    @Override
+    public StreamingHttpRequest rawPath(final String path) {
+        delegate.rawPath(path);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest path(final String path) {
+        delegate.path(path);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest appendPathSegments(final String... segments) {
+        delegate.appendPathSegments(segments);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest rawQuery(@Nullable final String query) {
+        delegate.rawQuery(query);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest query(@Nullable final String query) {
+        delegate.query(query);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest addQueryParameter(final String key, final String value) {
+        delegate.addQueryParameter(key, value);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest addQueryParameters(final String key, final Iterable<String> values) {
+        delegate.addQueryParameters(key, values);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest addQueryParameters(final String key, final String... values) {
+        delegate.addQueryParameters(key, values);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest setQueryParameter(final String key, final String value) {
+        delegate.setQueryParameter(key, value);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest setQueryParameters(final String key, final Iterable<String> values) {
+        delegate.setQueryParameters(key, values);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest setQueryParameters(final String key, final String... values) {
+        delegate.setQueryParameters(key, values);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest version(final HttpProtocolVersion version) {
+        delegate.version(version);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest method(final HttpRequestMethod method) {
+        delegate.method(method);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest encoding(final ContentCodec encoding) {
+        delegate.encoding(encoding);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest requestTarget(final String requestTarget) {
+        delegate.requestTarget(requestTarget);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest requestTarget(final String requestTarget, final Charset encoding) {
+        delegate.requestTarget(requestTarget, encoding);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest addHeader(final CharSequence name, final CharSequence value) {
+        delegate.addHeader(name, value);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest addHeaders(final HttpHeaders headers) {
+        delegate.addHeaders(headers);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest setHeader(final CharSequence name, final CharSequence value) {
+        delegate.setHeader(name, value);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest setHeaders(final HttpHeaders headers) {
+        delegate.setHeaders(headers);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest addCookie(final HttpCookiePair cookie) {
+        delegate.addCookie(cookie);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest addCookie(final CharSequence name, final CharSequence value) {
+        delegate.addCookie(name, value);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest addSetCookie(final HttpSetCookie cookie) {
+        delegate.addSetCookie(cookie);
+        return this;
+    }
+
+    @Override
+    public StreamingHttpRequest addSetCookie(final CharSequence name, final CharSequence value) {
+        delegate.addSetCookie(name, value);
+        return this;
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ConcurrencyControllerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ConcurrencyControllerTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.concurrent.api.DefaultThreadFactory;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.ReservedHttpConnection;
+import io.servicetalk.http.api.StreamingHttpConnectionFilter;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.netty.H2PriorKnowledgeFeatureParityTest.EchoHttp2Handler;
+import io.servicetalk.http.netty.StreamObserverTest.MulticastTransportEventsStreamingHttpConnectionFilter;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.netty.internal.ExecutionContextRule;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http2.Http2HeadersFrame;
+import io.netty.handler.codec.http2.Http2StreamChannel;
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.client.api.AutoRetryStrategyProvider.DISABLE_AUTO_RETRIES;
+import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.netty.H2PriorKnowledgeFeatureParityTest.bindH2Server;
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h2;
+import static io.servicetalk.http.netty.HttpsProxyTest.safeClose;
+import static io.servicetalk.http.netty.StreamObserverTest.safeSync;
+import static io.servicetalk.logging.api.LogLevel.TRACE;
+import static io.servicetalk.transport.netty.internal.ExecutionContextRule.cached;
+import static io.servicetalk.transport.netty.internal.NettyIoExecutors.createEventLoopGroup;
+import static java.lang.Integer.parseInt;
+import static java.lang.Thread.NORM_PRIORITY;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+public class H2ConcurrencyControllerTest {
+
+    private static final long MAX_CONCURRENT_STREAMS_VALUE = 1L;
+    private static final int N_ITERATIONS = 3;
+
+    @ClassRule
+    public static final ExecutionContextRule CTX = cached("client-io", "client-executor");
+
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+
+    private final EventLoopGroup serverEventLoopGroup;
+    private final Channel serverAcceptorChannel;
+    private final HttpClient client;
+    private final CountDownLatch[] latches = new CountDownLatch[N_ITERATIONS];
+
+    public H2ConcurrencyControllerTest() {
+        serverEventLoopGroup = createEventLoopGroup(1, new DefaultThreadFactory("server-io", true, NORM_PRIORITY));
+        for (int i = 0; i < N_ITERATIONS; i++) {
+            latches[i] = new CountDownLatch(1);
+        }
+        AtomicBoolean secondAndMore = new AtomicBoolean();
+        serverAcceptorChannel = bindH2Server(serverEventLoopGroup, new ChannelInitializer<Http2StreamChannel>() {
+            @Override
+            protected void initChannel(Http2StreamChannel ch) {
+                // Respond only for the first request which is used to propagate MAX_CONCURRENT_STREAMS_VALUE
+                if (secondAndMore.compareAndSet(false, true)) {
+                    ch.pipeline().addLast(EchoHttp2Handler.INSTANCE);
+                } else {
+                    // Do not respond to any subsequent requests, only release the associated latch to notify the client
+                    // that server received the request.
+                    ch.pipeline().addLast(new SimpleChannelInboundHandler<Http2HeadersFrame>() {
+                        @Override
+                        protected void channelRead0(final ChannelHandlerContext ctx, final Http2HeadersFrame msg) {
+                            String path = msg.headers().path().toString();
+                            int i = parseInt(path.substring(1));
+                            latches[i].countDown();
+                        }
+                    });
+                }
+            }
+        }, parentPipeline -> { }, h2Builder -> {
+            h2Builder.initialSettings().maxConcurrentStreams(MAX_CONCURRENT_STREAMS_VALUE);
+            return h2Builder;
+        });
+        final HostAndPort serverAddress = HostAndPort.of((InetSocketAddress) serverAcceptorChannel.localAddress());
+        client = HttpClients.forResolvedAddress(serverAddress)
+                .ioExecutor(CTX.ioExecutor())
+                .executionStrategy(defaultStrategy(CTX.executor()))
+                .autoRetryStrategy(DISABLE_AUTO_RETRIES)    // All exceptions should be propagated
+                .appendConnectionFilter(MulticastTransportEventsStreamingHttpConnectionFilter::new)
+                .appendConnectionFilter(connection -> new StreamingHttpConnectionFilter(connection) {
+                    @Override
+                    public Single<StreamingHttpResponse> request(HttpExecutionStrategy strategy,
+                                                                 StreamingHttpRequest request) {
+                        return delegate().request(strategy, request)
+                                .liftSync(subscriber -> new SingleSource.Subscriber<StreamingHttpResponse>() {
+                                    @Override
+                                    public void onSubscribe(final Cancellable cancellable) {
+                                        // Defer the cancel() signal to let the test thread start a new request
+                                        subscriber.onSubscribe(() -> CTX.executor()
+                                                .schedule(cancellable::cancel, Duration.ofMillis(100)));
+                                    }
+
+                                    @Override
+                                    public void onSuccess(@Nullable final StreamingHttpResponse result) {
+                                        subscriber.onSuccess(result);
+                                    }
+
+                                    @Override
+                                    public void onError(final Throwable t) {
+                                        subscriber.onError(t);
+                                    }
+                                });
+                    }
+                })
+                .protocols(h2().enableFrameLogging("servicetalk-tests-h2-frame-logger", TRACE, () -> true).build())
+                .build();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        safeSync(() -> serverAcceptorChannel.close().syncUninterruptibly());
+        safeSync(() -> serverEventLoopGroup.shutdownGracefully(0, 0, MILLISECONDS).syncUninterruptibly());
+        safeClose(client);
+    }
+
+    @Test
+    public void noMaxActiveStreamsViolatedError() throws Exception {
+        CountDownLatch maxConcurrencyUpdated = new CountDownLatch(1);
+        try (ReservedHttpConnection connection = client.reserveConnection(client.get("/")).map(conn -> {
+            conn.transportEventStream(MAX_CONCURRENCY).forEach(event -> {
+                if (event.event() == MAX_CONCURRENT_STREAMS_VALUE) {
+                    maxConcurrencyUpdated.countDown();
+                }
+            });
+            return conn;
+        }).toFuture().get()) {
+            awaitMaxConcurrentStreamsSettingsUpdate(connection, maxConcurrencyUpdated);
+
+            BlockingQueue<Throwable> exceptions = new LinkedBlockingDeque<>();
+            for (int i = 0; i < N_ITERATIONS; i++) {
+                final int idx = i;
+                Cancellable cancellable = client.request(client.get("/" + i))
+                        .whenOnError(exceptions::add)
+                        .afterFinally(() -> latches[idx].countDown())
+                        .subscribe(__ -> { /* response is not expected */ });
+                latches[i].await();
+                cancellable.cancel();
+            }
+            assertThat(exceptions, is(empty()));
+        }
+    }
+
+    private static void awaitMaxConcurrentStreamsSettingsUpdate(ReservedHttpConnection connection,
+                                                                CountDownLatch latch) throws Exception {
+        HttpResponse response = connection.request(connection.get("/")).toFuture().get();
+        assertThat(response.status(), is(OK));
+        latch.await();
+        connection.releaseAsync().toFuture().get();
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -582,7 +582,7 @@ public class H2PriorKnowledgeFeatureParityTest {
         }
     }
 
-    private void headerSetCookieRemovalAndIteration(HttpHeaders headers) {
+    private static void headerSetCookieRemovalAndIteration(HttpHeaders headers) {
         headers.add(SET_COOKIE, "qwerty=12345; Domain=somecompany.co.uk; Path=/1; " +
                 "Expires=Wed, 30 Aug 2019 00:00:00 GMT");
 
@@ -1324,9 +1324,9 @@ public class H2PriorKnowledgeFeatureParityTest {
     private static final class TestConnectionFilter extends StreamingHttpConnectionFilter {
         private final Publisher<? extends ConsumableEvent<Integer>> maxConcurrent;
 
-        protected TestConnectionFilter(final FilterableStreamingHttpConnection delegate,
-                                       Queue<FilterableStreamingHttpConnection> connectionQueue,
-                                       Queue<Publisher<? extends ConsumableEvent<Integer>>> maxConcurrentPubQueue) {
+        TestConnectionFilter(final FilterableStreamingHttpConnection delegate,
+                             Queue<FilterableStreamingHttpConnection> connectionQueue,
+                             Queue<Publisher<? extends ConsumableEvent<Integer>>> maxConcurrentPubQueue) {
             super(delegate);
             maxConcurrent = delegate.transportEventStream(MAX_CONCURRENCY).multicastToExactly(2);
             connectionQueue.add(delegate);
@@ -1342,7 +1342,7 @@ public class H2PriorKnowledgeFeatureParityTest {
     }
 
     @ChannelHandler.Sharable
-    private static final class EchoHttp2Handler extends ChannelDuplexHandler {
+    static final class EchoHttp2Handler extends ChannelDuplexHandler {
         static final EchoHttp2Handler INSTANCE = new EchoHttp2Handler();
 
         private EchoHttp2Handler() {
@@ -1372,11 +1372,11 @@ public class H2PriorKnowledgeFeatureParityTest {
             ctx.flush();
         }
 
-        private void onDataRead(ChannelHandlerContext ctx, Http2DataFrame data) {
+        private static void onDataRead(ChannelHandlerContext ctx, Http2DataFrame data) {
             ctx.write(new DefaultHttp2DataFrame(data.content().retainedDuplicate(), data.isEndStream()));
         }
 
-        private void onHeadersRead(ChannelHandlerContext ctx, Http2HeadersFrame headers) {
+        private static void onHeadersRead(ChannelHandlerContext ctx, Http2HeadersFrame headers) {
             if (headers.isEndStream()) {
                 ctx.write(new DefaultHttp2HeadersFrame(headers.headers(), true));
             } else {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,7 +134,7 @@ public class StreamObserverTest {
         safeClose(client);
     }
 
-    private static void safeSync(Runnable runnable) {
+    static void safeSync(Runnable runnable) {
         try {
             runnable.run();
         } catch (Exception e) {
@@ -182,7 +182,11 @@ public class StreamObserverTest {
                 clientDataObserver);
     }
 
-    private static final class MulticastTransportEventsStreamingHttpConnectionFilter
+    /**
+     * Filter that allows users to subscribe to
+     * {@link FilterableStreamingHttpConnection#transportEventStream(HttpEventKey)}.
+     */
+    static final class MulticastTransportEventsStreamingHttpConnectionFilter
             extends StreamingHttpConnectionFilter {
 
         private final Publisher<? extends ConsumableEvent<Integer>> maxConcurrent;


### PR DESCRIPTION
Motivation:

In #1307 we changed `LoadBalancedStreamingHttpClient` to not close the
connection on cancel for HTTP/2 protocol, because our existing API does
not expose methods for closing h2 stream instead of h2 connection.
Instead, we had to _prematurely_ mark the request as finished, because
in case of cancellation, there is no guarantee we will receive a terminal
signal on the response. Also, the stream is not aware of
`LoadBalancedStreamingHttpConnection` API and therefore it can not mark
the request as finished when it closes the stream.
That change significantly increased the probability users see
"Maximum active streams violated for this endpoint." Even though it's a
`RetryableException`, it creates pain and still may pop up after
auto-retry strategy used all attempts.

Modification:

- Introduce `OwnedRunnable` that can be passed to the transport layer
with the request object;
- Add pkg-private `StreamingHttpRequestWithContext` wrapper which
delivers `OwnedRunnable` to the transport;
- Generate that `OwnedRunnable` in `LoadBalancedStreamingHttpClient`;
- `LoadBalancedStreamingHttpClient` marks the request as finished only
if it owns `OwnedRunnable`;
- If h2-transport takes ownership of the `OwnedRunnable`,
`LoadBalancedStreamingHttpClient` is not responsible for marking the
request as finished anymore;
- Add tests to verify the fix;

Result:

HTTP/2 requests marked as finished only before they reach transport or
only after the stream closes.