### PR TITLE
Replace CharSequence equality checks with contentEquals

### DIFF
--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
@@ -144,7 +144,10 @@ public final class CharSequences {
      * @param b right hand side of comparison.
      * @return {@code true} if {@code a}'s content equals {@code b}.
      */
-    public static boolean contentEquals(final CharSequence a, final CharSequence b) {
+    public static boolean contentEquals(@Nullable final CharSequence a, @Nullable final CharSequence b) {
+        if (a == null || b == null) {
+            return a == b;
+        }
         if (a == b) {
             return true;
         }

--- a/servicetalk-encoding-api/src/main/java/io/servicetalk/encoding/api/AbstractContentCodec.java
+++ b/servicetalk-encoding-api/src/main/java/io/servicetalk/encoding/api/AbstractContentCodec.java
@@ -15,7 +15,8 @@
  */
 package io.servicetalk.encoding.api;
 
-import java.util.Objects;
+import static io.servicetalk.buffer.api.CharSequences.caseInsensitiveHashCode;
+import static io.servicetalk.buffer.api.CharSequences.contentEquals;
 
 abstract class AbstractContentCodec implements ContentCodec {
 
@@ -30,20 +31,20 @@ abstract class AbstractContentCodec implements ContentCodec {
     }
 
     @Override
-    public boolean equals(final Object o) {
+    public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof AbstractContentCodec)) {
             return false;
         }
         final AbstractContentCodec that = (AbstractContentCodec) o;
-        return name.equals(that.name);
+        return contentEquals(name, that.name);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name);
+        return caseInsensitiveHashCode(name);
     }
 
     @Override

--- a/servicetalk-encoding-api/src/main/java/io/servicetalk/encoding/api/AbstractContentCodec.java
+++ b/servicetalk-encoding-api/src/main/java/io/servicetalk/encoding/api/AbstractContentCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpCookiePair.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpCookiePair.java
@@ -15,8 +15,6 @@
  */
 package io.servicetalk.http.api;
 
-import javax.annotation.Nonnull;
-
 import static io.servicetalk.buffer.api.CharSequences.caseInsensitiveHashCode;
 import static io.servicetalk.buffer.api.CharSequences.contentEquals;
 import static io.servicetalk.buffer.api.CharSequences.indexOf;
@@ -36,7 +34,7 @@ public final class DefaultHttpCookiePair implements HttpCookiePair {
      * @param cookieName The <a href="https://tools.ietf.org/html/rfc6265#section-4.1.1">cookie-name</a>.
      * @param cookieValue The <a href="https://tools.ietf.org/html/rfc6265#section-4.1.1">cookie-value</a>.
      */
-    public DefaultHttpCookiePair(final @Nonnull CharSequence cookieName, final @Nonnull CharSequence cookieValue) {
+    public DefaultHttpCookiePair(final CharSequence cookieName, final CharSequence cookieValue) {
         this(cookieName, cookieValue, false);
     }
 
@@ -146,7 +144,8 @@ public final class DefaultHttpCookiePair implements HttpCookiePair {
     @Override
     public int hashCode() {
         int hash = 31 + caseInsensitiveHashCode(name);
-        return 31 * hash + caseInsensitiveHashCode(value);
+        hash = 31 * hash + caseInsensitiveHashCode(value);
+        return hash;
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpCookiePair.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpCookiePair.java
@@ -15,6 +15,10 @@
  */
 package io.servicetalk.http.api;
 
+import javax.annotation.Nonnull;
+
+import static io.servicetalk.buffer.api.CharSequences.caseInsensitiveHashCode;
+import static io.servicetalk.buffer.api.CharSequences.contentEquals;
 import static io.servicetalk.buffer.api.CharSequences.indexOf;
 import static io.servicetalk.http.api.HeaderUtils.validateCookieNameAndValue;
 
@@ -32,7 +36,7 @@ public final class DefaultHttpCookiePair implements HttpCookiePair {
      * @param cookieName The <a href="https://tools.ietf.org/html/rfc6265#section-4.1.1">cookie-name</a>.
      * @param cookieValue The <a href="https://tools.ietf.org/html/rfc6265#section-4.1.1">cookie-value</a>.
      */
-    public DefaultHttpCookiePair(final CharSequence cookieName, final CharSequence cookieValue) {
+    public DefaultHttpCookiePair(final @Nonnull CharSequence cookieName, final @Nonnull CharSequence cookieValue) {
         this(cookieName, cookieValue, false);
     }
 
@@ -129,18 +133,20 @@ public final class DefaultHttpCookiePair implements HttpCookiePair {
 
     @Override
     public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
         if (!(o instanceof HttpCookiePair)) {
             return false;
         }
         final HttpCookiePair rhs = (HttpCookiePair) o;
-        return name.equals(rhs.name()) && value.equals(rhs.value());
+        return contentEquals(name, rhs.name()) && contentEquals(value, rhs.value());
     }
 
     @Override
     public int hashCode() {
-        int hash = 31 + name.hashCode();
-        hash = 31 * hash + value.hashCode();
-        return hash;
+        int hash = 31 + caseInsensitiveHashCode(name);
+        return 31 * hash + caseInsensitiveHashCode(value);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
@@ -17,10 +17,10 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.CharSequences;
 
-import java.util.Objects;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.buffer.api.CharSequences.caseInsensitiveHashCode;
+import static io.servicetalk.buffer.api.CharSequences.contentEquals;
 import static io.servicetalk.buffer.api.CharSequences.contentEqualsIgnoreCase;
 import static io.servicetalk.buffer.api.CharSequences.equalsIgnoreCaseLower;
 import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
@@ -416,6 +416,9 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
 
     @Override
     public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
         if (!(o instanceof HttpSetCookie)) {
             return false;
         }
@@ -425,20 +428,21 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
         // if equals(a) == equals(b) then a.hasCode() == b.hashCode()
         // [1] https://tools.ietf.org/html/rfc6265#section-5.1.3
         // [2] https://tools.ietf.org/html/rfc6265#section-5.1.4
-        return name.equals(rhs.name()) && value.equals(rhs.value()) &&
-                contentEqualsIgnoreCase(domain, rhs.domain()) &&
-                Objects.equals(path, rhs.path());
+        return contentEquals(name, rhs.name()) &&
+               contentEquals(value, rhs.value()) &&
+               contentEqualsIgnoreCase(domain, rhs.domain()) &&
+               contentEquals(path, rhs.path());
     }
 
     @Override
     public int hashCode() {
-        int hash = 31 + name.hashCode();
-        hash = 31 * hash + value.hashCode();
+        int hash = 31 + caseInsensitiveHashCode(name);
+        hash = 31 * hash + caseInsensitiveHashCode(value);
         if (domain != null) {
             hash = 31 * hash + caseInsensitiveHashCode(domain);
         }
         if (path != null) {
-            hash = 31 * hash + path.hashCode();
+            hash = 31 * hash + caseInsensitiveHashCode(path);
         }
         return hash;
     }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpCookiePairTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpCookiePairTest.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.api;
 
 import org.junit.Test;
 
+import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -30,6 +31,12 @@ public class DefaultHttpCookiePairTest {
         assertThat(new DefaultHttpCookiePair("foo", "bar").hashCode(),
                 is(new DefaultHttpCookiePair("foo", "bar").hashCode()));
 
+        // comparing String and AsciiString
+        assertThat(new DefaultHttpCookiePair("foo", "bar"),
+                   is(new DefaultHttpCookiePair(newAsciiString("foo"), newAsciiString("bar"))));
+        assertThat(new DefaultHttpCookiePair("foo", "bar").hashCode(),
+                   is(new DefaultHttpCookiePair(newAsciiString("foo"), newAsciiString("bar")).hashCode()));
+
         // isWrapped attribute is ignored:
         assertThat(new DefaultHttpCookiePair("foo", "bar", true),
                 is(new DefaultHttpCookiePair("foo", "bar", false)));
@@ -41,24 +48,30 @@ public class DefaultHttpCookiePairTest {
     public void testNotEqual() {
         // Name is case-sensitive:
         assertThat(new DefaultHttpCookiePair("foo", "bar"),
-                is(not(new DefaultHttpCookiePair("Foo", "bar"))));
+                   is(not(new DefaultHttpCookiePair("Foo", "bar"))));
         assertThat(new DefaultHttpCookiePair("foo", "bar").hashCode(),
-                is(not(new DefaultHttpCookiePair("Foo", "bar").hashCode())));
+                is(not(new DefaultHttpCookiePair("fooo", "bar").hashCode())));
+
+        assertThat(new DefaultHttpCookiePair("foo", "bar"),
+                   is(not(new DefaultHttpCookiePair(newAsciiString("Foo"), newAsciiString("bar")))));
+        assertThat(new DefaultHttpCookiePair("foo", "bar").hashCode(),
+                   is(not(new DefaultHttpCookiePair(newAsciiString("fooo"), newAsciiString("bar")).hashCode())));
+
 
         assertThat(new DefaultHttpCookiePair("foo", "bar", true),
                 is(not(new DefaultHttpCookiePair("foO", "bar", true))));
         assertThat(new DefaultHttpCookiePair("foo", "bar", true).hashCode(),
-                is(not(new DefaultHttpCookiePair("foO", "bar", true).hashCode())));
+                is(not(new DefaultHttpCookiePair("fooo", "bar", true).hashCode())));
 
         // Value is case-sensitive:
         assertThat(new DefaultHttpCookiePair("foo", "bar"),
                 is(not(new DefaultHttpCookiePair("foo", "Bar"))));
         assertThat(new DefaultHttpCookiePair("foo", "bar").hashCode(),
-                is(not(new DefaultHttpCookiePair("foo", "Bar").hashCode())));
+                is(not(new DefaultHttpCookiePair("foo", "barr").hashCode())));
 
         assertThat(new DefaultHttpCookiePair("foo", "bar", false),
                 is(not(new DefaultHttpCookiePair("foo", "baR", false))));
         assertThat(new DefaultHttpCookiePair("foo", "bar", false),
-                is(not(new DefaultHttpCookiePair("foo", "baR", false).hashCode())));
+                is(not(new DefaultHttpCookiePair("foo", "barr", false).hashCode())));
     }
 }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpCookiePairTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpCookiePairTest.java
@@ -57,7 +57,6 @@ public class DefaultHttpCookiePairTest {
         assertThat(new DefaultHttpCookiePair("foo", "bar").hashCode(),
                    is(not(new DefaultHttpCookiePair(newAsciiString("fooo"), newAsciiString("bar")).hashCode())));
 
-
         assertThat(new DefaultHttpCookiePair("foo", "bar", true),
                 is(not(new DefaultHttpCookiePair("foO", "bar", true))));
         assertThat(new DefaultHttpCookiePair("foo", "bar", true).hashCode(),

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpSetCookieTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpSetCookieTest.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.api;
 
 import org.junit.Test;
 
+import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.http.api.HttpSetCookie.SameSite.Lax;
 import static io.servicetalk.http.api.HttpSetCookie.SameSite.None;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -31,6 +32,11 @@ public class DefaultHttpSetCookieTest {
                 is(new DefaultHttpSetCookie("foo", "bar")));
         assertThat(new DefaultHttpSetCookie("foo", "bar").hashCode(),
                 is(new DefaultHttpSetCookie("foo", "bar").hashCode()));
+
+        assertThat(new DefaultHttpSetCookie("foo", "bar"),
+                   is(new DefaultHttpSetCookie(newAsciiString("foo"), newAsciiString("bar"))));
+        assertThat(new DefaultHttpSetCookie("foo", "bar").hashCode(),
+                   is(new DefaultHttpSetCookie(newAsciiString("foo"), newAsciiString("bar")).hashCode()));
 
         // Domain is case-insensitive, other attributes are ignored:
         assertThat(new DefaultHttpSetCookie("foo", "bar", "/", "servicetalk.io", null, 1L, None, true, false, true),
@@ -47,13 +53,13 @@ public class DefaultHttpSetCookieTest {
         assertThat(new DefaultHttpSetCookie("foo", "bar"),
                 is(not(new DefaultHttpSetCookie("Foo", "bar"))));
         assertThat(new DefaultHttpSetCookie("foo", "bar").hashCode(),
-                is(not(new DefaultHttpSetCookie("Foo", "bar").hashCode())));
+                is(not(new DefaultHttpSetCookie("fooo", "bar").hashCode())));
 
         // Value is case-sensitive:
         assertThat(new DefaultHttpSetCookie("foo", "bar"),
                 is(not(new DefaultHttpSetCookie("foo", "Bar"))));
         assertThat(new DefaultHttpSetCookie("foo", "bar").hashCode(),
-                is(not(new DefaultHttpSetCookie("foo", "Bar").hashCode())));
+                is(not(new DefaultHttpSetCookie("foo", "barr").hashCode())));
 
         // Path is case-sensitive:
         assertThat(new DefaultHttpSetCookie("foo", "bar", "/path", "servicetalk.io",
@@ -62,7 +68,7 @@ public class DefaultHttpSetCookieTest {
                         null, 1L, None, true, false, true))));
         assertThat(new DefaultHttpSetCookie("foo", "bar", "/path", "servicetalk.io",
                         null, 1L, None, true, false, true).hashCode(),
-                is(not(new DefaultHttpSetCookie("foo", "bar", "/Path", "servicetalk.io",
+                is(not(new DefaultHttpSetCookie("foo", "bar", "/pathh", "servicetalk.io",
                         null, 1L, None, true, false, true).hashCode())));
 
         // Domain doesn't match:


### PR DESCRIPTION
Motivation:
CharSequence.equals does not have well-defined equals behavior. Such a call to equals may return false in cases where equality was expected.
https://errorprone.info/bugpattern/UndefinedEquals

Modifications:
replaced call to CharSequence.equals with CharSequences.contentEquals
temporarily using CharSequences.caseInsensitiveHashCode until CharSequences.hashCode is implemented

Result:
Comparing 2 different implementation of CharSequences created with the same chars returns true