### PR TITLE
Change `Verifiers.stepVerifier` back to `StepVerifiers.create`

### DIFF
--- a/servicetalk-concurrent-api-test/src/main/java/io/servicetalk/concurrent/api/test/StepVerifiers.java
+++ b/servicetalk-concurrent-api-test/src/main/java/io/servicetalk/concurrent/api/test/StepVerifiers.java
@@ -31,87 +31,72 @@ import static io.servicetalk.concurrent.api.test.TimeSources.nanoTimeNormalized;
  * asynchronous sources {@link Publisher}, {@link Single}, and {@link Completable}.
  * <p>
  * The steps are typically from the perspective of a {@link Subscriber}'s lifecycle.
- *
- * @deprecated Use {@link StepVerifiers} instead.
  */
-@Deprecated
-public final class Verifiers {
-    private Verifiers() {
+public final class StepVerifiers {
+    private StepVerifiers() {
     }
 
     /**
-     * Create a new {@link PublisherFirstStep}.
+     * Creates a new {@link PublisherFirstStep}.
      *
-     * @deprecated Use {@link StepVerifiers#create(Publisher)} instead.
      * @param source The {@link Publisher} to verify.
      * @param <T> The type of {@link Publisher}.
      * @return A {@link PublisherFirstStep} that can be used to verify {@code source}'s signal emission(s).
      */
-    @Deprecated
-    public static <T> PublisherFirstStep<T> stepVerifier(Publisher<T> source) {
-        return stepVerifierForSource(toSource(source));
+    public static <T> PublisherFirstStep<T> create(Publisher<T> source) {
+        return createForSource(toSource(source));
     }
 
     /**
-     * Create a new {@link PublisherFirstStep}.
+     * Creates a new {@link PublisherFirstStep}.
      *
-     * @deprecated Use {@link StepVerifiers#createForSource(PublisherSource)} instead.
      * @param source The {@link PublisherSource} to verify.
      * @param <T> The type of {@link PublisherSource}.
      * @return A {@link PublisherFirstStep} that can be used to verify {@code source}'s signal emission(s).
      */
-    @Deprecated
-    public static <T> PublisherFirstStep<T> stepVerifierForSource(PublisherSource<T> source) {
+    public static <T> PublisherFirstStep<T> createForSource(PublisherSource<T> source) {
         return new InlinePublisherFirstStep<>(source, nanoTimeNormalized());
     }
 
     /**
-     * Create a new {@link SingleFirstStep}.
+     * Creates a new {@link SingleFirstStep}.
      *
-     * @deprecated Use {@link StepVerifiers#create(Single)} instead.
      * @param source The {@link Single} to verify.
      * @param <T> The type of {@link Single}.
      * @return A {@link SingleFirstStep} that can be used to verify {@code source}'s signal emission(s).
      */
-    @Deprecated
-    public static <T> SingleFirstStep<T> stepVerifier(Single<T> source) {
-        return stepVerifierForSource(toSource(source));
+    public static <T> SingleFirstStep<T> create(Single<T> source) {
+        return createForSource(toSource(source));
     }
 
     /**
-     * Create a new {@link SingleFirstStep}.
+     * Creates a new {@link SingleFirstStep}.
      *
-     * @deprecated Use {@link StepVerifiers#createForSource(SingleSource)} instead.
      * @param source The {@link SingleSource} to verify.
      * @param <T> The type of {@link SingleSource}.
      * @return A {@link SingleFirstStep} that can be used to verify {@code source}'s signal emission(s).
      */
-    @Deprecated
-    public static <T> SingleFirstStep<T> stepVerifierForSource(SingleSource<T> source) {
+    public static <T> SingleFirstStep<T> createForSource(SingleSource<T> source) {
         return new InlineSingleFirstStep<>(source, nanoTimeNormalized());
     }
 
     /**
-     * Create a new {@link CompletableFirstStep}.
+     * Creates a new {@link CompletableFirstStep}.
      *
-     * @deprecated Use {@link StepVerifiers#create(Completable)} instead.
      * @param source The {@link Completable} to verify.
      * @return A {@link CompletableFirstStep} that can be used to verify {@code source}'s signal emission(s).
      */
-    @Deprecated
-    public static CompletableFirstStep stepVerifier(Completable source) {
-        return stepVerifierForSource(toSource(source));
+    public static CompletableFirstStep create(Completable source) {
+        return createForSource(toSource(source));
     }
 
     /**
-     * Create a new {@link CompletableFirstStep}.
+     * Creates a new {@link CompletableFirstStep}.
      *
-     * @deprecated Use {@link StepVerifiers#createForSource(CompletableSource)} instead.
      * @param source The {@link CompletableSource} to verify.
      * @return A {@link CompletableFirstStep} that can be used to verify {@code source}'s signal emission(s).
      */
-    @Deprecated
-    public static CompletableFirstStep stepVerifierForSource(CompletableSource source) {
+    public static CompletableFirstStep createForSource(CompletableSource source) {
         return new InlineCompletableFirstStep(source, nanoTimeNormalized());
     }
 }

--- a/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/CompletableStepVerifierTest.java
+++ b/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/CompletableStepVerifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,8 +33,7 @@ import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Completable.failed;
 import static io.servicetalk.concurrent.api.Completable.never;
 import static io.servicetalk.concurrent.api.Processors.newCompletableProcessor;
-import static io.servicetalk.concurrent.api.test.Verifiers.stepVerifier;
-import static io.servicetalk.concurrent.api.test.Verifiers.stepVerifierForSource;
+import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static java.time.Duration.ofDays;
 import static java.time.Duration.ofMillis;
@@ -53,7 +52,7 @@ public class CompletableStepVerifierTest {
 
     @Test
     public void expectCancellable() {
-        stepVerifier(completed())
+        StepVerifiers.create(completed())
                 .expectCancellable()
                 .expectComplete()
                 .verify();
@@ -63,7 +62,7 @@ public class CompletableStepVerifierTest {
     public void expectCancellableTimeout() {
         CountDownLatch latch = new CountDownLatch(1);
         try {
-            verifyException(() -> stepVerifier(completed().publishAndSubscribeOn(EXECUTOR_RULE.executor()))
+            verifyException(() -> StepVerifiers.create(completed().publishAndSubscribeOn(EXECUTOR_RULE.executor()))
                     .expectCancellableConsumed(cancellable -> {
                         try {
                             latch.await();
@@ -80,7 +79,7 @@ public class CompletableStepVerifierTest {
 
     @Test
     public void onComplete() {
-        assertNotNull(stepVerifier(completed())
+        assertNotNull(StepVerifiers.create(completed())
                 .expectComplete()
                 .verify());
     }
@@ -88,7 +87,7 @@ public class CompletableStepVerifierTest {
     @Test
     public void onCompleteDuplicateVerify() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(2);
-        StepVerifier verifier = stepVerifier(completed())
+        StepVerifier verifier = StepVerifiers.create(completed())
                 .expectCancellableConsumed(cancellable -> {
                     assertNotNull(cancellable);
                     latch.countDown();
@@ -101,77 +100,77 @@ public class CompletableStepVerifierTest {
 
     @Test
     public void onCompleteLargeTimeout() {
-        assertNotNull(stepVerifier(completed())
+        assertNotNull(StepVerifiers.create(completed())
                 .expectComplete()
                 .verify(ofDays(1)));
     }
 
     @Test
     public void onCompleteTimeout() {
-        verifyException(() -> stepVerifier(never())
+        verifyException(() -> StepVerifiers.create(never())
                 .expectComplete()
                 .verify(ofNanos(10)), "expectComplete");
     }
 
     @Test
     public void onError() {
-        stepVerifier(failed(DELIBERATE_EXCEPTION))
+        StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .expectError()
                 .verify();
     }
 
     @Test
     public void onErrorFail() {
-        verifyException(() -> stepVerifier(completed())
+        verifyException(() -> StepVerifiers.create(completed())
                 .expectError()
                 .verify(), "expectError");
     }
 
     @Test
     public void onErrorClass() {
-        stepVerifier(failed(DELIBERATE_EXCEPTION))
+        StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .expectError(DeliberateException.class)
                 .verify();
     }
 
     @Test
     public void onErrorClassFail() {
-        verifyException(() -> stepVerifier(completed())
+        verifyException(() -> StepVerifiers.create(completed())
                 .expectError(DeliberateException.class)
                 .verify(), "expectError");
     }
 
     @Test
     public void onErrorPredicate() {
-        stepVerifier(failed(DELIBERATE_EXCEPTION))
+        StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .expectErrorMatches(error -> error instanceof DeliberateException)
                 .verify();
     }
 
     @Test
     public void onErrorPredicateFail() {
-        verifyException(() -> stepVerifier(completed())
+        verifyException(() -> StepVerifiers.create(completed())
                 .expectErrorMatches(error -> error instanceof DeliberateException)
                 .verify(), "expectErrorMatches");
     }
 
     @Test
     public void onErrorConsumer() {
-        stepVerifier(failed(DELIBERATE_EXCEPTION))
+        StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .expectErrorConsumed(error -> assertThat(error, is(DELIBERATE_EXCEPTION)))
                 .verify();
     }
 
     @Test
     public void onErrorConsumerFail() {
-        verifyException(() -> stepVerifier(completed())
+        verifyException(() -> StepVerifiers.create(completed())
                 .expectErrorConsumed(error -> assertThat(error, is(DELIBERATE_EXCEPTION)))
                 .verify(), "expectErrorConsumed");
     }
 
     @Test
     public void expectOnSuccessWhenOnError() {
-        verifyException(() -> stepVerifier(failed(DELIBERATE_EXCEPTION))
+        verifyException(() -> StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                     .expectComplete()
                     .verify(), "expectComplete");
     }
@@ -180,7 +179,7 @@ public class CompletableStepVerifierTest {
     public void noSignalsSubscriptionCancelSucceeds() {
         // expectNoSignals and subscription event are dequeued/processed sequentially on the Subscriber thread
         // and the scenario isn't instructed to expect the subscription so we pass the test.
-        stepVerifier(never())
+        StepVerifiers.create(never())
                 .expectNoSignals(ofDays(1))
                 .thenCancel()
                 .verify();
@@ -188,7 +187,7 @@ public class CompletableStepVerifierTest {
 
     @Test
     public void noSignalsCompleteFail() {
-        verifyException(() -> stepVerifier(completed())
+        verifyException(() -> StepVerifiers.create(completed())
                 .expectCancellable()
                 .expectNoSignals(ofDays(1))
                 .expectComplete()
@@ -197,7 +196,7 @@ public class CompletableStepVerifierTest {
 
     @Test
     public void noSignalsErrorFails() {
-        verifyException(() -> stepVerifier(failed(DELIBERATE_EXCEPTION))
+        verifyException(() -> StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .expectCancellable()
                 .expectNoSignals(ofDays(1))
                 .expectError(DeliberateException.class)
@@ -206,7 +205,7 @@ public class CompletableStepVerifierTest {
 
     @Test
     public void noSignalsAfterSubscriptionSucceeds() {
-        stepVerifier(never())
+        StepVerifiers.create(never())
                 .expectCancellable()
                 .expectNoSignals(ofMillis(100))
                 .thenCancel()
@@ -215,14 +214,14 @@ public class CompletableStepVerifierTest {
 
     @Test
     public void thenCancelCompleted() {
-        stepVerifier(completed())
+        StepVerifiers.create(completed())
                 .thenCancel()
                 .verify();
     }
 
     @Test
     public void thenCancelFailed() {
-        stepVerifier(failed(DELIBERATE_EXCEPTION))
+        StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .thenCancel()
                 .verify();
     }
@@ -230,7 +229,7 @@ public class CompletableStepVerifierTest {
     @Test
     public void thenRun() {
         CompletableSource.Processor processor = newCompletableProcessor();
-        stepVerifierForSource(processor)
+        StepVerifiers.create(fromSource(processor))
                 .then(processor::onComplete)
                 .expectComplete()
                 .verify();
@@ -238,7 +237,7 @@ public class CompletableStepVerifierTest {
 
     @Test
     public void asyncContextOnError() {
-        stepVerifier(failed(DELIBERATE_EXCEPTION).publishAndSubscribeOn(EXECUTOR_RULE.executor()))
+        StepVerifiers.create(failed(DELIBERATE_EXCEPTION).publishAndSubscribeOn(EXECUTOR_RULE.executor()))
                 .expectCancellableConsumed(s -> {
                     assertNotNull(s);
                     AsyncContext.put(ASYNC_KEY, 10);
@@ -252,7 +251,7 @@ public class CompletableStepVerifierTest {
 
     @Test(expected = DeliberateException.class)
     public void thenRunThrows() {
-        stepVerifier(completed())
+        StepVerifiers.create(completed())
                 .then(() -> {
                     throw DELIBERATE_EXCEPTION;
                 })

--- a/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/PublisherStepVerifierTest.java
+++ b/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/PublisherStepVerifierTest.java
@@ -57,8 +57,8 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class PublisherStepVerifierTest {
     private static final AsyncContextMap.Key<Integer> ASYNC_KEY = AsyncContextMap.Key.newKey();
@@ -729,19 +729,14 @@ public class PublisherStepVerifierTest {
     }
 
     static void verifyException(Supplier<Duration> verifier, String classNamePrefix, String failedTestMethod) {
-        try {
-            verifier.get();
-        } catch (StepAssertionError error) {
-            StackTraceElement[] stackTraceElements = error.getStackTrace();
-            assertThat(stackTraceElements.length, greaterThanOrEqualTo(1));
-            assertThat("first stacktrace element expected <class: " + classNamePrefix +
-                    "> actual: " + stackTraceElements[0] + " error: " + error,
-                    stackTraceElements[0].getClassName(), startsWith(classNamePrefix));
-            StackTraceElement testMethodStackTrace = error.testMethodStackTrace();
-            assertEquals("unexpected test method failure: " + testMethodStackTrace, failedTestMethod,
-                    testMethodStackTrace.getMethodName());
-            return;
-        }
-        fail();
+        StepAssertionError error = assertThrows(StepAssertionError.class, verifier::get);
+        StackTraceElement[] stackTraceElements = error.getStackTrace();
+        assertThat(stackTraceElements.length, greaterThanOrEqualTo(1));
+        assertThat("first stacktrace element expected <class: " + classNamePrefix + "> actual: " +
+                        stackTraceElements[0] + " error: " + error,
+                stackTraceElements[0].getClassName(), startsWith(classNamePrefix));
+        StackTraceElement testMethodStackTrace = error.testMethodStackTrace();
+        assertEquals("unexpected test method failure: " + testMethodStackTrace, failedTestMethod,
+                testMethodStackTrace.getMethodName());
     }
 }

--- a/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/PublisherStepVerifierTest.java
+++ b/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/PublisherStepVerifierTest.java
@@ -660,7 +660,8 @@ public class PublisherStepVerifierTest {
 
     @Test
     public void asyncContextOnError() {
-        StepVerifiers.create(from("foo").concat(failed(DELIBERATE_EXCEPTION)).publishAndSubscribeOn(EXECUTOR_RULE.executor()))
+        StepVerifiers.create(from("foo").concat(failed(DELIBERATE_EXCEPTION))
+                        .publishAndSubscribeOn(EXECUTOR_RULE.executor()))
                 .expectSubscriptionConsumed(s -> {
                     assertNotNull(s);
                     AsyncContext.put(ASYNC_KEY, 10);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ResponseCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ResponseCancelTest.java
@@ -18,6 +18,7 @@ package io.servicetalk.http.netty;
 import io.servicetalk.client.api.DelegatingConnectionFactory;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.api.test.StepVerifiers;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.ReservedStreamingHttpConnection;
@@ -46,7 +47,6 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.failed;
-import static io.servicetalk.concurrent.api.test.Verifiers.stepVerifier;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
@@ -157,7 +157,7 @@ public class H2ResponseCancelTest extends AbstractNettyHttpServerTest {
         firstRequestReceivedLatch.await();
 
         AtomicReference<Cancellable> cancellable = new AtomicReference<>();
-        stepVerifier(requester.request(defaultStrategy(), newRequest(requester, "second"))
+        StepVerifiers.create(requester.request(defaultStrategy(), newRequest(requester, "second"))
                         .whenOnSuccess(responses::add)) // Add response to the queue to verify that we never receive it
                 .expectCancellableConsumed(cancellable::set)
                 .then(() -> {

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.api.test.StepVerifiers;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.ConnectionInfo.Protocol;
@@ -32,7 +33,6 @@ import org.junit.rules.Timeout;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.concurrent.api.Executors.immediate;
-import static io.servicetalk.concurrent.api.test.Verifiers.stepVerifier;
 import static io.servicetalk.transport.netty.internal.CloseHandler.forPipelinedRequestResponse;
 import static io.servicetalk.transport.netty.internal.FlushStrategies.defaultFlushStrategy;
 import static io.servicetalk.transport.netty.internal.NoopExecutionStrategy.NOOP_STRATEGY;
@@ -93,7 +93,7 @@ abstract class AbstractSslCloseNotifyAlertHandlingTest {
             assertThat("Underlying Channel is not closed", channel.isOpen(), is(false));
             assertThat("Unexpected inbound messages", channel.inboundMessages(), hasSize(0));
             assertThat("Unexpected outbound messages", channel.outboundMessages(), hasSize(0));
-            stepVerifier(conn.onClose()).expectComplete().verify();
+            StepVerifiers.create(conn.onClose()).expectComplete().verify();
         } finally {
             // In case of test errors, do the clean up:
             try {
@@ -112,7 +112,7 @@ abstract class AbstractSslCloseNotifyAlertHandlingTest {
 
     protected final void closeNotifyAndVerifyClosing() {
         channel.pipeline().fireUserEventTriggered(SslCloseCompletionEvent.SUCCESS);
-        stepVerifier(conn.onClosing()).expectComplete().verify();
+        StepVerifiers.create(conn.onClosing()).expectComplete().verify();
     }
 
     protected final void writeMsg(PublisherSource.Processor<String, String> writeSource, String msg) {

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertClientHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertClientHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.api.test.StepVerifiers;
 
 import org.junit.Test;
 
@@ -23,7 +24,6 @@ import java.nio.channels.ClosedChannelException;
 
 import static io.servicetalk.concurrent.api.Processors.newPublisherProcessor;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
-import static io.servicetalk.concurrent.api.test.Verifiers.stepVerifier;
 
 public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotifyAlertHandlingTest {
 
@@ -34,7 +34,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
     @Test
     public void afterExchangeIdleConnection() {
         sendRequest();
-        stepVerifier(conn.read())
+        StepVerifiers.create(conn.read())
                 .then(() -> channel.writeInbound(BEGIN))
                 .expectNext(BEGIN)
                 .then(() -> channel.writeInbound(END))
@@ -47,7 +47,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
     @Test
     public void afterRequestBeforeReadingResponse() {
         sendRequest();
-        stepVerifier(conn.read())
+        StepVerifiers.create(conn.read())
                 .then(this::closeNotifyAndVerifyClosing)
                 .expectError(ClosedChannelException.class)
                 .verify();
@@ -56,7 +56,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
     @Test
     public void afterRequestWhileReadingResponse() {
         sendRequest();
-        stepVerifier(conn.read())
+        StepVerifiers.create(conn.read())
                 .then(() -> channel.writeInbound(BEGIN))
                 .expectNext(BEGIN)
                 .then(this::closeNotifyAndVerifyClosing)
@@ -67,7 +67,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
     @Test
     public void whileWritingRequestBeforeReadingResponse() {
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
-        stepVerifier(conn.write(fromSource(writeSource)).merge(conn.read()))
+        StepVerifiers.create(conn.write(fromSource(writeSource)).merge(conn.read()))
                 .then(() -> {
                     // Start writing request
                     writeMsg(writeSource, BEGIN);
@@ -80,7 +80,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
     @Test
     public void whileWritingRequestAndReadingResponse() {
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
-        stepVerifier(conn.write(fromSource(writeSource)).merge(conn.read()))
+        StepVerifiers.create(conn.write(fromSource(writeSource)).merge(conn.read()))
                 .then(() -> {
                     // Start writing request
                     writeMsg(writeSource, BEGIN);
@@ -96,7 +96,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
     @Test
     public void whileWritingRequestAfterReadingResponse() {
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
-        stepVerifier(conn.write(fromSource(writeSource)).merge(conn.read()))
+        StepVerifiers.create(conn.write(fromSource(writeSource)).merge(conn.read()))
                 .then(() -> {
                     // Start writing request
                     writeMsg(writeSource, BEGIN);
@@ -112,7 +112,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
 
     private void sendRequest() {
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
-        stepVerifier(conn.write(fromSource(writeSource)))
+        StepVerifiers.create(conn.write(fromSource(writeSource)))
                 .then(() -> {
                     writeMsg(writeSource, BEGIN);
                     writeMsg(writeSource, END);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertServerHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertServerHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.api.test.StepVerifiers;
 import io.servicetalk.transport.netty.internal.CloseHandler.CloseEventObservedException;
 
 import org.junit.Test;
@@ -24,7 +25,6 @@ import java.nio.channels.ClosedChannelException;
 
 import static io.servicetalk.concurrent.api.Processors.newPublisherProcessor;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
-import static io.servicetalk.concurrent.api.test.Verifiers.stepVerifier;
 import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.CHANNEL_CLOSED_INBOUND;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
@@ -40,7 +40,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
     public void afterExchangeIdleConnection() {
         receiveRequest();
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
-        stepVerifier(conn.write(fromSource(writeSource)))
+        StepVerifiers.create(conn.write(fromSource(writeSource)))
                 .then(() -> {
                     writeMsg(writeSource, BEGIN);
                     writeMsg(writeSource, END);
@@ -59,7 +59,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
         receiveRequest();
 
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
-        stepVerifier(conn.write(fromSource(writeSource)))
+        StepVerifiers.create(conn.write(fromSource(writeSource)))
                 .then(this::closeNotifyAndVerifyClosing)
                 .expectError(RetryableClosureException.class)
                 .verify();
@@ -70,7 +70,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
         receiveRequest();
 
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
-        stepVerifier(conn.write(fromSource(writeSource)))
+        StepVerifiers.create(conn.write(fromSource(writeSource)))
                 .then(() -> {
                     writeMsg(writeSource, BEGIN);
                     closeNotifyAndVerifyClosing();
@@ -81,7 +81,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
 
     @Test
     public void whileReadingRequestBeforeSendingResponse() {
-        stepVerifier(conn.write(fromSource(newPublisherProcessor())).merge(conn.read()))
+        StepVerifiers.create(conn.write(fromSource(newPublisherProcessor())).merge(conn.read()))
                 .then(() -> {
                     // Start reading request
                     channel.writeInbound(BEGIN);
@@ -95,7 +95,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
     @Test
     public void whileReadingRequestAndSendingResponse() {
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
-        stepVerifier(conn.write(fromSource(writeSource)).merge(conn.read()))
+        StepVerifiers.create(conn.write(fromSource(writeSource)).merge(conn.read()))
                 .then(() -> {
                     // Start reading request
                     channel.writeInbound(BEGIN);
@@ -111,7 +111,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
     @Test
     public void whileReadingRequestAfterSendingResponse() {
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
-        stepVerifier(conn.write(fromSource(writeSource)).merge(conn.read()))
+        StepVerifiers.create(conn.write(fromSource(writeSource)).merge(conn.read()))
                 .then(() -> {
                     // Start reading request
                     channel.writeInbound(BEGIN);
@@ -126,7 +126,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
     }
 
     private void receiveRequest() {
-        stepVerifier(conn.read())
+        StepVerifiers.create(conn.read())
                 .then(() -> channel.writeInbound(BEGIN))
                 .expectNext(BEGIN)
                 .then(() -> channel.writeInbound(END))


### PR DESCRIPTION
Motivation:

`stepVerifier` is not a verb and may reduce the developer ergonomics.
`StepVerifiers.create` expresses better what’s happening. It also more
consistent with other reactive-streams libraries.

Modifications:

- Copy `Verifiers` factory and rename it to `StepVerifiers`;
- Deprecated `Verifiers` class and reference `StepVerifiers` as a replacement;
- Update existing tests to use `StepVerifiers`;

Result:

Better developer's experience for our test utilities.