### PR TITLE
Add TCP Fast Open support

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -67,10 +67,12 @@ public abstract class GrpcServerBuilder {
     /**
      * The maximum queue length for incoming connection indications (a request to connect) is set to the backlog
      * parameter. If a connection indication arrives when the queue is full, the connection may time out.
-     *
+     * @deprecated Use {@link #listenSocketOption(SocketOption, Object)} with key
+     * {@link ServiceTalkSocketOptions#SO_BACKLOG}.
      * @param backlog the backlog to use when accepting connections.
      * @return {@code this}.
      */
+    @Deprecated
     public abstract GrpcServerBuilder backlog(int backlog);
 
     /**
@@ -101,6 +103,17 @@ public abstract class GrpcServerBuilder {
      * @see ServiceTalkSocketOptions
      */
     public abstract <T> GrpcServerBuilder socketOption(SocketOption<T> option, T value);
+
+    /**
+     * Adds a {@link SocketOption} that is applied to the server socket channel which listens/accepts socket channels.
+     * @param <T> the type of the value.
+     * @param option the option to apply.
+     * @param value the value.
+     * @return this.
+     * @see StandardSocketOptions
+     * @see ServiceTalkSocketOptions
+     */
+    public abstract <T> GrpcServerBuilder listenSocketOption(SocketOption<T> option, T value);
 
     /**
      * Enable wire-logging for this server.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -73,7 +73,10 @@ public abstract class GrpcServerBuilder {
      * @return {@code this}.
      */
     @Deprecated
-    public abstract GrpcServerBuilder backlog(int backlog);
+    public GrpcServerBuilder backlog(int backlog) {
+        listenSocketOption(ServiceTalkSocketOptions.SO_BACKLOG, backlog);
+        return this;
+    }
 
     /**
      * Set the SSL/TLS configuration.

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -63,13 +63,6 @@ final class DefaultGrpcServerBuilder extends GrpcServerBuilder implements Server
         return this;
     }
 
-    @Deprecated
-    @Override
-    public GrpcServerBuilder backlog(final int backlog) {
-        httpServerBuilder.backlog(backlog);
-        return this;
-    }
-
     @Override
     public GrpcServerBuilder sslConfig(final ServerSslConfig config) {
         httpServerBuilder.sslConfig(config);

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -63,6 +63,7 @@ final class DefaultGrpcServerBuilder extends GrpcServerBuilder implements Server
         return this;
     }
 
+    @Deprecated
     @Override
     public GrpcServerBuilder backlog(final int backlog) {
         httpServerBuilder.backlog(backlog);
@@ -87,6 +88,13 @@ final class DefaultGrpcServerBuilder extends GrpcServerBuilder implements Server
         return this;
     }
 
+    @Override
+    public <T> GrpcServerBuilder listenSocketOption(final SocketOption<T> option, final T value) {
+        httpServerBuilder.listenSocketOption(option, value);
+        return this;
+    }
+
+    @Deprecated
     @Override
     public GrpcServerBuilder enableWireLogging(final String loggerName) {
         httpServerBuilder.enableWireLogging(loggerName);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -76,7 +76,10 @@ public abstract class HttpServerBuilder {
      * @return {@code this}.
      */
     @Deprecated
-    public abstract HttpServerBuilder backlog(int backlog);
+    public HttpServerBuilder backlog(int backlog) {
+        listenSocketOption(ServiceTalkSocketOptions.SO_BACKLOG, backlog);
+        return this;
+    }
 
     /**
      * Set the SSL/TLS configuration.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -70,10 +70,12 @@ public abstract class HttpServerBuilder {
     /**
      * Sets the maximum queue length for incoming connection indications (a request to connect) is set to the backlog
      * parameter. If a connection indication arrives when the queue is full, the connection may time out.
-     *
+     * @deprecated Use {@link #listenSocketOption(SocketOption, Object)} with key
+     * {@link ServiceTalkSocketOptions#SO_BACKLOG}.
      * @param backlog the backlog to use when accepting connections.
      * @return {@code this}.
      */
+    @Deprecated
     public abstract HttpServerBuilder backlog(int backlog);
 
     /**
@@ -94,7 +96,7 @@ public abstract class HttpServerBuilder {
     public abstract HttpServerBuilder sslConfig(ServerSslConfig defaultConfig, Map<String, ServerSslConfig> sniMap);
 
     /**
-     * Adds a {@link SocketOption} that is applied.
+     * Adds a {@link SocketOption} that is applied to connected/accepted socket channels.
      *
      * @param <T> the type of the value.
      * @param option the option to apply.
@@ -104,6 +106,17 @@ public abstract class HttpServerBuilder {
      * @see ServiceTalkSocketOptions
      */
     public abstract <T> HttpServerBuilder socketOption(SocketOption<T> option, T value);
+
+    /**
+     * Adds a {@link SocketOption} that is applied to the server socket channel which listens/accepts socket channels.
+     * @param <T> the type of the value.
+     * @param option the option to apply.
+     * @param value the value.
+     * @return this.
+     * @see StandardSocketOptions
+     * @see ServiceTalkSocketOptions
+     */
+    public abstract <T> HttpServerBuilder listenSocketOption(SocketOption<T> option, T value);
 
     /**
      * Enables wire-logging for this server.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -51,6 +51,7 @@ final class DefaultHttpServerBuilder extends HttpServerBuilder {
         return this;
     }
 
+    @Deprecated
     @Override
     public HttpServerBuilder backlog(final int backlog) {
         config.tcpConfig().backlog(backlog);
@@ -72,6 +73,12 @@ final class DefaultHttpServerBuilder extends HttpServerBuilder {
     @Override
     public <T> HttpServerBuilder socketOption(final SocketOption<T> option, final T value) {
         config.tcpConfig().socketOption(option, value);
+        return this;
+    }
+
+    @Override
+    public <T> HttpServerBuilder listenSocketOption(final SocketOption<T> option, final T value) {
+        config.tcpConfig().listenSocketOption(option, value);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -27,6 +27,7 @@ import io.servicetalk.transport.api.ConnectionAcceptor;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServerSslConfig;
+import io.servicetalk.transport.api.ServiceTalkSocketOptions;
 import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketAddress;
@@ -51,10 +52,18 @@ final class DefaultHttpServerBuilder extends HttpServerBuilder {
         return this;
     }
 
+    /**
+     * Sets the maximum queue length for incoming connection indications (a request to connect) is set to the backlog
+     * parameter. If a connection indication arrives when the queue is full, the connection may time out.
+     *
+     * @deprecated Use {@link #listenSocketOption(SocketOption, Object)} with key
+     * {@link ServiceTalkSocketOptions#SO_BACKLOG}.
+     * @param backlog the backlog to use when accepting connections.
+     * @return {@code this}.
+     */
     @Deprecated
-    @Override
-    public HttpServerBuilder backlog(final int backlog) {
-        config.tcpConfig().backlog(backlog);
+    public HttpServerBuilder backlog(int backlog) {
+        listenSocketOption(ServiceTalkSocketOptions.SO_BACKLOG, backlog);
         return this;
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MutualSslTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MutualSslTest.java
@@ -58,16 +58,16 @@ public class MutualSslTest {
     @Rule
     public final Timeout timeout = new ServiceTalkTestTimeout();
     @DataPoints("serverSslProvider")
-    public static final SslProvider[] serverSslProvider = new SslProvider[] {JDK, OPENSSL};
+    public static final SslProvider[] SERVER_PROVIDERS = {JDK, OPENSSL};
     @DataPoints("clientSslProvider")
-    public static final SslProvider[] clientSslProvider = new SslProvider[] {JDK, OPENSSL};
+    public static final SslProvider[] CLIENT_PROVIDERS = {JDK, OPENSSL};
     @DataPoints("serverListenOptions")
     @SuppressWarnings("rawtypes")
-    public static final List<Map<SocketOption, Object>> serverListenOptions =
+    public static final List<Map<SocketOption, Object>> SERVER_LISTEN_OPTIONS =
             asList(emptyMap(), serverTcpFastOpenOptions());
     @DataPoints("clientOptions")
     @SuppressWarnings("rawtypes")
-    public static final List<Map<SocketOption, Object>> clientOptions = asList(emptyMap(), clientTcpFastOpenOptions());
+    public static final List<Map<SocketOption, Object>> CLIENT_OPTIONS = asList(emptyMap(), clientTcpFastOpenOptions());
 
     @Theory
     public void mutualSsl(@FromDataPoints("serverSslProvider") SslProvider serverSslProvider,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MutualSslTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MutualSslTest.java
@@ -35,7 +35,9 @@ import org.junit.runners.Parameterized;
 
 import java.net.InetSocketAddress;
 import java.net.SocketOption;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -71,26 +73,25 @@ public class MutualSslTest {
         this.clientOptions = clientOptions;
     }
 
-    @Parameterized.Parameters(name = "server={0} client={1} server opts={2} client opts={3}")
+    @Parameterized.Parameters(name = "{index}: server={0} client={1} server opts={2} client opts={3}")
     public static Collection<Object[]> sslProviders() {
-        return asList(
-                new Object[]{JDK, JDK, emptyMap(), emptyMap()},
-                new Object[]{JDK, OPENSSL, emptyMap(), emptyMap()},
-                new Object[]{OPENSSL, JDK, emptyMap(), emptyMap()},
-                new Object[]{OPENSSL, OPENSSL, emptyMap(), emptyMap()},
-                new Object[]{JDK, JDK, emptyMap(), clientTcpFastOpenOptions()},
-                new Object[]{JDK, OPENSSL, emptyMap(), clientTcpFastOpenOptions()},
-                new Object[]{OPENSSL, JDK, emptyMap(), clientTcpFastOpenOptions()},
-                new Object[]{OPENSSL, OPENSSL, emptyMap(), clientTcpFastOpenOptions()},
-                new Object[]{JDK, JDK, serverTcpFastOpenOptions(), emptyMap()},
-                new Object[]{JDK, OPENSSL, serverTcpFastOpenOptions(), emptyMap()},
-                new Object[]{OPENSSL, JDK, serverTcpFastOpenOptions(), emptyMap()},
-                new Object[]{OPENSSL, OPENSSL, serverTcpFastOpenOptions(), emptyMap()},
-                new Object[]{JDK, JDK, serverTcpFastOpenOptions(), clientTcpFastOpenOptions()},
-                new Object[]{JDK, OPENSSL, serverTcpFastOpenOptions(), clientTcpFastOpenOptions()},
-                new Object[]{OPENSSL, JDK, serverTcpFastOpenOptions(), clientTcpFastOpenOptions()},
-                new Object[]{OPENSSL, OPENSSL, serverTcpFastOpenOptions(), clientTcpFastOpenOptions()}
-        );
+        final SslProvider[] providers = new SslProvider[] {JDK, OPENSSL};
+        @SuppressWarnings("rawtypes")
+        final List<Map<SocketOption, Object>> serverOpts = asList(emptyMap(), serverTcpFastOpenOptions());
+        @SuppressWarnings("rawtypes")
+        final List<Map<SocketOption, Object>> clientOpts = asList(emptyMap(), clientTcpFastOpenOptions());
+        final List<Object[]> results = new ArrayList<>(
+                providers.length * 2 * serverOpts.size() * clientOpts.size());
+        for (SslProvider serverProvider : providers) {
+            for (SslProvider clientProvider : providers) {
+                for (@SuppressWarnings("rawtypes") Map<SocketOption, Object> serverOpt : serverOpts) {
+                    for (@SuppressWarnings("rawtypes") Map<SocketOption, Object> clientOpt : clientOpts) {
+                        results.add(new Object[] {serverProvider, clientProvider, serverOpt, clientOpt});
+                    }
+                }
+            }
+        }
+        return results;
     }
 
     @Test

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MutualSslTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MutualSslTest.java
@@ -75,7 +75,7 @@ public class MutualSslTest {
                           @SuppressWarnings("rawtypes")
                           @FromDataPoints("serverListenOptions") Map<SocketOption, Object> serverListenOptions,
                           @SuppressWarnings("rawtypes")
-                          @FromDataPoints("serverListenOptions") Map<SocketOption, Object> clientOptions)
+                          @FromDataPoints("clientOptions") Map<SocketOption, Object> clientOptions)
             throws Exception {
         HttpServerBuilder serverBuilder = HttpServers.forAddress(localAddress(0))
                 .sslConfig(new ServerSslConfigBuilder(

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TcpFastOpenTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TcpFastOpenTest.java
@@ -60,7 +60,7 @@ public class TcpFastOpenTest {
         this.clientOptions = clientOptions;
     }
 
-    @Parameterized.Parameters(name = "server opts={0} client opts={1}")
+    @Parameterized.Parameters(name = "{index}: server opts={0} client opts={1}")
     public static Collection<Object[]> sslProviders() {
         return asList(
                 new Object[]{emptyMap(), emptyMap()},
@@ -81,7 +81,7 @@ public class TcpFastOpenTest {
     }
 
     @Test
-    public void mutualSsl() throws Exception {
+    public void requestSucceedsEvenIfTcpFastOpenNotEnabledOrSupported() throws Exception {
         HttpServerBuilder serverBuilder = HttpServers.forAddress(localAddress(0));
         for (@SuppressWarnings("rawtypes") Entry<SocketOption, Object> entry : serverListenOptions.entrySet()) {
             @SuppressWarnings("unchecked")

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TcpFastOpenTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TcpFastOpenTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.ServerContext;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.net.InetSocketAddress;
+import java.net.SocketOption;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static io.servicetalk.transport.api.ServiceTalkSocketOptions.TCP_FASTOPEN_BACKLOG;
+import static io.servicetalk.transport.api.ServiceTalkSocketOptions.TCP_FASTOPEN_CONNECT;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class TcpFastOpenTest {
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+    @SuppressWarnings("rawtypes")
+    private final Map<SocketOption, Object> serverListenOptions;
+    @SuppressWarnings("rawtypes")
+    private final Map<SocketOption, Object> clientOptions;
+
+    public TcpFastOpenTest(
+            @SuppressWarnings("rawtypes") final Map<SocketOption, Object> serverListenOptions,
+            @SuppressWarnings("rawtypes") final Map<SocketOption, Object> clientOptions) {
+        this.serverListenOptions = serverListenOptions;
+        this.clientOptions = clientOptions;
+    }
+
+    @Parameterized.Parameters(name = "server opts={0} client opts={1}")
+    public static Collection<Object[]> sslProviders() {
+        return asList(
+                new Object[]{emptyMap(), emptyMap()},
+                new Object[]{emptyMap(), clientTcpFastOpenOptions()},
+                new Object[]{serverTcpFastOpenOptions(), emptyMap()},
+                new Object[]{serverTcpFastOpenOptions(), clientTcpFastOpenOptions()}
+        );
+    }
+
+    @SuppressWarnings("rawtypes")
+    static Map<SocketOption, Object> clientTcpFastOpenOptions() {
+        return singletonMap(TCP_FASTOPEN_CONNECT, true);
+    }
+
+    @SuppressWarnings("rawtypes")
+    static Map<SocketOption, Object> serverTcpFastOpenOptions() {
+        return singletonMap(TCP_FASTOPEN_BACKLOG, 1);
+    }
+
+    @Test
+    public void mutualSsl() throws Exception {
+        HttpServerBuilder serverBuilder = HttpServers.forAddress(localAddress(0));
+        for (@SuppressWarnings("rawtypes") Entry<SocketOption, Object> entry : serverListenOptions.entrySet()) {
+            @SuppressWarnings("unchecked")
+            SocketOption<Object> option = entry.getKey();
+            serverBuilder.listenSocketOption(option, entry.getValue());
+        }
+        try (ServerContext serverContext = serverBuilder.listenBlockingAndAwait(
+                (ctx, request, responseFactory) -> responseFactory.ok());
+             BlockingHttpClient client = newClientBuilder(serverContext).buildBlocking()) {
+            assertEquals(HttpResponseStatus.OK, client.request(client.get("/")).status());
+        }
+    }
+
+    private SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> newClientBuilder(
+            ServerContext serverContext) {
+        SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
+                HttpClients.forSingleAddress(serverHostAndPort(serverContext));
+        for (@SuppressWarnings("rawtypes") Entry<SocketOption, Object> entry : clientOptions.entrySet()) {
+            @SuppressWarnings("unchecked")
+            SocketOption<Object> option = entry.getKey();
+            builder.socketOption(option, entry.getValue());
+        }
+        return builder;
+    }
+}

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractReadOnlyTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractReadOnlyTcpConfig.java
@@ -44,14 +44,19 @@ abstract class AbstractReadOnlyTcpConfig<SecurityConfig> {
     private final UserDataLoggerConfig wireLoggerConfig;
 
     protected AbstractReadOnlyTcpConfig(final AbstractTcpConfig<SecurityConfig> from) {
-        options = from.options() == null ? emptyMap() : unmodifiableMap(new HashMap<>(from.options()));
+        options = nonNullOptions(from.options());
         idleTimeoutMs = from.idleTimeoutMs();
         flushStrategy = from.flushStrategy();
         wireLoggerConfig = from.wireLoggerConfig();
     }
 
+    @SuppressWarnings("rawtypes")
+    static Map<ChannelOption, Object> nonNullOptions(@Nullable Map<ChannelOption, Object> options) {
+        return options == null ? emptyMap() : unmodifiableMap(new HashMap<>(options));
+    }
+
     /**
-     * Returns the {@link ChannelOption}s for all channels.
+     * Returns the {@link ChannelOption}s for accepted channels.
      *
      * @return Unmodifiable map of options
      */

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
@@ -16,17 +16,21 @@
 package io.servicetalk.tcp.netty.internal;
 
 import io.servicetalk.transport.api.ServerSslConfig;
+import io.servicetalk.transport.api.ServiceTalkSocketOptions;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver;
 
+import io.netty.channel.ChannelOption;
 import io.netty.handler.ssl.SslContext;
 import io.netty.util.DomainWildcardMappingBuilder;
 import io.netty.util.Mapping;
 
+import java.net.SocketOption;
 import java.util.Map;
 import java.util.Map.Entry;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.transport.api.ServiceTalkSocketOptions.SO_BACKLOG;
 import static io.servicetalk.transport.api.TransportObservers.asSafeObserver;
 import static io.servicetalk.transport.netty.internal.SslContextFactory.forServer;
 
@@ -34,16 +38,18 @@ import static io.servicetalk.transport.netty.internal.SslContextFactory.forServe
  * Read only view of {@link TcpServerConfig}.
  */
 public final class ReadOnlyTcpServerConfig extends AbstractReadOnlyTcpConfig<ServerSslConfig> {
+    @SuppressWarnings("rawtypes")
+    private final Map<ChannelOption, Object> listenOptions;
     private final TransportObserver transportObserver;
     @Nullable
     private final SslContext sslContext;
     @Nullable
     private final Mapping<String, SslContext> sniMapping;
-    private final int backlog;
     private final boolean alpnConfigured;
 
     ReadOnlyTcpServerConfig(final TcpServerConfig from) {
         super(from);
+        listenOptions = nonNullOptions(from.listenOptions());
         final TransportObserver transportObserver = from.transportObserver();
         this.transportObserver = transportObserver == NoopTransportObserver.INSTANCE ? transportObserver :
                 asSafeObserver(transportObserver);
@@ -72,7 +78,6 @@ public final class ReadOnlyTcpServerConfig extends AbstractReadOnlyTcpConfig<Ser
             sniMapping = null;
             alpnConfigured = false;
         }
-        backlog = from.backlog();
     }
 
     /**
@@ -112,11 +117,27 @@ public final class ReadOnlyTcpServerConfig extends AbstractReadOnlyTcpConfig<Ser
     }
 
     /**
-     * Returns the maximum queue length for incoming connection indications (a request to connect).
+     * Returns the {@link SocketOption}s that are applied to the server socket channel which listens/accepts socket
+     * channels.
      *
+     * @return Unmodifiable map of options
+     */
+    @SuppressWarnings("rawtypes")
+    public Map<ChannelOption, Object> listenOptions() {
+        return listenOptions;
+    }
+
+    /**
+     * Returns the maximum queue length for incoming connection indications (a request to connect).
+     * @deprecated Use {@link #listenOptions()} with key {@link ServiceTalkSocketOptions#SO_BACKLOG}.
      * @return backlog
      */
+    @Deprecated
     public int backlog() {
-        return backlog;
+        final Integer i = (Integer) listenOptions.get(ChannelOption.SO_BACKLOG);
+        if (i == null) {
+            throw new IllegalStateException(SO_BACKLOG + " has not been set");
+        }
+        return i;
     }
 }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.transport.api.ServiceTalkSocketOptions.SO_BACKLOG;
 import static io.servicetalk.transport.api.TransportObservers.asSafeObserver;
 import static io.servicetalk.transport.netty.internal.SslContextFactory.forServer;
 
@@ -135,9 +134,6 @@ public final class ReadOnlyTcpServerConfig extends AbstractReadOnlyTcpConfig<Ser
     @Deprecated
     public int backlog() {
         final Integer i = (Integer) listenOptions.get(ChannelOption.SO_BACKLOG);
-        if (i == null) {
-            throw new IllegalStateException(SO_BACKLOG + " has not been set");
-        }
-        return i;
+        return i == null ? 0 : i;
     }
 }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerBinder.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerBinder.java
@@ -171,10 +171,13 @@ public final class TcpServerBinder {
             ChannelOption<Object> option = opt.getKey();
             bs.childOption(option, opt.getValue());
         }
+        for (@SuppressWarnings("rawtypes") Map.Entry<ChannelOption, Object> opt : config.listenOptions().entrySet()) {
+            @SuppressWarnings("unchecked")
+            ChannelOption<Object> option = opt.getKey();
+            bs.option(option, opt.getValue());
+        }
 
         bs.childOption(ChannelOption.AUTO_READ, autoRead);
-
-        bs.option(ChannelOption.SO_BACKLOG, config.backlog());
 
         // Set the correct ByteBufAllocator based on our BufferAllocator to minimize memory copies.
         ByteBufAllocator byteBufAllocator = POOLED_ALLOCATOR;

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServiceTalkSocketOptions.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServiceTalkSocketOptions.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.transport.api;
 
+import java.net.SocketAddress;
 import java.net.SocketOption;
 
 import static java.util.Objects.requireNonNull;
@@ -40,6 +41,41 @@ public final class ServiceTalkSocketOptions {
      * Allow to idle timeout in milli seconds after which the connection is closed.
      */
     public static final SocketOption<Long> IDLE_TIMEOUT = new ServiceTalkSocketOption<>("IDLE_TIMEOUT", Long.class);
+
+    /**
+     * The number of pending accepted connections for server sockets. For example this value is used for methods like
+     * {@link java.nio.channels.ServerSocketChannel#bind(SocketAddress, int)} and
+     * <a href="https://man7.org/linux/man-pages/man2/listen.2.html">listen(int sockfd, int backlog)</a>.
+     */
+    public static final SocketOption<Integer> SO_BACKLOG = new ServiceTalkSocketOption<>("SO_BACKLOG", Integer.class);
+
+    /**
+     * Configure the backlog queue size for accepting pending TCP fast open SYNs as described in
+     * <a href="https://tools.ietf.org/html/rfc7413#appendix-A.2">RFC 7413 Passive Open</a>.
+     * <p>
+     * Note this option may not be supported by the underlying transport (e.g. currently only supported by Netty's
+     * native EPOLL transport).
+     */
+    public static final SocketOption<Integer> TCP_FASTOPEN_BACKLOG =
+            new ServiceTalkSocketOption<>("TCP_FASTOPEN_BACKLOG", Integer.class);
+
+    /**
+     * Enable TCP fast open connect on the client side as described in
+     * <a href="https://tools.ietf.org/html/rfc7413#appendix-A.1">RFC 7413 Active Open</a>.
+     * <p>
+     * Note the following caveats of this option:
+     * <ul>
+     *     <li>it may not be supported by the underlying transport (e.g. currently only supported by Netty's native
+     *     EPOLL transport)</li>
+     *     <li>the data that is written in TFO must be idempotent (see
+     *     <a href="https://lwn.net/Articles/508865/">LWN article</a> for more info). The TLS client_hello
+     *     <a href="https://tools.ietf.org/html/rfc7413#section-6.3.2">is idempotent</a> and this option is therefore
+     *     safe to use with TLS.</li>
+     *     <li>data must be written before attempting to connect the socket (clarifies data is idempotent)</li>
+     * </ul>
+     */
+    public static final SocketOption<Boolean> TCP_FASTOPEN_CONNECT =
+            new ServiceTalkSocketOption<>("TCP_FASTOPEN_CONNECT", Boolean.class);
 
     private ServiceTalkSocketOptions() {
     }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServiceTalkSocketOptions.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServiceTalkSocketOptions.java
@@ -52,7 +52,7 @@ public final class ServiceTalkSocketOptions {
      * <ul>
      *     <li>it may not be supported by the underlying transport (e.g. supported by Netty's
      *     <a href="https://netty.io/wiki/native-transports.html#using-the-linux-native-transport">linux EPOLL
-     *     transport</a></li>
+     *     transport</a>)</li>
      *     <li>the data that is written in TFO must be idempotent (see
      *     <a href="https://lwn.net/Articles/508865/">LWN article</a> for more info). The TLS client_hello
      *     <a href="https://tools.ietf.org/html/rfc7413#section-6.3.2">is idempotent</a> and this option is therefore
@@ -78,7 +78,7 @@ public final class ServiceTalkSocketOptions {
      * <p>
      * Note this option may not be supported by the underlying transport (e.g. supported by Netty's
      * <a href="https://netty.io/wiki/native-transports.html#using-the-linux-native-transport">linux EPOLL
-     * transport</a>.
+     * transport)</a>.
      */
     public static final SocketOption<Integer> TCP_FASTOPEN_BACKLOG =
             new ServiceTalkSocketOption<>("TCP_FASTOPEN_BACKLOG", Integer.class);

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServiceTalkSocketOptions.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServiceTalkSocketOptions.java
@@ -17,11 +17,13 @@ package io.servicetalk.transport.api;
 
 import java.net.SocketAddress;
 import java.net.SocketOption;
+import java.net.StandardSocketOptions;
+import java.nio.channels.ServerSocketChannel;
 
 import static java.util.Objects.requireNonNull;
 
 /**
- * {@link SocketOption}s that can be used beside {@link java.net.StandardSocketOptions}.
+ * {@link SocketOption}s that can be used beside {@link StandardSocketOptions}.
  */
 public final class ServiceTalkSocketOptions {
 
@@ -43,30 +45,14 @@ public final class ServiceTalkSocketOptions {
     public static final SocketOption<Long> IDLE_TIMEOUT = new ServiceTalkSocketOption<>("IDLE_TIMEOUT", Long.class);
 
     /**
-     * The number of pending accepted connections for server sockets. For example this value is used for methods like
-     * {@link java.nio.channels.ServerSocketChannel#bind(SocketAddress, int)} and
-     * <a href="https://man7.org/linux/man-pages/man2/listen.2.html">listen(int sockfd, int backlog)</a>.
-     */
-    public static final SocketOption<Integer> SO_BACKLOG = new ServiceTalkSocketOption<>("SO_BACKLOG", Integer.class);
-
-    /**
-     * Configure the backlog queue size for accepting pending TCP fast open SYNs as described in
-     * <a href="https://tools.ietf.org/html/rfc7413#appendix-A.2">RFC 7413 Passive Open</a>.
-     * <p>
-     * Note this option may not be supported by the underlying transport (e.g. currently only supported by Netty's
-     * native EPOLL transport).
-     */
-    public static final SocketOption<Integer> TCP_FASTOPEN_BACKLOG =
-            new ServiceTalkSocketOption<>("TCP_FASTOPEN_BACKLOG", Integer.class);
-
-    /**
      * Enable TCP fast open connect on the client side as described in
      * <a href="https://tools.ietf.org/html/rfc7413#appendix-A.1">RFC 7413 Active Open</a>.
      * <p>
      * Note the following caveats of this option:
      * <ul>
-     *     <li>it may not be supported by the underlying transport (e.g. currently only supported by Netty's native
-     *     EPOLL transport)</li>
+     *     <li>it may not be supported by the underlying transport (e.g. supported by Netty's
+     *     <a href="https://netty.io/wiki/native-transports.html#using-the-linux-native-transport">linux EPOLL
+     *     transport</a></li>
      *     <li>the data that is written in TFO must be idempotent (see
      *     <a href="https://lwn.net/Articles/508865/">LWN article</a> for more info). The TLS client_hello
      *     <a href="https://tools.ietf.org/html/rfc7413#section-6.3.2">is idempotent</a> and this option is therefore
@@ -76,6 +62,26 @@ public final class ServiceTalkSocketOptions {
      */
     public static final SocketOption<Boolean> TCP_FASTOPEN_CONNECT =
             new ServiceTalkSocketOption<>("TCP_FASTOPEN_CONNECT", Boolean.class);
+
+    // -- Server/listen socket specific options --
+
+    /**
+     * The number of pending accepted connections for server sockets. For example this value is used for methods like
+     * {@link ServerSocketChannel#bind(SocketAddress, int)} and
+     * <a href="https://man7.org/linux/man-pages/man2/listen.2.html">listen(int sockfd, int backlog)</a>.
+     */
+    public static final SocketOption<Integer> SO_BACKLOG = new ServiceTalkSocketOption<>("SO_BACKLOG", Integer.class);
+
+    /**
+     * The number of pending SYNs with data payload for server sockets as described in
+     * <a href="https://tools.ietf.org/html/rfc7413#appendix-A.2">RFC 7413 Passive Open</a>.
+     * <p>
+     * Note this option may not be supported by the underlying transport (e.g. supported by Netty's
+     * <a href="https://netty.io/wiki/native-transports.html#using-the-linux-native-transport">linux EPOLL
+     * transport</a>.
+     */
+    public static final SocketOption<Integer> TCP_FASTOPEN_BACKLOG =
+            new ServiceTalkSocketOption<>("TCP_FASTOPEN_BACKLOG", Integer.class);
 
     private ServiceTalkSocketOptions() {
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SocketOptionUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SocketOptionUtils.java
@@ -77,7 +77,7 @@ public final class SocketOptionUtils {
         @SuppressWarnings("unchecked")
         OptConverter<T> converter = (OptConverter<T>) SOCKET_OPT_MAP.get(option);
         if (converter != null) {
-            channelOpts.put(converter.option, converter.sockToChan.apply(value));
+            channelOpts.put(converter.option, converter.toChannelValue.apply(value));
         } else {
             throw unsupported(option);
         }
@@ -101,7 +101,7 @@ public final class SocketOptionUtils {
         @SuppressWarnings("unchecked")
         OptConverter<T> converter = (OptConverter<T>) SOCKET_OPT_MAP.get(option);
         if (converter != null) {
-            return (T) converter.chanToSock.apply(config.getOption(converter.option));
+            return (T) converter.toSocketValue.apply(config.getOption(converter.option));
         } else if (option == ServiceTalkSocketOptions.IDLE_TIMEOUT) {
             return (T) idleTimeoutMs;
         }
@@ -118,8 +118,8 @@ public final class SocketOptionUtils {
     }
 
     private static <T, R> void putOpt(ChannelOption<T> channelOpt, SocketOption<R> socketOpt,
-                                      Function<T, R> channelToSocket, Function<R, T> socketToChannel) {
-        SOCKET_OPT_MAP.put(socketOpt, new OptConverter<>(channelOpt, channelToSocket, socketToChannel));
+                                      Function<T, R> toSocketValue, Function<R, T> toChannelValue) {
+        SOCKET_OPT_MAP.put(socketOpt, new OptConverter<>(channelOpt, toSocketValue, toChannelValue));
     }
 
     @Nullable
@@ -129,15 +129,15 @@ public final class SocketOptionUtils {
 
     private static final class OptConverter<T> {
         private final ChannelOption<T> option;
-        private final Function<T, Object> chanToSock;
-        private final Function<Object, T> sockToChan;
+        private final Function<T, Object> toSocketValue;
+        private final Function<Object, T> toChannelValue;
 
         @SuppressWarnings("unchecked")
-        private OptConverter(final ChannelOption<T> option, final Function<T, ?> chanToSock,
-                             final Function<?, T> sockToChan) {
+        private OptConverter(final ChannelOption<T> option, final Function<T, ?> toSocketValue,
+                             final Function<?, T> toChannelValue) {
             this.option = option;
-            this.chanToSock = (Function<T, Object>) chanToSock;
-            this.sockToChan = (Function<Object, T>) sockToChan;
+            this.toSocketValue = (Function<T, Object>) toSocketValue;
+            this.toChannelValue = (Function<Object, T>) toChannelValue;
         }
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SocketOptionUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SocketOptionUtils.java
@@ -20,6 +20,7 @@ import io.servicetalk.transport.api.ServiceTalkSocketOptions;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.WriteBufferWaterMark;
+import io.netty.channel.epoll.EpollChannelOption;
 
 import java.net.SocketOption;
 import java.net.StandardSocketOptions;
@@ -75,6 +76,12 @@ public final class SocketOptionUtils {
             final int writeBufferThreshold = (Integer) value;
             channelOpts.put(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(writeBufferThreshold >>> 1,
                     writeBufferThreshold));
+        } else if (option == ServiceTalkSocketOptions.SO_BACKLOG) {
+            channelOpts.put(ChannelOption.SO_BACKLOG, value);
+        } else if (option == ServiceTalkSocketOptions.TCP_FASTOPEN_BACKLOG) {
+            channelOpts.put(EpollChannelOption.TCP_FASTOPEN, value);
+        } else if (option == ServiceTalkSocketOptions.TCP_FASTOPEN_CONNECT) {
+            channelOpts.put(ChannelOption.TCP_FASTOPEN_CONNECT, value);
         } else {
             throw unsupported(option);
         }
@@ -135,6 +142,15 @@ public final class SocketOptionUtils {
         if (option == ServiceTalkSocketOptions.WRITE_BUFFER_THRESHOLD) {
             final WriteBufferWaterMark result = config.getOption(ChannelOption.WRITE_BUFFER_WATER_MARK);
             return result == null ? null : (T) Integer.valueOf(result.high());
+        }
+        if (option == ServiceTalkSocketOptions.SO_BACKLOG) {
+            return (T) config.getOption(ChannelOption.SO_BACKLOG);
+        }
+        if (option == ServiceTalkSocketOptions.TCP_FASTOPEN_BACKLOG) {
+            return (T) config.getOption(EpollChannelOption.TCP_FASTOPEN);
+        }
+        if (option == ServiceTalkSocketOptions.TCP_FASTOPEN_CONNECT) {
+            return (T) config.getOption(ChannelOption.TCP_FASTOPEN_CONNECT);
         }
         if (option == ServiceTalkSocketOptions.IDLE_TIMEOUT) {
             return (T) idleTimeoutMs;


### PR DESCRIPTION
Motivation:
Netty recently added support for
[TCP fast open](https://tools.ietf.org/html/rfc7413) on the client, and
has had server support for a while. We currently don't expose the
necessary configuration knobs to enable this feature, but it may be able
to reduce round trips and reduce connection setup latency.

Modifications:
- Add socket options to configure client and server TCP fast open.
- Add mechanism to configure the listen/acceptor socket options, and use
  this for the backlog option which was an outlier.

Result:
TCP Fast Open can be enabled for client and server. Note that it is only
supported by Netty's native EPOLL transport on linux, and only
initiated on the client when TLS is enabled.