### PR TITLE
Add gRPC application level error example

### DIFF
--- a/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
@@ -12,5 +12,6 @@
 * xref:{page-version}@servicetalk-examples::grpc/index.adoc[gRPC]
 ** xref:{page-version}@servicetalk-examples::grpc/index.adoc#HelloWorld[Hello World]
 ** xref:{page-version}@servicetalk-examples::grpc/index.adoc#Compression[Compression]
+** xref:{page-version}@servicetalk-examples::grpc/index.adoc#errors[Application Errors]
 ** xref:{page-version}@servicetalk-examples::grpc/index.adoc#route-guide[Route Guide]
 ** xref:{page-version}@servicetalk-examples::grpc/index.adoc#protoc-options[Protoc Options]

--- a/servicetalk-examples/docs/modules/ROOT/pages/grpc/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/grpc/index.adoc
@@ -80,9 +80,23 @@ xref:{page-version}@servicetalk::programming-paradigms.adoc#asynchronous-and-str
 
 Extends the async "Hello World" example to demonstrate compression of the response body.
 
-* link:{source-root}/servicetalk-examples/grpc/compression/src/main/java/io/servicetalk/examples/grpc/compression/async/CompressionExampleServer.java[CompressionExampleServer] - Waits for hello request from the client and responds with a compressed greeting response.
-* link:{source-root}/servicetalk-examples/grpc/compression/src/main/java/io/servicetalk/examples/grpc/compression/async/CompressionExampleClient.java[CompressionExampleClient] - Sends a hello request to the server and receives a compressed greeting response.
+* link:{source-root}/servicetalk-examples/grpc/compression/src/main/java/io/servicetalk/examples/grpc/compression/CompressionExampleServer.java[CompressionExampleServer] - Waits for hello request from the client and responds with a compressed greeting response.
+* link:{source-root}/servicetalk-examples/grpc/compression/src/main/java/io/servicetalk/examples/grpc/compression/CompressionExampleClient.java[CompressionExampleClient] - Sends a hello request to the server and receives a
+  compressed greeting response.
 
+[#errors]
+== Application Errors
+The gRPC protocol supports propagating application level errors, and also provides serialization/deserialization of
+these objects. This example demonstrates a server returning an application level error to the client via the gRPC
+transport. The client intentionally omits the `token` field which is required, and the server returns an application
+level error. In this case the application level error type happens to be defined in
+link:https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto[error_details.proto], but it
+could be any protobuf object.
+
+* link:{source-root}/servicetalk-examples/grpc/compression/src/main/java/io/servicetalk/examples/grpc/errors/ErrorExampleServer.java[ErrorExampleServer] - Requires each request has a non-empty `token` field or else returns an
+error.
+* link:{source-root}/servicetalk-examples/grpc/compression/src/main/java/io/servicetalk/examples/grpc/errors/ErrorExampleClient.java[ErrorExampleClient] - Sends a request with missing `token` field to simulate an error
+  condition on the server.
 
 [#protoc-options]
 == Protoc Options

--- a/servicetalk-examples/grpc/errors/README.adoc
+++ b/servicetalk-examples/grpc/errors/README.adoc
@@ -1,0 +1,3 @@
+== ServiceTalk gRPC Compression Example
+
+Extends "Hello World" ServiceTalk gRPC example to demonstrate compression of request and response bodies.

--- a/servicetalk-examples/grpc/errors/README.adoc
+++ b/servicetalk-examples/grpc/errors/README.adoc
@@ -1,3 +1,3 @@
-== ServiceTalk gRPC Compression Example
+== ServiceTalk gRPC Application Errors Example
 
-Extends "Hello World" ServiceTalk gRPC example to demonstrate compression of request and response bodies.
+Extends "Hello World" ServiceTalk gRPC example to demonstrate how services can return application level errors which are propagated to the client via the gRPC transport.

--- a/servicetalk-examples/grpc/errors/build.gradle
+++ b/servicetalk-examples/grpc/errors/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-examples/grpc/errors/build.gradle
+++ b/servicetalk-examples/grpc/errors/build.gradle
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+buildscript {
+  dependencies {
+    classpath "com.google.protobuf:protobuf-gradle-plugin:$protobufGradlePluginVersion"
+  }
+}
+
+apply plugin: "java"
+apply plugin: "com.google.protobuf"
+apply from: "../../gradle/idea.gradle"
+
+dependencies {
+  implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-grpc-netty")
+  implementation project(":servicetalk-grpc-protoc")
+  implementation project(":servicetalk-grpc-protobuf")
+
+  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+}
+
+protobuf {
+  protoc {
+    artifact = "com.google.protobuf:protoc:$protobufVersion"
+  }
+  plugins {
+    servicetalk_grpc {
+      //// Users are expected to use "artifact" instead of "path". we use "path"
+      //// only because we want to use the gradle project local version of the plugin
+      // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
+      path = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
+                  "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+    }
+  }
+  generateProtoTasks {
+    all().each { task ->
+      task.plugins {
+        servicetalk_grpc {
+          // Need to tell protobuf-gradle-plugin to output in the correct directory if all generated
+          // code for a single proto goes to a single file (e.g. "java_multiple_files = false" in the .proto).
+          outputSubDir = "java"
+        }
+      }
+    }
+  }
+  generatedFilesBaseDir = "$buildDir/generated/sources/proto"
+}
+
+// The following setting must be omitted in users projects and is necessary here
+// only because we want to use the locally built version of the plugin
+afterEvaluate {
+  generateProto.dependsOn(":servicetalk-grpc-protoc:buildExecutable")
+}

--- a/servicetalk-examples/grpc/errors/src/main/java/io/servicetalk/examples/grpc/errors/ErrorExampleClient.java
+++ b/servicetalk-examples/grpc/errors/src/main/java/io/servicetalk/examples/grpc/errors/ErrorExampleClient.java
@@ -23,7 +23,7 @@ import io.grpc.examples.errors.Greeter.BlockingGreeterClient;
 import io.grpc.examples.errors.HelloRequest;
 
 /**
- * Extends the async "Hello World" example to include support for application error propagation.
+ * Extends the blocking "Hello World" example to include support for application error propagation.
  */
 public final class ErrorExampleClient {
     public static void main(String... args) throws Exception {

--- a/servicetalk-examples/grpc/errors/src/main/java/io/servicetalk/examples/grpc/errors/ErrorExampleClient.java
+++ b/servicetalk-examples/grpc/errors/src/main/java/io/servicetalk/examples/grpc/errors/ErrorExampleClient.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.grpc.errors;
+
+import io.servicetalk.grpc.api.GrpcStatusException;
+import io.servicetalk.grpc.netty.GrpcClients;
+
+import io.grpc.examples.errors.Greeter;
+import io.grpc.examples.errors.Greeter.BlockingGreeterClient;
+import io.grpc.examples.errors.HelloRequest;
+
+/**
+ * Extends the async "Hello World" example to include support for application error propagation.
+ */
+public final class ErrorExampleClient {
+    public static void main(String... args) throws Exception {
+        try (BlockingGreeterClient client = GrpcClients.forAddress("localhost", 8080)
+                .buildBlocking(new Greeter.ClientFactory())) {
+            try {
+                System.out.println(client.sayHello(HelloRequest.newBuilder().setName("Foo").build()));
+            } catch (GrpcStatusException e) {
+                System.err.println("Expected error stack trace:");
+                e.printStackTrace();
+                System.err.println("Expected error application status:");
+                System.err.println(e.applicationStatus());
+            }
+        }
+    }
+}

--- a/servicetalk-examples/grpc/errors/src/main/java/io/servicetalk/examples/grpc/errors/ErrorExampleServer.java
+++ b/servicetalk-examples/grpc/errors/src/main/java/io/servicetalk/examples/grpc/errors/ErrorExampleServer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.grpc.errors;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.grpc.api.GrpcServiceContext;
+import io.servicetalk.grpc.api.GrpcStatusException;
+import io.servicetalk.grpc.netty.GrpcServers;
+
+import com.google.rpc.BadRequest;
+import com.google.rpc.BadRequest.FieldViolation;
+import com.google.rpc.Status;
+import io.grpc.examples.errors.Greeter.GreeterService;
+import io.grpc.examples.errors.HelloReply;
+import io.grpc.examples.errors.HelloRequest;
+
+import static com.google.protobuf.Any.pack;
+import static io.servicetalk.concurrent.api.Single.failed;
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.grpc.api.GrpcStatusCode.INVALID_ARGUMENT;
+
+/**
+ * Extends the async "Hello World" example to include support for application error propagation.
+ */
+public class ErrorExampleServer {
+    public static void main(String... args) throws Exception {
+        GrpcServers.forPort(8080)
+                .listenAndAwait(new ErrorGreeterService())
+                .awaitShutdown();
+    }
+
+    private static final class ErrorGreeterService implements GreeterService {
+        @Override
+        public Single<HelloReply> sayHello(final GrpcServiceContext ctx, final HelloRequest request) {
+            if (request.getToken().isEmpty()) {
+                return failed(GrpcStatusException.of(Status.newBuilder()
+                        .setCode(INVALID_ARGUMENT.value())
+                        .setMessage("example message for invalid argument")
+                        .addDetails(pack(BadRequest.newBuilder().addFieldViolations(
+                                FieldViolation.newBuilder()
+                                        .setField(HelloRequest.getDescriptor().findFieldByNumber(2).getFullName())
+                                        .setDescription("missing required field!")
+                                        .build())
+                                .build()))
+                        .build()));
+            } else {
+                return succeeded(HelloReply.newBuilder().setMessage("hello " + request.getName()).build());
+            }
+        }
+    }
+}

--- a/servicetalk-examples/grpc/errors/src/main/java/io/servicetalk/examples/grpc/errors/package-info.java
+++ b/servicetalk-examples/grpc/errors/src/main/java/io/servicetalk/examples/grpc/errors/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.grpc.errors;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-examples/grpc/errors/src/main/proto/errors.proto
+++ b/servicetalk-examples/grpc/errors/src/main/proto/errors.proto
@@ -1,0 +1,39 @@
+// Copyright 2015 The gRPC Authors
+// Copyright 2021 Apple Inc. and the ServiceTalk project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.errors";
+option java_outer_classname = "ErrorsExampleProto";
+
+package errors;
+
+// The greeting service definition.
+service Greeter {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+    // a value is required for the token field
+    string token = 2;
+}
+
+// The response message containing the greetings
+message HelloReply {
+    string message = 1;
+}

--- a/servicetalk-examples/grpc/errors/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/grpc/errors/src/main/resources/log4j2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="info">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d %30t [%-5level] %-30logger{1} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <!-- Prints server start and shutdown -->
+    <Logger name="io.servicetalk.http.netty.H2ServerParentConnectionContext" level="DEBUG"/>
+
+    <!-- Prints default subscriber errors-->
+    <Logger name="io.servicetalk.concurrent.api" level="DEBUG"/>
+
+    <!-- Use `-Dservicetalk.logger.level=DEBUG` to change the root logger level via command line  -->
+    <Root level="${sys:servicetalk.logger.level:-INFO}">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/settings.gradle
+++ b/settings.gradle
@@ -41,6 +41,7 @@ include "servicetalk-annotations",
         "servicetalk-examples:grpc:routeguide",
         "servicetalk-examples:grpc:protoc-options",
         "servicetalk-examples:grpc:compression",
+        "servicetalk-examples:grpc:errors",
         "servicetalk-examples:http:helloworld",
         "servicetalk-examples:http:mutual-tls",
         "servicetalk-examples:http:http2",
@@ -90,6 +91,7 @@ project(":servicetalk-examples:grpc:helloworld").name = "servicetalk-examples-gr
 project(":servicetalk-examples:grpc:routeguide").name = "servicetalk-examples-grpc-routeguide"
 project(":servicetalk-examples:grpc:protoc-options").name = "servicetalk-examples-grpc-protoc-options"
 project(":servicetalk-examples:grpc:compression").name = "servicetalk-examples-grpc-compression"
+project(":servicetalk-examples:grpc:errors").name = "servicetalk-examples-grpc-errors"
 project(":servicetalk-examples:http:http2").name = "servicetalk-examples-http-http2"
 project(":servicetalk-examples:http:helloworld").name = "servicetalk-examples-http-helloworld"
 project(":servicetalk-examples:http:jaxrs").name = "servicetalk-examples-http-jaxrs"


### PR DESCRIPTION
Motivation:
How to return an application level error over the gRPC transport is a
common question, and we don't have an isolated example for this case.

Motivation:
- Add an example which demonstrates the server returning an application
  level error over the gRPC transport

Result:
Example exists demonstrating server returning application level error
via the gRPC transport.