### PR TITLE
FlakyTest: CancellationTest - Improve close handling

### DIFF
--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultJerseyStreamingHttpRouter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultJerseyStreamingHttpRouter.java
@@ -314,7 +314,6 @@ final class DefaultJerseyStreamingHttpRouter implements StreamingHttpService {
                 } finally {
                     if (!reentry && !stateUpdater.compareAndSet(this, State.READING, State.INIT)) {
                         // Closed while we were in progress.
-                        state = State.CLOSED;
                         close0();
                     }
                 }
@@ -333,7 +332,6 @@ final class DefaultJerseyStreamingHttpRouter implements StreamingHttpService {
                 } finally {
                     if (!reentry && !stateUpdater.compareAndSet(this, State.READING, State.INIT)) {
                         // Closed while we were in progress.
-                        state = State.CLOSED;
                         close0();
                     }
                 }
@@ -363,12 +361,12 @@ final class DefaultJerseyStreamingHttpRouter implements StreamingHttpService {
         public void close() {
             final State prevState = stateUpdater.getAndSet(this, State.PENDING_CLOSE);
             if (prevState == State.INIT) {
-                state = State.CLOSED;
                 close0();
             }
         }
 
         private void close0() {
+            state = State.CLOSED;
             super.close();
         }
     }

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultJerseyStreamingHttpRouter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultJerseyStreamingHttpRouter.java
@@ -287,18 +287,29 @@ final class DefaultJerseyStreamingHttpRouter implements StreamingHttpService {
             super(baseUri, requestUri, httpMethod, securityContext, propertiesDelegate, configuration);
         }
 
+        /**
+         * The following overloads are overriden because the inherited ones call directly {@code super}
+         * {@link ContainerRequest#readEntity(Class, Type, Annotation[], PropertiesDelegate)} thus our
+         * implementation of {@link ContainerRequest#readEntity(Class, Type, Annotation[], PropertiesDelegate)} doesn't
+         * get invoked when not called directly.
+         */
+
+        @Override
         public <T> T readEntity(final Class<T> rawType) {
             return readEntity(rawType, getPropertiesDelegate());
         }
 
+        @Override
         public <T> T readEntity(final Class<T> rawType, final Annotation[] annotations) {
             return readEntity(rawType, annotations, getPropertiesDelegate());
         }
 
+        @Override
         public <T> T readEntity(final Class<T> rawType, final Type type) {
             return readEntity(rawType, type, getPropertiesDelegate());
         }
 
+        @Override
         public <T> T readEntity(final Class<T> rawType, final Type type, final Annotation[] annotations) {
             return readEntity(rawType, type, annotations, getPropertiesDelegate());
         }

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/CancellationTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/CancellationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,6 @@ import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -206,7 +205,9 @@ public class CancellationTest {
 
         cancelledLatch.await();
 
-        assertThat(errorRef.get(), is(nullValue()));
+        if (errorRef.get() != null) {
+            throw new RuntimeException(errorRef.get());
+        }
     }
 
     private void testCancelResponseSingle(final StreamingHttpRequest req) throws Exception {
@@ -258,7 +259,9 @@ public class CancellationTest {
 
         cancelledLatch.await();
 
-        assertThat(errorRef.get(), is(nullValue()));
+        if (errorRef.get() != null) {
+            throw new RuntimeException(errorRef.get());
+        }
     }
 
     private static StreamingHttpRequest get(final String resourcePath) {

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/CancellationTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/CancellationTest.java
@@ -206,7 +206,7 @@ public class CancellationTest {
         cancelledLatch.await();
 
         if (errorRef.get() != null) {
-            throw new RuntimeException(errorRef.get());
+            throw new AssertionError(errorRef.get());
         }
     }
 
@@ -260,7 +260,7 @@ public class CancellationTest {
         cancelledLatch.await();
 
         if (errorRef.get() != null) {
-            throw new RuntimeException(errorRef.get());
+            throw new AssertionError(errorRef.get());
         }
     }
 

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/CancellationTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/CancellationTest.java
@@ -205,8 +205,9 @@ public class CancellationTest {
 
         cancelledLatch.await();
 
-        if (errorRef.get() != null) {
-            throw new AssertionError(errorRef.get());
+        final Throwable error = errorRef.get();
+        if (error != null) {
+            throw new AssertionError(error);
         }
     }
 
@@ -246,6 +247,13 @@ public class CancellationTest {
 
                 @Override
                 public void onError(final Throwable t) {
+                    if (t instanceof IllegalStateException &&
+                            t.getMessage().contains("input stream has already been closed")) {
+                        // Ignore racy cancellation, it's ordered safely.
+                        cancelledLatch.countDown();
+                        return;
+                    }
+
                     errorRef.compareAndSet(null, t);
                     cancelledLatch.countDown();
                 }
@@ -259,8 +267,9 @@ public class CancellationTest {
 
         cancelledLatch.await();
 
-        if (errorRef.get() != null) {
-            throw new AssertionError(errorRef.get());
+        final Throwable error = errorRef.get();
+        if (error != null) {
+            throw new AssertionError(error);
         }
     }
 

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/CancellationTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/CancellationTest.java
@@ -247,13 +247,10 @@ public class CancellationTest {
 
                 @Override
                 public void onError(final Throwable t) {
-                    if (t instanceof IllegalStateException) {
-                        // Ignore racy cancellation, it's ordered safely.
-                        cancelledLatch.countDown();
-                        return;
+                    // Ignore racy cancellation, it's ordered safely.
+                    if (!(t instanceof IllegalStateException)) {
+                        errorRef.compareAndSet(null, t);
                     }
-
-                    errorRef.compareAndSet(null, t);
                     cancelledLatch.countDown();
                 }
             });

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/CancellationTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/CancellationTest.java
@@ -247,8 +247,7 @@ public class CancellationTest {
 
                 @Override
                 public void onError(final Throwable t) {
-                    if (t instanceof IllegalStateException &&
-                            t.getMessage().contains("input stream has already been closed")) {
+                    if (t instanceof IllegalStateException) {
                         // Ignore racy cancellation, it's ordered safely.
                         cancelledLatch.countDown();
                         return;


### PR DESCRIPTION
Motivation:
The `EntityInputStream` is not thread safe, and the cancellation is triggering a `close` from any thread, while the access path is through the offloaded thread. 

Modifications:
Extend the `ContainerRequest` to capture close and handoff it to the offloaded thread if a read is already in progress, or close it atomically otherwise.

Result:
Better thread visibility and serialization of events in case of a read is in progress.

Fixes: #999