### PR TITLE
gRPC Router reduce error log noise

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -94,8 +94,6 @@ import static java.util.Collections.unmodifiableMap;
  * implementation of a <a href="https://www.grpc.io">gRPC</a> method.
  */
 final class GrpcRouter {
-    private static final Logger LOGGER = LoggerFactory.getLogger(GrpcRouter.class);
-
     private final Map<String, RouteProvider> routes;
     private final Map<String, RouteProvider> streamingRoutes;
     private final Map<String, RouteProvider> blockingRoutes;
@@ -271,13 +269,10 @@ final class GrpcRouter {
                                                         serializationProvider.serializerFor(responseEncoding,
                                                                 responseClass)))
                                         .recoverWith(cause -> {
-                                            LOGGER.error("Unexpected exception from route: {}, path: {}.", route, path,
-                                                    cause);
                                             return succeeded(newErrorResponse(responseFactory, finalServiceContext,
                                                     cause, ctx.executionContext().bufferAllocator()));
                                         });
                             } catch (Throwable t) {
-                                LOGGER.error("Unexpected exception from route: {}, path: {}.", route, path, t);
                                 return succeeded(newErrorResponse(responseFactory, serviceContext, t,
                                         ctx.executionContext().bufferAllocator()));
                             }
@@ -476,7 +471,6 @@ final class GrpcRouter {
                                         ctx.executionContext().bufferAllocator()).payloadBody(response,
                                                 serializationProvider.serializerFor(responseEncoding, responseClass));
                             } catch (Throwable t) {
-                                LOGGER.error("Unexpected exception from route: {}, path: {}.", route, path, t);
                                 return newErrorResponse(responseFactory, serviceContext, t,
                                         ctx.executionContext().bufferAllocator());
                             }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -265,10 +265,8 @@ final class GrpcRouter {
                                                 .payloadBody(rawResp,
                                                         serializationProvider.serializerFor(responseEncoding,
                                                                 responseClass)))
-                                        .recoverWith(cause -> {
-                                            return succeeded(newErrorResponse(responseFactory, finalServiceContext,
-                                                    cause, ctx.executionContext().bufferAllocator()));
-                                        });
+                                        .recoverWith(cause -> succeeded(newErrorResponse(responseFactory,
+                                                finalServiceContext, cause, ctx.executionContext().bufferAllocator())));
                             } catch (Throwable t) {
                                 return succeeded(newErrorResponse(responseFactory, serviceContext, t,
                                         ctx.executionContext().bufferAllocator()));

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -55,9 +55,6 @@ import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.ServerContext;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -35,9 +35,6 @@ import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServiceTalkSocketOptions;
 import io.servicetalk.transport.api.TransportObserver;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.SocketOption;
 import java.net.StandardSocketOptions;
 import java.util.Arrays;

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -359,8 +359,6 @@ public abstract class GrpcServerBuilder {
     }
 
     private static final class CatchAllHttpServiceFilter extends StreamingHttpServiceFilter {
-        private static final Logger LOGGER = LoggerFactory.getLogger(CatchAllHttpServiceFilter.class);
-
         CatchAllHttpServiceFilter(final StreamingHttpService service) {
             super(service);
         }
@@ -378,10 +376,9 @@ public abstract class GrpcServerBuilder {
             return handle.recoverWith(cause -> convertToGrpcErrorResponse(ctx, responseFactory, cause));
         }
 
-        private Single<StreamingHttpResponse> convertToGrpcErrorResponse(
+        private static Single<StreamingHttpResponse> convertToGrpcErrorResponse(
                 final HttpServiceContext ctx, final StreamingHttpResponseFactory responseFactory,
                 final Throwable cause) {
-            LOGGER.error("Unexpected error from service {}.", delegate(), cause);
             return succeeded(newErrorResponse(responseFactory, null, cause,
                     ctx.executionContext().bufferAllocator()));
         }


### PR DESCRIPTION
Motivation:
GrpcRouter and GrpcServerBuilder will catch exceptions and translate
them into errors which get propagated into trailers. The exception path
is the expected way for servers to return application level errors to
clients. These methods also log error level log messages which is noisy
and can be replicated via a filter or in the application level if
necessary.

Modifications:
- Remove error level logging in GrpcRouter and CatchAllHttpServiceFilter

Result:
Less error level logging on exception paths which maybe expected by the
application.