### PR TITLE
`HeaderUtils#pathMatches` incorrectly compares two different `CharSequence` implementations

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -318,7 +318,7 @@ public final class HeaderUtils {
         }
 
         if (requestPath.length() == cookiePath.length()) {
-            return requestPath.equals(cookiePath);
+            return contentEquals(requestPath, cookiePath);
         }
         final boolean actualStartsWithSlash = cookiePath.charAt(0) == '/';
         final int length = min(actualStartsWithSlash ? cookiePath.length() - 1 :

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HeaderUtilsTest.java
@@ -30,6 +30,7 @@ import static io.netty.util.AsciiString.of;
 import static io.servicetalk.http.api.HeaderUtils.checkContentType;
 import static io.servicetalk.http.api.HeaderUtils.isTchar;
 import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
+import static io.servicetalk.http.api.HeaderUtils.pathMatches;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
 import static io.servicetalk.http.api.HttpHeaderNames.ORIGIN;
@@ -271,6 +272,17 @@ public class HeaderUtilsTest {
             assertEquals("Unexpected result for byte: " + value,
                     originalValidateTokenLogic(value), isTchar(value));
         }
+    }
+
+    @Test
+    public void pathMatchesTest() {
+        assertTrue(pathMatches("/a/b/c", "/a/b/c"));
+        assertTrue(pathMatches("/a/b/cxxxx", "/a/b/c"));
+        assertTrue(pathMatches(new StringBuilder("/a/b/c"), new StringBuilder("/a/b/c")));
+        assertTrue(pathMatches("/a/b/c", new StringBuilder("/a/b/c")));
+
+        assertFalse(pathMatches("xxx/a/b/c", "/a/b/c"));
+        assertFalse(pathMatches(new StringBuilder("/a/b/c"), new StringBuilder("/a/B/c")));
     }
 
     private static boolean originalValidateTokenLogic(final byte value) {


### PR DESCRIPTION
Motivation:
  This code uses `CharSequence.equals` that does not have well-defined equals behavior. Such a call to equals may return false in cases where equality was expected.
https://errorprone.info/bugpattern/UndefinedEquals

Modifications:
  replaced call to `CharSequence.equals` with `CharSequences.contentEquals`
  
Result:  
 unit test comparing 2 different implementation of `CharSequences` is now passing