### PR TITLE
Add Lazy Execution Interoperability section to docs

### DIFF
--- a/servicetalk-concurrent-api/docs/modules/ROOT/pages/asynchronous-primitives.adoc
+++ b/servicetalk-concurrent-api/docs/modules/ROOT/pages/asynchronous-primitives.adoc
@@ -61,7 +61,7 @@ public CompletionStage<String> doWorkCompletionStage(String state) {
 }
 ----
 
-The way to call this method may like this:
+Here is an example how to call `doWorkCompletionStage` and converting the result from `CompletionStage` to `Single`:
 [source, java]
 ----
 public Single<String> handleRequest(StringBuilder mutableInput) {

--- a/servicetalk-concurrent-api/docs/modules/ROOT/pages/asynchronous-primitives.adoc
+++ b/servicetalk-concurrent-api/docs/modules/ROOT/pages/asynchronous-primitives.adoc
@@ -53,7 +53,7 @@ generically implement retries on the sources as opposed to the methods that crea
 
 === Lazy Execution Interoperability
 ServiceTalk provides utilities to interoperate with hot/eager sources. For example assume the following method exists
-and is you need to convert into a `Single`:
+and you need to convert into a `Single`:
 [source, java]
 ----
 public CompletionStage<String> doWorkCompletionStage(String state) {
@@ -68,7 +68,7 @@ public Single<String> handleRequest(StringBuilder mutableInput) {
   Single.defer(() -> {
     // Any state that may change across invocations associated with the async operation should be computed inside the
     // Supplier. This defers the work to compute the state, and will be re-run if there is a re-subscribe (e.g. to retry
-    // the operation). Deferring state computation is not unique to interoperability, and is a general characteristics
+    // the operation). Deferring state computation is not unique to interoperability, and is a general characteristic
     // of cold/lazy sources.
     String newRequest = "new request" + mutableInput.toString();
     return Single.fromStage(doWorkCompletionStage(newRequest));

--- a/servicetalk-concurrent-api/docs/modules/ROOT/pages/asynchronous-primitives.adoc
+++ b/servicetalk-concurrent-api/docs/modules/ROOT/pages/asynchronous-primitives.adoc
@@ -51,6 +51,31 @@ available, there is an implicit association between the source and the work it r
 powerful as it means that work can be re-done without invoking the method that created the source. Thus enabling us to
 generically implement retries on the sources as opposed to the methods that create the sources.
 
+=== Lazy Execution Interoperability
+ServiceTalk provides utilities to interoperate with hot/eager sources. For example assume the following method exists
+and is you need to convert into a `Single`:
+[source, java]
+----
+public CompletionStage<String> doWorkCompletionStage(String state) {
+  // Assume pre-existing asynchronous implementation exists
+}
+----
+
+The way to call this method may like this:
+[source, java]
+----
+public Single<String> handleRequest(StringBuilder mutableInput) {
+  Single.defer(() -> {
+    // Any state that may change across invocations associated with the async operation should be computed inside the
+    // Supplier. This defers the work to compute the state, and will be re-run if there is a re-subscribe (e.g. to retry
+    // the operation). Deferring state computation is not unique to interoperability, and is a general characteristics
+    // of cold/lazy sources.
+    String newRequest = "new request" + mutableInput.toString();
+    return Single.fromStage(doWorkCompletionStage(newRequest));
+  });
+}
+----
+
 == Specifications
 
 As defined <<Interoperability, above>>, ServiceTalk defines its own interfaces (specifications consistent with the


### PR DESCRIPTION
Motivation:
Interoperability with pre-existing asynchronous sources is common for
pre-existing code. Our docs provide general advice but no practical
examples for how to convert between hot/eager sources and ServiceTalk's
lazy/cold sources.

Modifications:
- Add a section in the docs which provides example code to convert from
  hot/eager sources.

Result:
Docs provide more information about conversion between hot/eager sources
to ServiceTalk cold/lazy sources.