### PR TITLE
`LoadBalancedStreamingHttpClient` should not hide `PayloadInfo` of requests

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -241,7 +241,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                 @Override
                 protected void handleSubscribe(final Subscriber<? super StreamingHttpResponse> subscriber) {
                     final StreamObserver observer = multiplexedObserver.onNewStream();
-                    final StreamingHttpRequest originalRequest;
+                    final StreamingHttpRequest originalReq;
                     final Promise<Http2StreamChannel> promise;
                     final SequentialCancellable sequentialCancellable;
                     Runnable ownedRunnable = null;
@@ -257,7 +257,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                             final StreamingHttpRequestWithContext wrappedRequest =
                                     (StreamingHttpRequestWithContext) request;
                             // Unwrap the original request to let the following transformations access the PayloadInfo
-                            originalRequest = wrappedRequest.unwrap();
+                            originalReq = wrappedRequest.unwrap();
                             OwnedRunnable runnable = wrappedRequest.runnable();
                             if (runnable.own()) {
                                 ownedRunnable = runnable;
@@ -273,7 +273,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                         } else {
                             // User wrapped the original request object at the connection level
                             // (after LoadBalancedStreamingHttpClient) => Runnable will always be owned by originator
-                            originalRequest = request;
+                            originalReq = request;
                         }
                         bs.open(promise);
                         sequentialCancellable = new SequentialCancellable(() -> promise.cancel(true));
@@ -293,11 +293,11 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
 
                     final Runnable onCloseRunnable = ownedRunnable;
                     if (promise.isDone()) {
-                        childChannelActive(promise, subscriber, sequentialCancellable, strategy, originalRequest, observer,
+                        childChannelActive(promise, subscriber, sequentialCancellable, strategy, originalReq, observer,
                                 allowDropTrailersReadFromTransport, onCloseRunnable);
                     } else {
                         promise.addListener((FutureListener<Http2StreamChannel>) future -> childChannelActive(
-                                future, subscriber, sequentialCancellable, strategy, originalRequest, observer,
+                                future, subscriber, sequentialCancellable, strategy, originalReq, observer,
                                 allowDropTrailersReadFromTransport, onCloseRunnable));
                     }
                 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingHttpRequestWithContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingHttpRequestWithContext.java
@@ -56,6 +56,10 @@ final class StreamingHttpRequestWithContext implements StreamingHttpRequest {
         return runnable;
     }
 
+    StreamingHttpRequest unwrap() {
+        return delegate;
+    }
+
     @Override
     public HttpProtocolVersion version() {
         return delegate.version();


### PR DESCRIPTION
Motivation:

`LoadBalancedStreamingHttpClient` uses `StreamingHttpRequestWithContext`
wrapper to deliver `Runnable` to the underlying HTTP/2 transport level.
However, if we do not unwrap the request as soon as transport receives
it, the wrapper hides `PayloadInfo` interface of the original request
object and the following request processing can not apply required
optimizations for the payload body and flush strategy.

Modifications:

- Unwrap the original request object as soon as
`StreamingHttpRequestWithContext` finished its mission;

Result:

HTTP processing again sees `PayloadInfo` and can apply optimizations for
aggregated API (flush on end).