### PR TITLE
gRPC Unix Domain Socket Client Support

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -36,6 +36,7 @@ import io.servicetalk.transport.api.IoExecutor;
 
 import java.net.SocketOption;
 import java.util.function.BooleanSupplier;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static io.servicetalk.concurrent.api.Single.failed;
@@ -91,6 +92,13 @@ public abstract class GrpcClientBuilder<U, R>
     @Override
     public abstract GrpcClientBuilder<U, R> autoRetryStrategy(
             AutoRetryStrategyProvider autoRetryStrategyProvider);
+
+    @Override
+    public abstract GrpcClientBuilder<U, R> unresolvedAddressToHost(
+            Function<U, CharSequence> unresolvedAddressToHostFunction);
+
+    @Override
+    public abstract GrpcClientBuilder<U, R> disableHostHeaderFallback();
 
     @Override
     public abstract GrpcClientBuilder<U, R> serviceDiscoverer(

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/SingleAddressGrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/SingleAddressGrpcClientBuilder.java
@@ -26,6 +26,7 @@ import io.servicetalk.concurrent.api.BiIntPredicate;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpLoadBalancerFactory;
+import io.servicetalk.http.api.HttpMetaData;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -35,6 +36,7 @@ import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketOption;
 import java.util.function.BooleanSupplier;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 interface SingleAddressGrpcClientBuilder<U, R,
@@ -114,6 +116,29 @@ interface SingleAddressGrpcClientBuilder<U, R,
      * @return {@code this}
      */
     SingleAddressGrpcClientBuilder<U, R, SDE> autoRetryStrategy(AutoRetryStrategyProvider autoRetryStrategyProvider);
+
+    /**
+     * Provides a means to convert {@link U} unresolved address type into a {@link CharSequence}.
+     * An example of where this maybe used is to convert the {@link U} to a default host header. It may also
+     * be used in the event of proxying.
+     *
+     * @param unresolvedAddressToHostFunction invoked to convert the {@link U} unresolved address type into a
+     * {@link CharSequence} suitable for use in
+     * <a href="https://tools.ietf.org/html/rfc7230#section-5.4">Host Header</a> format.
+     * @return {@code this}
+     */
+    SingleAddressGrpcClientBuilder<U, R, SDE> unresolvedAddressToHost(
+            Function<U, CharSequence> unresolvedAddressToHostFunction);
+
+    /**
+     * Disables automatically setting {@code Host} headers by inferring from the address or {@link HttpMetaData}.
+     * <p>
+     * This setting disables the default filter such that no {@code Host} header will be manipulated.
+     *
+     * @return {@code this}
+     * @see #unresolvedAddressToHost(Function)
+     */
+    SingleAddressGrpcClientBuilder<U, R, SDE> disableHostHeaderFallback();
 
     /**
      * Set a {@link ServiceDiscoverer} to resolve addresses of remote servers to connect to.

--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -44,6 +44,7 @@ dependencies {
   testImplementation project(":servicetalk-router-utils-internal")
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-utils-internal")
+  testImplementation project(":servicetalk-transport-netty")
   testImplementation "io.grpc:grpc-core:$grpcVersion"
   testImplementation("io.grpc:grpc-netty:$grpcVersion") {
     exclude group: "io.netty"

--- a/servicetalk-grpc-netty/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-grpc-netty/gradle/spotbugs/test-exclusions.xml
@@ -24,6 +24,8 @@
       <Source name="~CompatProto\.java"/>
       <Source name="~EsProto\.java"/>
       <Source name="~TesterProto\.java"/>
+      <Source name="~HelloReply\.java"/>
+      <Source name="~HelloRequest\.java"/>
     </Or>
   </Match>
   <Match>

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
@@ -37,6 +37,7 @@ import io.servicetalk.transport.api.IoExecutor;
 
 import java.net.SocketOption;
 import java.util.function.BooleanSupplier;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h2Default;
@@ -123,6 +124,19 @@ final class DefaultGrpcClientBuilder<U, R> extends GrpcClientBuilder<U, R> {
     public GrpcClientBuilder<U, R> autoRetryStrategy(
             final AutoRetryStrategyProvider autoRetryStrategyProvider) {
         httpClientBuilder.autoRetryStrategy(autoRetryStrategyProvider);
+        return this;
+    }
+
+    @Override
+    public GrpcClientBuilder<U, R> unresolvedAddressToHost(
+            final Function<U, CharSequence> unresolvedAddressToHostFunction) {
+        httpClientBuilder.unresolvedAddressToHost(unresolvedAddressToHostFunction);
+        return this;
+    }
+
+    @Override
+    public GrpcClientBuilder<U, R> disableHostHeaderFallback() {
+        httpClientBuilder.disableHostHeaderFallback();
         return this;
     }
 

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcClients.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcClients.java
@@ -84,8 +84,7 @@ public final class GrpcClients {
     }
 
     /**
-     * Creates a {@link GrpcClientBuilder} for an address with default {@link LoadBalancer} and DNS
-     * {@link ServiceDiscoverer}.
+     * Creates a {@link GrpcClientBuilder} for an address with default {@link LoadBalancer}.
      *
      * @param address the {@code ResolvedAddress} to connect to.
      * @return new builder for the address
@@ -95,8 +94,7 @@ public final class GrpcClients {
     }
 
     /**
-     * Creates a {@link GrpcClientBuilder} for an address with default {@link LoadBalancer} and DNS
-     * {@link ServiceDiscoverer}.
+     * Creates a {@link GrpcClientBuilder} for an address with default {@link LoadBalancer}.
      *
      * @param address the {@code InetSocketAddress} to connect to.
      * @return new builder for the address
@@ -107,8 +105,7 @@ public final class GrpcClients {
     }
 
     /**
-     * Creates a {@link GrpcClientBuilder} for an address with default {@link LoadBalancer} and DNS {@link
-     * ServiceDiscoverer}.
+     * Creates a {@link GrpcClientBuilder} for an address with default {@link LoadBalancer}.
      *
      * @param address the {@code ResolvedAddress} to connect. This address will also be used for the
      * {@link HttpHeaderNames#HOST}. Use {@link GrpcClientBuilder#unresolvedAddressToHost(Function)}

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcClients.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcClients.java
@@ -19,10 +19,13 @@ import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.grpc.api.GrpcClientBuilder;
+import io.servicetalk.http.api.HttpHeaderNames;
 import io.servicetalk.http.netty.HttpClients;
 import io.servicetalk.transport.api.HostAndPort;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.function.Function;
 
 /**
  * A factory to create <a href="https://www.grpc.io">gRPC</a> clients.
@@ -100,6 +103,21 @@ public final class GrpcClients {
      */
     public static GrpcClientBuilder<InetSocketAddress, InetSocketAddress> forResolvedAddress(
             final InetSocketAddress address) {
+        return new DefaultGrpcClientBuilder<>(HttpClients.forResolvedAddress(address));
+    }
+
+    /**
+     * Creates a {@link GrpcClientBuilder} for an address with default {@link LoadBalancer} and DNS {@link
+     * ServiceDiscoverer}.
+     *
+     * @param address the {@code ResolvedAddress} to connect. This address will also be used for the
+     * {@link HttpHeaderNames#HOST}. Use {@link GrpcClientBuilder#unresolvedAddressToHost(Function)}
+     * if you want to override that value or {@link GrpcClientBuilder#disableHostHeaderFallback()} if you
+     * want to disable this behavior.
+     * @param <T> The type of {@link SocketAddress}.
+     * @return new builder for the address
+     */
+    public static <T extends SocketAddress> GrpcClientBuilder<T, T> forResolvedAddress(final T address) {
         return new DefaultGrpcClientBuilder<>(HttpClients.forResolvedAddress(address));
     }
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcUdsTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcUdsTest.java
@@ -61,8 +61,8 @@ public class GrpcUdsTest {
                 .ioExecutor(ioExecutor)
                 .listenAndAwait((GreeterService) (ctx, request) ->
                         succeeded(HelloReply.newBuilder().setMessage(greetingPrefix + request.getName()).build()));
-        BlockingGreeterClient client = forResolvedAddress(serverContext.listenAddress())
-                .buildBlocking(new ClientFactory())) {
+             BlockingGreeterClient client = forResolvedAddress(serverContext.listenAddress())
+                     .buildBlocking(new ClientFactory())) {
             assertEquals(expectedResponse,
                     client.sayHello(HelloRequest.newBuilder().setName(name).build()).getMessage());
         }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcUdsTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcUdsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.netty;
+
+import io.servicetalk.transport.api.IoExecutor;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.netty.internal.IoThreadFactory;
+
+import io.grpc.examples.helloworld.Greeter.BlockingGreeterClient;
+import io.grpc.examples.helloworld.Greeter.ClientFactory;
+import io.grpc.examples.helloworld.Greeter.GreeterService;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.grpc.netty.GrpcClients.forResolvedAddress;
+import static io.servicetalk.grpc.netty.GrpcServers.forAddress;
+import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
+import static io.servicetalk.transport.netty.internal.AddressUtils.newSocketAddress;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+
+public class GrpcUdsTest {
+    private static IoExecutor ioExecutor;
+
+    @BeforeClass
+    public static void beforeClass() {
+        ioExecutor = createIoExecutor(new IoThreadFactory("io-executor"));
+    }
+
+    @AfterClass
+    public static void afterClass() throws ExecutionException, InterruptedException {
+        ioExecutor.closeAsync().toFuture().get();
+    }
+
+    @Test
+    public void udsRoundTrip() throws Exception {
+        assumeTrue(ioExecutor.isUnixDomainSocketSupported());
+        String greetingPrefix = "Hello ";
+        String name = "foo";
+        String expectedResponse = greetingPrefix + name;
+        try (ServerContext serverContext = forAddress(newSocketAddress())
+                .ioExecutor(ioExecutor)
+                .listenAndAwait((GreeterService) (ctx, request) ->
+                        succeeded(HelloReply.newBuilder().setMessage(greetingPrefix + request.getName()).build()));
+        BlockingGreeterClient client = forResolvedAddress(serverContext.listenAddress())
+                .buildBlocking(new ClientFactory())) {
+            assertEquals(expectedResponse,
+                    client.sayHello(HelloRequest.newBuilder().setName(name).build()).getMessage());
+        }
+    }
+}

--- a/servicetalk-grpc-netty/src/test/proto/helloworld.proto
+++ b/servicetalk-grpc-netty/src/test/proto/helloworld.proto
@@ -1,0 +1,37 @@
+// Copyright 2015 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.helloworld";
+option java_outer_classname = "HelloWorldProto";
+option objc_class_prefix = "HLW";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+    string message = 1;
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -200,8 +200,7 @@ public final class HttpClients {
     }
 
     /**
-     * Creates a {@link SingleAddressHttpClientBuilder} for an address with default {@link LoadBalancer} and DNS {@link
-     * ServiceDiscoverer}.
+     * Creates a {@link SingleAddressHttpClientBuilder} for an address with default {@link LoadBalancer}.
      *
      * @param address the {@code ResolvedAddress} to connect. This address will also be used for the
      * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
@@ -215,8 +214,7 @@ public final class HttpClients {
     }
 
     /**
-     * Creates a {@link SingleAddressHttpClientBuilder} for an address via a proxy, with default {@link LoadBalancer}
-     * and DNS {@link ServiceDiscoverer}.
+     * Creates a {@link SingleAddressHttpClientBuilder} for an address via a proxy, with default {@link LoadBalancer}.
      *
      * @param address the {@code ResolvedAddress} to connect to via the proxy. This address will also be used for the
      * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
@@ -232,8 +230,7 @@ public final class HttpClients {
     }
 
     /**
-     * Creates a {@link SingleAddressHttpClientBuilder} for an address with default {@link LoadBalancer} and DNS {@link
-     * ServiceDiscoverer}.
+     * Creates a {@link SingleAddressHttpClientBuilder} for an address with default {@link LoadBalancer}.
      *
      * @param address the {@code ResolvedAddress} to connect. This address will also be used for the
      * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
@@ -247,8 +244,7 @@ public final class HttpClients {
     }
 
     /**
-     * Creates a {@link SingleAddressHttpClientBuilder} for an address via a proxy, with default {@link LoadBalancer}
-     * and DNS {@link ServiceDiscoverer}.
+     * Creates a {@link SingleAddressHttpClientBuilder} for an address via a proxy, with default {@link LoadBalancer}.
      *
      * @param address the {@code ResolvedAddress} to connect to via the proxy. This address will also be used for the
      * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}


### PR DESCRIPTION
Motivation:
gRPC client builders do not expose methods to easily configure UDS
address.

Modifications:
- Add GrpcClients.forResolvedAddress(..) method that allows for passing
  a UDS type of SocketAddress.

Result:
gRPC Clients can more easily be built for UDS.