### PR TITLE
Publish concurrent-jdkflow artifacts during release

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -69,21 +69,19 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/test/TEST-*.xml'
-          check_name: Test Report
+          check_name: Test Report JDK ${{ matrix.java }}
       - name: Publish Checkstyle Report
         if: always()
-        # v1.2
         uses: jwgmeligmeyling/checkstyle-github-action@50292990e18466f2c5d95d04ff5fab931254fa5f
         with:
-          name: Checkstyle Report
+          name: Checkstyle Report JDK ${{ matrix.java }}
           path: '**/build/reports/checkstyle/*.xml'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish PMD Report
         if: always()
-        # v1.2
         uses: jwgmeligmeyling/pmd-github-action@322e346bd76a0757c4d54ff9209e245965aa066d
         with:
-          name: PMD Report
+          name: PMD Report JDK ${{ matrix.java }}
           path: '**/build/reports/pmd/*.xml'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish SpotBugs Report
@@ -91,6 +89,6 @@ jobs:
         # v1.2
         uses: jwgmeligmeyling/spotbugs-github-action@b8e2c3523acb34c87f14e18cbcd2d87db8c8584e
         with:
-          name: SpotBugs Report
+          name: SpotBugs Report JDK ${{ matrix.java }}
           path: '**/build/reports/spotbugs/*.xml'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -4,17 +4,21 @@ on:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 jobs:
-  build-jdk8:
+  build:
+    name: Release JDK ${{ matrix.java }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 8, 11 ]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Check NO SNAPSHOT version suffix
         run: if [[ $(cat gradle.properties | grep version= | sed 's/^version=//') =~ .*-SNAPSHOT ]]; then exit 1; else exit 0; fi
-      - name: Set up JDK 8
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: ${{ matrix.java }}
       - name: Print JDK Version
         run: java -version
       - name: Make gradlew Executable
@@ -34,7 +38,31 @@ jobs:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_TOKEN: ${{ secrets.SONATYPE_TOKEN }}
           CI: true
-        run: ./gradlew --parallel --max-workers=4 -PreleaseBuild=true clean check && ./gradlew -PreleaseBuild=true publish
+        run: |
+          # Build arguments to feed to the single gradlew publish command
+          if [ "${{ matrix.java }}" = "8" ]; then
+            FIRST_GRADLE_TARGETS=" clean check"
+            SECOND_GRADLE_TARGETS=" publish"
+          else
+            FIRST_GRADLE_TARGETS=""
+            SECOND_GRADLE_TARGETS=""
+
+            # Execute the printJavaTargetCompatibility task to get the java target compatibility for each subproject
+            # and extract the projects that require jdk9+.
+            while read -r line
+            do
+              javaTarget=$(echo "$line" | sed -e 's/^version: \(.*\) name:.*/\1/g')
+              if [ "$javaTarget" = "1.9" ] || [ "$javaTarget" = "1.10" ] || [ "$javaTarget" -gt "8" ] 2> /dev/null
+              then
+                currDir=$(echo "$line" | sed -e 's/^version:.* name: \(.*\)$/\1/g')
+                FIRST_GRADLE_TARGETS="$FIRST_GRADLE_TARGETS :$currDir:clean :$currDir:check"
+                SECOND_GRADLE_TARGETS="$SECOND_GRADLE_TARGETS :$currDir:publish"
+              fi
+            done < <(./gradlew printJavaTargetCompatibility)
+          fi
+
+          # Execute the gradlew command to publish the build
+          ./gradlew --parallel --max-workers=4 -PreleaseBuild=true$FIRST_GRADLE_TARGETS && ./gradlew -PreleaseBuild=true$SECOND_GRADLE_TARGETS
       - name: Publish Test Results
         if: always()
         uses: scacap/action-surefire-report@fd75ee04fbef040d0198e50ad153fcf997a0cf78

--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -5,17 +5,21 @@ on:
     tags-ignore:
       - "[0-9]+.[0-9]+.[0-9]+"
 jobs:
-  build-jdk8:
+  build:
+    name: Snapshot JDK ${{ matrix.java }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 8, 11 ]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Check SNAPSHOT version suffix
         run: if [[ $(cat gradle.properties | grep version= | sed 's/^version=//') =~ .*-SNAPSHOT ]]; then exit 0; else exit 1; fi
-      - name: Set up JDK 8
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: ${{ matrix.java }}
       - name: Print JDK Version
         run: java -version
       - name: Make gradlew Executable
@@ -35,35 +39,56 @@ jobs:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_TOKEN: ${{ secrets.SONATYPE_TOKEN }}
           CI: true
-        run: ./gradlew --parallel --max-workers=4 clean check && ./gradlew publish
+        run: |
+          # Build arguments to feed to the single gradlew publish command
+          if [ "${{ matrix.java }}" = "8" ]; then
+            FIRST_GRADLE_TARGETS=" clean check"
+            SECOND_GRADLE_TARGETS=" publish"
+          else
+            FIRST_GRADLE_TARGETS=""
+            SECOND_GRADLE_TARGETS=""
+
+            # Execute the printJavaTargetCompatibility task to get the java target compatibility for each subproject
+            # and extract the projects that require jdk9+.
+            while read -r line
+            do
+              javaTarget=$(echo "$line" | sed -e 's/^version: \(.*\) name:.*/\1/g')
+              if [ "$javaTarget" = "1.9" ] || [ "$javaTarget" = "1.10" ] || [ "$javaTarget" -gt "8" ] 2> /dev/null
+              then
+                currDir=$(echo "$line" | sed -e 's/^version:.* name: \(.*\)$/\1/g')
+                FIRST_GRADLE_TARGETS="$FIRST_GRADLE_TARGETS :$currDir:clean :$currDir:check"
+                SECOND_GRADLE_TARGETS="$SECOND_GRADLE_TARGETS :$currDir:publish"
+              fi
+            done < <(./gradlew printJavaTargetCompatibility)
+          fi
+
+          # Execute the gradlew command to publish the build
+          ./gradlew --parallel --max-workers=4$FIRST_GRADLE_TARGETS && ./gradlew$SECOND_GRADLE_TARGETS
       - name: Publish Test Results
         if: always()
         uses: scacap/action-surefire-report@fd75ee04fbef040d0198e50ad153fcf997a0cf78
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/test/TEST-*.xml'
-          check_name: Test Report
+          check_name: Test Report JDK ${{ matrix.java }}
       - name: Publish Checkstyle Report
         if: always()
-        # v1.2
         uses: jwgmeligmeyling/checkstyle-github-action@50292990e18466f2c5d95d04ff5fab931254fa5f
         with:
-          name: Checkstyle Report
+          name: Checkstyle Report JDK ${{ matrix.java }}
           path: '**/build/reports/checkstyle/*.xml'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish PMD Report
         if: always()
-        # v1.2
         uses: jwgmeligmeyling/pmd-github-action@322e346bd76a0757c4d54ff9209e245965aa066d
         with:
-          name: PMD Report
+          name: PMD Report JDK ${{ matrix.java }}
           path: '**/build/reports/pmd/*.xml'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish SpotBugs Report
         if: always()
-        # v1.2
         uses: jwgmeligmeyling/spotbugs-github-action@b8e2c3523acb34c87f14e18cbcd2d87db8c8584e
         with:
-          name: SpotBugs Report
+          name: SpotBugs Report JDK ${{ matrix.java }}
           path: '**/build/reports/spotbugs/*.xml'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -36,3 +36,14 @@ task validateLocalDocSite(type: Exec) {
   commandLine './gradlew', 'clean', 'validateLocalSite'
 }
 quality.dependsOn validateLocalDocSite
+
+subprojects {
+  // Used by ci-release.yaml to determine which modules need to be built/released with JDK11.
+  task printJavaTargetCompatibility {
+    doLast {
+      if (project.parent == project.rootProject) {
+        println("version: " + project.properties.targetCompatibility + " name: " + project.name)
+      }
+    }
+  }
+}

--- a/servicetalk-concurrent-jdkflow/build.gradle
+++ b/servicetalk-concurrent-jdkflow/build.gradle
@@ -16,10 +16,9 @@
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
-if(!JavaVersion.current().isJava9Compatible()){
+if (!JavaVersion.current().isJava9Compatible()) {
     project.tasks.all { task -> task.enabled = false }
 }
-
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_9

--- a/servicetalk-concurrent-jdkflow/build.gradle
+++ b/servicetalk-concurrent-jdkflow/build.gradle
@@ -25,6 +25,10 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_9
 }
 
+compileJava {
+    options.compilerArgs.addAll(['--release', '9'])
+}
+
 dependencies {
     api project(":servicetalk-concurrent-api")
 

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkRootPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkRootPlugin.groovy
@@ -51,8 +51,7 @@ final class ServiceTalkRootPlugin extends ServiceTalkCorePlugin {
         }
 
         gradle.projectsEvaluated {
-          subprojects.findAll {!it.name.contains("examples") &&
-              !(it.name.contains("jdkflow") && !JavaVersion.current().isJava9Compatible())}.each { prj ->
+          subprojects.findAll {!it.name.contains("examples")}.each { prj ->
             prj.tasks.withType(Javadoc).each { javadocTask ->
               source += javadocTask.source
               classpath += javadocTask.classpath


### PR DESCRIPTION
Motivation:
The concurrent-jdkflow requires JDK9+ in order to build, but our release
currently only builds on JDK8. The concurrent-jdkflow artifacts are
currently not published during the release process as a result.

Modifications:
- Add task in ci-release which builds on JDK11 and publishes the
  concurrent-jdkflow artifacts

Result:
concurrent-jdkflow will be published in the next release.