### PR TITLE
Fix broken SSL APIs related to SNI and hostname

### DIFF
--- a/servicetalk-examples/http/http2/src/main/java/io/servicetalk/examples/http/http2/alpn/HttpServerWithAlpn.java
+++ b/servicetalk-examples/http/http2/src/main/java/io/servicetalk/examples/http/http2/alpn/HttpServerWithAlpn.java
@@ -33,7 +33,7 @@ public final class HttpServerWithAlpn {
         HttpServers.forPort(8080)
                 .protocols(h2Default(), h1Default()) // Configure support for HTTP/2 and HTTP/1.1 protocols
                 // Configure TLS certificates:
-                .secure().commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                .secure().keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey).commit()
                 // Note: this example demonstrates only blocking-aggregated programming paradigm, for asynchronous and
                 // streaming API see helloworld examples.
                 .listenBlockingAndAwait((ctx, request, responseFactory) ->

--- a/servicetalk-examples/http/mutual-tls/src/main/java/io/servicetalk/examples/http/mutualtls/HttpClientMutualTLS.java
+++ b/servicetalk-examples/http/mutual-tls/src/main/java/io/servicetalk/examples/http/mutualtls/HttpClientMutualTLS.java
@@ -31,15 +31,14 @@ public final class HttpClientMutualTLS {
         // Note: this example demonstrates only blocking-aggregated programming paradigm, for asynchronous and
         // streaming API see helloworld examples.
         try (BlockingHttpClient client = HttpClients.forSingleAddress("localhost", 8080)
-                .secure()   // Start TLS configuration
+                .secure()
                 // Our self-signed certificates do not support hostname verification, but this MUST NOT be disabled in
                 // production because it may leave you vulnerable to MITM attacks.
                 .disableHostnameVerification()
                 // The client only trusts the CA which signed the example server's certificate.
                 .trustManager(DefaultTestCerts::loadServerCAPem)
                 // Specify the client's certificate/key pair to use to authenticate to the server.
-                .keyManager(DefaultTestCerts::loadClientPem, DefaultTestCerts::loadClientKey)
-                .commit()   // Finish TLS configuration
+                .keyManager(DefaultTestCerts::loadClientPem, DefaultTestCerts::loadClientKey).commit()
                 .buildBlocking()) {
             HttpResponse response = client.request(client.get("/"));
             System.out.println(response.toString((name, value) -> value));

--- a/servicetalk-examples/http/mutual-tls/src/main/java/io/servicetalk/examples/http/mutualtls/HttpServerMutualTLS.java
+++ b/servicetalk-examples/http/mutual-tls/src/main/java/io/servicetalk/examples/http/mutualtls/HttpServerMutualTLS.java
@@ -35,7 +35,7 @@ public final class HttpServerMutualTLS {
                 // The server only trusts the CA which signed the example clients's certificate.
                 .trustManager(DefaultTestCerts::loadClientCAPem)
                 // Specify the server's certificate/key pair to use to authenticate to the server.
-                .commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                .keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey).commit()
                 // Note: this example demonstrates only blocking-aggregated programming paradigm, for asynchronous and
                 // streaming API see helloworld examples.
                 .listenBlockingAndAwait((ctx, request, responseFactory) ->

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientSecurityConfigurator.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientSecurityConfigurator.java
@@ -61,26 +61,16 @@ public interface GrpcClientSecurityConfigurator<U, R> extends ClientSecurityConf
             String hostNameVerificationAlgorithm);
 
     @Override
-    GrpcClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationAlgorithm,
-                                                              String hostNameVerificationHost);
-
-    @Override
-    GrpcClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationAlgorithm,
-                                                              String hostNameVerificationHost,
-                                                              int hostNameVerificationPort);
-
-    @Override
-    GrpcClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationHost);
-
-    @Override
-    GrpcClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationHost,
-                                                              int hostNameVerificationPort);
+    GrpcClientSecurityConfigurator<U, R> disableHostnameVerification();
 
     @Override
     GrpcClientSecurityConfigurator<U, R> sniHostname(String sniHostname);
 
     @Override
-    GrpcClientSecurityConfigurator<U, R> disableHostnameVerification();
+    GrpcClientSecurityConfigurator<U, R> peerHost(String peerHost);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> peerPort(int peerPort);
 
     @Override
     GrpcClientSecurityConfigurator<U, R> keyManager(KeyManagerFactory keyManagerFactory);

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -76,31 +76,11 @@ public abstract class GrpcServerBuilder {
     /**
      * Initiate security configuration for this server. Calling any {@code commit} method on the returned
      * {@link GrpcServerSecurityConfigurator} will commit the configuration.
-     * <p>
-     * Additionally use {@link #secure(String...)} to define configurations for specific
-     * <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> hostnames. If such configuration is additionally
-     * defined then configuration using this method is used as default if the hostname does not match any of the
-     * specified hostnames.
      *
      * @return {@link GrpcServerSecurityConfigurator} to configure security for this server. It is
      * mandatory to call any one of the {@code commit} methods after all configuration is done.
      */
     public abstract GrpcServerSecurityConfigurator secure();
-
-    /**
-     * Initiate security configuration for this server for the passed {@code sniHostnames}.
-     * Calling any {@code commit} method on the returned {@link GrpcServerSecurityConfigurator} will commit the
-     * configuration.
-     * <p>
-     * When using this method, it is mandatory to also define the default configuration using {@link #secure()} which
-     * is used when the hostname does not match any of the specified {@code sniHostnames}.
-     *
-     * @param sniHostnames <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> hostnames for which this
-     * config is being defined.
-     * @return {@link GrpcServerSecurityConfigurator} to configure security for this server. It is
-     * mandatory to call any one of the {@code commit} methods after all configuration is done.
-     */
-    public abstract GrpcServerSecurityConfigurator secure(String... sniHostnames);
 
     /**
      * Add a {@link SocketOption} that is applied.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerSecurityConfigurator.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerSecurityConfigurator.java
@@ -33,6 +33,17 @@ public interface GrpcServerSecurityConfigurator extends ServerSecurityConfigurat
     GrpcServerSecurityConfigurator trustManager(TrustManagerFactory trustManagerFactory);
 
     @Override
+    GrpcServerSecurityConfigurator keyManager(KeyManagerFactory keyManagerFactory);
+
+    @Override
+    GrpcServerSecurityConfigurator keyManager(Supplier<InputStream> keyCertChainSupplier,
+                                              Supplier<InputStream> keySupplier);
+
+    @Override
+    GrpcServerSecurityConfigurator keyManager(Supplier<InputStream> keyCertChainSupplier,
+                                              Supplier<InputStream> keySupplier, String keyPassword);
+
+    @Override
     GrpcServerSecurityConfigurator protocols(String... protocols);
 
     @Override
@@ -50,47 +61,12 @@ public interface GrpcServerSecurityConfigurator extends ServerSecurityConfigurat
     @Override
     GrpcServerSecurityConfigurator clientAuth(ClientAuth clientAuth);
 
-    /**
-     * Commit configuring server security.
-     *
-     * @param keyManagerFactory an {@link KeyManagerFactory}.
-     * @return Original {@link GrpcServerBuilder} that initiated the security configuration process.
-     */
-    GrpcServerBuilder commit(KeyManagerFactory keyManagerFactory);
+    @Override
+    GrpcServerSecurityConfigurator newSniConfig(String sniHostname);
 
     /**
      * Commit configuring server security.
-     *
-     * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a {@code X.509} certificate
-     * chain in {@code PEM} format.
-     * <p>
-     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
-     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
-     * @param keySupplier an {@link Supplier} that will provide an input stream for a {@code KCS#8} private key in
-     * {@code PEM} format.
-     * <p>
-     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
-     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
      * @return Original {@link GrpcServerBuilder} that initiated the security configuration process.
      */
-    GrpcServerBuilder commit(Supplier<InputStream> keyCertChainSupplier, Supplier<InputStream> keySupplier);
-
-    /**
-     * Commit configuring server security.
-     *
-     * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a {@code X.509} certificate
-     * chain in {@code PEM} format.
-     * <p>
-     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
-     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
-     * @param keySupplier an {@link Supplier} that will provide an input stream for a {@code KCS#8} private key in
-     * {@code PEM} format.
-     * <p>
-     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
-     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
-     * @param keyPassword the password of the {@code keyFile}.
-     * @return Original {@link GrpcServerBuilder} that initiated the security configuration process.
-     */
-    GrpcServerBuilder commit(Supplier<InputStream> keyCertChainSupplier, Supplier<InputStream> keySupplier,
-                             String keyPassword);
+    GrpcServerBuilder commit();
 }

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientSecurityConfigurator.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientSecurityConfigurator.java
@@ -90,31 +90,8 @@ final class DefaultGrpcClientSecurityConfigurator<U, R> implements GrpcClientSec
     }
 
     @Override
-    public GrpcClientSecurityConfigurator<U, R> hostnameVerification(final String hostNameVerificationAlgorithm,
-                                                                     final String hostNameVerificationHost) {
-        delegate.hostnameVerification(hostNameVerificationAlgorithm, hostNameVerificationHost);
-        return this;
-    }
-
-    @Override
-    public GrpcClientSecurityConfigurator<U, R> hostnameVerification(final String hostNameVerificationAlgorithm,
-                                                                     final String hostNameVerificationHost,
-                                                                     final int hostNameVerificationPort) {
-        delegate.hostnameVerification(hostNameVerificationAlgorithm, hostNameVerificationHost,
-                hostNameVerificationPort);
-        return this;
-    }
-
-    @Override
-    public GrpcClientSecurityConfigurator<U, R> hostnameVerification(final String hostNameVerificationHost) {
-        delegate.hostnameVerification(hostNameVerificationHost);
-        return this;
-    }
-
-    @Override
-    public GrpcClientSecurityConfigurator<U, R> hostnameVerification(final String hostNameVerificationHost,
-                                                                     final int hostNameVerificationPort) {
-        delegate.hostnameVerification(hostNameVerificationHost, hostNameVerificationPort);
+    public GrpcClientSecurityConfigurator<U, R> disableHostnameVerification() {
+        delegate.disableHostnameVerification();
         return this;
     }
 
@@ -125,8 +102,14 @@ final class DefaultGrpcClientSecurityConfigurator<U, R> implements GrpcClientSec
     }
 
     @Override
-    public GrpcClientSecurityConfigurator<U, R> disableHostnameVerification() {
-        delegate.disableHostnameVerification();
+    public GrpcClientSecurityConfigurator<U, R> peerHost(final String peerHost) {
+        delegate.peerHost(peerHost);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> peerPort(final int peerPort) {
+        delegate.peerPort(peerPort);
         return this;
     }
 

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -76,12 +76,6 @@ final class DefaultGrpcServerBuilder extends GrpcServerBuilder implements Server
     }
 
     @Override
-    public GrpcServerSecurityConfigurator secure(final String... sniHostnames) {
-        HttpServerSecurityConfigurator secure = httpServerBuilder.secure(sniHostnames);
-        return new DefaultGrpcServerSecurityConfigurator(secure, this);
-    }
-
-    @Override
     public <T> GrpcServerBuilder socketOption(final SocketOption<T> option, final T value) {
         httpServerBuilder.socketOption(option, value);
         return this;

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerSecurityConfigurator.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerSecurityConfigurator.java
@@ -47,6 +47,27 @@ final class DefaultGrpcServerSecurityConfigurator implements GrpcServerSecurityC
     }
 
     @Override
+    public GrpcServerSecurityConfigurator keyManager(final KeyManagerFactory keyManagerFactory) {
+        delegate.keyManager(keyManagerFactory);
+        return this;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator keyManager(final Supplier<InputStream> keyCertChainSupplier,
+                                                     final Supplier<InputStream> keySupplier) {
+        delegate.keyManager(keyCertChainSupplier, keySupplier);
+        return this;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator keyManager(final Supplier<InputStream> keyCertChainSupplier,
+                                                     final Supplier<InputStream> keySupplier,
+                                                     final String keyPassword) {
+        delegate.keyManager(keyCertChainSupplier, keySupplier, keyPassword);
+        return this;
+    }
+
+    @Override
     public GrpcServerSecurityConfigurator protocols(final String... protocols) {
         delegate.protocols(protocols);
         return this;
@@ -83,22 +104,13 @@ final class DefaultGrpcServerSecurityConfigurator implements GrpcServerSecurityC
     }
 
     @Override
-    public GrpcServerBuilder commit(final KeyManagerFactory keyManagerFactory) {
-        delegate.commit(keyManagerFactory);
-        return original;
+    public GrpcServerSecurityConfigurator newSniConfig(final String sniHostname) {
+        return new DefaultGrpcServerSecurityConfigurator(delegate.newSniConfig(sniHostname), original);
     }
 
     @Override
-    public GrpcServerBuilder commit(final Supplier<InputStream> keyCertChainSupplier,
-                                    final Supplier<InputStream> keySupplier) {
-        delegate.commit(keyCertChainSupplier, keySupplier);
-        return original;
-    }
-
-    @Override
-    public GrpcServerBuilder commit(final Supplier<InputStream> keyCertChainSupplier,
-                                    final Supplier<InputStream> keySupplier, final String keyPassword) {
-        delegate.commit(keyCertChainSupplier, keySupplier, keyPassword);
+    public GrpcServerBuilder commit() {
+        delegate.commit();
         return original;
     }
 }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -854,7 +854,7 @@ public class ProtocolCompatibilityTest {
                 });
         return ssl ?
                 serverBuilder.secure().provider(OPENSSL)
-                        .commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey) :
+                        .keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey).commit() :
                 serverBuilder;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -76,31 +76,11 @@ public abstract class HttpServerBuilder {
     /**
      * Initiates security configuration for this server. Calling any {@code commit} method on the returned
      * {@link HttpServerSecurityConfigurator} will commit the configuration.
-     * <p>
-     * Additionally use {@link #secure(String...)} to define configurations for specific
-     * <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> hostnames. If such configuration is additionally
-     * defined then configuration using this method is used as default if the hostname does not match any of the
-     * specified hostnames.
      *
      * @return {@link HttpServerSecurityConfigurator} to configure security for this server. It is
      * mandatory to call any one of the {@code commit} methods after all configuration is done.
      */
     public abstract HttpServerSecurityConfigurator secure();
-
-    /**
-     * Initiates security configuration for this server for the passed {@code sniHostnames}.
-     * Calling any {@code commit} method on the returned {@link HttpServerSecurityConfigurator} will commit the
-     * configuration.
-     * <p>
-     * When using this method, it is mandatory to also define the default configuration using {@link #secure()} which
-     * is used when the hostname does not match any of the specified {@code sniHostnames}.
-     *
-     * @param sniHostnames <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> hostnames for which this
-     * config is being defined.
-     * @return {@link HttpServerSecurityConfigurator} to configure security for this server. It is
-     * mandatory to call any one of the {@code commit} methods after all configuration is done.
-     */
-    public abstract HttpServerSecurityConfigurator secure(String... sniHostnames);
 
     /**
      * Adds a {@link SocketOption} that is applied.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerSecurityConfigurator.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerSecurityConfigurator.java
@@ -33,6 +33,17 @@ public interface HttpServerSecurityConfigurator extends ServerSecurityConfigurat
     HttpServerSecurityConfigurator trustManager(TrustManagerFactory trustManagerFactory);
 
     @Override
+    HttpServerSecurityConfigurator keyManager(KeyManagerFactory keyManagerFactory);
+
+    @Override
+    HttpServerSecurityConfigurator keyManager(Supplier<InputStream> keyCertChainSupplier,
+                                              Supplier<InputStream> keySupplier);
+
+    @Override
+    HttpServerSecurityConfigurator keyManager(Supplier<InputStream> keyCertChainSupplier,
+                                              Supplier<InputStream> keySupplier, String keyPassword);
+
+    @Override
     HttpServerSecurityConfigurator protocols(String... protocols);
 
     @Override
@@ -50,47 +61,12 @@ public interface HttpServerSecurityConfigurator extends ServerSecurityConfigurat
     @Override
     HttpServerSecurityConfigurator clientAuth(ClientAuth clientAuth);
 
-    /**
-     * Commit configuring server security.
-     *
-     * @param keyManagerFactory an {@link KeyManagerFactory}.
-     * @return Original {@link HttpServerBuilder} that initiated the security configuration process.
-     */
-    HttpServerBuilder commit(KeyManagerFactory keyManagerFactory);
+    @Override
+    HttpServerSecurityConfigurator newSniConfig(String sniHostname);
 
     /**
      * Commit configuring server security.
-     *
-     * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a {@code X.509} certificate
-     * chain in {@code PEM} format.
-     * <p>
-     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
-     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
-     * @param keySupplier an {@link Supplier} that will provide an input stream for a {@code KCS#8} private key in
-     * {@code PEM} format.
-     * <p>
-     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
-     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
      * @return Original {@link HttpServerBuilder} that initiated the security configuration process.
      */
-    HttpServerBuilder commit(Supplier<InputStream> keyCertChainSupplier, Supplier<InputStream> keySupplier);
-
-    /**
-     * Commit configuring server security.
-     *
-     * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a {@code X.509} certificate
-     * chain in {@code PEM} format.
-     * <p>
-     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
-     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
-     * @param keySupplier an {@link Supplier} that will provide an input stream for a {@code KCS#8} private key in
-     * {@code PEM} format.
-     * <p>
-     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
-     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
-     * @param keyPassword the password of the {@code keyFile}.
-     * @return Original {@link HttpServerBuilder} that initiated the security configuration process.
-     */
-    HttpServerBuilder commit(Supplier<InputStream> keyCertChainSupplier, Supplier<InputStream> keySupplier,
-                             String keyPassword);
+    HttpServerBuilder commit();
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientSecurityConfigurator.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientSecurityConfigurator.java
@@ -61,26 +61,16 @@ public interface PartitionedHttpClientSecurityConfigurator<U, R> extends ClientS
             String hostNameVerificationAlgorithm);
 
     @Override
-    PartitionedHttpClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationAlgorithm,
-                                                                         String hostNameVerificationHost);
-
-    @Override
-    PartitionedHttpClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationAlgorithm,
-                                                                         String hostNameVerificationHost,
-                                                                         int hostNameVerificationPort);
-
-    @Override
-    PartitionedHttpClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationHost);
-
-    @Override
-    PartitionedHttpClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationHost,
-                                                                         int hostNameVerificationPort);
+    PartitionedHttpClientSecurityConfigurator<U, R> disableHostnameVerification();
 
     @Override
     PartitionedHttpClientSecurityConfigurator<U, R> sniHostname(String sniHostname);
 
     @Override
-    PartitionedHttpClientSecurityConfigurator<U, R> disableHostnameVerification();
+    PartitionedHttpClientSecurityConfigurator<U, R> peerHost(String peerHost);
+
+    @Override
+    PartitionedHttpClientSecurityConfigurator<U, R> peerPort(int peerPort);
 
     @Override
     PartitionedHttpClientSecurityConfigurator<U, R> keyManager(KeyManagerFactory keyManagerFactory);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientSecurityConfigurator.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientSecurityConfigurator.java
@@ -61,26 +61,16 @@ public interface SingleAddressHttpClientSecurityConfigurator<U, R> extends Clien
             String hostNameVerificationAlgorithm);
 
     @Override
-    SingleAddressHttpClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationAlgorithm,
-                                                                           String hostNameVerificationHost);
+    SingleAddressHttpClientSecurityConfigurator<U, R> disableHostnameVerification();
 
     @Override
-    SingleAddressHttpClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationAlgorithm,
-                                                                           String hostNameVerificationHost,
-                                                                           int hostNameVerificationPort);
+    SingleAddressHttpClientSecurityConfigurator<U, R> peerHost(String peerHost);
 
     @Override
-    SingleAddressHttpClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationHost);
-
-    @Override
-    SingleAddressHttpClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationHost,
-                                                                           int hostNameVerificationPort);
+    SingleAddressHttpClientSecurityConfigurator<U, R> peerPort(int peerPort);
 
     @Override
     SingleAddressHttpClientSecurityConfigurator<U, R> sniHostname(String sniHostname);
-
-    @Override
-    SingleAddressHttpClientSecurityConfigurator<U, R> disableHostnameVerification();
 
     @Override
     SingleAddressHttpClientSecurityConfigurator<U, R> keyManager(KeyManagerFactory keyManagerFactory);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -58,16 +58,9 @@ final class DefaultHttpServerBuilder extends HttpServerBuilder {
 
     @Override
     public HttpServerSecurityConfigurator secure() {
-        return new DefaultHttpServerSecurityConfigurator(securityConfig -> {
-            config.tcpConfig().secure(securityConfig);
-            return DefaultHttpServerBuilder.this;
-        });
-    }
-
-    @Override
-    public HttpServerSecurityConfigurator secure(final String... sniHostnames) {
-        return new DefaultHttpServerSecurityConfigurator(securityConfig -> {
-            config.tcpConfig().secure(securityConfig, sniHostnames);
+        return new DefaultHttpServerSecurityConfigurator((defaultConfig, sniConfigs) -> {
+            config.tcpConfig().secure(defaultConfig);
+            config.tcpConfig().secure(sniConfigs);
             return DefaultHttpServerBuilder.this;
         });
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientSecurityConfigurator.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientSecurityConfigurator.java
@@ -92,31 +92,8 @@ final class DefaultPartitionedHttpClientSecurityConfigurator<U, R>
     }
 
     @Override
-    public PartitionedHttpClientSecurityConfigurator<U, R> hostnameVerification(
-            final String hostNameVerificationAlgorithm, final String hostNameVerificationHost) {
-        delegate.hostnameVerification(hostNameVerificationAlgorithm, hostNameVerificationHost);
-        return this;
-    }
-
-    @Override
-    public PartitionedHttpClientSecurityConfigurator<U, R> hostnameVerification(
-            final String hostNameVerificationAlgorithm, final String hostNameVerificationHost,
-            final int hostNameVerificationPort) {
-        delegate.hostnameVerification(hostNameVerificationAlgorithm, hostNameVerificationHost,
-                hostNameVerificationPort);
-        return this;
-    }
-
-    @Override
-    public PartitionedHttpClientSecurityConfigurator<U, R> hostnameVerification(final String hostNameVerificationHost) {
-        delegate.hostnameVerification(hostNameVerificationHost);
-        return this;
-    }
-
-    @Override
-    public PartitionedHttpClientSecurityConfigurator<U, R> hostnameVerification(final String hostNameVerificationHost,
-                                                                                final int hostNameVerificationPort) {
-        delegate.hostnameVerification(hostNameVerificationHost, hostNameVerificationPort);
+    public PartitionedHttpClientSecurityConfigurator<U, R> disableHostnameVerification() {
+        delegate.disableHostnameVerification();
         return this;
     }
 
@@ -127,8 +104,14 @@ final class DefaultPartitionedHttpClientSecurityConfigurator<U, R>
     }
 
     @Override
-    public PartitionedHttpClientSecurityConfigurator<U, R> disableHostnameVerification() {
-        delegate.disableHostnameVerification();
+    public PartitionedHttpClientSecurityConfigurator<U, R> peerHost(final String peerHost) {
+        delegate.peerHost(peerHost);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> peerPort(final int peerPort) {
+        delegate.peerPort(peerPort);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientSecurityConfigurator.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientSecurityConfigurator.java
@@ -33,9 +33,9 @@ final class DefaultSingleAddressHttpClientSecurityConfigurator<U, R>
     private final Function<ReadOnlyClientSecurityConfig, SingleAddressHttpClientBuilder<U, R>> configConsumer;
 
     DefaultSingleAddressHttpClientSecurityConfigurator(
-            final String serverHostname, final int serverPort,
+            final String peerHost, final int peerPort,
             final Function<ReadOnlyClientSecurityConfig, SingleAddressHttpClientBuilder<U, R>> configConsumer) {
-        config = new ClientSecurityConfig(serverHostname, serverPort);
+        config = new ClientSecurityConfig(peerHost, peerPort);
         this.configConsumer = configConsumer;
     }
 
@@ -96,35 +96,6 @@ final class DefaultSingleAddressHttpClientSecurityConfigurator<U, R>
     }
 
     @Override
-    public SingleAddressHttpClientSecurityConfigurator<U, R> hostnameVerification(
-            final String hostNameVerificationAlgorithm, final String hostNameVerificationHost) {
-        config.hostNameVerification(hostNameVerificationAlgorithm, hostNameVerificationHost);
-        return this;
-    }
-
-    @Override
-    public SingleAddressHttpClientSecurityConfigurator<U, R> hostnameVerification(
-            final String hostNameVerificationAlgorithm, final String hostNameVerificationHost,
-            final int hostNameVerificationPort) {
-        config.hostNameVerification(hostNameVerificationAlgorithm, hostNameVerificationHost, hostNameVerificationPort);
-        return this;
-    }
-
-    @Override
-    public SingleAddressHttpClientSecurityConfigurator<U, R> hostnameVerification(
-            final String hostNameVerificationHost) {
-        config.hostNameVerification(hostNameVerificationHost);
-        return this;
-    }
-
-    @Override
-    public SingleAddressHttpClientSecurityConfigurator<U, R> hostnameVerification(
-            final String hostNameVerificationHost, final int hostNameVerificationPort) {
-        config.hostNameVerification(hostNameVerificationHost, hostNameVerificationPort);
-        return this;
-    }
-
-    @Override
     public SingleAddressHttpClientSecurityConfigurator<U, R> sniHostname(final String sniHostname) {
         config.sniHostname(sniHostname);
         return this;
@@ -133,6 +104,18 @@ final class DefaultSingleAddressHttpClientSecurityConfigurator<U, R>
     @Override
     public SingleAddressHttpClientSecurityConfigurator<U, R> disableHostnameVerification() {
         config.disableHostnameVerification();
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> peerHost(final String peerHost) {
+        config.peerHost(peerHost);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> peerPort(final int peerPort) {
+        config.peerPort(peerPort);
         return this;
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -158,8 +158,8 @@ public abstract class AbstractNettyHttpServerTest {
                 .transportObserver(serverTransportObserver)
                 .enableWireLogging("servicetalk-tests-wire-logger", TRACE, () -> true);
         if (sslEnabled) {
-            serverBuilder.secure().commit(DefaultTestCerts::loadServerPem,
-                    DefaultTestCerts::loadServerKey);
+            serverBuilder.secure().keyManager(DefaultTestCerts::loadServerPem,
+                    DefaultTestCerts::loadServerKey).commit();
         }
         if (serviceFilterFactory != null) {
             serverBuilder.appendServiceFilter(serviceFilterFactory);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
@@ -120,7 +120,7 @@ public class AlpnClientAndServerTest {
                 .protocols(toProtocolConfigs(supportedProtocols))
                 .secure()
                 .provider(OPENSSL)
-                .commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                .keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey).commit()
                 .listenBlocking((ctx, request, responseFactory) -> {
                     serviceContext.put(ctx);
                     requestVersion.put(request.version());

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
@@ -141,7 +141,8 @@ public class ConnectionCloseHeaderHandlingTest {
                 // Dummy proxy helps to emulate old intermediate systems that do not support half-closed TCP connections
                 proxyTunnel = new ProxyTunnel();
                 proxyAddress = proxyTunnel.startProxy();
-                serverBuilder.secure().commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey);
+                serverBuilder.secure().keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                        .commit();
             } else {
                 proxyTunnel = null;
             }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
@@ -169,7 +169,8 @@ public class GracefulConnectionClosureHandlingTest {
             // Dummy proxy helps to emulate old intermediate systems that do not support half-closed TCP connections
             proxyTunnel = new ProxyTunnel();
             proxyAddress = proxyTunnel.startProxy();
-            serverBuilder.secure().commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey);
+            serverBuilder.secure().keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                    .commit();
         } else {
             proxyTunnel = null;
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionContextProtocolTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionContextProtocolTest.java
@@ -101,7 +101,7 @@ public class HttpConnectionContextProtocolTest {
         final HttpServerBuilder builder = HttpServers.forAddress(localAddress(0))
                 .protocols(config.protocols);
         if (config.secure) {
-            builder.secure().commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey);
+            builder.secure().keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey).commit();
         }
         return builder.listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok()
                 .payloadBody(ctx.protocol().name(), textSerializer()));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
@@ -94,7 +94,7 @@ public class HttpsProxyTest {
     public void startServer() throws Exception {
         serverContext = HttpServers.forAddress(localAddress(0))
                 .ioExecutor(serverIoExecutor = createIoExecutor(new IoThreadFactory("server-io-executor")))
-                .secure().commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                .secure().keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey).commit()
                 .listenAndAwait((ctx, request, responseFactory) -> succeeded(responseFactory.ok()
                         .payloadBody("host: " + request.headers().get(HOST), textSerializer())));
         serverAddress = serverHostAndPort(serverContext);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MutualSslTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MutualSslTest.java
@@ -67,7 +67,7 @@ public class MutualSslTest {
                 .provider(serverSslProvider)
                 .clientAuth(REQUIRE)
                 .trustManager(DefaultTestCerts::loadClientCAPem)
-                .commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                .keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey).commit()
                 .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
              BlockingHttpClient client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
                      .secure()

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
@@ -160,7 +160,8 @@ public class SecurityHandshakeObserverTest {
                 .ioExecutor(SERVER_CTX.ioExecutor())
                 .executionStrategy(defaultStrategy(SERVER_CTX.executor()))
                 .secure()
-                .commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                .keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                .commit()
                 .transportObserver(serverTransportObserver)
                 .listenStreamingAndAwait(new TestServiceStreaming());
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SniTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SniTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.test.resources.DefaultTestCerts;
+import io.servicetalk.transport.api.ServerContext;
+
+import org.junit.Test;
+
+import java.util.function.Function;
+import javax.net.ssl.SSLHandshakeException;
+
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class SniTest {
+    private static final String SNI_HOSTNAME = "servicetalk.io";
+    @Test
+    public void sniSuccess() throws Exception {
+        try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
+                .secure()
+                // Need a key that won't be trusted by the client, just use the client's key.
+                .keyManager(DefaultTestCerts::loadClientPem, DefaultTestCerts::loadClientKey)
+                .newSniConfig(SNI_HOSTNAME)
+                .keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                .commit()
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
+             BlockingHttpClient client = newClient(serverContext)) {
+            assertEquals(HttpResponseStatus.OK, client.request(client.get("/")).status());
+        }
+    }
+
+    @Test
+    public void sniDefaultFallbackSuccess() throws Exception {
+        sniDefaultFallbackSuccess(SniTest::newClient);
+    }
+
+    private static void sniDefaultFallbackSuccess(Function<ServerContext, BlockingHttpClient> clientFunc)
+            throws Exception {
+        try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
+                .secure()
+                .keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                .newSniConfig("no_match" + SNI_HOSTNAME)
+                // Need a key that won't be trusted by the client, just use the client's key.
+                .keyManager(DefaultTestCerts::loadClientPem, DefaultTestCerts::loadClientKey)
+                .commit()
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
+             BlockingHttpClient client = clientFunc.apply(serverContext)) {
+            assertEquals(HttpResponseStatus.OK, client.request(client.get("/")).status());
+        }
+    }
+
+    @Test
+    public void sniFailExpected() throws Exception {
+        try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
+                .secure()
+                .keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                .newSniConfig(SNI_HOSTNAME)
+                // Need a key that won't be trusted by the client, just use the client's key.
+                .keyManager(DefaultTestCerts::loadClientPem, DefaultTestCerts::loadClientKey)
+                .commit()
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
+             BlockingHttpClient client = newClient(serverContext)) {
+            assertThrows(SSLHandshakeException.class, () -> client.request(client.get("/")));
+        }
+    }
+
+    @Test
+    public void sniDefaultFallbackFailExpected() throws Exception {
+        try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
+                .secure()
+                // Need a key that won't be trusted by the client, just use the client's key.
+                .keyManager(DefaultTestCerts::loadClientPem, DefaultTestCerts::loadClientKey)
+                .newSniConfig("no_match" + SNI_HOSTNAME)
+                .keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                .commit()
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
+             BlockingHttpClient client = newClient(serverContext)) {
+            assertThrows(SSLHandshakeException.class, () -> client.request(client.get("/")));
+        }
+    }
+
+    @Test
+    public void sniClientDefaultServerSuccess() throws Exception {
+        try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
+                .secure()
+                .keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                .commit()
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
+             BlockingHttpClient client = newClient(serverContext)) {
+            assertEquals(HttpResponseStatus.OK, client.request(client.get("/")).status());
+        }
+    }
+
+    @Test
+    public void noSniClientDefaultServerFallbackSuccess() throws Exception {
+        sniDefaultFallbackSuccess(serverContext -> HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                .secure()
+                .disableHostnameVerification() // test certificates hostname isn't coordinated with each test
+                .trustManager(DefaultTestCerts::loadServerCAPem)
+                .commit()
+                .buildBlocking());
+    }
+
+    private static BlockingHttpClient newClient(ServerContext serverContext) {
+        return HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                .secure()
+                .sniHostname(SNI_HOSTNAME)
+                .disableHostnameVerification() // test certificates hostname isn't coordinated with each test
+                .trustManager(DefaultTestCerts::loadServerCAPem)
+                .commit()
+                .buildBlocking();
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslAndNonSslConnectionsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslAndNonSslConnectionsTest.java
@@ -111,7 +111,7 @@ public class SslAndNonSslConnectionsTest {
         when(SECURE_STREAMING_HTTP_SERVICE.closeAsync()).thenReturn(completed());
         when(SECURE_STREAMING_HTTP_SERVICE.closeAsyncGracefully()).thenReturn(completed());
         secureServerCtx = HttpServers.forAddress(localAddress(0))
-                .secure().commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                .secure().keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey).commit()
                 .executionStrategy(noOffloadsStrategy())
                 .listenStreamingAndAwait(SECURE_STREAMING_HTTP_SERVICE);
         final String secureServerHostHeader = hostHeader(serverHostAndPort(secureServerCtx));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslProvidersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslProvidersTest.java
@@ -66,7 +66,7 @@ public class SslProvidersTest {
         serverContext = HttpServers.forAddress(localAddress(0))
                 .secure()
                 .provider(serverSslProvider)
-                .commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                .keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey).commit()
                 .listenBlockingAndAwait((ctx, request, responseFactory) -> {
                     assertThat(ctx.sslSession(), is(notNullValue()));
                     assertThat(request.path(), is("/path"));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/Tls13Test.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/Tls13Test.java
@@ -110,7 +110,7 @@ public class Tls13Test {
             serverSecurityConfigurator.ciphers(singletonList(cipher));
         }
         try (ServerContext serverContext = serverSecurityConfigurator
-                .commit(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                .keyManager(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey).commit()
                 .listenBlockingAndAwait((ctx, request, responseFactory) -> {
                     assertThat(request.payloadBody(textDeserializer()), equalTo("request-payload-body"));
                     SSLSession sslSession = ctx.sslSession();

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpClientConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpClientConfig.java
@@ -29,14 +29,10 @@ import static io.servicetalk.transport.netty.internal.SslContextFactory.forClien
  */
 public final class ReadOnlyTcpClientConfig
         extends AbstractReadOnlyTcpConfig<ReadOnlyClientSecurityConfig, ReadOnlyTcpClientConfig> {
-
     @Nullable
     private final SslContext sslContext;
     @Nullable
-    private final String sslHostnameVerificationAlgorithm;
-    @Nullable
-    private final String sslHostnameVerificationHost;
-    private final int sslHostnameVerificationPort;
+    private final ReadOnlyClientSecurityConfig sslConfig;
 
     /**
      * Copy constructor.
@@ -45,18 +41,8 @@ public final class ReadOnlyTcpClientConfig
      */
     ReadOnlyTcpClientConfig(final TcpClientConfig from, final List<String> supportedAlpnProtocols) {
         super(from, supportedAlpnProtocols.isEmpty() ? null : supportedAlpnProtocols.get(0));
-        final ReadOnlyClientSecurityConfig securityConfig = from.securityConfig();
-        if (securityConfig != null) {
-            sslContext = forClient(securityConfig, supportedAlpnProtocols);
-            sslHostnameVerificationAlgorithm = securityConfig.hostnameVerificationAlgorithm();
-            sslHostnameVerificationHost = securityConfig.hostnameVerificationHost();
-            sslHostnameVerificationPort = securityConfig.hostnameVerificationPort();
-        } else {
-            sslContext = null;
-            sslHostnameVerificationAlgorithm = null;
-            sslHostnameVerificationHost = null;
-            sslHostnameVerificationPort = -1;
-        }
+        sslConfig = from.securityConfig();
+        sslContext = sslConfig != null ? forClient(sslConfig, supportedAlpnProtocols) : null;
     }
 
     @Nullable
@@ -66,33 +52,12 @@ public final class ReadOnlyTcpClientConfig
     }
 
     /**
-     * Returns the hostname verification algorithm, if any.
+     * Get the {@link ReadOnlyClientSecurityConfig}.
      *
-     * @return hostname verification algorithm, {@code null} if none specified
+     * @return the {@link ReadOnlyClientSecurityConfig}.
      */
     @Nullable
-    public String sslHostnameVerificationAlgorithm() {
-        return sslHostnameVerificationAlgorithm;
-    }
-
-    /**
-     * Get the non-authoritative name of the host.
-     *
-     * @return the non-authoritative name of the host
-     */
-    @Nullable
-    public String sslHostnameVerificationHost() {
-        return sslHostnameVerificationHost;
-    }
-
-    /**
-     * Get the non-authoritative port.
-     * <p>
-     * Only valid if {@link #sslHostnameVerificationHost()} is not {@code null}.
-     *
-     * @return the non-authoritative port
-     */
-    public int sslHostnameVerificationPort() {
-        return sslHostnameVerificationPort;
+    public ReadOnlyClientSecurityConfig sslConfig() {
+        return sslConfig;
     }
 }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
@@ -20,8 +20,8 @@ import io.servicetalk.transport.netty.internal.NoopTransportObserver;
 import io.servicetalk.transport.netty.internal.ReadOnlyServerSecurityConfig;
 
 import io.netty.handler.ssl.SslContext;
-import io.netty.util.DomainNameMapping;
-import io.netty.util.DomainNameMappingBuilder;
+import io.netty.util.DomainWildcardMappingBuilder;
+import io.netty.util.Mapping;
 
 import java.util.List;
 import java.util.Map;
@@ -40,7 +40,7 @@ public final class ReadOnlyTcpServerConfig
     @Nullable
     private final SslContext sslContext;
     @Nullable
-    private final DomainNameMapping<SslContext> mappings;
+    private final Mapping<String, SslContext> mappings;
     private final int backlog;
 
     /**
@@ -59,7 +59,7 @@ public final class ReadOnlyTcpServerConfig
                 throw new IllegalStateException("No default security config defined but found SNI config mappings");
             }
             sslContext = forServer(securityConfig, supportedAlpnProtocols);
-            final DomainNameMappingBuilder<SslContext> mappingBuilder = new DomainNameMappingBuilder<>(sslContext);
+            DomainWildcardMappingBuilder<SslContext> mappingBuilder = new DomainWildcardMappingBuilder<>(sslContext);
             for (Map.Entry<String, ReadOnlyServerSecurityConfig> sniConfigEntries : from.sniConfigs().entrySet()) {
                 mappingBuilder.add(sniConfigEntries.getKey(),
                         forServer(sniConfigEntries.getValue(), supportedAlpnProtocols));
@@ -91,12 +91,12 @@ public final class ReadOnlyTcpServerConfig
     }
 
     /**
-     * Gets {@link DomainNameMapping}, if any.
+     * Gets the {@link Mapping} for SNI.
      *
-     * @return Configured mapping, {@code null} if none configured
+     * @return the {@link Mapping} for SNI, {@code null} if SNI isn't enabled.
      */
     @Nullable
-    public DomainNameMapping<SslContext> domainNameMapping() {
+    public Mapping<String, SslContext> sniMapping() {
         return mappings;
     }
 

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
@@ -21,6 +21,7 @@ import io.servicetalk.transport.netty.internal.ChannelInitializer;
 import io.servicetalk.transport.netty.internal.ConnectionObserverInitializer;
 import io.servicetalk.transport.netty.internal.IdleTimeoutInitializer;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
+import io.servicetalk.transport.netty.internal.SniServerChannelInitializer;
 import io.servicetalk.transport.netty.internal.SslServerChannelInitializer;
 import io.servicetalk.transport.netty.internal.WireLoggingInitializer;
 
@@ -47,15 +48,15 @@ public class TcpServerChannelInitializer implements ChannelInitializer {
 
         if (observer != NoopConnectionObserver.INSTANCE) {
             delegate = delegate.andThen(new ConnectionObserverInitializer(observer,
-                    config.sslContext() != null || config.domainNameMapping() != null));
+                    config.sslContext() != null || config.sniMapping() != null));
         }
 
         if (config.idleTimeoutMs() != null) {
             delegate = delegate.andThen(new IdleTimeoutInitializer(config.idleTimeoutMs()));
         }
 
-        if (config.domainNameMapping() != null) {
-            delegate = delegate.andThen(new SslServerChannelInitializer(config.domainNameMapping()));
+        if (config.sniMapping() != null) {
+            delegate = delegate.andThen(new SniServerChannelInitializer(config.sniMapping()));
         } else if (config.sslContext() != null) {
             delegate = delegate.andThen(new SslServerChannelInitializer(config.sslContext()));
         }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
@@ -21,7 +21,6 @@ import io.servicetalk.transport.netty.internal.ReadOnlyServerSecurityConfig;
 
 import io.netty.util.NetUtil;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -63,19 +62,11 @@ public final class TcpServerConfig extends AbstractTcpConfig<ReadOnlyServerSecur
     /**
      * Add security related config.
      *
-     * @param securityConfig the {@link ReadOnlyServerSecurityConfig} for the passed hostnames
-     * @param sniHostnames SNI hostnames for which this config is defined
+     * @param sniConfigs Map which provides configuration for individual SNI entries.
      * @return {@code this}
      */
-    public TcpServerConfig secure(final ReadOnlyServerSecurityConfig securityConfig, final String... sniHostnames) {
-        requireNonNull(securityConfig);
-        requireNonNull(sniHostnames);
-        if (sniConfigs == null) {
-            sniConfigs = new HashMap<>();
-        }
-        for (String sniHostname : sniHostnames) {
-            sniConfigs.put(sniHostname, securityConfig);
-        }
+    public TcpServerConfig secure(final Map<String, ReadOnlyServerSecurityConfig> sniConfigs) {
+        this.sniConfigs = sniConfigs;
         return this;
     }
 

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverErrorsTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverErrorsTest.java
@@ -100,7 +100,8 @@ public final class SecureTcpTransportObserverErrorsTest extends AbstractTranspor
                 serverConfig.secure(serverSecurityConfig);
                 break;
             case WRONG_HOSTNAME_VERIFICATION:
-                clientSecurityConfig.hostNameVerification("HTTPS", "foo");
+                clientSecurityConfig.hostNameVerificationAlgorithm("HTTPS");
+                clientSecurityConfig.peerHost("foo");
                 clientConfig.secure(clientSecurityConfig);
                 serverConfig.secure(serverSecurityConfig);
                 break;

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ClientSecurityConfigurator.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ClientSecurityConfigurator.java
@@ -32,6 +32,17 @@ public interface ClientSecurityConfigurator extends SecurityConfigurator {
     ClientSecurityConfigurator trustManager(TrustManagerFactory trustManagerFactory);
 
     @Override
+    ClientSecurityConfigurator keyManager(KeyManagerFactory keyManagerFactory);
+
+    @Override
+    ClientSecurityConfigurator keyManager(Supplier<InputStream> keyCertChainSupplier,
+                                          Supplier<InputStream> keySupplier);
+
+    @Override
+    ClientSecurityConfigurator keyManager(Supplier<InputStream> keyCertChainSupplier, Supplier<InputStream> keySupplier,
+                                          String keyPassword);
+
+    @Override
     ClientSecurityConfigurator protocols(String... protocols);
 
     @Override
@@ -51,72 +62,11 @@ public interface ClientSecurityConfigurator extends SecurityConfigurator {
      *
      * @param hostNameVerificationAlgorithm The algorithm to use when verifying the host name.
      * See <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#jssenames">
-     * Supported algorithm names</a>.
+     * Endpoint Identification Algorithm Name</a>.
      * @return {@code this}.
      * @see SSLParameters#setEndpointIdentificationAlgorithm(String)
      */
     ClientSecurityConfigurator hostnameVerificationAlgorithm(String hostNameVerificationAlgorithm);
-
-    /**
-     * Determines what algorithm to use for hostname verification.
-     *
-     * @param hostNameVerificationAlgorithm The algorithm to use when verifying the host name.
-     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#jssenames">
-     * Supported algorithm names</a>.
-     * @param hostNameVerificationHost the host name used to verify the
-     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
-     * @return {@code this}.
-     * @see SSLParameters#setEndpointIdentificationAlgorithm(String)
-     */
-    ClientSecurityConfigurator hostnameVerification(String hostNameVerificationAlgorithm,
-                                                    String hostNameVerificationHost);
-
-    /**
-     * Determines what algorithm to use for hostname verification.
-     *
-     * @param hostNameVerificationAlgorithm The algorithm to use when verifying the host name.
-     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#jssenames">
-     * Supported algorithm names</a>.
-     * @param hostNameVerificationHost the host name used to verify the
-     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
-     * @param hostNameVerificationPort The port which maybe used to verify the
-     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
-     * @return {@code this}.
-     * @see SSLParameters#setEndpointIdentificationAlgorithm(String)
-     */
-    ClientSecurityConfigurator hostnameVerification(String hostNameVerificationAlgorithm,
-                                                    String hostNameVerificationHost, int hostNameVerificationPort);
-
-    /**
-     * Set the host name used to verify the <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server
-     * identity</a>.
-     *
-     * @param hostNameVerificationHost the host name used to verify the
-     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
-     * @return {@code this}.
-     */
-    ClientSecurityConfigurator hostnameVerification(String hostNameVerificationHost);
-
-    /**
-     * Set the host name and port used to verify the <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server
-     * identity</a>.
-     *
-     * @param hostNameVerificationHost the host name used to verify the
-     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
-     * @param hostNameVerificationPort The port which maybe used to verify the
-     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
-     * @return {@code this}.
-     * @see SSLParameters#setEndpointIdentificationAlgorithm(String)
-     */
-    ClientSecurityConfigurator hostnameVerification(String hostNameVerificationHost, int hostNameVerificationPort);
-
-    /**
-     * Set the <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> host name.
-     *
-     * @param sniHostname The <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> host name.
-     * @return {@code this}.
-     */
-    ClientSecurityConfigurator sniHostname(String sniHostname);
 
     /**
      * Disable verification of the <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
@@ -126,48 +76,24 @@ public interface ClientSecurityConfigurator extends SecurityConfigurator {
     ClientSecurityConfigurator disableHostnameVerification();
 
     /**
-     * Identifying certificate for this host. {@code keyManagerFactory} may be {@code null}, which disables mutual
-     * authentication. The {@link KeyManagerFactory} which take preference over any configured {@link Supplier}.
-     *
-     * @param keyManagerFactory an {@link KeyManagerFactory}.
+     * Set the non-authoritative name of the peer, will be used for host name verification (if enabled).
+     * @param peerHost the non-authoritative name of the peer, will be used for host name verification (if enabled).
      * @return {@code this}.
      */
-    ClientSecurityConfigurator keyManager(KeyManagerFactory keyManagerFactory);
+    ClientSecurityConfigurator peerHost(String peerHost);
 
     /**
-     * Identifying certificate for this host. {@code keyCertChainInputStream} and {@code keyInputStream} may
-     * be {@code null}, which disables mutual authentication.
-     *
-     * @param keyCertChainSupplier a {@link Supplier} that will provide an input stream for a {@code X.509} certificate
-     * chain in {@code PEM} format.
-     * <p>
-     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
-     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
-     * @param keySupplier an {@link Supplier} that will provide an input stream for a KCS#8 private key in PEM format.
-     * <p>
-     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
-     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * Set the non-authoritative port of the peer.
+     * @param peerPort the non-authoritative port of the peer.
      * @return {@code this}.
      */
-    ClientSecurityConfigurator keyManager(Supplier<InputStream> keyCertChainSupplier,
-                                          Supplier<InputStream> keySupplier);
+    ClientSecurityConfigurator peerPort(int peerPort);
 
     /**
-     * Identifying certificate for this host. {@code keyCertChainInputStream} and {@code keyInputStream} may
-     * be {@code null}, which disables mutual authentication.
+     * Set the <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> host name.
      *
-     * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a {@code X.509} certificate
-     * chain in {@code PEM} format.
-     * <p>
-     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
-     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
-     * @param keySupplier an {@link Supplier} that will provide an input stream for a KCS#8 private key in PEM format.
-     * <p>
-     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
-     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
-     * @param keyPassword the password of the {@code keyInputStream}.
+     * @param sniHostname The <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> host name.
      * @return {@code this}.
      */
-    ClientSecurityConfigurator keyManager(Supplier<InputStream> keyCertChainSupplier, Supplier<InputStream> keySupplier,
-                                          String keyPassword);
+    ClientSecurityConfigurator sniHostname(String sniHostname);
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/SecurityConfigurator.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/SecurityConfigurator.java
@@ -84,7 +84,7 @@ public interface SecurityConfigurator {
      * <p>
      * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
      * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
-     * @param keySupplier an {@link Supplier} that will provide an input stream for a KCS#8 private key in PEM format.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a PKCS#8 private key in PEM format.
      * <p>
      * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
      * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
@@ -101,7 +101,7 @@ public interface SecurityConfigurator {
      * <p>
      * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
      * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
-     * @param keySupplier an {@link Supplier} that will provide an input stream for a KCS#8 private key in PEM format.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a PKCS#8 private key in PEM format.
      * <p>
      * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
      * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/SecurityConfigurator.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/SecurityConfigurator.java
@@ -17,6 +17,7 @@ package io.servicetalk.transport.api;
 
 import java.io.InputStream;
 import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManagerFactory;
 
@@ -64,6 +65,51 @@ public interface SecurityConfigurator {
      * @return {@code this}.
      */
     SecurityConfigurator trustManager(TrustManagerFactory trustManagerFactory);
+
+    /**
+     * Identifying certificate for this host. {@code keyManagerFactory} may be {@code null}, which disables mutual
+     * authentication. The {@link KeyManagerFactory} which take preference over any configured {@link Supplier}.
+     *
+     * @param keyManagerFactory an {@link KeyManagerFactory}.
+     * @return {@code this}.
+     */
+    SecurityConfigurator keyManager(KeyManagerFactory keyManagerFactory);
+
+    /**
+     * Identifying certificate for this host. {@code keyCertChainInputStream} and {@code keyInputStream} may
+     * be {@code null}, which disables mutual authentication.
+     *
+     * @param keyCertChainSupplier a {@link Supplier} that will provide an input stream for a {@code X.509} certificate
+     * chain in {@code PEM} format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a KCS#8 private key in PEM format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @return {@code this}.
+     */
+    SecurityConfigurator keyManager(Supplier<InputStream> keyCertChainSupplier, Supplier<InputStream> keySupplier);
+
+    /**
+     * Identifying certificate for this host. {@code keyCertChainInputStream} and {@code keyInputStream} may
+     * be {@code null}, which disables mutual authentication.
+     *
+     * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a {@code X.509} certificate
+     * chain in {@code PEM} format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a KCS#8 private key in PEM format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @param keyPassword the password of the {@code keyInputStream}.
+     * @return {@code this}.
+     */
+    SecurityConfigurator keyManager(Supplier<InputStream> keyCertChainSupplier, Supplier<InputStream> keySupplier,
+                                    String keyPassword);
 
     /**
      * The SSL protocols to enable, in the order of preference.

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServerSecurityConfigurator.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServerSecurityConfigurator.java
@@ -17,6 +17,7 @@ package io.servicetalk.transport.api;
 
 import java.io.InputStream;
 import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManagerFactory;
 
@@ -51,6 +52,17 @@ public interface ServerSecurityConfigurator extends SecurityConfigurator {
     ServerSecurityConfigurator trustManager(TrustManagerFactory trustManagerFactory);
 
     @Override
+    ServerSecurityConfigurator keyManager(KeyManagerFactory keyManagerFactory);
+
+    @Override
+    ServerSecurityConfigurator keyManager(Supplier<InputStream> keyCertChainSupplier,
+                                          Supplier<InputStream> keySupplier);
+
+    @Override
+    ServerSecurityConfigurator keyManager(Supplier<InputStream> keyCertChainSupplier, Supplier<InputStream> keySupplier,
+                                          String keyPassword);
+
+    @Override
     ServerSecurityConfigurator protocols(String... protocols);
 
     @Override
@@ -72,4 +84,13 @@ public interface ServerSecurityConfigurator extends SecurityConfigurator {
      * @return {@code this}.
      */
     ServerSecurityConfigurator clientAuth(ClientAuth clientAuth);
+
+    /**
+     * Create a new {@link ServerSecurityConfigurator} which is used when the client requests
+     * <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> for {@code sniHostname}.
+     * @param sniHostname The hostname to match in the TLS client_hello SNI extension.
+     * @return a new {@link ServerSecurityConfigurator} which is used when the client requests
+     * <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> for {@code sniHostname}.
+     */
+    ServerSecurityConfigurator newSniConfig(String sniHostname);
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ClientSecurityConfig.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ClientSecurityConfig.java
@@ -29,19 +29,20 @@ import static java.util.Objects.requireNonNull;
  * Client security configuration.
  */
 public class ClientSecurityConfig extends ReadOnlyClientSecurityConfig {
-
     /**
      * Creates new instance.
      *
-     * @param serverHostname Hostname for the server.
-     * @param serverPort Port for the server.
+     * @param peerHost the non-authoritative name of the peer, will be used for host name verification (if enabled).
+     * @param peerPort the non-authoritative port of the peer.
      */
-    public ClientSecurityConfig(final String serverHostname, final int serverPort) {
-        super(serverHostname, serverPort);
+    public ClientSecurityConfig(final String peerHost, final int peerPort) {
+        super(peerHost, peerPort);
     }
 
     /**
      * Determines what algorithm to use for hostname verification.
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#jssenames">
+     * Endpoint Identification Algorithm Name</a>
      *
      * @param hostNameVerificationAlgorithm The algorithm to use when verifying the host name.
      */
@@ -50,57 +51,19 @@ public class ClientSecurityConfig extends ReadOnlyClientSecurityConfig {
     }
 
     /**
-     * Determines what algorithm to use for hostname verification.
-     *
-     * @param hostNameVerificationAlgorithm The algorithm to use when verifying the host name.
-     * @param hostNameVerificationHost the host name used to verify the
-     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
+     * Set the non-authoritative name of the peer, will be used for host name verification (if enabled).
+     * @param peerHost the non-authoritative name of the peer, will be used for host name verification (if enabled).
      */
-    public void hostNameVerification(final String hostNameVerificationAlgorithm,
-                                     final String hostNameVerificationHost) {
-        this.hostnameVerificationAlgorithm = requireNonNull(hostNameVerificationAlgorithm);
-        this.hostNameVerificationHost = hostNameVerificationHost;
+    public void peerHost(final String peerHost) {
+        this.peerHost = requireNonNull(peerHost);
     }
 
     /**
-     * Determines what algorithm to use for hostname verification.
-     *
-     * @param hostNameVerificationAlgorithm The algorithm to use when verifying the host name.
-     * @param hostNameVerificationHost the host name used to verify the
-     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
-     * @param hostNameVerificationPort The port which maybe used to verify the
-     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
+     * Set the non-authoritative port of the peer.
+     * @param peerPort the non-authoritative port of the peer.
      */
-    public void hostNameVerification(final String hostNameVerificationAlgorithm,
-                                     final String hostNameVerificationHost, final int hostNameVerificationPort) {
-        this.hostnameVerificationAlgorithm = requireNonNull(hostNameVerificationAlgorithm);
-        this.hostNameVerificationHost = hostNameVerificationHost;
-        this.hostNameVerificationPort = hostNameVerificationPort;
-    }
-
-    /**
-     * Set the host name used to verify the <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server
-     * identity</a>.
-     *
-     * @param hostNameVerificationHost the host name used to verify the
-     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
-     */
-    public void hostNameVerification(final String hostNameVerificationHost) {
-        this.hostNameVerificationHost = hostNameVerificationHost;
-    }
-
-    /**
-     * Set the host name and port used to verify the <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server
-     * identity</a>.
-     *
-     * @param hostNameVerificationHost the host name used to verify the
-     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
-     * @param hostNameVerificationPort The port which maybe used to verify the
-     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
-     */
-    public void hostNameVerification(final String hostNameVerificationHost, final int hostNameVerificationPort) {
-        this.hostNameVerificationHost = hostNameVerificationHost;
-        this.hostNameVerificationPort = hostNameVerificationPort;
+    public void peerPort(final int peerPort) {
+        this.peerPort = peerPort;
     }
 
     /**
@@ -117,8 +80,6 @@ public class ClientSecurityConfig extends ReadOnlyClientSecurityConfig {
      */
     public void disableHostnameVerification() {
         hostnameVerificationAlgorithm = null;
-        hostNameVerificationHost = null;
-        hostNameVerificationPort = -1;
     }
 
     /**
@@ -232,6 +193,9 @@ public class ClientSecurityConfig extends ReadOnlyClientSecurityConfig {
      * @return This config as a {@link ReadOnlyClientSecurityConfig}.
      */
     public ReadOnlyClientSecurityConfig asReadOnly() {
+        if (trustManagerFactory == null && trustCertChainSupplier == null) {
+            throw new IllegalStateException("Client security config requires trust material!");
+        }
         return new ReadOnlyClientSecurityConfig(this);
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ClientSecurityConfig.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ClientSecurityConfig.java
@@ -163,7 +163,7 @@ public class ClientSecurityConfig extends ReadOnlyClientSecurityConfig {
      *
      * @param keyCertChainSupplier a {@link Supplier} that will provide an input stream for a {@code X.509} certificate
      * chain in {@code PEM} format.
-     * @param keySupplier an {@link Supplier} that will provide an input stream for a KCS#8 private key in PEM format.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a PKCS#8 private key in PEM format.
      */
     public void keyManager(final Supplier<InputStream> keyCertChainSupplier, final Supplier<InputStream> keySupplier) {
         this.keyCertChainSupplier = requireNonNull(keyCertChainSupplier);
@@ -177,7 +177,7 @@ public class ClientSecurityConfig extends ReadOnlyClientSecurityConfig {
      *
      * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a {@code X.509} certificate
      * chain in {@code PEM} format.
-     * @param keySupplier an {@link Supplier} that will provide an input stream for a KCS#8 private key in PEM format.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a PKCS#8 private key in PEM format.
      * @param keyPassword the password of the {@code keyInputStream}.
      */
     public void keyManager(final Supplier<InputStream> keyCertChainSupplier, final Supplier<InputStream> keySupplier,

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ReadOnlyClientSecurityConfig.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ReadOnlyClientSecurityConfig.java
@@ -23,27 +23,26 @@ import static java.util.Objects.requireNonNull;
  * Read-only security config for clients.
  */
 public class ReadOnlyClientSecurityConfig extends ReadOnlySecurityConfig {
+    /**
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#jssenames">
+     * Endpoint Identification Algorithm Name</a>.
+     */
     @Nullable
     protected String hostnameVerificationAlgorithm = "HTTPS";
-    @Nullable
-    protected String hostNameVerificationHost;
-    /**
-     * Only valid if {@link #hostNameVerificationHost} is valid.
-     */
-    protected int hostNameVerificationPort;
+    protected String peerHost;
+    protected int peerPort;
     @Nullable
     protected String sniHostname;
 
     /**
      * Creates new instance.
      *
-     * @param serverHostname Hostname for the server.
-     * @param serverPort Port for the server.
+     * @param peerHost the non-authoritative name of the peer, will be used for host name verification (if enabled).
+     * @param peerPort the non-authoritative port of the peer.
      */
-    protected ReadOnlyClientSecurityConfig(final String serverHostname, final int serverPort) {
-        hostNameVerificationHost = requireNonNull(serverHostname);
-        hostNameVerificationPort = serverPort;
-        sniHostname = serverHostname;
+    protected ReadOnlyClientSecurityConfig(final String peerHost, final int peerPort) {
+        this.peerHost = requireNonNull(peerHost);
+        this.peerPort = peerPort;
     }
 
     /**
@@ -54,8 +53,8 @@ public class ReadOnlyClientSecurityConfig extends ReadOnlySecurityConfig {
     protected ReadOnlyClientSecurityConfig(final ReadOnlyClientSecurityConfig from) {
         super(from);
         hostnameVerificationAlgorithm = from.hostnameVerificationAlgorithm;
-        hostNameVerificationHost = from.hostNameVerificationHost;
-        hostNameVerificationPort = from.hostNameVerificationPort;
+        peerHost = from.peerHost;
+        peerPort = from.peerPort;
         sniHostname = from.sniHostname;
     }
 
@@ -70,22 +69,19 @@ public class ReadOnlyClientSecurityConfig extends ReadOnlySecurityConfig {
     }
 
     /**
-     * Returns the host name verification host.
-     *
-     * @return The host name verification host.
+     * Get the non-authoritative name of the peer, will be used for host name verification (if enabled).
+     * @return the non-authoritative name of the peer, will be used for host name verification (if enabled).
      */
-    @Nullable
-    public String hostnameVerificationHost() {
-        return hostNameVerificationHost;
+    public String peerHost() {
+        return peerHost;
     }
 
     /**
-     * Returns the host name verification port.
-     *
-     * @return The host name verification port.
+     * Get the non-authoritative port of the peer.
+     * @return the non-authoritative port of the peer.
      */
-    public int hostnameVerificationPort() {
-        return hostNameVerificationPort;
+    public int peerPort() {
+        return peerPort;
     }
 
     /**

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ReadOnlySecurityConfig.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ReadOnlySecurityConfig.java
@@ -30,10 +30,8 @@ import static java.util.Collections.unmodifiableList;
  * A base security config for both client and server.
  */
 class ReadOnlySecurityConfig {
-    @SuppressWarnings("rawtypes")
-    private static final Supplier NULL_SUPPLIER = () -> null;
-
-    Supplier<InputStream> trustCertChainSupplier = nullSupplier();
+    @Nullable
+    Supplier<InputStream> trustCertChainSupplier;
     @Nullable
     TrustManagerFactory trustManagerFactory;
     @Nullable
@@ -46,8 +44,10 @@ class ReadOnlySecurityConfig {
 
     @Nullable
     protected KeyManagerFactory keyManagerFactory;
-    protected Supplier<InputStream> keyCertChainSupplier = nullSupplier();
-    protected Supplier<InputStream> keySupplier = nullSupplier();
+    @Nullable
+    protected Supplier<InputStream> keyCertChainSupplier;
+    @Nullable
+    protected Supplier<InputStream> keySupplier;
     @Nullable
     protected String keyPassword;
 
@@ -68,6 +68,7 @@ class ReadOnlySecurityConfig {
         keyPassword = from.keyPassword;
     }
 
+    @Nullable
     Supplier<InputStream> trustCertChainSupplier() {
         return trustCertChainSupplier;
     }
@@ -104,10 +105,12 @@ class ReadOnlySecurityConfig {
         return keyManagerFactory;
     }
 
+    @Nullable
     Supplier<InputStream> keyCertChainSupplier() {
         return keyCertChainSupplier;
     }
 
+    @Nullable
     Supplier<InputStream> keySupplier() {
         return keySupplier;
     }
@@ -115,10 +118,5 @@ class ReadOnlySecurityConfig {
     @Nullable
     String keyPassword() {
         return keyPassword;
-    }
-
-    @SuppressWarnings("unchecked")
-    static <T> Supplier<T> nullSupplier() {
-        return NULL_SUPPLIER;
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ServerSecurityConfig.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ServerSecurityConfig.java
@@ -112,7 +112,7 @@ public class ServerSecurityConfig extends ReadOnlyServerSecurityConfig {
      *
      * @param keyCertChainSupplier a {@link Supplier} that will provide an input stream for a {@code X.509} certificate
      * chain in {@code PEM} format.
-     * @param keySupplier an {@link Supplier} that will provide an input stream for a KCS#8 private key in PEM format.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a PKCS#8 private key in PEM format.
      */
     public void keyManager(final Supplier<InputStream> keyCertChainSupplier, final Supplier<InputStream> keySupplier) {
         this.keyCertChainSupplier = requireNonNull(keyCertChainSupplier);
@@ -126,7 +126,7 @@ public class ServerSecurityConfig extends ReadOnlyServerSecurityConfig {
      *
      * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a {@code X.509} certificate
      * chain in {@code PEM} format.
-     * @param keySupplier an {@link Supplier} that will provide an input stream for a KCS#8 private key in PEM format.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a PKCS#8 private key in PEM format.
      * @param keyPassword the password of the {@code keyInputStream}.
      */
     public void keyManager(final Supplier<InputStream> keyCertChainSupplier, final Supplier<InputStream> keySupplier,

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ServerSecurityConfig.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ServerSecurityConfig.java
@@ -151,6 +151,9 @@ public class ServerSecurityConfig extends ReadOnlyServerSecurityConfig {
      * @return This config as a {@link ReadOnlyServerSecurityConfig}.
      */
     public ReadOnlyServerSecurityConfig asReadOnly() {
+        if (keyManagerFactory == null && keyCertChainSupplier == null) {
+            throw new IllegalStateException("Server security config requires key material!");
+        }
         return new ReadOnlyServerSecurityConfig(this);
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SniServerChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SniServerChannelInitializer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.handler.ssl.SniHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.util.Mapping;
+
+import javax.net.ssl.SSLEngine;
+
+import static io.servicetalk.transport.netty.internal.CopyByteBufHandlerChannelInitializer.POOLED_ALLOCATOR;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * SNI {@link ChannelInitializer} for servers.
+ */
+public final class SniServerChannelInitializer implements ChannelInitializer {
+    private final Mapping<String, SslContext> sniMapping;
+
+    /**
+     * Create a new instance.
+     * @param sniMapping to use for SNI configuration.
+     */
+    public SniServerChannelInitializer(final Mapping<String, SslContext> sniMapping) {
+        this.sniMapping = requireNonNull(sniMapping);
+    }
+
+    @Override
+    public void init(final Channel channel) {
+        channel.pipeline().addLast(new SniHandlerWithPooledAllocator(sniMapping));
+    }
+
+    /**
+     * Overrides the {@link ByteBufAllocator} used by {@link SslHandler} when it needs to copy data to direct memory if
+     * required by {@link SSLEngine}. {@link SslHandler} releases allocated direct {@link ByteBuf}s after processing.
+     */
+    private static final class SniHandlerWithPooledAllocator extends SniHandler {
+        SniHandlerWithPooledAllocator(final Mapping<String, SslContext> mapping) {
+            super(mapping);
+        }
+
+        @Override
+        protected SslHandler newSslHandler(final SslContext context, final ByteBufAllocator ignore) {
+            return super.newSslHandler(context, POOLED_ALLOCATOR);
+        }
+    }
+}

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslContextFactory.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslContextFactory.java
@@ -21,6 +21,8 @@ import io.netty.handler.ssl.SslContextBuilder;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLException;
 
@@ -57,8 +59,8 @@ public final class SslContextFactory {
             InputStream keyCertChainSupplier = null;
             InputStream keySupplier = null;
             try {
-                keyCertChainSupplier = config.keyCertChainSupplier().get();
-                keySupplier = config.keySupplier().get();
+                keyCertChainSupplier = supplierNullSafe(config.keyCertChainSupplier());
+                keySupplier = supplierNullSafe(config.keySupplier());
                 builder.keyManager(keyCertChainSupplier, keySupplier, config.keyPassword());
             } finally {
                 try {
@@ -98,8 +100,8 @@ public final class SslContextFactory {
             InputStream keyCertChainSupplier = null;
             InputStream keySupplier = null;
             try {
-                keyCertChainSupplier = config.keyCertChainSupplier().get();
-                keySupplier = config.keySupplier().get();
+                keyCertChainSupplier = supplierNullSafe(config.keyCertChainSupplier());
+                keySupplier = supplierNullSafe(config.keySupplier());
                 builder = SslContextBuilder.forServer(keyCertChainSupplier, keySupplier, config.keyPassword());
             } finally {
                 try {
@@ -138,11 +140,16 @@ public final class SslContextFactory {
         }
     }
 
+    @Nullable
+    private static <T> T supplierNullSafe(@Nullable Supplier<T> supplier) {
+        return supplier == null ? null : supplier.get();
+    }
+
     private static void configureTrustManager(ReadOnlySecurityConfig config, SslContextBuilder builder) {
         if (config.trustManagerFactory() != null) {
             builder.trustManager(config.trustManagerFactory());
         } else {
-            InputStream trustManagerStream = config.trustCertChainSupplier().get();
+            InputStream trustManagerStream = supplierNullSafe(config.trustCertChainSupplier());
             try {
                 builder.trustManager(trustManagerStream);
             } finally {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslServerChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslServerChannelInitializer.java
@@ -15,16 +15,8 @@
  */
 package io.servicetalk.transport.netty.internal;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
-import io.netty.handler.ssl.SniHandler;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslHandler;
-import io.netty.util.DomainNameMapping;
-
-import javax.annotation.Nullable;
-import javax.net.ssl.SSLEngine;
 
 import static io.servicetalk.transport.netty.internal.CopyByteBufHandlerChannelInitializer.POOLED_ALLOCATOR;
 import static io.servicetalk.transport.netty.internal.SslUtils.newHandler;
@@ -33,55 +25,19 @@ import static java.util.Objects.requireNonNull;
 /**
  * SSL {@link ChannelInitializer} for servers.
  */
-public class SslServerChannelInitializer implements ChannelInitializer {
-
-    @Nullable
-    private final DomainNameMapping<SslContext> domainNameMapping;
-    @Nullable
+public final class SslServerChannelInitializer implements ChannelInitializer {
     private final SslContext sslContext;
 
     /**
      * New instance.
-     * @param sslContext to use for configuring SSL.
+     * @param sslContext to use for default SSL configuration.
      */
     public SslServerChannelInitializer(SslContext sslContext) {
         this.sslContext = requireNonNull(sslContext);
-        domainNameMapping = null;
-    }
-
-    /**
-     * New instance.
-     * @param domainNameMapping to use for configuring SSL.
-     */
-    public SslServerChannelInitializer(DomainNameMapping<SslContext> domainNameMapping) {
-        this.domainNameMapping = requireNonNull(domainNameMapping);
-        sslContext = null;
     }
 
     @Override
     public void init(Channel channel) {
-        if (sslContext != null) {
-            SslHandler sslHandler = newHandler(sslContext, POOLED_ALLOCATOR);
-            channel.pipeline().addLast(sslHandler);
-        } else {
-            assert domainNameMapping != null;
-            channel.pipeline().addLast(new SniHandlerWithPooledAllocator(domainNameMapping));
-        }
-    }
-
-    /**
-     * Overrides the {@link ByteBufAllocator} used by {@link SslHandler} when it needs to copy data to direct memory if
-     * required by {@link SSLEngine}. {@link SslHandler} releases allocated direct {@link ByteBuf}s after processing.
-     */
-    private static final class SniHandlerWithPooledAllocator extends SniHandler {
-
-        SniHandlerWithPooledAllocator(final DomainNameMapping<SslContext> domainNameMapping) {
-            super(domainNameMapping);
-        }
-
-        @Override
-        protected SslHandler newSslHandler(final SslContext context, final ByteBufAllocator ignore) {
-            return super.newSslHandler(context, POOLED_ALLOCATOR);
-        }
+        channel.pipeline().addLast(newHandler(sslContext, POOLED_ALLOCATOR));
     }
 }


### PR DESCRIPTION
Motivation:
The server SSL config APIs for SNI didn't allow configuring SSL
associated with each individual SNI host. The client APIs coupled the
host name verification algorithm with the non-authoritative peer
host/port. This doesn't correctly represent the semantics of SSL.

Modifications:
- Server side SSL config object supports a new method which allows
  creating a new SSL config object for each SNI host. A map of hostname
  to SSL config is kept internally and used to create the SniHandler.
- Server side SSL config object now uses a consistent way to configure
  the KeyManager material as the client. The protocol specific
  commit(key*) methods were removed and the implementations were
  simplified as a result.
- Client side SSL config object removes methods which couple the host
  name verification algorithm to the non-authoritative peer host/port,
  and adds new methods which allow setting them independently.
- Client implementation now always uses the non-authoritative peer
  host/port (regardless of hostname verification) which is required for
  client session resumption.

Result:
SSL config APIs now correctly represent SNI semantics for client and
server. The client SSL config decouples the non-authoritative peer
host/port from the verification algorithm.