### PR TITLE
gRPC missing grpc-status error code update

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
@@ -52,6 +52,7 @@ import static io.servicetalk.encoding.api.ContentCodings.identity;
 import static io.servicetalk.encoding.api.internal.HeaderUtils.encodingFor;
 import static io.servicetalk.grpc.api.GrpcStatusCode.INTERNAL;
 import static io.servicetalk.grpc.api.GrpcStatusCode.UNIMPLEMENTED;
+import static io.servicetalk.grpc.api.GrpcStatusCode.UNKNOWN;
 import static io.servicetalk.http.api.HeaderUtils.hasContentType;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
 import static io.servicetalk.http.api.HttpHeaderNames.SERVER;
@@ -232,7 +233,7 @@ final class GrpcUtils {
         final GrpcStatusCode statusCode = extractGrpcStatusCodeFromHeaders(headers);
         if (statusCode == null) {
             // This is a protocol violation as we expect to receive grpc-status.
-            throw new GrpcStatus(INTERNAL, null, "Response does not contain " +
+            throw new GrpcStatus(UNKNOWN, null, "Response does not contain " +
                     GRPC_STATUS_CODE_TRAILER + " header or trailer").asException();
         }
         final GrpcStatusException grpcStatusException = convertToGrpcStatusException(statusCode, headers);

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcClientRequiresTrailersTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcClientRequiresTrailersTest.java
@@ -172,7 +172,7 @@ public class GrpcClientRequiresTrailersTest {
     }
 
     private static void assertGrpcStatusException(GrpcStatusException grpcStatusException) {
-        assertThat(grpcStatusException.status().code(), is(GrpcStatusCode.INTERNAL));
+        assertThat(grpcStatusException.status().code(), is(GrpcStatusCode.UNKNOWN));
         assertThat(grpcStatusException.status().description(),
                 equalTo("Response does not contain grpc-status header or trailer"));
     }


### PR DESCRIPTION
Motivation:
If the client receives a response with no grpc-status we return an error
as [required by the spec](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md).
However we currently return a status code of INTERNAL but the UNKNOWN
status code is more appropriate [1][2].

[1] https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
> Error parsing returned status, UNKNOWN, Client

[2] https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md
> 200 is UNKNOWN because there should be a grpc-status in case of truly OK response.

Modifications:
- Change error status code to UNKNOWN if the grpc-status is not present.

Result:
More appropriate error code when grpc-status is missing from the
response on the client side.