### PR TITLE
Clarify AsyncContext put API relative to @Nullable

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContext.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContext.java
@@ -92,7 +92,7 @@ public final class AsyncContext {
      * Convenience method for to put all the key/value pairs into the current context.
      *
      * @param map contains the key/value pairs that will be added.
-     * @throws ConcurrentModificationException Done on a best effort basis if {@code entries} is detected to be modified
+     * @throws ConcurrentModificationException done on a best effort basis if {@code entries} is detected to be modified
      * while attempting to put all entries.
      * @throws NullPointerException if {@code key} or {@code value} is {@code null} and the underlying
      * {@link AsyncContextMap} implementation doesn't support {@code null} keys or values.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContext.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContext.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
+import java.util.ConcurrentModificationException;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -77,9 +78,13 @@ public final class AsyncContext {
      * @param key   the key used to index {@code value}. Cannot be {@code null}.
      * @param value the value to put.
      * @param <T>   The type of object associated with {@code key}.
+     * @throws NullPointerException if {@code key} or {@code value} is {@code null} and the underlying
+     * {@link AsyncContextMap} implementation doesn't support {@code null} keys or values.
+     * @throws UnsupportedOperationException if this method is not supported by the underlying {@link AsyncContextMap}
+     * implementation.
      * @see AsyncContextMap#put(AsyncContextMap.Key, Object)
      */
-    public static <T> void put(AsyncContextMap.Key<T> key, T value) {
+    public static <T> void put(AsyncContextMap.Key<T> key, @Nullable T value) {
         current().put(key, value);
     }
 
@@ -87,6 +92,12 @@ public final class AsyncContext {
      * Convenience method for to put all the key/value pairs into the current context.
      *
      * @param map contains the key/value pairs that will be added.
+     * @throws ConcurrentModificationException Done on a best effort basis if {@code entries} is detected to be modified
+     * while attempting to put all entries.
+     * @throws NullPointerException if {@code key} or {@code value} is {@code null} and the underlying
+     * {@link AsyncContextMap} implementation doesn't support {@code null} keys or values.
+     * @throws UnsupportedOperationException if this method is not supported by the underlying {@link AsyncContextMap}
+     * implementation.
      * @see AsyncContextMap#putAll(Map)
      */
     public static void putAll(Map<AsyncContextMap.Key<?>, Object> map) {
@@ -97,6 +108,8 @@ public final class AsyncContext {
      * Convenience method to remove a key/value pair from the current context.
      *
      * @param key The key to remove.
+     * @throws UnsupportedOperationException if this method is not supported by the underlying {@link AsyncContextMap}
+     * implementation.
      * @see AsyncContextMap#remove(AsyncContextMap.Key)
      */
     public static void remove(AsyncContextMap.Key<?> key) {
@@ -107,6 +120,8 @@ public final class AsyncContext {
      * Convenience method to remove all the key/value pairs from the current context.
      *
      * @param entries A {@link Iterable} which contains all the keys to remove.
+     * @throws UnsupportedOperationException if this method is not supported by the underlying {@link AsyncContextMap}
+     * implementation.
      * @see AsyncContextMap#removeAll(Iterable)
      */
     public static void removeAll(Iterable<AsyncContextMap.Key<?>> entries) {
@@ -116,6 +131,8 @@ public final class AsyncContext {
     /**
      * Convenience method to clear all the key/value pairs from the current context.
      *
+     * @throws UnsupportedOperationException if this method is not supported by the underlying {@link AsyncContextMap}
+     * implementation.
      * @see AsyncContextMap#clear()
      */
     public static void clear() {
@@ -127,7 +144,11 @@ public final class AsyncContext {
      *
      * @param key the key to lookup.
      * @param <T> The anticipated type of object associated with {@code key}.
-     * @return the value associated with {@code key}, or {@code null} if no value is associated.
+     * @return the value associated with {@code key}, or {@code null} if no value is associated. {@code null} can
+     * also indicate the value associated with {@code key} is {@code null} (if {@code null} values are supported by the
+     * underlying {@link AsyncContextMap} implementation).
+     * @throws NullPointerException (optional behavior) if {@code key} is {@code null} and the underlying
+     * {@link AsyncContextMap} implementation doesn't support {@code null} keys or values.
      * @see AsyncContextMap#get(AsyncContextMap.Key)
      */
     @Nullable
@@ -141,6 +162,8 @@ public final class AsyncContext {
      * @param key the key to lookup.
      * @return {@code true} if the current context contains a key/value entry corresponding to {@code key}.
      * {@code false} otherwise.
+     * @throws NullPointerException (optional behavior) if {@code key} is {@code null} and the underlying
+     * {@link AsyncContextMap} implementation doesn't support {@code null} keys or values.
      * @see AsyncContextMap#containsKey(AsyncContextMap.Key)
      */
     public static boolean containsKey(AsyncContextMap.Key<?> key) {
@@ -164,6 +187,7 @@ public final class AsyncContext {
      * if the consumer wants to keep iterating or {@code false} to stop iteration at the current key/value pair.
      * @return {@code null} if {@code consumer} iterated through all key/value pairs or the {@link AsyncContextMap.Key}
      * at which the iteration stopped.
+     * @throws NullPointerException if {@code consumer} is null.
      * @see AsyncContextMap#forEach(BiPredicate)
      */
     @Nullable

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextMap.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextMap.java
@@ -98,7 +98,7 @@ public interface AsyncContextMap {
      * @return {@code true} if this context contains a key/value entry corresponding to {@code key}.
      * {@code false} otherwise.
      * @throws NullPointerException (optional behavior) if {@code key} is {@code null} and the implementation doesn't
-     * support {@code null} keys or values.s
+     * support {@code null} keys or values.
      */
     boolean containsKey(AsyncContextMap.Key<?> key);
 
@@ -135,7 +135,7 @@ public interface AsyncContextMap {
      * Put all the key/value pairs into this {@link AsyncContextMap}.
      *
      * @param map The entries to insert into this {@link AsyncContextMap}.
-     * @throws ConcurrentModificationException Done on a best effort basis if {@code entries} is detected to be modified
+     * @throws ConcurrentModificationException done on a best effort basis if {@code entries} is detected to be modified
      * while attempting to put all entries.
      * @throws NullPointerException if {@code key}s or {@code value}s from {@code map} are {@code null} and the
      * implementation doesn't support {@code null} keys or values.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextMap.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextMap.java
@@ -82,7 +82,11 @@ public interface AsyncContextMap {
      *
      * @param key the key to lookup.
      * @param <T> The anticipated type of object associated with {@code key}.
-     * @return the value associated with {@code key}, or {@code null} if no value is associated.
+     * @return the value associated with {@code key}, or {@code null} if no value is associated. {@code null} can also
+     * indicate the value associated with {@code key} is {@code null} (if {@code null} values are supported by the
+     * implementation).
+     * @throws NullPointerException (optional behavior) if {@code key} is {@code null} and the implementation doesn't
+     * support {@code null} keys or values.
      */
     @Nullable
     <T> T get(AsyncContextMap.Key<T> key);
@@ -93,6 +97,8 @@ public interface AsyncContextMap {
      * @param key the key to lookup.
      * @return {@code true} if this context contains a key/value entry corresponding to {@code key}.
      * {@code false} otherwise.
+     * @throws NullPointerException (optional behavior) if {@code key} is {@code null} and the implementation doesn't
+     * support {@code null} keys or values.s
      */
     boolean containsKey(AsyncContextMap.Key<?> key);
 
@@ -115,13 +121,15 @@ public interface AsyncContextMap {
      * @param key   the key used to index {@code value}. Cannot be {@code null}.
      * @param value the value to put.
      * @param <T>   The type of object associated with {@code key}.
-     * @return The previous value associated with the {@code key}, or {@code null} if there was none. A {@code null}
-     * value may also indicate there was a previous value which was {@code null}.
-     * @throws NullPointerException if {@code key} is {@code null}, or {@code value} is {@code null}.
+     * @return The previous value associated with the {@code key}, or {@code null} if there was none. {@code null} can
+     * also indicate the value associated value with {@code key} is {@code null} (if {@code null} values are supported
+     * by the implementation).
+     * @throws NullPointerException if {@code key} or {@code value} is {@code null} and the implementation doesn't
+     * support {@code null} keys or values.
      * @throws UnsupportedOperationException if this method is not supported.
      */
     @Nullable
-    <T> T put(AsyncContextMap.Key<T> key, T value);
+    <T> T put(AsyncContextMap.Key<T> key, @Nullable T value);
 
     /**
      * Put all the key/value pairs into this {@link AsyncContextMap}.
@@ -129,6 +137,8 @@ public interface AsyncContextMap {
      * @param map The entries to insert into this {@link AsyncContextMap}.
      * @throws ConcurrentModificationException Done on a best effort basis if {@code entries} is detected to be modified
      * while attempting to put all entries.
+     * @throws NullPointerException if {@code key}s or {@code value}s from {@code map} are {@code null} and the
+     * implementation doesn't support {@code null} keys or values.
      * @throws UnsupportedOperationException if this method is not supported.
      */
     void putAll(Map<AsyncContextMap.Key<?>, Object> map);
@@ -170,6 +180,7 @@ public interface AsyncContextMap {
      * if the consumer wants to keep iterating or {@code false} to stop iteration at the current key/value pair.
      * @return {@code null} if {@code consumer} iterated through all key/value pairs or the {@link AsyncContextMap.Key}
      * at which the iteration stopped.
+     * @throws NullPointerException if {@code consumer} is null.
      */
     @Nullable
     AsyncContextMap.Key<?> forEach(BiPredicate<Key<?>, Object> consumer);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ConcurrentAsyncContextMap.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ConcurrentAsyncContextMap.java
@@ -59,7 +59,8 @@ final class ConcurrentAsyncContextMap implements AsyncContextMap {
     @SuppressWarnings("unchecked")
     @Nullable
     @Override
-    public <T> T put(final Key<T> key, final T value) {
+    public <T> T put(final Key<T> key, @Nullable final T value) {
+        assert value != null;
         return (T) theMap.put(key, value);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CopyOnWriteAsyncContextMap.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CopyOnWriteAsyncContextMap.java
@@ -67,7 +67,7 @@ final class CopyOnWriteAsyncContextMap implements AsyncContextMap {
 
     @Nullable
     @Override
-    public <T> T put(final Key<T> key, final T value) {
+    public <T> T put(final Key<T> key, @Nullable final T value) {
         return map.put(key, value, this, mapUpdater);
     }
 
@@ -124,7 +124,7 @@ final class CopyOnWriteAsyncContextMap implements AsyncContextMap {
         int size();
 
         @Nullable
-        <T> T put(Key<T> key, T value, CopyOnWriteAsyncContextMap owner,
+        <T> T put(Key<T> key, @Nullable T value, CopyOnWriteAsyncContextMap owner,
                   AtomicReferenceFieldUpdater<CopyOnWriteAsyncContextMap, CopyAsyncContextMap> mapUpdater);
 
         CopyAsyncContextMap putAll(Map<Key<?>, Object> map);
@@ -170,7 +170,7 @@ final class CopyOnWriteAsyncContextMap implements AsyncContextMap {
 
         @Nullable
         @Override
-        public <T> T put(final Key<T> key, final T value,
+        public <T> T put(final Key<T> key, @Nullable final T value,
                          CopyOnWriteAsyncContextMap owner,
                          AtomicReferenceFieldUpdater<CopyOnWriteAsyncContextMap, CopyAsyncContextMap> mapUpdater) {
             return mapUpdater.compareAndSet(owner, this, new OneAsyncContextMap(key, value)) ? null :
@@ -279,7 +279,7 @@ final class CopyOnWriteAsyncContextMap implements AsyncContextMap {
 
         @SuppressWarnings("unchecked")
         @Override
-        public <T> T put(final Key<T> key, final T value, CopyOnWriteAsyncContextMap owner,
+        public <T> T put(final Key<T> key, @Nullable final T value, CopyOnWriteAsyncContextMap owner,
                          AtomicReferenceFieldUpdater<CopyOnWriteAsyncContextMap, CopyAsyncContextMap> mapUpdater) {
             assert this.key != null;
             if (this.key.equals(key)) {
@@ -700,7 +700,7 @@ final class CopyOnWriteAsyncContextMap implements AsyncContextMap {
 
         @SuppressWarnings("unchecked")
         @Override
-        public <T> T put(final Key<T> key, final T value, CopyOnWriteAsyncContextMap owner,
+        public <T> T put(final Key<T> key, @Nullable final T value, CopyOnWriteAsyncContextMap owner,
                          AtomicReferenceFieldUpdater<CopyOnWriteAsyncContextMap, CopyAsyncContextMap> mapUpdater) {
             assert keyOne != null && keyTwo != null;
             if (keyOne.equals(key)) {
@@ -1165,7 +1165,7 @@ final class CopyOnWriteAsyncContextMap implements AsyncContextMap {
         @SuppressWarnings("unchecked")
         @Nullable
         @Override
-        public <T> T put(final Key<T> key, final T value, CopyOnWriteAsyncContextMap owner,
+        public <T> T put(final Key<T> key, @Nullable final T value, CopyOnWriteAsyncContextMap owner,
                          AtomicReferenceFieldUpdater<CopyOnWriteAsyncContextMap, CopyAsyncContextMap> mapUpdater) {
             assert keyOne != null && keyTwo != null && keyThree != null;
             if (keyOne.equals(key)) {
@@ -1623,7 +1623,7 @@ final class CopyOnWriteAsyncContextMap implements AsyncContextMap {
         @SuppressWarnings("unchecked")
         @Nullable
         @Override
-        public <T> T put(final Key<T> key, final T value, CopyOnWriteAsyncContextMap owner,
+        public <T> T put(final Key<T> key, @Nullable final T value, CopyOnWriteAsyncContextMap owner,
                          AtomicReferenceFieldUpdater<CopyOnWriteAsyncContextMap, CopyAsyncContextMap> mapUpdater) {
             assert keyOne != null && keyTwo != null && keyThree != null && keyFour != null;
             if (keyOne.equals(key)) {
@@ -2057,7 +2057,7 @@ final class CopyOnWriteAsyncContextMap implements AsyncContextMap {
         @SuppressWarnings("unchecked")
         @Nullable
         @Override
-        public <T> T put(final Key<T> key, final T value, CopyOnWriteAsyncContextMap owner,
+        public <T> T put(final Key<T> key, @Nullable final T value, CopyOnWriteAsyncContextMap owner,
                          AtomicReferenceFieldUpdater<CopyOnWriteAsyncContextMap, CopyAsyncContextMap> mapUpdater) {
             assert keyOne != null && keyTwo != null && keyThree != null && keyFour != null && keyFive != null;
             if (keyOne.equals(key)) {
@@ -2483,7 +2483,7 @@ final class CopyOnWriteAsyncContextMap implements AsyncContextMap {
         @SuppressWarnings("unchecked")
         @Nullable
         @Override
-        public <T> T put(final Key<T> key, final T value, CopyOnWriteAsyncContextMap owner,
+        public <T> T put(final Key<T> key, @Nullable final T value, CopyOnWriteAsyncContextMap owner,
                          AtomicReferenceFieldUpdater<CopyOnWriteAsyncContextMap, CopyAsyncContextMap> mapUpdater) {
             assert keyOne != null && keyTwo != null && keyThree != null && keyFour != null && keyFive != null &&
                     keySix != null;


### PR DESCRIPTION
Motivation:
The AsyncContext API and implementation are inconsistent on how null
values are treated for the put(key, value) method.

Modifications:
- Make the AsyncContext and AsyncContextMap APIs consistent with
  java.util.Map API relative to null values. The API allows null values
  and permits the implementation to not support it.

Result:
AsyncContext APIs have the same semantics as java.util.Map for null
values on the put(key, value) method.