### PR TITLE
Grpc deadlines

### DIFF
--- a/servicetalk-examples/grpc/compression/src/main/java/io/servicetalk/examples/grpc/compression/CompressionExampleClient.java
+++ b/servicetalk-examples/grpc/compression/src/main/java/io/servicetalk/examples/grpc/compression/CompressionExampleClient.java
@@ -50,7 +50,8 @@ public final class CompressionExampleClient {
     /**
      * Metadata that, when provided to a sayHello, will cause the request to be compressed.
      */
-    private static final Greeter.SayHelloMetadata COMPRESS_REQUEST = new Greeter.SayHelloMetadata(ContentCodings.deflateDefault());
+    private static final Greeter.SayHelloMetadata COMPRESS_REQUEST =
+            new Greeter.SayHelloMetadata(ContentCodings.deflateDefault());
 
     public static void main(String... args) throws Exception {
         try (GreeterClient client = GrpcClients.forAddress("localhost", 8080).build(new ClientFactory()

--- a/servicetalk-examples/grpc/helloworld/src/main/java/io/servicetalk/examples/grpc/helloworld/async/HelloWorldServer.java
+++ b/servicetalk-examples/grpc/helloworld/src/main/java/io/servicetalk/examples/grpc/helloworld/async/HelloWorldServer.java
@@ -19,17 +19,24 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.grpc.api.GrpcServiceContext;
 import io.servicetalk.grpc.netty.GrpcServers;
 
-import io.grpc.examples.helloworld.Greeter;
 import io.grpc.examples.helloworld.Greeter.GreeterService;
-import io.grpc.examples.helloworld.Greeter.ServiceFactory;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
 
+import java.util.concurrent.TimeUnit;
+
 import static io.servicetalk.concurrent.api.Single.succeeded;
 
+/**
+ * Implementation of the
+ * <a herf="https://github.com/grpc/grpc/blob/master/examples/protos/helloworld.proto">gRPC hello world example</a>
+ * using async ServiceTalk APIS.
+ * <p/>
+ * Start this server first and then run the {@link HelloWorldClient}.
+ */
 public class HelloWorldServer {
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String... args) throws Exception {
         GrpcServers.forPort(8080)
                 .listenAndAwait(new MyGreeterService())
                 .awaitShutdown();
@@ -39,6 +46,12 @@ public class HelloWorldServer {
 
         @Override
         public Single<HelloReply> sayHello(final GrpcServiceContext ctx, final HelloRequest request) {
+            try {
+                TimeUnit.SECONDS.sleep(30);
+            } catch (InterruptedException woken) {
+                Thread.interrupted();
+            }
+
             return succeeded(HelloReply.newBuilder().setMessage("Hello " + request.getName()).build());
         }
     }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
@@ -79,7 +79,7 @@ final class DefaultGrpcClientCallFactory implements GrpcClientCallFactory {
         final List<ContentCodec> supportedCodings = serializationProvider.supportedMessageCodings();
         return (metadata, request) -> {
             final StreamingHttpRequest httpRequest = streamingHttpClient.post(metadata.path());
-            initRequest(httpRequest, supportedCodings);
+            initRequest(httpRequest, supportedCodings, metadata.deadline());
             httpRequest.payloadBody(request.map(GrpcUtils::uncheckedCast),
                     serializationProvider.serializerFor(metadata.requestEncoding(), requestClass));
             @Nullable
@@ -143,7 +143,7 @@ final class DefaultGrpcClientCallFactory implements GrpcClientCallFactory {
         final List<ContentCodec> supportedCodings = serializationProvider.supportedMessageCodings();
         return (metadata, request) -> {
             final BlockingStreamingHttpRequest httpRequest = client.post(metadata.path());
-            initRequest(httpRequest, supportedCodings);
+            initRequest(httpRequest, supportedCodings, metadata.deadline());
             httpRequest.payloadBody(request, serializationProvider
                     .serializerFor(metadata.requestEncoding(), requestClass));
             @Nullable
@@ -210,7 +210,7 @@ final class DefaultGrpcClientCallFactory implements GrpcClientCallFactory {
                                                           final List<ContentCodec> supportedCodings,
                                                           final Class<Req> requestClass) {
         final HttpRequest httpRequest = requestFactory.post(metadata.path());
-        initRequest(httpRequest, supportedCodings);
+        initRequest(httpRequest, supportedCodings, metadata.deadline());
         return httpRequest.payloadBody(uncheckedCast(rawReq),
                 serializationProvider.serializerFor(metadata.requestEncoding(), requestClass));
     }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientMetadata.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientMetadata.java
@@ -17,6 +17,7 @@ package io.servicetalk.grpc.api;
 
 import io.servicetalk.encoding.api.ContentCodec;
 
+import java.time.Duration;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.encoding.api.ContentCodings.identity;
@@ -31,8 +32,12 @@ public class DefaultGrpcClientMetadata extends DefaultGrpcMetadata implements Gr
 
     private final ContentCodec requestEncoding;
 
+    @Nullable
+    private final Duration deadline;
+
     /**
-     * Creates a new instance.
+     * Creates a new instance which uses the provided path and the default execution strategy, no content codec
+     * (identity), or no deadline.
      *
      * @param path for the associated <a href="https://www.grpc.io">gRPC</a> method.
      */
@@ -40,12 +45,36 @@ public class DefaultGrpcClientMetadata extends DefaultGrpcMetadata implements Gr
         this(path, (GrpcExecutionStrategy) null);
     }
 
+    /**
+     * Creates a new instance which uses the provided path and content codec, the default execution strategy,
+     * and no deadline.
+     *
+     * @param path for the associated <a href="https://www.grpc.io">gRPC</a> method.
+     * @param requestEncoding {@link ContentCodec} to use for the associated <a href="https://www.grpc.io">gRPC</a>
+     * method.
+     */
     protected DefaultGrpcClientMetadata(final String path, final ContentCodec requestEncoding) {
         this(path, null, requestEncoding);
     }
 
     /**
-     * Creates a new instance.
+     * Creates a new instance which uses the provided path, content codec and deadline and the default execution
+     * strategy.
+     *
+     * @param path for the associated <a href="https://www.grpc.io">gRPC</a> method.
+     * @param requestEncoding {@link ContentCodec} to use for the associated <a href="https://www.grpc.io">gRPC</a>
+     * method.
+     * @param deadline A timeout deadline after which the response is no longer wanted.
+     */
+    protected DefaultGrpcClientMetadata(final String path,
+                                        final ContentCodec requestEncoding,
+                                        final Duration deadline) {
+        this(path, null, requestEncoding, deadline);
+    }
+
+    /**
+     * Creates a new instance which uses the provided path and execution strategy and the default content codec
+     * (identity) and no deadline.
      *
      * @param path for the associated <a href="https://www.grpc.io">gRPC</a> method.
      * @param strategy {@link GrpcExecutionStrategy} to use for the associated <a href="https://www.grpc.io">gRPC</a>
@@ -53,15 +82,44 @@ public class DefaultGrpcClientMetadata extends DefaultGrpcMetadata implements Gr
      */
     protected DefaultGrpcClientMetadata(final String path,
                                         @Nullable final GrpcExecutionStrategy strategy) {
-        this(path, strategy, identity());
+        this(path, strategy, identity(), null);
     }
 
+    /**
+     * Creates a new instance which uses the provided path, content codec and the default execution
+     * strategy and no deadline.
+     *
+     * @param path for the associated <a href="https://www.grpc.io">gRPC</a> method.
+     * @param strategy {@link GrpcExecutionStrategy} to use for the associated <a href="https://www.grpc.io">gRPC</a>
+     * method.
+     * @param requestEncoding {@link ContentCodec} to use for the associated <a href="https://www.grpc.io">gRPC</a>
+     * method.
+     */
     protected DefaultGrpcClientMetadata(final String path,
                                         @Nullable final GrpcExecutionStrategy strategy,
                                         final ContentCodec requestEncoding) {
+        this(path, strategy, requestEncoding, null);
+    }
+
+    /**
+     * Creates a new instance which uses the provided path, content codec and deadline and the default execution
+     * strategy.
+     *
+     * @param path for the associated <a href="https://www.grpc.io">gRPC</a> method.
+     * @param strategy {@link GrpcExecutionStrategy} to use for the associated <a href="https://www.grpc.io">gRPC</a>
+     * method.
+     * @param requestEncoding {@link ContentCodec} to use for the associated <a href="https://www.grpc.io">gRPC</a>
+     * method.
+     * @param deadline A timeout deadline after which the response is no longer wanted.
+     */
+    protected DefaultGrpcClientMetadata(final String path,
+                                        @Nullable final GrpcExecutionStrategy strategy,
+                                        final ContentCodec requestEncoding,
+                                        @Nullable final Duration deadline) {
         super(path);
         this.strategy = strategy;
         this.requestEncoding = requestEncoding;
+        this.deadline = deadline;
     }
 
     @Override
@@ -72,5 +130,11 @@ public class DefaultGrpcClientMetadata extends DefaultGrpcMetadata implements Gr
     @Override
     public ContentCodec requestEncoding() {
         return requestEncoding;
+    }
+
+    @Override
+    @Nullable
+    public Duration deadline() {
+        return deadline;
     }
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientMetadata.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientMetadata.java
@@ -17,6 +17,7 @@ package io.servicetalk.grpc.api;
 
 import io.servicetalk.encoding.api.ContentCodec;
 
+import java.time.Duration;
 import javax.annotation.Nullable;
 
 /**
@@ -42,4 +43,15 @@ public interface GrpcClientMetadata extends GrpcMetadata {
      * <a href="https://www.grpc.io">gRPC</a> method.
      */
     ContentCodec requestEncoding();
+
+    /**
+     * Deadline after which the client no longer wants response.
+     *
+     * @return {@link Duration} of associated deadline or null if no deadline. All durations greater than 99999999 hours
+     * will be treated as infinite (no deadline).
+     */
+    @Nullable
+    default Duration deadline() {
+        return null;
+    }
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatusCode.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatusCode.java
@@ -41,7 +41,7 @@ public enum GrpcStatusCode {
     NOT_FOUND(5),
     /** Some entity that we attempted to create already exists. */
     ALREADY_EXISTS(6),
-    /** Permission denied for a particular clinet. Different from UNAUTHENTICATED. */
+    /** Permission denied for a particular client. Different from {@link #UNAUTHENTICATED}. */
     PERMISSION_DENIED(7),
     /** Resource exhausted. */
     RESOURCE_EXHAUSTED(8),

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/package-info.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Core <a href="https://www.grpc.io">gRPC</a> API
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.grpc.api;
 

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Words.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Words.java
@@ -41,6 +41,7 @@ final class Words {
     static final String service = "service";
     static final String strategy = "strategy";
     static final String requestEncoding = "requestEncoding";
+    static final String deadline = "deadline";
     static final String supportedMessageCodings = "supportedMessageCodings";
     static final String strategyFactory = strategy + "Factory";
     static final String Service = "Service";


### PR DESCRIPTION
initial work in progress. The identified elements of this task include:
- [X] Extending protoc code generation to include deadline in ClientMetadata
- [ ] (?) Extending client factory to include default deadline
- [X] Adding “grpc-timeout” http header to request
- [X] Extending http header serialization to ensure timeout header is written first
- [X] set client timer for timeout
            - [X] cancel request on timeout
            - [X] report cancellation to app 
- [ ]  Reading “grpc-timeout” http header from request
- [ ]  server handle request cancel from client
- [ ]  set server timer for request timeout
   - [ ]  cancel request/response on timeout
   - [ ]  report cancellation to client