### PR TITLE
Make ReflectionUtils#trySetAccessible(..) internal utility public

### DIFF
--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/ReflectionUtils.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/ReflectionUtils.java
@@ -86,7 +86,7 @@ public final class ReflectionUtils {
      */
     @SuppressWarnings("JavadocReference")
     @Nullable
-    static Throwable trySetAccessible(final AccessibleObject object, final boolean checkAccessible) {
+    public static Throwable trySetAccessible(final AccessibleObject object, final boolean checkAccessible) {
         if (checkAccessible && !IS_EXPLICIT_TRY_REFLECTION_SET_ACCESSIBLE) {
             return new UnsupportedOperationException("Reflective setAccessible(true) disabled");
         }

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/ReflectionUtils.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/ReflectionUtils.java
@@ -81,7 +81,7 @@ public final class ReflectionUtils {
 
     /**
      * Try to call {@link AccessibleObject#setAccessible(boolean)} but will catch any {@link SecurityException} and
-     * {@link java.lang.reflect.InaccessibleObjectException} (for JDK 9) and return it.
+     * {@code java.lang.reflect.InaccessibleObjectException} (for JDK 9) and return it.
      * The caller must check if it returns {@code null} and if not handle the returned exception.
      * @param object The object to attempt to make accessible.
      * @param checkAccessible {@code true} to respect system property configuration which may limit
@@ -90,7 +90,6 @@ public final class ReflectionUtils {
      * @return a {@link Throwable} indicating the exception that occurred while attempting to make {@code object}
      * accessible, or {@code null} if the operation was successful.
      */
-    @SuppressWarnings("JavadocReference")
     @Nullable
     public static Throwable trySetAccessible(final AccessibleObject object, final boolean checkAccessible) {
         if (checkAccessible && !IS_EXPLICIT_TRY_REFLECTION_SET_ACCESSIBLE) {

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/ReflectionUtils.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/ReflectionUtils.java
@@ -83,6 +83,12 @@ public final class ReflectionUtils {
      * Try to call {@link AccessibleObject#setAccessible(boolean)} but will catch any {@link SecurityException} and
      * {@link java.lang.reflect.InaccessibleObjectException} (for JDK 9) and return it.
      * The caller must check if it returns {@code null} and if not handle the returned exception.
+     * @param object The object to attempt to make accessible.
+     * @param checkAccessible {@code true} to respect system property configuration which may limit
+     * {@link AccessibleObject#setAccessible(boolean)} attempts. {@code false} to try regardless of system property
+     * configuration.
+     * @return a {@link Throwable} indicating the exception that occurred while attempting to make {@code object}
+     * accessible, or {@code null} if the operation was successful.
      */
     @SuppressWarnings("JavadocReference")
     @Nullable


### PR DESCRIPTION
Motivation:
There are some extension modules that would benefit from the safety
provided by trySetAccessible(..) which avoids JDK9+ warnings about
reflection access going away. However this method is currently package
private.

Modifications:
- Make ReflectionUtils#trySetAccessible(..) internal utility public

Result:
ReflectionUtils#trySetAccessible(..) remains an internal utility
(subject to change in the future) but is now publicly accessible.