### PR TITLE
BufferOutputStream.write(int b) should write as byte and not int

### DIFF
--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/BufferOutputStream.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/BufferOutputStream.java
@@ -28,7 +28,7 @@ final class BufferOutputStream extends OutputStream {
 
     @Override
     public void write(final int b) {
-        buffer.writeInt(b);
+        buffer.writeByte(b);
     }
 
     @Override


### PR DESCRIPTION
Motivation: BufferOutputStream.write(final int b) writes a byte as int which is wrong.

Modifications:
* in write(final int b){..} method body buffer.writeInt(b) is changed to buffer.writeByte(b)

Result:
Fixes the above bug. Only internal changes and no API changes.