### PR TITLE
Require gRPC blocking streaming services to close GrpcPayloadWriter

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -530,11 +530,13 @@ final class GrpcRouter {
                                 setStatusOk(payloadWriter.trailers(), ctx.executionContext().bufferAllocator());
                                 route.handle(serviceContext, request.payloadBody(deserializer), grpcPayloadWriter);
                             } catch (Throwable t) {
-                                // Override OK status with error details in case of failure
-                                final HttpPayloadWriter<Resp> payloadWriter = grpcPayloadWriter.payloadWriter();
-                                setStatus(payloadWriter.trailers(), t, ctx.executionContext().bufferAllocator());
-                            } finally {
-                                grpcPayloadWriter.close();
+                                try {
+                                    final HttpPayloadWriter<Resp> payloadWriter = grpcPayloadWriter.payloadWriter();
+                                    setStatus(payloadWriter.trailers(), t, ctx.executionContext().bufferAllocator());
+                                } finally {
+                                    // Error is propagated in trailers, payload should close normally.
+                                    grpcPayloadWriter.close();
+                                }
                             }
                         }
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcServiceContextProtocolTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcServiceContextProtocolTest.java
@@ -185,13 +185,15 @@ public class GrpcServiceContextProtocolTest {
         @Override
         public void testBiDiStream(GrpcServiceContext ctx, BlockingIterable<TestRequest> request,
                                    GrpcPayloadWriter<TestResponse> responseWriter) throws Exception {
-           responseWriter.write(newResponse(ctx));
+            responseWriter.write(newResponse(ctx));
+            responseWriter.close();
         }
 
         @Override
         public void testResponseStream(GrpcServiceContext ctx, TestRequest request,
                                        GrpcPayloadWriter<TestResponse> responseWriter) throws Exception {
             responseWriter.write(newResponse(ctx));
+            responseWriter.close();
         }
     }
 }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -875,6 +875,7 @@ public class ProtocolCompatibilityTest {
                         for (CompatRequest requestItem : request) {
                             responseWriter.write(computeResponse(requestItem.getId()));
                         }
+                        responseWriter.close();
                     }
 
                     @Override
@@ -902,6 +903,7 @@ public class ProtocolCompatibilityTest {
                         for (int i = 0; i < request.getId(); i++) {
                             responseWriter.write(computeResponse(i));
                         }
+                        responseWriter.close();
                     }
                 }, codings));
         return TestServerContext.fromServiceTalkServerContext(serverContext);

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/SingleRequestOrResponseApiTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/SingleRequestOrResponseApiTest.java
@@ -226,6 +226,7 @@ public class SingleRequestOrResponseApiTest {
             for (int i = 0; i < numberOfResponses; i++) {
                 responseWriter.write(newResponse());
             }
+            responseWriter.close();
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpService.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.oio.api.PayloadWriter;
 
 /**
  * The equivalent of {@link StreamingHttpService} but with synchronous/blocking APIs instead of asynchronous APIs.
@@ -27,7 +28,8 @@ public interface BlockingStreamingHttpService extends GracefulAutoCloseable {
      *
      * @param ctx Context of the service.
      * @param request to handle.
-     * @param response to send to the client.
+     * @param response to send to the client. The implementation of this method is responsible for calling
+     * {@link PayloadWriter#close()} on the {@link BlockingStreamingHttpServerResponse#payloadWriter()}.
      * @throws Exception If an exception occurs during request processing.
      */
     void handle(HttpServiceContext ctx, BlockingStreamingHttpRequest request,


### PR DESCRIPTION
Motivation:
The HTTP blocking streaming APIs passes ownership of the
HttpPayloadWriter to the user to close. The user may process the stream
on another thread after the handle method has returned, or close the
stream with an exception status. The gRPC blocking streaming handle
method always force closes the stream after the user code returns.

Modifications:
- Remove the force closure in gRPC blocking streaming routing layer
- Fix tests which were not invoking close()

Result:
HTTP and gRPC blocking streaming APIs are more consistent, and the user
has the ability to control when the GrpcPayloadWriter is closed.