### PR TITLE
Migrate tests in `servicetalk-concurrent-api` module from junit4 to junit5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -41,9 +41,6 @@ testngVersion=6.14.3
 hamcrestVersion=1.3
 mockitoCoreVersion=2.28.2
 
-# expected format: <number>[ns|μs|ms|s|m|h|d])
-defaultTestTimeout=30s
-
 reactiveStreamsVersion=1.0.3
 jcToolsVersion=3.3.0
 jacksonVersion=2.10.5.1
@@ -72,3 +69,7 @@ shadowPluginVersion=4.0.4
 # https://issues.sonatype.org/browse/MVNCENTRAL-5276
 # https://issues.apache.org/jira/browse/INFRA-14923
 systemProp.org.gradle.internal.publish.checksums.insecure=true
+
+# Test properties
+# expected format for timeout: <number>[ns|μs|ms|s|m|h|d])
+junit5DefaultTimeout=30s

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+# Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,9 +36,13 @@ jsonUnitVersion=2.8.1
 
 jmhCoreVersion=1.28
 junitVersion=4.13.2
+junit5Version=5.7.1
 testngVersion=6.14.3
 hamcrestVersion=1.3
 mockitoCoreVersion=2.28.2
+
+# expected format: <number>[ns|μs|ms|s|m|h|d])
+defaultTestTimeout=30s
 
 reactiveStreamsVersion=1.0.3
 jcToolsVersion=3.3.0

--- a/servicetalk-concurrent-api/build.gradle
+++ b/servicetalk-concurrent-api/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,11 @@
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
+test {
+  useJUnitPlatform()
+  systemProperty 'junit.jupiter.execution.timeout.default', "$defaultTestTimeout"
+}
+
 dependencies {
   api project(":servicetalk-concurrent")
 
@@ -28,15 +33,19 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-test-resources")
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
+  testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testFixturesImplementation project(":servicetalk-utils-internal")
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  testFixturesImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testFixturesImplementation "junit:junit:$junitVersion"
   testFixturesImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testFixturesImplementation "org.slf4j:slf4j-api:$slf4jVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-concurrent-api/build.gradle
+++ b/servicetalk-concurrent-api/build.gradle
@@ -18,7 +18,10 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 test {
   useJUnitPlatform()
-  systemProperty 'junit.jupiter.execution.timeout.default', "$defaultTestTimeout"
+  def junit5TimeoutParamName = "junit.jupiter.execution.timeout.default"
+  def junit5Timeout = System.getProperty(junit5TimeoutParamName) ?: "$junit5DefaultTimeout"
+  systemProperty junit5TimeoutParamName, "$junit5Timeout"
+  systemProperty "junit.jupiter.extensions.autodetection.enabled", "true"
 }
 
 dependencies {

--- a/servicetalk-concurrent-api/build.gradle
+++ b/servicetalk-concurrent-api/build.gradle
@@ -19,7 +19,7 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 test {
   useJUnitPlatform()
   def junit5TimeoutParamName = "junit.jupiter.execution.timeout.default"
-  def junit5Timeout = System.getProperty(junit5TimeoutParamName) ?: "$junit5DefaultTimeout"
+  def junit5Timeout = System.getProperty(junit5TimeoutParamName, "$junit5DefaultTimeout")
   systemProperty junit5TimeoutParamName, "$junit5Timeout"
   systemProperty "junit.jupiter.extensions.autodetection.enabled", "true"
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractCompositeCancellableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractCompositeCancellableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.Cancellable;
 
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -31,8 +31,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public abstract class AbstractCompositeCancellableTest<T extends Cancellable> {
-    @ClassRule
-    public static final ExecutorRule<Executor> EXECUTOR_RULE = ExecutorRule.newRule();
+    @RegisterExtension
+    public static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.newExtension();
 
     protected abstract T newCompositeCancellable();
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractCompositeCancellableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractCompositeCancellableTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.verify;
 
 public abstract class AbstractCompositeCancellableTest<T extends Cancellable> {
     @RegisterExtension
-    public static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.newExtension();
+    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
 
     protected abstract T newCompositeCancellable();
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractToFutureTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractToFutureTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.verify;
 public abstract class AbstractToFutureTest<T> {
 
     @RegisterExtension
-    public final ExecutorExtension<Executor> exec = ExecutorExtension.newExtension();
+    public final ExecutorExtension<Executor> exec = ExecutorExtension.withCachedExecutor();
 
     protected final Cancellable mockCancellable = Mockito.mock(Cancellable.class);
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractToFutureTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractToFutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,9 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.Cancellable;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
 import java.util.concurrent.CancellationException;
@@ -38,17 +36,15 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 public abstract class AbstractToFutureTest<T> {
 
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
-    @Rule
-    public final ExecutorRule<Executor> exec = ExecutorRule.newRule();
+    @RegisterExtension
+    public final ExecutorExtension<Executor> exec = ExecutorExtension.newExtension();
 
     protected final Cancellable mockCancellable = Mockito.mock(Cancellable.class);
 
@@ -151,11 +147,11 @@ public abstract class AbstractToFutureTest<T> {
         verify(mockCancellable, never()).cancel();
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testFailedWithNull() {
         Future<T> future = toFuture();
         assertThat(future.isDone(), is(false));
-        failSource(null);
+        assertThrows(NullPointerException.class, () -> failSource(null));
     }
 
     @Test
@@ -188,11 +184,11 @@ public abstract class AbstractToFutureTest<T> {
         verify(mockCancellable, never()).cancel();
     }
 
-    @Test(expected = TimeoutException.class)
-    public void testGetTimeoutException() throws Exception {
+    @Test
+    public void testGetTimeoutException() {
         Future<T> future = toFuture();
         assertThat(future.isDone(), is(false));
-        assertThat(future.get(10, MILLISECONDS), is(expectedResult()));
+        assertThrows(TimeoutException.class, () -> future.get(10, MILLISECONDS));
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AsyncContextDisableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AsyncContextDisableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,19 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.api.AsyncContextMap.Key;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class AsyncContextDisableTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
     private static final Key<String> K1 = Key.newKey("k1");
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AsyncContextDisableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AsyncContextDisableTest.java
@@ -16,10 +16,8 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.api.AsyncContextMap.Key;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -27,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class AsyncContextDisableTest {
     private static final Key<String> K1 = Key.newKey("k1");
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/BlockingProcessorSignalsHolderTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/BlockingProcessorSignalsHolderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,10 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.TimeoutException;
 
@@ -27,16 +26,14 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class BlockingProcessorSignalsHolderTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
     private final DefaultBlockingProcessorSignalsHolder<Integer> buffer;
     @SuppressWarnings("unchecked")
     private final ProcessorSignalsConsumer<Integer> consumer = mock(ProcessorSignalsConsumer.class);
@@ -55,8 +52,8 @@ public class BlockingProcessorSignalsHolderTest {
 
     @Test
     public void consumeEmpty() {
-        assertThrows("Unexpected consume when empty.", TimeoutException.class,
-                () -> buffer.consume(consumer, 1, MILLISECONDS));
+        assertThrows(TimeoutException.class,
+                () -> buffer.consume(consumer, 1, MILLISECONDS), "Unexpected consume when empty.");
         verifyZeroInteractions(consumer);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/BlockingProcessorSignalsHolderTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/BlockingProcessorSignalsHolderTest.java
@@ -15,10 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
-
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.TimeoutException;
 
@@ -32,7 +29,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class BlockingProcessorSignalsHolderTest {
     private final DefaultBlockingProcessorSignalsHolder<Integer> buffer;
     @SuppressWarnings("unchecked")

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/BufferStrategiesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/BufferStrategiesTest.java
@@ -16,12 +16,10 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.api.BufferStrategy.Accumulator;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -47,7 +45,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class BufferStrategiesTest {
     private final BlockingQueue<TestCompletable> timers = new LinkedBlockingDeque<>();
     private final Executor executor = mock(Executor.class);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/BufferStrategiesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/BufferStrategiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,12 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.api.BufferStrategy.Accumulator;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.After;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -48,10 +47,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class BufferStrategiesTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
     private final BlockingQueue<TestCompletable> timers = new LinkedBlockingDeque<>();
     private final Executor executor = mock(Executor.class);
     private final java.util.concurrent.ExecutorService jdkExecutor = Executors.newCachedThreadPool();
@@ -64,12 +61,12 @@ public class BufferStrategiesTest {
         }));
     }
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    public void tearDown() {
         jdkExecutor.shutdownNow();
     }
 
-    @Ignore("https://github.com/apple/servicetalk/issues/1259")
+    @Disabled("https://github.com/apple/servicetalk/issues/1259")
     @Test
     public void sizeOrDurationConcurrent() throws Exception {
         final int maxBoundaries = 1_000;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CancellableSetTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CancellableSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.Cancellable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ClosableConcurrentStackTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ClosableConcurrentStackTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.verify;
 
 public class ClosableConcurrentStackTest {
     @RegisterExtension
-    public static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.newExtension();
+    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
 
     @Test
     public void singleThreadPushClose() {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ClosableConcurrentStackTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ClosableConcurrentStackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.Cancellable;
 
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -35,15 +35,15 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isIn;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class ClosableConcurrentStackTest {
-    @ClassRule
-    public static final ExecutorRule<Executor> EXECUTOR_RULE = ExecutorRule.newRule();
+    @RegisterExtension
+    public static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.newExtension();
 
     @Test
     public void singleThreadPushClose() {
@@ -119,8 +119,8 @@ public class ClosableConcurrentStackTest {
                 } catch (Exception e) {
                     throw new AssertionError(e);
                 }
-                assertTrue("failed for index: " + finalI, stack.push(finalI));
-                assertTrue("failed for index: " + finalI, stack.relaxedRemove(finalI));
+                assertTrue(stack.push(finalI), () -> "failed for index: " + finalI);
+                assertTrue(stack.relaxedRemove(finalI), () -> "failed for index: " + finalI);
             }));
         }
 
@@ -146,7 +146,7 @@ public class ClosableConcurrentStackTest {
                 }
                 stack.push(finalI);
             }).concat(EXECUTOR_RULE.executor().submit(() ->
-                    assertTrue("failed for index: " + finalI, stack.relaxedRemove(finalI)))));
+                    assertTrue(stack.relaxedRemove(finalI), () -> "failed for index: " + finalI))));
         }
 
         Future<Void> future = mergeAll(completableList, itemCount).toFuture();
@@ -170,7 +170,7 @@ public class ClosableConcurrentStackTest {
                 } catch (Exception e) {
                     throw new AssertionError(e);
                 }
-                assertTrue("failed for index: " + finalI, stack.push(c));
+                assertTrue(stack.push(c), () -> "failed for index: " + finalI);
                 return c;
             }));
         }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CollectingPublisherSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CollectingPublisherSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,10 +25,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CollectingPublisherSubscriberTest {
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableAmbTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableAmbTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collection;
 import java.util.function.BiFunction;
@@ -31,103 +31,133 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-@RunWith(Parameterized.class)
 public class CompletableAmbTest {
 
-    private final TestCompletable first = new TestCompletable();
-    private final TestCompletable second = new TestCompletable();
-    private final TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
-    private final TestCancellable cancellable = new TestCancellable();
+    private TestCompletable first;
+    private TestCompletable second;
+    private TestCompletableSubscriber subscriber;
+    private TestCancellable cancellable;
 
-    public CompletableAmbTest(final BiFunction<Completable, Completable, Completable> ambSupplier) {
+    @BeforeEach
+    void beforeEach() {
+        first = new TestCompletable();
+        second = new TestCompletable();
+        subscriber = new TestCompletableSubscriber();
+        cancellable = new TestCancellable();
+    }
+
+    private void setUp(final BiFunction<Completable, Completable, Completable> ambSupplier) {
         toSource(ambSupplier.apply(first, second)).subscribe(subscriber);
         subscriber.awaitSubscription();
         assertThat("First source not subscribed.", first.isSubscribed(), is(true));
         assertThat("Second source not subscribed.", second.isSubscribed(), is(true));
     }
 
-    @Parameterized.Parameters
     public static Collection<BiFunction<Completable, Completable, Completable>> data() {
         return asList(Completable::ambWith,
                 (first, second) -> amb(first, second),
                 (first, second) -> amb(asList(first, second)));
     }
 
-    @Test
-    public void successFirst() {
+    @ParameterizedTest(name = "{displayName} [{index}]")
+    @MethodSource("data")
+    public void successFirst(final BiFunction<Completable, Completable, Completable> ambSupplier) {
+        setUp(ambSupplier);
         sendSuccessToAndVerify(first);
         verifyCancelled(second);
     }
 
-    @Test
-    public void successSecond() {
+    @ParameterizedTest(name = "{displayName} [{index}]")
+    @MethodSource("data")
+    public void successSecond(final BiFunction<Completable, Completable, Completable> ambSupplier) {
+        setUp(ambSupplier);
         sendSuccessToAndVerify(second);
         verifyCancelled(first);
     }
 
-    @Test
-    public void failFirst() {
+    @ParameterizedTest(name = "{displayName} [{index}]")
+    @MethodSource("data")
+    public void failFirst(final BiFunction<Completable, Completable, Completable> ambSupplier) {
+        setUp(ambSupplier);
         sendErrorToAndVerify(first);
         verifyCancelled(second);
     }
 
-    @Test
-    public void failSecond() {
+    @ParameterizedTest(name = "{displayName} [{index}]")
+    @MethodSource("data")
+    public void failSecond(final BiFunction<Completable, Completable, Completable> ambSupplier) {
+        setUp(ambSupplier);
         sendErrorToAndVerify(second);
         verifyCancelled(first);
     }
 
-    @Test
-    public void successFirstThenSecond() {
+    @ParameterizedTest(name = "{displayName} [{index}]")
+    @MethodSource("data")
+    public void successFirstThenSecond(final BiFunction<Completable, Completable, Completable> ambSupplier) {
+        setUp(ambSupplier);
         sendSuccessToAndVerify(first);
         verifyCancelled(second);
         second.onComplete();
     }
 
-    @Test
-    public void successSecondThenFirst() {
+    @ParameterizedTest(name = "{displayName} [{index}]")
+    @MethodSource("data")
+    public void successSecondThenFirst(final BiFunction<Completable, Completable, Completable> ambSupplier) {
+        setUp(ambSupplier);
         sendSuccessToAndVerify(second);
         verifyCancelled(first);
         first.onComplete();
     }
 
-    @Test
-    public void failFirstThenSecond() {
+    @ParameterizedTest(name = "{displayName} [{index}]")
+    @MethodSource("data")
+    public void failFirstThenSecond(final BiFunction<Completable, Completable, Completable> ambSupplier) {
+        setUp(ambSupplier);
         sendErrorToAndVerify(first);
         verifyCancelled(second);
         second.onError(DELIBERATE_EXCEPTION);
     }
 
-    @Test
-    public void failSecondThenFirst() {
+    @ParameterizedTest(name = "{displayName} [{index}]")
+    @MethodSource("data")
+    public void failSecondThenFirst(final BiFunction<Completable, Completable, Completable> ambSupplier) {
+        setUp(ambSupplier);
         sendErrorToAndVerify(second);
         verifyCancelled(first);
         first.onError(DELIBERATE_EXCEPTION);
     }
 
-    @Test
-    public void successFirstThenSecondFail() {
+    @ParameterizedTest(name = "{displayName} [{index}]")
+    @MethodSource("data")
+    public void successFirstThenSecondFail(final BiFunction<Completable, Completable, Completable> ambSupplier) {
+        setUp(ambSupplier);
         sendSuccessToAndVerify(first);
         verifyCancelled(second);
         second.onError(DELIBERATE_EXCEPTION);
     }
 
-    @Test
-    public void successSecondThenFirstFail() {
+    @ParameterizedTest(name = "{displayName} [{index}]")
+    @MethodSource("data")
+    public void successSecondThenFirstFail(final BiFunction<Completable, Completable, Completable> ambSupplier) {
+        setUp(ambSupplier);
         sendSuccessToAndVerify(second);
         verifyCancelled(first);
         first.onError(DELIBERATE_EXCEPTION);
     }
 
-    @Test
-    public void failFirstThenSecondSuccess() {
+    @ParameterizedTest(name = "{displayName} [{index}]")
+    @MethodSource("data")
+    public void failFirstThenSecondSuccess(final BiFunction<Completable, Completable, Completable> ambSupplier) {
+        setUp(ambSupplier);
         sendErrorToAndVerify(first);
         verifyCancelled(second);
         second.onComplete();
     }
 
-    @Test
-    public void failSecondThenFirstSuccess() {
+    @ParameterizedTest(name = "{displayName} [{index}]")
+    @MethodSource("data")
+    public void failSecondThenFirstSuccess(final BiFunction<Completable, Completable, Completable> ambSupplier) {
+        setUp(ambSupplier);
         sendErrorToAndVerify(second);
         verifyCancelled(first);
         first.onComplete();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableExecutorPreservationTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableExecutorPreservationTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class CompletableExecutorPreservationTest {
     @RegisterExtension
-    public static final ExecutorExtension EXEC = ExecutorExtension.withNamePrefix("test");
+    static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor("test");
 
     private Completable completable;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableExecutorPreservationTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableExecutorPreservationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,23 +15,23 @@
  */
 package io.servicetalk.concurrent.api;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.time.Duration;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class CompletableExecutorPreservationTest {
-    @ClassRule
-    public static final ExecutorRule EXEC = ExecutorRule.withNamePrefix("test");
+    @RegisterExtension
+    public static final ExecutorExtension EXEC = ExecutorExtension.withNamePrefix("test");
 
     private Completable completable;
 
-    @Before
+    @BeforeEach
     public void setupCompletable() {
         completable = completed().publishAndSubscribeOnOverride(EXEC.executor());
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableMergeWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableMergeWithPublisherTest.java
@@ -17,11 +17,9 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.stubbing.Answer;
 
@@ -31,7 +29,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static io.servicetalk.concurrent.api.ExecutorExtension.newExtension;
+import static io.servicetalk.concurrent.api.ExecutorExtension.withCachedExecutor;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
@@ -52,10 +50,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class CompletableMergeWithPublisherTest {
     @RegisterExtension
-    public final ExecutorExtension<Executor> executorExtension = newExtension();
+    final ExecutorExtension<Executor> executorExtension = withCachedExecutor();
     private final TestSubscription subscription = new TestSubscription();
     private final TestPublisher<String> publisher = new TestPublisher.Builder<String>()
             .disableAutoOnSubscribe().build();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableMergeWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableMergeWithPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,12 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.stubbing.Answer;
 
 import java.util.concurrent.CountDownLatch;
@@ -31,7 +31,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static io.servicetalk.concurrent.api.ExecutorRule.newRule;
+import static io.servicetalk.concurrent.api.ExecutorExtension.newExtension;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
@@ -41,8 +41,8 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atMost;
@@ -52,11 +52,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class CompletableMergeWithPublisherTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExecutorRule<Executor> executorRule = newRule();
+    @RegisterExtension
+    public final ExecutorExtension<Executor> executorExtension = newExtension();
     private final TestSubscription subscription = new TestSubscription();
     private final TestPublisher<String> publisher = new TestPublisher.Builder<String>()
             .disableAutoOnSubscribe().build();
@@ -394,8 +393,8 @@ public class CompletableMergeWithPublisherTest {
         TestCompletable completable = new TestCompletable.Builder().disableAutoOnSubscribe().build();
         TestCancellable testCancellable = new TestCancellable();
         CountDownLatch latch = new CountDownLatch(1);
-        toSource(applyMerge(completable.publishOn(executorRule.executor()), delayError,
-                publisher.publishOn(executorRule.executor())).afterOnNext(item -> {
+        toSource(applyMerge(completable.publishOn(executorExtension.executor()), delayError,
+                            publisher.publishOn(executorExtension.executor())).afterOnNext(item -> {
             // The goal of this test is to have the Completable terminate, but have onNext signals from the Publisher be
             // delayed on the Executor. Even in this case the merge operator should correctly sequence the onComplete to
             // the downstream subscriber until after all the onNext events have completed.
@@ -439,7 +438,7 @@ public class CompletableMergeWithPublisherTest {
         TestCompletable completable = new TestCompletable();
         toSource(applyMerge(completable, delayError)).subscribe(subscriber);
         publisher.onSubscribe(subscription);
-        Future<Void> f = executorRule.executor().submit(() -> {
+        Future<Void> f = executorExtension.executor().submit(() -> {
             try {
                 barrier.await();
             } catch (Exception e) {
@@ -483,7 +482,7 @@ public class CompletableMergeWithPublisherTest {
         }).when(mockSubscriber).onNext(any());
         toSource(applyMerge(completable, delayError)).subscribe(mockSubscriber);
         publisher.onSubscribe(subscription);
-        Future<Void> f = executorRule.executor().submit(() -> {
+        Future<Void> f = executorExtension.executor().submit(() -> {
             try {
                 nextLatch2.await();
             } catch (Exception e) {
@@ -576,7 +575,7 @@ public class CompletableMergeWithPublisherTest {
         }).when(mockSubscriber).onNext(any());
         toSource(applyMerge(completable, delayError)).subscribe(mockSubscriber);
         publisher.onSubscribe(subscription);
-        Future<Void> f = executorRule.executor().submit(() -> {
+        Future<Void> f = executorExtension.executor().submit(() -> {
             try {
                 nextLatch2.await();
             } catch (Exception e) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableProcessorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,12 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.CompletableSource.Subscriber;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
@@ -41,15 +40,14 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class CompletableProcessorTest {
-    @ClassRule
-    public static final ExecutorRule<Executor> EXECUTOR_RULE = ExecutorRule.newRule();
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
+    @RegisterExtension
+    public static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.newExtension();
     private final TestCompletableSubscriber rule = new TestCompletableSubscriber();
     private final TestCompletableSubscriber rule2 = new TestCompletableSubscriber();
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableProcessorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableProcessorTest.java
@@ -17,11 +17,9 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.CompletableSource.Subscriber;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.lang.ref.ReferenceQueue;
@@ -44,10 +42,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class CompletableProcessorTest {
     @RegisterExtension
-    public static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.newExtension();
+    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
     private final TestCompletableSubscriber rule = new TestCompletableSubscriber();
     private final TestCompletableSubscriber rule2 = new TestCompletableSubscriber();
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcatPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcatPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcatWithOrderingTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcatWithOrderingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,16 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class ConcatWithOrderingTest {
-
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
 
     protected final StringBuilder sb = new StringBuilder();
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcatWithOrderingTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcatWithOrderingTest.java
@@ -15,15 +15,11 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
-
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class ConcatWithOrderingTest {
 
     protected final StringBuilder sb = new StringBuilder();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcurrentUtilsTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcurrentUtilsTest.java
@@ -15,12 +15,9 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -39,7 +36,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public final class ConcurrentUtilsTest {
     private static final AtomicIntegerFieldUpdater<ConcurrentUtilsTest> lockUpdater =
             AtomicIntegerFieldUpdater.newUpdater(ConcurrentUtilsTest.class, "lock");

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcurrentUtilsTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcurrentUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,12 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -31,35 +30,33 @@ import static io.servicetalk.concurrent.internal.ConcurrentUtils.releaseLock;
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.releaseReentrantLock;
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.tryAcquireLock;
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.tryAcquireReentrantLock;
-import static io.servicetalk.concurrent.internal.ServiceTalkTestTimeout.DEFAULT_TIMEOUT_SECONDS;
+import static io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension.DEFAULT_TIMEOUT_SECONDS;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public final class ConcurrentUtilsTest {
     private static final AtomicIntegerFieldUpdater<ConcurrentUtilsTest> lockUpdater =
             AtomicIntegerFieldUpdater.newUpdater(ConcurrentUtilsTest.class, "lock");
     private static final AtomicLongFieldUpdater<ConcurrentUtilsTest> reentrantLockUpdater =
             AtomicLongFieldUpdater.newUpdater(ConcurrentUtilsTest.class, "reentrantLock");
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
     @SuppressWarnings("unused")
     private volatile int lock;
     @SuppressWarnings("unused")
     private volatile long reentrantLock;
     private ExecutorService executor;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         executor = newCachedThreadPool();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         executor.shutdown();
         executor.awaitTermination(DEFAULT_TIMEOUT_SECONDS, SECONDS);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultAsyncContextProviderTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultAsyncContextProviderTest.java
@@ -22,13 +22,11 @@ import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.AsyncContextMap.Key;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -63,7 +61,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class DefaultAsyncContextProviderTest {
     private static final Key<String> K1 = Key.newKey("k1");
     private static final Key<String> K2 = Key.newKey("k2");

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultAsyncContextProviderTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultAsyncContextProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,15 +22,13 @@ import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.AsyncContextMap.Key;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -54,21 +52,19 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.DefaultAsyncContextProvider.INSTANCE;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
-import static io.servicetalk.concurrent.internal.ServiceTalkTestTimeout.DEFAULT_TIMEOUT_SECONDS;
+import static io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension.DEFAULT_TIMEOUT_SECONDS;
 import static java.lang.Integer.bitCount;
 import static java.lang.Integer.numberOfTrailingZeros;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class DefaultAsyncContextProviderTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
     private static final Key<String> K1 = Key.newKey("k1");
     private static final Key<String> K2 = Key.newKey("k2");
     private static final Key<String> K3 = Key.newKey("k3");
@@ -80,19 +76,19 @@ public class DefaultAsyncContextProviderTest {
 
     private static ScheduledExecutorService executor;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         AsyncContext.autoEnable();
         executor = Executors.newScheduledThreadPool(4);
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() throws Exception {
         executor.shutdown();
         executor.awaitTermination(DEFAULT_TIMEOUT_SECONDS, SECONDS);
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         AsyncContext.clear();
     }
@@ -124,7 +120,7 @@ public class DefaultAsyncContextProviderTest {
         new ContextCaptureCompletableSubscriber()
                 .subscribeAndWait(completable)
                 .verifyContext(map -> {
-                    Assert.assertEquals("v1", map.get(K1));
+                    assertEquals("v1", map.get(K1));
                     assertNull(map.get(K2));
                 });
 
@@ -133,8 +129,8 @@ public class DefaultAsyncContextProviderTest {
         new ContextCaptureCompletableSubscriber()
                 .subscribeAndWait(completable)
                 .verifyContext(map -> {
-                    Assert.assertEquals("v1", map.get(K1));
-                    Assert.assertEquals("v2", map.get(K2));
+                    assertEquals("v1", map.get(K1));
+                    assertEquals("v2", map.get(K2));
                 });
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultBlockingIterableProcessorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultBlockingIterableProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,7 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.BlockingIterable;
 import io.servicetalk.concurrent.BlockingIterator;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
@@ -28,13 +26,11 @@ import java.util.concurrent.TimeoutException;
 
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DefaultBlockingIterableProcessorTest {
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
 
     private final BlockingIterable.Processor<Integer> processor;
 
@@ -65,17 +61,15 @@ public class DefaultBlockingIterableProcessorTest {
     }
 
     @Test
-    public void hasNextTimesout() throws TimeoutException {
+    public void hasNextTimesout() {
         BlockingIterator<Integer> iterator = processor.iterator();
-        expectedException.expect(instanceOf(TimeoutException.class));
-        iterator.hasNext(1, TimeUnit.SECONDS);
+        assertThrows(TimeoutException.class, () -> iterator.hasNext(10, TimeUnit.MILLISECONDS));
     }
 
     @Test
-    public void nextTimesout() throws TimeoutException {
+    public void nextTimesout() {
         BlockingIterator<Integer> iterator = processor.iterator();
-        expectedException.expect(instanceOf(TimeoutException.class));
-        iterator.next(1, TimeUnit.SECONDS);
+        assertThrows(TimeoutException.class, () -> iterator.next(10, TimeUnit.MILLISECONDS));
     }
 
     @Test
@@ -90,8 +84,7 @@ public class DefaultBlockingIterableProcessorTest {
         BlockingIterator<Integer> iterator = processor.iterator();
         processor.close();
         iterator.close();
-        expectedException.expect(instanceOf(CancellationException.class));
-        iterator.hasNext();
+        assertThrows(CancellationException.class, () -> iterator.hasNext());
     }
 
     @Test
@@ -99,23 +92,20 @@ public class DefaultBlockingIterableProcessorTest {
         BlockingIterator<Integer> iterator = processor.iterator();
         processor.fail(DELIBERATE_EXCEPTION);
         iterator.close();
-        expectedException.expect(instanceOf(CancellationException.class));
-        iterator.hasNext();
+        assertThrows(CancellationException.class, () -> iterator.hasNext());
     }
 
     @Test
     public void postIteratorCloseHasNextThrows() throws Exception {
         BlockingIterator<Integer> iterator = processor.iterator();
         iterator.close();
-        expectedException.expect(instanceOf(CancellationException.class));
-        iterator.hasNext();
+        assertThrows(CancellationException.class, () -> iterator.hasNext());
     }
 
     @Test
     public void postIteratorCloseNextThrows() throws Exception {
         BlockingIterator<Integer> iterator = processor.iterator();
         iterator.close();
-        expectedException.expect(instanceOf(CancellationException.class));
-        iterator.next();
+        assertThrows(CancellationException.class, () -> iterator.next());
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultExecutorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultExecutorTest.java
@@ -93,10 +93,7 @@ public final class DefaultExecutorTest {
 
     @AfterEach
     public void tearDown() {
-        if (executor != null) {
-            executor.closeAsync().subscribe();
-            executor = null;
-        }
+        executor.closeAsync().subscribe();
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] - {1}")

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultExecutorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,20 +18,18 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.internal.DeliberateException;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.internal.TerminalNotification;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestReporter;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -46,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.BlockingTestUtils.awaitIndefinitelyNonNull;
@@ -63,66 +62,58 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assume.assumeThat;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-@RunWith(Parameterized.class)
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public final class DefaultExecutorTest {
 
     private static final int UNBOUNDED = -1;
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExpectedException expected = ExpectedException.none();
+    private Executor executor;
 
-    private final Executor executor;
-    private final String name;
-    private final boolean supportsCancellation;
-    private final int size;
-
-    public DefaultExecutorTest(Supplier<Executor> executorSupplier, String name, boolean supportsCancellation,
-                               int size) {
+    public static Stream<Arguments> executors() {
         // Use new executor for each test per parameter.
-        executor = executorSupplier.get();
-        this.name = name;
-        this.supportsCancellation = supportsCancellation;
-        this.size = size;
+        return Stream.of(
+                newArguments(() -> newFixedSizeExecutor(2), "fixed-size-2", true, 2),
+                newArguments(() -> io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor(), "cached",
+                        true, UNBOUNDED),
+                newArguments(() -> {
+                    ExecutorService service = Executors.newCachedThreadPool();
+                    //noinspection Convert2MethodRef,FunctionalExpressionCanBeFolded
+                    return from(command -> service.execute(command));
+                }, "simple-executor", false, UNBOUNDED),
+                newArguments(() -> from(newScheduledThreadPool(2)), "scheduled",
+                        true,
+                        UNBOUNDED /*Size defines core size, else is unbounded*/),
+                newArguments(() -> from(new ThreadPoolExecutor(2, 2, 60, SECONDS,
+                                new SynchronousQueue<>()), newScheduledThreadPool(2)),
+                        "different-executors", true, 2));
     }
 
-    @Parameterized.Parameters(name = "{index} - {1}")
-    public static Collection<Object[]> executors() {
-        List<Object[]> nameAndExecutorPairs = new ArrayList<>();
-        nameAndExecutorPairs.add(newParams(() -> newFixedSizeExecutor(2), "fixed-size-2", true, 2));
-        nameAndExecutorPairs.add(newParams(io.servicetalk.concurrent.api.Executors::newCachedThreadExecutor, "cached",
-                true, UNBOUNDED));
-        nameAndExecutorPairs.add(newParams(() -> {
-            ExecutorService service = Executors.newCachedThreadPool();
-            //noinspection Convert2MethodRef,FunctionalExpressionCanBeFolded
-            return from(command -> service.execute(command));
-        }, "simple-executor", false, UNBOUNDED));
-        nameAndExecutorPairs.add(newParams(() -> from(newScheduledThreadPool(2)), "scheduled", true,
-                UNBOUNDED /*Size defines core size, else is unbounded*/));
-        nameAndExecutorPairs.add(newParams(() -> from(new ThreadPoolExecutor(2, 2, 60, SECONDS,
-                new SynchronousQueue<>()), newScheduledThreadPool(2)), "different-executors", true, 2));
-        return nameAndExecutorPairs;
-    }
-
-    @After
+    @AfterEach
     public void tearDown() {
-        executor.closeAsync().subscribe();
+        if (executor != null) {
+            executor.closeAsync().subscribe();
+            executor = null;
+        }
     }
 
-    @Test
-    public void execution() throws Throwable {
+    @ParameterizedTest(name = "{displayName} [{index}] - {1}")
+    @MethodSource("executors")
+    public void execution(Supplier<Executor> executorSupplier, String name, boolean supportsCancellation,
+                          int size, TestReporter testReporter) throws Throwable {
+        executor = executorSupplier.get();
         Task task = new Task();
         executor.execute(task);
         task.awaitDone();
     }
 
-    @Test
-    public void longRunningTasksDoesNotHaltOthers() throws Throwable {
+    @ParameterizedTest(name = "{displayName} [{index}] - {1}")
+    @MethodSource("executors")
+    public void longRunningTasksDoesNotHaltOthers(Supplier<Executor> executorSupplier, String name,
+                                                  boolean supportsCancellation, int size) throws Throwable {
+        executor = executorSupplier.get();
         Task awaitForever = Task.newAwaitForeverTask();
         executor.execute(awaitForever);
         Task task = new Task();
@@ -130,8 +121,11 @@ public final class DefaultExecutorTest {
         task.awaitDone();
     }
 
-    @Test
-    public void interDependentTasksCanRun() throws Throwable {
+    @ParameterizedTest(name = "{displayName} [{index}] - {1}")
+    @MethodSource("executors")
+    public void interDependentTasksCanRun(Supplier<Executor> executorSupplier, String name,
+                                          boolean supportsCancellation, int size) throws Throwable {
+        executor = executorSupplier.get();
         Task first = new Task();
         Task second = new Task(() -> {
             try {
@@ -145,60 +139,84 @@ public final class DefaultExecutorTest {
         second.awaitDone();
     }
 
-    @Test
-    public void scheduledTasks() throws Throwable {
+    @ParameterizedTest(name = "{displayName} [{index}] - {1}")
+    @MethodSource("executors")
+    public void scheduledTasks(Supplier<Executor> executorSupplier, String name, boolean supportsCancellation,
+                               int size) throws Throwable {
+        executor = executorSupplier.get();
         Task scheduled = new Task();
         executor.schedule(scheduled, 1, MILLISECONDS);
         scheduled.awaitDone();
     }
 
-    @Test
-    public void cancelExecute() throws Throwable {
-        assumeTrue("Ignoring executor: " + name + ", it does not support cancellation.", supportsCancellation);
+    @ParameterizedTest(name = "{displayName} [{index}] - {1}")
+    @MethodSource("executors")
+    public void cancelExecute(Supplier<Executor> executorSupplier, String name, boolean supportsCancellation,
+                              int size) throws Throwable {
+        executor = executorSupplier.get();
+        assumeTrue(supportsCancellation, () -> "Ignoring executor: " + name + ", it does not support cancellation.");
         CountDownLatch latch = new CountDownLatch(1);
         Task awaitTillCancelled = Task.awaitFor(latch);
         Cancellable cancellable = executor.execute(awaitTillCancelled);
         awaitTillCancelled.awaitStart();
         cancellable.cancel();
-        expected.expectCause(instanceOf(InterruptedException.class));
-        awaitTillCancelled.awaitDone();
+        Executable executable = () -> awaitTillCancelled.awaitDone();
+        Exception e = assertThrows(Exception.class, executable);
+        assertThat(e.getCause(), instanceOf(InterruptedException.class));
     }
 
-    @Test
-    public void executeRejection() {
-        assumeTrue("Ignoring executor: " + name + ", it has an unbounded thread pool.", size > 0);
+    @ParameterizedTest(name = "{displayName} [{index}] - {1}")
+    @MethodSource("executors")
+    public void executeRejection(Supplier<Executor> executorSupplier, String name,
+                                 boolean supportsCancellation, int size) {
+        executor = executorSupplier.get();
+        assumeTrue(size > 0, () -> "Ignoring executor: " + name + ", it has an unbounded thread pool.");
+
         for (int i = 0; i < size; i++) {
             executor.execute(Task.newAwaitForeverTask());
         }
         Task reject = new Task();
-        expected.expect(RejectedExecutionException.class);
-        executor.execute(reject);
+        assertThrows(RejectedExecutionException.class, () -> executor.execute(reject));
     }
 
     @Test
     public void rejectSchedule() {
-        Executor executor = from(new RejectAllScheduler());
-        expected.expect(RejectedExecutionException.class);
-        executor.schedule(() -> { }, 1, SECONDS);
+        executor = from(new RejectAllScheduler());
+        assertThrows(RejectedExecutionException.class, () -> {
+            executor.schedule(() -> {
+            }, 1, SECONDS);
+        });
     }
 
-    @Test
-    public void timerRaw() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - {1}")
+    @MethodSource("executors")
+    public void timerRaw(Supplier<Executor> executorSupplier, String name,
+                         boolean supportsCancellation, int size) throws Exception {
+        executor = executorSupplier.get();
         executor.timer(1, NANOSECONDS).toFuture().get();
     }
 
-    @Test
-    public void timerDuration() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - {1}")
+    @MethodSource("executors")
+    public void timerDuration(Supplier<Executor> executorSupplier, String name,
+                              boolean supportsCancellation, int size) throws Exception {
+        executor = executorSupplier.get();
         executor.timer(ofNanos(1)).toFuture().get();
     }
 
-    @Test
-    public void timerRawCancel() throws InterruptedException {
+    @ParameterizedTest(name = "{displayName} [{index}] - {1}")
+    @MethodSource("executors")
+    public void timerRawCancel(Supplier<Executor> executorSupplier, String name,
+                               boolean supportsCancellation, int size) throws InterruptedException {
+        executor = executorSupplier.get();
         timerCancel(executor.timer(100, MILLISECONDS));
     }
 
-    @Test
-    public void timerDurationCancel() throws InterruptedException {
+    @ParameterizedTest(name = "{displayName} [{index}] - {1}")
+    @MethodSource("executors")
+    public void timerDurationCancel(Supplier<Executor> executorSupplier, String name, boolean supportsCancellation,
+                                    int size) throws InterruptedException {
+        executor = executorSupplier.get();
         timerCancel(executor.timer(ofNanos(1)));
     }
 
@@ -228,35 +246,39 @@ public final class DefaultExecutorTest {
         // fire before we cancelled we just ignore the test.
         Thread.sleep(100);
         Throwable cause = refCause.get();
-        assumeThat(cause, is(not(DELIBERATE_EXCEPTION)));
+        assumeTrue(cause != DELIBERATE_EXCEPTION);
         assertNull(cause);
     }
 
     @Test
-    public void timerRawRejected() throws Exception {
-        Executor executor = from(new RejectAllScheduler());
-        expected.expect(ExecutionException.class);
-        expected.expectCause(instanceOf(RejectedExecutionException.class));
-        executor.timer(1, NANOSECONDS).toFuture().get();
+    public void timerRawRejected() {
+        executor = from(new RejectAllScheduler());
+        Executable executable = () -> executor.timer(1, NANOSECONDS).toFuture().get();
+        assertThrowsExecutionException(executable, RejectedExecutionException.class);
     }
 
     @Test
-    public void timerDurationRejected() throws Exception {
-        Executor executor = from(new RejectAllScheduler());
-        expected.expect(ExecutionException.class);
-        expected.expectCause(instanceOf(RejectedExecutionException.class));
-        executor.timer(ofNanos(1)).toFuture().get();
+    public void timerDurationRejected() {
+        executor = from(new RejectAllScheduler());
+        Executable executable = () -> executor.timer(ofNanos(1)).toFuture().get();
+        assertThrowsExecutionException(executable, RejectedExecutionException.class);
     }
 
-    @Test
-    public void submitRunnable() throws Throwable {
+    @ParameterizedTest(name = "{displayName} [{index}] - {1}")
+    @MethodSource("executors")
+    public void submitRunnable(Supplier<Executor> executorSupplier, String name, boolean supportsCancellation,
+                               int size) throws Throwable {
+        executor = executorSupplier.get();
         Task submitted = new Task();
         executor.submit(submitted).toFuture().get();
         submitted.awaitDone();
     }
 
-    @Test
-    public void submitRunnableSupplier() throws Throwable {
+    @ParameterizedTest(name = "{displayName} [{index}] - {1}")
+    @MethodSource("executors")
+    public void submitRunnableSupplier(Supplier<Executor> executorSupplier, String name, boolean supportsCancellation,
+                                       int size) throws Throwable {
+        executor = executorSupplier.get();
         Task submitted1 = new Task();
         Task submitted2 = new Task();
         AtomicBoolean returnedSubmitted1 = new AtomicBoolean();
@@ -268,49 +290,58 @@ public final class DefaultExecutorTest {
     }
 
     @Test
-    public void submitRunnableRejected() throws Throwable {
-        Executor executor = from(new RejectAllExecutor());
-        expected.expect(ExecutionException.class);
-        expected.expectCause(instanceOf(RejectedExecutionException.class));
-        executor.submit(() -> { }).toFuture().get();
+    public void submitRunnableRejected() {
+        executor = from(new RejectAllExecutor());
+        Executable executable = () -> executor.submit(() -> { }).toFuture().get();
+        assertThrowsExecutionException(executable, RejectedExecutionException.class);
     }
 
     @Test
-    public void submitRunnableSupplierRejected() throws Throwable {
-        Executor executor = from(new RejectAllExecutor());
-        expected.expect(ExecutionException.class);
-        expected.expectCause(instanceOf(RejectedExecutionException.class));
-        executor.submitRunnable(() -> () -> { }).toFuture().get();
+    public void submitRunnableSupplierRejected() {
+        executor = from(new RejectAllExecutor());
+        Executable executable = () -> executor.submitRunnable(() -> () -> { }).toFuture().get();
+        assertThrowsExecutionException(executable, RejectedExecutionException.class);
     }
 
-    @Test
-    public void submitRunnableThrows() throws Throwable {
-        expected.expect(ExecutionException.class);
-        expected.expectCause(instanceOf(DeliberateException.class));
-        executor.submit((Runnable) () -> {
+    @ParameterizedTest(name = "{displayName} [{index}] - {1}")
+    @MethodSource("executors")
+    public void submitRunnableThrows(Supplier<Executor> executorSupplier, String name, boolean supportsCancellation,
+                                     int size) {
+        executor = executorSupplier.get();
+        Executable executable = () -> executor.submit((Runnable) () -> {
             throw DELIBERATE_EXCEPTION;
         }).toFuture().get();
+        assertThrowsExecutionException(executable, DeliberateException.class);
     }
 
-    @Test
-    public void submitRunnableSupplierThrows() throws Throwable {
-        expected.expect(ExecutionException.class);
-        expected.expectCause(instanceOf(DeliberateException.class));
-        executor.submitRunnable(() -> () -> {
+    @ParameterizedTest(name = "{displayName} [{index}] - {1}")
+    @MethodSource("executors")
+    public void submitRunnableSupplierThrows(Supplier<Executor> executorSupplier, String name,
+                                             boolean supportsCancellation,
+                                             int size) {
+        executor = executorSupplier.get();
+        Executable executable = () -> executor.submitRunnable(() -> () -> {
             throw DELIBERATE_EXCEPTION;
         }).toFuture().get();
+        assertThrowsExecutionException(executable, DeliberateException.class);
     }
 
-    @Test
-    public void submitCallable() throws Throwable {
+    @ParameterizedTest(name = "{displayName} [{index}] - {1}")
+    @MethodSource("executors")
+    public void submitCallable(Supplier<Executor> executorSupplier, String name, boolean supportsCancellation,
+                               int size) throws Throwable {
+        executor = executorSupplier.get();
         CallableTask<Integer> submitted = new CallableTask<>(() -> 1);
         Integer result = awaitIndefinitelyNonNull(executor.submit(submitted));
         submitted.awaitDone();
         assertThat(result, is(1));
     }
 
-    @Test
-    public void submitCallableSupplier() throws Throwable {
+    @ParameterizedTest(name = "{displayName} [{index}] - {1}")
+    @MethodSource("executors")
+    public void submitCallableSupplier(Supplier<Executor> executorSupplier, String name, boolean supportsCancellation,
+                                       int size) throws Throwable {
+        executor = executorSupplier.get();
         CallableTask<Integer> submitted1 = new CallableTask<>(() -> 1);
         CallableTask<Integer> submitted2 = new CallableTask<>(() -> 2);
         AtomicBoolean returnedSubmitted1 = new AtomicBoolean();
@@ -325,42 +356,49 @@ public final class DefaultExecutorTest {
     }
 
     @Test
-    public void submitCallableRejected() throws Throwable {
-        Executor executor = from(new RejectAllExecutor());
-        expected.expect(ExecutionException.class);
-        expected.expectCause(instanceOf(RejectedExecutionException.class));
-        executor.submit(() -> 1).toFuture().get();
+    public void submitCallableRejected() {
+        executor = from(new RejectAllExecutor());
+        Executable executable = () -> executor.submit(() -> 1).toFuture().get();
+        assertThrowsExecutionException(executable, RejectedExecutionException.class);
     }
 
     @Test
-    public void submitCallableSupplierRejected() throws Throwable {
-        Executor executor = from(new RejectAllExecutor());
-        expected.expect(ExecutionException.class);
-        expected.expectCause(instanceOf(RejectedExecutionException.class));
-        executor.submitCallable(() -> () -> 1).toFuture().get();
+    public void submitCallableSupplierRejected() {
+        executor = from(new RejectAllExecutor());
+        Executable executable = () -> executor.submitCallable(() -> () -> 1).toFuture().get();
+        assertThrowsExecutionException(executable, RejectedExecutionException.class);
     }
 
-    @Test
-    public void submitCallableThrows() throws Throwable {
-        expected.expect(ExecutionException.class);
-        expected.expectCause(instanceOf(DeliberateException.class));
-        executor.submit((Callable<Integer>) () -> {
+    @ParameterizedTest(name = "{displayName} [{index}] - {1}")
+    @MethodSource("executors")
+    public void submitCallableThrows(Supplier<Executor> executorSupplier, String name,
+                                     boolean supportsCancellation, int size) {
+        executor = executorSupplier.get();
+        Executable executable = () -> executor.submit((Callable<Integer>) () -> {
             throw DELIBERATE_EXCEPTION;
         }).toFuture().get();
+        assertThrowsExecutionException(executable, DeliberateException.class);
     }
 
-    @Test
-    public void submitCallableSupplierThrows() throws Throwable {
-        expected.expect(ExecutionException.class);
-        expected.expectCause(instanceOf(DeliberateException.class));
-        executor.submitCallable(() -> (Callable<Integer>) () -> {
+    @ParameterizedTest(name = "{displayName} [{index}] - {1}")
+    @MethodSource("executors")
+    public void submitCallableSupplierThrows(Supplier<Executor> executorSupplier, String name,
+                                             boolean supportsCancellation, int size) {
+        executor = executorSupplier.get();
+        Executable executable = () -> executor.submitCallable(() -> (Callable<Integer>) () -> {
             throw DELIBERATE_EXCEPTION;
         }).toFuture().get();
+        assertThrowsExecutionException(executable, DeliberateException.class);
     }
 
-    private static Object[] newParams(Supplier<Executor> executorSupplier, String name, boolean supportsCancellation,
-                                      int size) {
-        return new Object[]{executorSupplier, name, supportsCancellation, size};
+    private static void assertThrowsExecutionException(Executable executable, Class cause) {
+        ExecutionException e = assertThrows(ExecutionException.class, executable);
+        assertThat(e.getCause(), instanceOf(cause));
+    }
+
+    private static Arguments newArguments(Supplier<Executor> executorSupplier, String name,
+                                          boolean supportsCancellation, int size) {
+        return Arguments.of(executorSupplier, name, supportsCancellation, size);
     }
 
     private static final class CallableTask<V> implements Callable<V> {
@@ -447,6 +485,7 @@ public final class DefaultExecutorTest {
     }
 
     private static final class RejectAllExecutor implements java.util.concurrent.Executor {
+
         @Override
         public void execute(final Runnable command) {
             throw new RejectedExecutionException(DELIBERATE_EXCEPTION);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/From2PublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/From2PublisherTest.java
@@ -17,12 +17,9 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -44,8 +41,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class From2PublisherTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
     private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/From3PublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/From3PublisherTest.java
@@ -17,12 +17,9 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -44,8 +41,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class From3PublisherTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
     private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/FromInputStreamPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/FromInputStreamPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,12 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.internal.DuplicateSubscribeException;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -55,10 +54,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class FromInputStreamPublisherTest {
-
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
 
     private final TestPublisherSubscriber<byte[]> sub1 = new TestPublisherSubscriber<>();
     private final TestPublisherSubscriber<byte[]> sub2 = new TestPublisherSubscriber<>();
@@ -69,7 +66,7 @@ public class FromInputStreamPublisherTest {
     private InputStream inputStream;
     private Publisher<byte[]> pub;
 
-    @Before
+    @BeforeEach
     public void setup() {
         inputStream = mock(InputStream.class);
         pub = new FromInputStreamPublisher(inputStream);
@@ -287,7 +284,7 @@ public class FromInputStreamPublisherTest {
     }
 
     @Test
-    public void consumeSimpleStream() throws Exception {
+    public void consumeSimpleStream() {
         initChunkedStream(smallBuff, of(10, 0), of(10, 0));
         toSource(pub).subscribe(sub1);
         sub1.awaitSubscription().request(1); // smallBuff

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/FromInputStreamPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/FromInputStreamPublisherTest.java
@@ -18,12 +18,10 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.internal.DuplicateSubscribeException;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -54,7 +52,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class FromInputStreamPublisherTest {
 
     private final TestPublisherSubscriber<byte[]> sub1 = new TestPublisherSubscriber<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/IterableMergeCompletableDelayErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/IterableMergeCompletableDelayErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.api.MergeCompletableTest.CompletableHolder;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/IterableMergeCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/IterableMergeCompletableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.api.MergeCompletableTest.CompletableHolder;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MapPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MapPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MergeCompletableDelayErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MergeCompletableDelayErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MergeCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MergeCompletableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.CompletableSource.Subscriber;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MulticastPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MulticastPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,12 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,13 +52,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
+@Timeout(60)
 public class MulticastPublisherTest {
 
     private TestPublisher<Integer> source = new TestPublisher.Builder<Integer>().disableAutoOnSubscribe().build();
     private TestSubscription subscription = new TestSubscription();
-
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout(60, SECONDS);
 
     @Test
     public void emitItemsAndThenError() {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MulticastPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MulticastPublisherTest.java
@@ -17,12 +17,10 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,7 +50,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 @Timeout(60)
 public class MulticastPublisherTest {
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MulticastRealizedSourcePublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MulticastRealizedSourcePublisherTest.java
@@ -18,10 +18,8 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.internal.TerminalNotification;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,7 +44,6 @@ import static org.hamcrest.core.Is.is;
  * {@link Subscriber#onSubscribe(Subscription)}.
  */
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class MulticastRealizedSourcePublisherTest {
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MulticastRealizedSourcePublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MulticastRealizedSourcePublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,11 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.internal.TerminalNotification;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,10 +45,9 @@ import static org.hamcrest.core.Is.is;
  * Test for {@link MulticastPublisher} when the source terminates from within
  * {@link Subscriber#onSubscribe(Subscription)}.
  */
-public class MulticastRealizedSourcePublisherTest {
 
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
+@ExtendWith(TimeoutTracingInfoExtension.class)
+public class MulticastRealizedSourcePublisherTest {
 
     @Test
     public void testOnSubscribeErrors() throws InterruptedException {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterableTest.java
@@ -17,10 +17,8 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.BlockingIterator;
 import io.servicetalk.concurrent.internal.DeliberateException;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -44,7 +42,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public final class PublisherAsBlockingIterableTest {
 
     private final TestPublisher<Integer> source = new TestPublisher<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,10 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.BlockingIterator;
 import io.servicetalk.concurrent.internal.DeliberateException;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -36,21 +35,17 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.rules.ExpectedException.none;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public final class PublisherAsBlockingIterableTest {
-
-    @Rule
-    public final ExpectedException expected = none();
-    @Rule
-    public final ServiceTalkTestTimeout timeout = new ServiceTalkTestTimeout();
 
     private final TestPublisher<Integer> source = new TestPublisher<>();
 
@@ -64,8 +59,7 @@ public final class PublisherAsBlockingIterableTest {
 
     @Test
     public void removeNotSupported() {
-        expected.expect(instanceOf(UnsupportedOperationException.class));
-        source.toIterable().iterator().remove();
+        assertThrows(UnsupportedOperationException.class, () -> source.toIterable().iterator().remove());
     }
 
     @Test
@@ -80,19 +74,16 @@ public final class PublisherAsBlockingIterableTest {
         DeliberateException de = new DeliberateException();
         Iterator<Integer> iterator = Publisher.<Integer>failed(de).toIterable().iterator();
         assertThat("Item expected but not found.", iterator.hasNext(), is(true));
-        expected.expect(sameInstance(de));
-        iterator.next();
+        assertSame(de, assertThrows(DeliberateException.class, () -> iterator.next()));
     }
 
     @Test
     public void doubleHashNextWithError() {
         DeliberateException de = new DeliberateException();
-        Iterator<Integer> iterator = Publisher.<Integer>failed(de)
-                .toIterable().iterator();
+        Iterator<Integer> iterator = Publisher.<Integer>failed(de).toIterable().iterator();
         assertThat("Item expected but not found.", iterator.hasNext(), is(true));
         assertThat("Second hasNext inconsistent with first.", iterator.hasNext(), is(true));
-        expected.expect(sameInstance(de));
-        iterator.next();
+        assertSame(de, assertThrows(DeliberateException.class, () -> iterator.next()));
     }
 
     @Test
@@ -105,8 +96,7 @@ public final class PublisherAsBlockingIterableTest {
     public void nextWithEmpty() {
         Iterator<Integer> iterator = Publisher.<Integer>empty().toIterable().iterator();
         assertThat("Item not expected but found.", iterator.hasNext(), is(false));
-        expected.expect(instanceOf(NoSuchElementException.class));
-        iterator.next();
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Test
@@ -119,15 +109,10 @@ public final class PublisherAsBlockingIterableTest {
         assertThat("hasNext timed out.", iterator.hasNext(-1, MILLISECONDS), is(true));
         assertThat("Unexpected item found.", iterator.next(-1, MILLISECONDS), is(1));
         assertThat("Unexpected item found.", iterator.next(-1, MILLISECONDS), is(2));
-        expected.expect(instanceOf(TimeoutException.class));
-        try {
-            iterator.hasNext(10, MILLISECONDS);
-            fail("expected exception");
-        } catch (TimeoutException e) {
-            assertThat("Unexpected item found.", iterator.hasNext(-1, MILLISECONDS), is(false));
-            assertTrue(subscription.isCancelled());
-            throw e;
-        }
+
+        assertThrows(TimeoutException.class, () -> iterator.hasNext(10, MILLISECONDS));
+        assertThat("Unexpected item found.", iterator.hasNext(-1, MILLISECONDS), is(false));
+        assertTrue(subscription.isCancelled());
     }
 
     @Test
@@ -140,14 +125,11 @@ public final class PublisherAsBlockingIterableTest {
         assertThat("hasNext timed out.", iterator.hasNext(-1, MILLISECONDS), is(true));
         assertThat("Unexpected item found.", iterator.next(-1, MILLISECONDS), is(1));
         assertThat("Unexpected item found.", iterator.next(-1, MILLISECONDS), is(2));
-        expected.expect(instanceOf(TimeoutException.class));
-        try {
-            iterator.next(10, MILLISECONDS);
-        } catch (TimeoutException e) {
-            assertThat("Unexpected item found.", iterator.hasNext(-1, MILLISECONDS), is(false));
-            assertTrue(subscription.isCancelled());
-            throw e;
-        }
+
+        assertThrows(TimeoutException.class, () -> iterator.next(10, MILLISECONDS));
+
+        assertThat("Unexpected item found.", iterator.hasNext(-1, MILLISECONDS), is(false));
+        assertTrue(subscription.isCancelled());
     }
 
     @Test
@@ -194,12 +176,11 @@ public final class PublisherAsBlockingIterableTest {
         source.onNext(2);
         assertThat("Unexpected item found.", iterator.next(), is(2));
         source.onComplete();
-        expected.expect(instanceOf(NoSuchElementException.class));
-        iterator.next();
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Test
-    public void nextWithTimeoutWithoutHasNextAndTerminal() throws TimeoutException {
+    public void nextWithTimeoutWithoutHasNextAndTerminal() {
         BlockingIterator<Integer> iterator = source.toIterable().iterator();
         assertTrue(source.isSubscribed());
         source.onNext(1);
@@ -207,8 +188,7 @@ public final class PublisherAsBlockingIterableTest {
         source.onNext(2);
         assertThat("Unexpected item found.", iterator.next(), is(2));
         source.onComplete();
-        expected.expect(instanceOf(NoSuchElementException.class));
-        iterator.next(10, MILLISECONDS);
+        assertThrows(NoSuchElementException.class, () -> iterator.next(10, MILLISECONDS));
     }
 
     @Test
@@ -257,8 +237,8 @@ public final class PublisherAsBlockingIterableTest {
         DeliberateException de = new DeliberateException();
         source.onError(de);
         assertThat("Item not expected but found.", iterator.hasNext(), is(true));
-        expected.expect(is(de));
-        iterator.next();
+        Exception e = assertThrows(DeliberateException.class, () -> iterator.next());
+        assertThat(e, is(de));
     }
 
     @Test
@@ -333,8 +313,8 @@ public final class PublisherAsBlockingIterableTest {
         source.onError(de);
         verifyNextIs(iterator, 1);
         assertThat("Item expected but not found.", iterator.hasNext(), is(true));
-        expected.expect(sameInstance(de));
-        iterator.next();
+        Exception e = assertThrows(DeliberateException.class, () -> iterator.next());
+        assertThat(e, sameInstance(de));
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferConcurrencyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferConcurrencyTest.java
@@ -17,11 +17,9 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.api.AsyncContextMap.Key;
 import io.servicetalk.concurrent.api.BufferStrategy.Accumulator;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.CountDownLatch;
@@ -30,7 +28,7 @@ import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Completable.failed;
-import static io.servicetalk.concurrent.api.ExecutorExtension.withNamePrefix;
+import static io.servicetalk.concurrent.api.ExecutorExtension.withCachedExecutor;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static java.time.Duration.ofMillis;
@@ -43,13 +41,12 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PublisherBufferConcurrencyTest {
     private static final String THREAD_NAME_PREFIX = "buffer-concurrency-test";
     private static final Key<Integer> CTX_KEY = Key.newKey("foo");
 
     @RegisterExtension
-    public final ExecutorExtension<Executor> executorExtension = withNamePrefix(THREAD_NAME_PREFIX);
+    final ExecutorExtension<Executor> executorExtension = withCachedExecutor(THREAD_NAME_PREFIX);
 
     @Test
     public void largeRun() throws Exception {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferConcurrencyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,12 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.api.AsyncContextMap.Key;
 import io.servicetalk.concurrent.api.BufferStrategy.Accumulator;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
@@ -30,7 +30,7 @@ import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Completable.failed;
-import static io.servicetalk.concurrent.api.ExecutorRule.withNamePrefix;
+import static io.servicetalk.concurrent.api.ExecutorExtension.withNamePrefix;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static java.time.Duration.ofMillis;
@@ -41,16 +41,15 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PublisherBufferConcurrencyTest {
     private static final String THREAD_NAME_PREFIX = "buffer-concurrency-test";
     private static final Key<Integer> CTX_KEY = Key.newKey("foo");
 
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExecutorRule<Executor> executorRule = withNamePrefix(THREAD_NAME_PREFIX);
+    @RegisterExtension
+    public final ExecutorExtension<Executor> executorExtension = withNamePrefix(THREAD_NAME_PREFIX);
 
     @Test
     public void largeRun() throws Exception {
@@ -59,7 +58,7 @@ public class PublisherBufferConcurrencyTest {
 
     @Test
     public void executorIsPreserved() throws Exception {
-        final Executor executor = executorRule.executor();
+        final Executor executor = executorExtension.executor();
         runTest(beforeBuffer -> beforeBuffer.publishOn(executor),
                 afterBuffer -> afterBuffer.beforeOnNext(__ ->
                         assertThat("Unexpected thread in onNext.", Thread.currentThread().getName(),
@@ -126,7 +125,7 @@ public class PublisherBufferConcurrencyTest {
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
 
         CountDownLatch waitForOnNextReturn = new CountDownLatch(1);
-        executorRule.executor().submit(() -> original.onNext(1))
+        executorExtension.executor().submit(() -> original.onNext(1))
                 .beforeFinally(waitForOnNextReturn::countDown).subscribe();
         waitForAdd.await();
         subscriber.awaitSubscription().request(1);
@@ -148,7 +147,7 @@ public class PublisherBufferConcurrencyTest {
                          final UnaryOperator<Publisher<Iterable<Integer>>> afterBuffer) throws Exception {
         final int maxRange = 1000;
         final int repeatMax = 100;
-        final Executor executor = executorRule.executor();
+        final Executor executor = executorExtension.executor();
         Publisher<Integer> original = Publisher.range(0, maxRange)
                 .repeatWhen(count -> count == repeatMax ? failed(DELIBERATE_EXCEPTION) :
                         executor.timer(ofMillis(1)));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,13 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.api.BufferStrategy.Accumulator;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.hamcrest.Matcher;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.annotation.Nullable;
 
@@ -37,12 +36,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PublisherBufferTest {
     private static final int EMPTY_ACCUMULATOR_VAL = -1;
     public static final int BUFFER_SIZE_HINT = 8;
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
     private final TestPublisher<Integer> original = new TestPublisher<>();
     private final TestPublisher<SumAccumulator> boundaries = new TestPublisher<>();
     private final TestPublisherSubscriber<Integer> bufferSubscriber = new TestPublisherSubscriber<>();
@@ -228,7 +225,7 @@ public class PublisherBufferTest {
         verifyCancelled(original);
     }
 
-    @Ignore("Accumulator will not emit boundary ATM")
+    @Disabled("Accumulator will not emit boundary ATM")
     @Test
     public void accumulateEmitsBoundary() {
         bufferSubscriber.awaitSubscription().request(1);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferTest.java
@@ -16,13 +16,11 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.api.BufferStrategy.Accumulator;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.annotation.Nullable;
 
@@ -36,7 +34,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PublisherBufferTest {
     private static final int EMPTY_ACCUMULATOR_VAL = -1;
     public static final int BUFFER_SIZE_HINT = 8;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherConcatMapIterableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherConcatMapIterableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,14 +20,12 @@ import io.servicetalk.concurrent.PublisherSource.Processor;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.internal.DeliberateException;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -55,20 +53,18 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PublisherConcatMapIterableTest {
-    @ClassRule
-    public static final ExecutorRule<Executor> EXECUTOR_RULE = ExecutorRule.newRule();
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
+    @RegisterExtension
+    public static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.newExtension();
 
     private final TestPublisher<List<String>> publisher = new TestPublisher<>();
     private final TestPublisher<BlockingIterable<String>> cancellablePublisher = new TestPublisher<>();
@@ -304,8 +300,9 @@ public class PublisherConcatMapIterableTest {
                     throw DELIBERATE_EXCEPTION;
                 })).subscribe(subscriber);
         subscriber.awaitSubscription();
-        expectedException.expect(is(DELIBERATE_EXCEPTION));
-        publisher.onError(DELIBERATE_EXCEPTION);
+        DeliberateException exception = assertThrows(DeliberateException.class,
+                                                  () -> publisher.onError(DELIBERATE_EXCEPTION));
+        assertThat(exception, is(DELIBERATE_EXCEPTION));
     }
 
     @Test
@@ -331,8 +328,9 @@ public class PublisherConcatMapIterableTest {
                     throw DELIBERATE_EXCEPTION;
                 })).subscribe(subscriber);
         subscriber.awaitSubscription();
-        expectedException.expect(is(DELIBERATE_EXCEPTION));
-        publisher.onComplete();
+        DeliberateException exception = assertThrows(DeliberateException.class,
+                                                     () -> publisher.onComplete());
+        assertThat(exception, is(DELIBERATE_EXCEPTION));
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherConcatMapIterableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherConcatMapIterableTest.java
@@ -20,11 +20,9 @@ import io.servicetalk.concurrent.PublisherSource.Processor;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.internal.DeliberateException;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.ArrayList;
@@ -61,10 +59,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PublisherConcatMapIterableTest {
     @RegisterExtension
-    public static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.newExtension();
+    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
 
     private final TestPublisher<List<String>> publisher = new TestPublisher<>();
     private final TestPublisher<BlockingIterable<String>> cancellablePublisher = new TestPublisher<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherExecutorPreservationTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherExecutorPreservationTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class PublisherExecutorPreservationTest {
     @RegisterExtension
-    public static final ExecutorExtension EXEC = ExecutorExtension.withNamePrefix("test");
+    static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor("test");
 
     private Publisher<String> publisher;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherExecutorPreservationTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherExecutorPreservationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,19 @@
  */
 package io.servicetalk.concurrent.api;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class PublisherExecutorPreservationTest {
-    @ClassRule
-    public static final ExecutorRule EXEC = ExecutorRule.withNamePrefix("test");
+    @RegisterExtension
+    public static final ExecutorExtension EXEC = ExecutorExtension.withNamePrefix("test");
 
     private Publisher<String> publisher;
 
-    @Before
+    @BeforeEach
     public void setupPublisher() {
         publisher = Publisher.<String>empty().publishAndSubscribeOnOverride(EXEC.executor());
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
@@ -18,13 +18,11 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.PublisherSource.Processor;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.internal.DeliberateException;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -75,7 +73,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PublisherFlatMapMergeTest {
     private static final long TERMINAL_POLL_MS = 10;
     @Nullable

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,13 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.PublisherSource.Processor;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.internal.DeliberateException;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -67,19 +66,18 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PublisherFlatMapMergeTest {
     private static final long TERMINAL_POLL_MS = 10;
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
     @Nullable
     private static ExecutorService executorService;
     @Nullable
@@ -88,13 +86,13 @@ public class PublisherFlatMapMergeTest {
     private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
     private TestPublisher<Integer> publisher = new TestPublisher<>();
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         executorService = java.util.concurrent.Executors.newFixedThreadPool(10);
         executor = io.servicetalk.concurrent.api.Executors.from(executorService);
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() throws Exception {
         if (executor != null) {
             executor.closeAsync().toFuture().get();
@@ -1137,7 +1135,7 @@ public class PublisherFlatMapMergeTest {
         if (cause != null) {
             throw cause;
         }
-        assertFalse("The countDownLatch didn't timeout, and there was also no exception?!", timedOut);
+        assertFalse(timedOut, "The countDownLatch didn't timeout, and there was also no exception?!");
     }
 
     private static final class TestSubscriptionPublisherPair<T> {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,13 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.internal.DeliberateException;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -59,29 +58,27 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PublisherFlatMapSingleTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
     private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
     private TestPublisher<Integer> source = new TestPublisher<>();
     private final TestSubscription subscription = new TestSubscription();
     private static ExecutorService executorService;
     private static Executor executor;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         executorService = Executors.newFixedThreadPool(10);
         executor = io.servicetalk.concurrent.api.Executors.from(executorService);
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() throws Exception {
         executor.closeAsync().toFuture().get();
     }
@@ -535,7 +532,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testEmitFromQueue() throws Exception {
+    public void testEmitFromQueue() {
         List<TestSingle<Integer>> emittedSingles = new ArrayList<>();
         io.servicetalk.concurrent.test.internal.TestPublisherSubscriber<Integer> subscriber =
                 new io.servicetalk.concurrent.test.internal.TestPublisherSubscriber<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
@@ -18,13 +18,11 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.internal.DeliberateException;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -64,7 +62,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PublisherFlatMapSingleTest {
     private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
     private TestPublisher<Integer> source = new TestPublisher<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherGroupByConcurrencyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherGroupByConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +17,15 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.internal.TerminalNotification;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -44,33 +44,31 @@ import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
+@Timeout(30)
 public final class PublisherGroupByConcurrencyTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout(30, SECONDS);
-
     private final TestPublisherSubscriber<Integer> groupsSubscriber = new TestPublisherSubscriber<>();
     private ConcurrentLinkedQueue<Integer> allItemsReceivedOnAllGroups;
     private TestPublisher<Integer> source;
     private ExecutorService executor;
     private AtomicBoolean allWorkDone;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         source = new TestPublisher<>();
         allItemsReceivedOnAllGroups = new ConcurrentLinkedQueue<>();
         executor = newCachedThreadPool();
         allWorkDone = new AtomicBoolean();
     }
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    public void tearDown() {
         executor.shutdown();
         allItemsReceivedOnAllGroups.clear();
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherGroupByConcurrencyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherGroupByConcurrencyTest.java
@@ -18,14 +18,12 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.internal.TerminalNotification;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -50,7 +48,6 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 @Timeout(30)
 public final class PublisherGroupByConcurrencyTest {
     private final TestPublisherSubscriber<Integer> groupsSubscriber = new TestPublisherSubscriber<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherGroupByTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherGroupByTest.java
@@ -19,12 +19,10 @@ import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.internal.QueueFullException;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
@@ -57,7 +55,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PublisherGroupByTest {
     private TestPublisher<Integer> source;
     private TestPublisherSubscriber<Boolean> subscriber;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherGroupByTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherGroupByTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,12 @@ import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.internal.QueueFullException;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
@@ -52,22 +51,20 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PublisherGroupByTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
     private TestPublisher<Integer> source;
     private TestPublisherSubscriber<Boolean> subscriber;
     private TestSubscription subscription = new TestSubscription();
     private List<TestPublisherSubscriber<Integer>> groupSubs = new ArrayList<>();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         source = new TestPublisher<>();
         subscriber = new TestPublisherSubscriber<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherProcessorConcurrencyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherProcessorConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
@@ -39,8 +39,8 @@ public class PublisherProcessorConcurrencyTest {
 
     private final ExecutorService executorService = newCachedThreadPool();
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    public void tearDown() {
         executorService.shutdownNow();
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherProcessorSignalsHolderTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherProcessorSignalsHolderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherProcessorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.internal.DuplicateSubscribeException;
 import io.servicetalk.concurrent.internal.TerminalNotification;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RedoStrategiesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RedoStrategiesTest.java
@@ -15,10 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
-
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
 import java.util.concurrent.LinkedBlockingQueue;
@@ -36,13 +33,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class RedoStrategiesTest {
 
     protected LinkedBlockingQueue<LegacyTestCompletable> timers;
     protected Executor timerExecutor;
 
-    @SuppressWarnings("unchecked")
     @BeforeEach
     public void setUp() {
         timers = new LinkedBlockingQueue<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RedoStrategiesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RedoStrategiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
 import java.util.concurrent.LinkedBlockingQueue;
@@ -36,17 +36,15 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class RedoStrategiesTest {
-
-    @Rule
-    public final ServiceTalkTestTimeout timeout = new ServiceTalkTestTimeout();
 
     protected LinkedBlockingQueue<LegacyTestCompletable> timers;
     protected Executor timerExecutor;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         timers = new LinkedBlockingQueue<>();
         timerExecutor = mock(Executor.class);
         when(timerExecutor.timer(anyLong(), any(TimeUnit.class))).thenAnswer(invocation -> {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RepeatStrategiesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RepeatStrategiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.function.IntFunction;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ResumeCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ResumeCompletableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -27,10 +27,10 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ResumeCompletableTest {
 
@@ -38,7 +38,7 @@ public final class ResumeCompletableTest {
     private TestCompletable first;
     private TestCompletable second;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         subscriber = new TestCompletableSubscriber();
         first = new TestCompletable();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ResumePublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ResumePublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -28,9 +28,9 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ResumePublisherTest {
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ResumeSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ResumeSingleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -28,10 +28,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ResumeSingleTest {
 
@@ -39,7 +39,7 @@ public final class ResumeSingleTest {
     private TestSingle<Integer> first;
     private TestSingle<Integer> second;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         subscriber = new TestSingleSubscriber<>();
         first = new TestSingle<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RetryStrategiesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RetryStrategiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.internal.DeliberateException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
@@ -71,7 +71,7 @@ public class RetryStrategiesTest extends RedoStrategiesTest {
     }
 
     @Test
-    public void testBackoffCauseFilter() throws Exception {
+    public void testBackoffCauseFilter() {
         testCauseFilter(retryWithExponentialBackoffFullJitter(1, cause -> cause instanceof IllegalStateException,
                 ofSeconds(1), ofDays(10), timerExecutor));
     }
@@ -103,7 +103,7 @@ public class RetryStrategiesTest extends RedoStrategiesTest {
     }
 
     @Test
-    public void testExpBackoffCauseFilter() throws Exception {
+    public void testExpBackoffCauseFilter() {
         testCauseFilter(retryWithExponentialBackoffFullJitter(1, cause -> cause instanceof IllegalStateException,
                 ofSeconds(1), ofDays(10), timerExecutor));
     }
@@ -139,12 +139,12 @@ public class RetryStrategiesTest extends RedoStrategiesTest {
     }
 
     @Test
-    public void testExpBackoffWithJitterCauseFilter() throws Exception {
+    public void testExpBackoffWithJitterCauseFilter() {
         testCauseFilter(retryWithExponentialBackoffDeltaJitter(1, cause -> cause instanceof IllegalStateException,
                 ofSeconds(1), ofMillis(10), ofDays(10), timerExecutor));
     }
 
-    private void testCauseFilter(BiIntFunction<Throwable, Completable> actualStrategy) throws Exception {
+    private void testCauseFilter(BiIntFunction<Throwable, Completable> actualStrategy) {
         RetryStrategy strategy = new RetryStrategy(actualStrategy);
         io.servicetalk.concurrent.test.internal.TestCompletableSubscriber subscriber =
                 strategy.invokeAndListen(DELIBERATE_EXCEPTION);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ScanWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ScanWithPublisherTest.java
@@ -18,12 +18,11 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.internal.DeliberateException;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.annotation.Nullable;
 
@@ -39,10 +38,8 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class ScanWithPublisherTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
     @Test
     public void scanWithComplete() {
         scanWithNoTerminalMapper(true);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ScanWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ScanWithPublisherTest.java
@@ -18,11 +18,9 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.internal.DeliberateException;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.annotation.Nullable;
 
@@ -38,7 +36,6 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class ScanWithPublisherTest {
     @Test
     public void scanWithComplete() {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SchedulerOffloadTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SchedulerOffloadTest.java
@@ -15,11 +15,8 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.Exchanger;
 import java.util.concurrent.TimeUnit;
@@ -29,7 +26,6 @@ import static io.servicetalk.concurrent.api.Executors.from;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SchedulerOffloadTest {
 
     public static final String EXPECTED_THREAD_PREFIX = "jdk-executor";

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SchedulerOffloadTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SchedulerOffloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,11 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.Exchanger;
 import java.util.concurrent.TimeUnit;
@@ -30,10 +29,8 @@ import static io.servicetalk.concurrent.api.Executors.from;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SchedulerOffloadTest {
-
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
 
     public static final String EXPECTED_THREAD_PREFIX = "jdk-executor";
     @Nullable
@@ -42,7 +39,7 @@ public class SchedulerOffloadTest {
     public SchedulerOffloadTest() {
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (executor != null) {
             executor.closeAsync().toFuture().get();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SequentialSubscriptionTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SequentialSubscriptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,15 +18,15 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.internal.FlowControlUtils;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
@@ -34,8 +34,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
-import static io.servicetalk.concurrent.internal.ServiceTalkTestTimeout.DEFAULT_TIMEOUT_SECONDS;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
+import static io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension.DEFAULT_TIMEOUT_SECONDS;
 import static java.lang.Long.MAX_VALUE;
 import static java.lang.Long.MIN_VALUE;
 import static java.lang.Math.min;
@@ -46,7 +46,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.AdditionalMatchers.leq;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
@@ -55,17 +56,15 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public final class SequentialSubscriptionTest {
     private static final int ITERATIONS_FOR_CONCURRENT_TESTS = 500;
-    @Rule
-    public final ServiceTalkTestTimeout timeout = new ServiceTalkTestTimeout();
-
     private SequentialSubscription s;
     private Subscription s1;
     private Subscription s2;
     private ExecutorService executor;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         s1 = mock(Subscription.class);
         s = new SequentialSubscription(s1);
@@ -73,7 +72,7 @@ public final class SequentialSubscriptionTest {
         executor = newCachedThreadPool();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         executor.shutdownNow();
         executor.awaitTermination(DEFAULT_TIMEOUT_SECONDS, SECONDS);
@@ -148,9 +147,9 @@ public final class SequentialSubscriptionTest {
         verifyNoMoreInteractions(s1);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testSwitchToNull() {
-        s.switchTo(null);
+        assertThrows(NullPointerException.class, () -> s.switchTo(null));
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SequentialSubscriptionTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SequentialSubscriptionTest.java
@@ -18,7 +18,6 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.internal.FlowControlUtils;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -26,7 +25,6 @@ import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
@@ -56,7 +54,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public final class SequentialSubscriptionTest {
     private static final int ITERATIONS_FOR_CONCURRENT_TESTS = 500;
     private SequentialSubscription s;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbSubscribeThrowsTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbSubscribeThrowsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,11 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Collection;
 import java.util.function.BiFunction;
+import java.util.stream.Stream;
 
 import static io.servicetalk.concurrent.api.Single.amb;
 import static io.servicetalk.concurrent.api.Single.defer;
@@ -33,7 +32,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 
-@RunWith(Parameterized.class)
 public class SingleAmbSubscribeThrowsTest {
 
     private volatile boolean throwFromFirst;
@@ -42,10 +40,9 @@ public class SingleAmbSubscribeThrowsTest {
     private final TestSingle<Integer> second = new TestSingle<>();
     private final TestCancellable cancellable = new TestCancellable();
     private final TestSingleSubscriber<Integer> subscriber = new TestSingleSubscriber<>();
-    private final Single<Integer> amb;
+    private Single<Integer> amb;
 
-    public SingleAmbSubscribeThrowsTest(
-            final BiFunction<Single<Integer>, Single<Integer>, Single<Integer>> ambSupplier) {
+    private void init(final BiFunction<Single<Integer>, Single<Integer>, Single<Integer>> ambSupplier) {
         amb = ambSupplier.apply(defer(() -> {
             if (throwFromFirst) {
                 throw DELIBERATE_EXCEPTION;
@@ -59,15 +56,16 @@ public class SingleAmbSubscribeThrowsTest {
         }));
     }
 
-    @Parameterized.Parameters
-    public static Collection<BiFunction<Single<Integer>, Single<Integer>, Single<Integer>>> data() {
-        return asList(Single::ambWith,
+    public static Stream<BiFunction<Single<Integer>, Single<Integer>, Single<Integer>>> data() {
+        return Stream.of(Single::ambWith,
                 (first, second) -> amb(first, second),
                 (first, second) -> amb(asList(first, second)));
     }
 
-    @Test
-    public void firstSubscribeThrows() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void firstSubscribeThrows(final BiFunction<Single<Integer>, Single<Integer>, Single<Integer>> ambSupplier) {
+        init(ambSupplier);
         throwFromFirst = true;
         subscribeToAmbAndVerifyFail();
         second.onSubscribe(cancellable);
@@ -76,8 +74,10 @@ public class SingleAmbSubscribeThrowsTest {
         second.onSuccess(2);
     }
 
-    @Test
-    public void secondSubscribeThrows() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void secondSubscribeThrows(final BiFunction<Single<Integer>, Single<Integer>, Single<Integer>> ambSupplier) {
+        init(ambSupplier);
         throwFromSecond = true;
         subscribeToAmbAndVerifyFail();
         first.onSubscribe(cancellable);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,8 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collection;
 import java.util.function.BiFunction;
@@ -32,7 +31,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 
-@RunWith(Parameterized.class)
 public class SingleAmbTest {
 
     private final TestSingle<Integer> first = new TestSingle<>();
@@ -40,95 +38,131 @@ public class SingleAmbTest {
     private final TestSingleSubscriber<Integer> subscriber = new TestSingleSubscriber<>();
     private final TestCancellable cancellable = new TestCancellable();
 
-    public SingleAmbTest(final BiFunction<Single<Integer>, Single<Integer>, Single<Integer>> ambSupplier) {
+    private void init(final BiFunction<Single<Integer>, Single<Integer>,
+            Single<Integer>> ambSupplier) {
         toSource(ambSupplier.apply(first, second)).subscribe(subscriber);
         subscriber.awaitSubscription();
         assertThat("First source not subscribed.", first.isSubscribed(), is(true));
         assertThat("Second source not subscribed.", second.isSubscribed(), is(true));
     }
 
-    @Parameterized.Parameters
     public static Collection<BiFunction<Single<Integer>, Single<Integer>, Single<Integer>>> data() {
         return asList(Single::ambWith,
                 (first, second) -> amb(first, second),
                 (first, second) -> amb(asList(first, second)));
     }
 
-    @Test
-    public void successFirst() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void successFirst(final BiFunction<Single<Integer>, Single<Integer>,
+            Single<Integer>> ambSupplier) {
+        init(ambSupplier);
         sendSuccessToAndVerify(first);
         verifyCancelled(second);
     }
 
-    @Test
-    public void successSecond() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void successSecond(final BiFunction<Single<Integer>, Single<Integer>,
+            Single<Integer>> ambSupplier) {
+        init(ambSupplier);
         sendSuccessToAndVerify(second);
         verifyCancelled(first);
     }
 
-    @Test
-    public void failFirst() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void failFirst(final BiFunction<Single<Integer>, Single<Integer>,
+            Single<Integer>> ambSupplier) {
+        init(ambSupplier);
         sendErrorToAndVerify(first);
         verifyCancelled(second);
     }
 
-    @Test
-    public void failSecond() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void failSecond(final BiFunction<Single<Integer>, Single<Integer>,
+            Single<Integer>> ambSupplier) {
+        init(ambSupplier);
         sendErrorToAndVerify(second);
         verifyCancelled(first);
     }
 
-    @Test
-    public void successFirstThenSecond() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void successFirstThenSecond(final BiFunction<Single<Integer>, Single<Integer>,
+            Single<Integer>> ambSupplier) {
+        init(ambSupplier);
         sendSuccessToAndVerify(first);
         verifyCancelled(second);
         second.onSuccess(2);
     }
 
-    @Test
-    public void successSecondThenFirst() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void successSecondThenFirst(final BiFunction<Single<Integer>, Single<Integer>,
+            Single<Integer>> ambSupplier) {
+        init(ambSupplier);
         sendSuccessToAndVerify(second);
         verifyCancelled(first);
         first.onSuccess(2);
     }
 
-    @Test
-    public void failFirstThenSecond() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void failFirstThenSecond(final BiFunction<Single<Integer>, Single<Integer>,
+            Single<Integer>> ambSupplier) {
+        init(ambSupplier);
         sendErrorToAndVerify(first);
         verifyCancelled(second);
         second.onError(DELIBERATE_EXCEPTION);
     }
 
-    @Test
-    public void failSecondThenFirst() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void failSecondThenFirst(final BiFunction<Single<Integer>, Single<Integer>,
+            Single<Integer>> ambSupplier) {
+        init(ambSupplier);
         sendErrorToAndVerify(second);
         verifyCancelled(first);
         first.onError(DELIBERATE_EXCEPTION);
     }
 
-    @Test
-    public void successFirstThenSecondFail() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void successFirstThenSecondFail(final BiFunction<Single<Integer>, Single<Integer>,
+            Single<Integer>> ambSupplier) {
+        init(ambSupplier);
         sendSuccessToAndVerify(first);
         verifyCancelled(second);
         second.onError(DELIBERATE_EXCEPTION);
     }
 
-    @Test
-    public void successSecondThenFirstFail() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void successSecondThenFirstFail(final BiFunction<Single<Integer>, Single<Integer>,
+            Single<Integer>> ambSupplier) {
+        init(ambSupplier);
         sendSuccessToAndVerify(second);
         verifyCancelled(first);
         first.onError(DELIBERATE_EXCEPTION);
     }
 
-    @Test
-    public void failFirstThenSecondSuccess() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void failFirstThenSecondSuccess(final BiFunction<Single<Integer>, Single<Integer>,
+            Single<Integer>> ambSupplier) {
+        init(ambSupplier);
         sendErrorToAndVerify(first);
         verifyCancelled(second);
         second.onSuccess(2);
     }
 
-    @Test
-    public void failSecondThenFirstSuccess() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void failSecondThenFirstSuccess(final BiFunction<Single<Integer>, Single<Integer>,
+            Single<Integer>> ambSupplier) {
+        init(ambSupplier);
         sendErrorToAndVerify(second);
         verifyCancelled(first);
         first.onSuccess(2);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbWithAsyncTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbWithAsyncTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,14 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.api.AsyncContextMap.Key;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.function.Executable;
 
-import static io.servicetalk.concurrent.api.ExecutorRule.withNamePrefix;
+import static io.servicetalk.concurrent.api.ExecutorExtension.withNamePrefix;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.Single.never;
 import static io.servicetalk.concurrent.api.Single.succeeded;
@@ -32,8 +32,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.rules.ExpectedException.none;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SingleAmbWithAsyncTest {
     private static final String FIRST_EXECUTOR_THREAD_NAME_PREFIX = "first";
     private static final String SECOND_EXECUTOR_THREAD_NAME_PREFIX = "second";
@@ -45,24 +46,24 @@ public class SingleAmbWithAsyncTest {
     private static final int BEFORE_ON_SUBSCRIBE_KEY_VAL = 2;
     private static final int BEFORE_ON_SUBSCRIBE_KEY_VAL_2 = 3;
 
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExpectedException expectedException = none();
-    @Rule
-    public final ExecutorRule<Executor> firstExec = withNamePrefix(FIRST_EXECUTOR_THREAD_NAME_PREFIX);
-    @Rule
-    public final ExecutorRule<Executor> secondExec = withNamePrefix(SECOND_EXECUTOR_THREAD_NAME_PREFIX);
+    @RegisterExtension
+    public final ExecutorExtension<Executor> firstExec = withNamePrefix(FIRST_EXECUTOR_THREAD_NAME_PREFIX);
+    @RegisterExtension
+    public final ExecutorExtension<Executor> secondExec = withNamePrefix(SECOND_EXECUTOR_THREAD_NAME_PREFIX);
 
     @Test
     public void offloadSuccessFromFirst() throws Exception {
         assertThat("Unexpected result.", testOffloadSecond(succeeded(1), never()), is(1));
     }
 
+    private static void assertThrowsWithDeliberateExceptionAsCause(Executable executable) {
+        Exception exception = assertThrows(Exception.class, executable);
+        assertThat(exception.getCause(), sameInstance(DELIBERATE_EXCEPTION));
+    }
+
     @Test
-    public void offloadErrorFromFirst() throws Exception {
-        expectedException.expectCause(sameInstance(DELIBERATE_EXCEPTION));
-        testOffloadSecond(never(), failed(DELIBERATE_EXCEPTION));
+    public void offloadErrorFromFirst() {
+        assertThrowsWithDeliberateExceptionAsCause(() -> testOffloadSecond(never(), failed(DELIBERATE_EXCEPTION)));
     }
 
     @Test
@@ -71,9 +72,8 @@ public class SingleAmbWithAsyncTest {
     }
 
     @Test
-    public void offloadErrorFromSecond() throws Exception {
-        expectedException.expectCause(sameInstance(DELIBERATE_EXCEPTION));
-        testOffloadSecond(never(), failed(DELIBERATE_EXCEPTION));
+    public void offloadErrorFromSecond() {
+        assertThrowsWithDeliberateExceptionAsCause(() -> testOffloadSecond(never(), failed(DELIBERATE_EXCEPTION)));
     }
 
     @Test
@@ -82,9 +82,9 @@ public class SingleAmbWithAsyncTest {
     }
 
     @Test
-    public void contextFromSubscribeFirstError() throws Exception {
-        expectedException.expectCause(sameInstance(DELIBERATE_EXCEPTION));
-        testContextFromSubscribe(failed(DELIBERATE_EXCEPTION), never());
+    public void contextFromSubscribeFirstError() {
+        assertThrowsWithDeliberateExceptionAsCause(
+                () -> testContextFromSubscribe(failed(DELIBERATE_EXCEPTION), never()));
     }
 
     @Test
@@ -93,9 +93,9 @@ public class SingleAmbWithAsyncTest {
     }
 
     @Test
-    public void contextFromSubscribeSecondError() throws Exception {
-        expectedException.expectCause(sameInstance(DELIBERATE_EXCEPTION));
-        testContextFromSubscribe(never(), failed(DELIBERATE_EXCEPTION));
+    public void contextFromSubscribeSecondError() {
+        assertThrowsWithDeliberateExceptionAsCause(
+                () -> testContextFromSubscribe(never(), failed(DELIBERATE_EXCEPTION)));
     }
 
     @Test
@@ -104,9 +104,9 @@ public class SingleAmbWithAsyncTest {
     }
 
     @Test
-    public void contextFromSecondSubscribeFirstError() throws Exception {
-        expectedException.expectCause(sameInstance(DELIBERATE_EXCEPTION));
-        testContextFromSecondSubscribe(failed(DELIBERATE_EXCEPTION), never());
+    public void contextFromSecondSubscribeFirstError() {
+        assertThrowsWithDeliberateExceptionAsCause(() ->
+                testContextFromSecondSubscribe(failed(DELIBERATE_EXCEPTION), never()));
     }
 
     @Test
@@ -115,9 +115,9 @@ public class SingleAmbWithAsyncTest {
     }
 
     @Test
-    public void contextFromSecondSubscribeSecondError() throws Exception {
-        expectedException.expectCause(sameInstance(DELIBERATE_EXCEPTION));
-        testContextFromSecondSubscribe(never(), failed(DELIBERATE_EXCEPTION));
+    public void contextFromSecondSubscribeSecondError() {
+        assertThrowsWithDeliberateExceptionAsCause(() ->
+                testContextFromSecondSubscribe(never(), failed(DELIBERATE_EXCEPTION)));
     }
 
     @Test
@@ -126,9 +126,9 @@ public class SingleAmbWithAsyncTest {
     }
 
     @Test
-    public void contextFromOnSubscribeFirstError() throws Exception {
-        expectedException.expectCause(sameInstance(DELIBERATE_EXCEPTION));
-        testContextFromOnSubscribe(failed(DELIBERATE_EXCEPTION), never());
+    public void contextFromOnSubscribeFirstError() {
+        assertThrowsWithDeliberateExceptionAsCause(
+                () -> testContextFromOnSubscribe(failed(DELIBERATE_EXCEPTION), never()));
     }
 
     @Test
@@ -137,9 +137,9 @@ public class SingleAmbWithAsyncTest {
     }
 
     @Test
-    public void contextFromOnSubscribeSecondError() throws Exception {
-        expectedException.expectCause(sameInstance(DELIBERATE_EXCEPTION));
-        testContextFromOnSubscribe(never(), failed(DELIBERATE_EXCEPTION));
+    public void contextFromOnSubscribeSecondError() {
+        assertThrowsWithDeliberateExceptionAsCause(
+                () -> testContextFromOnSubscribe(never(), failed(DELIBERATE_EXCEPTION)));
     }
 
     @Test
@@ -148,9 +148,9 @@ public class SingleAmbWithAsyncTest {
     }
 
     @Test
-    public void contextFromSecondOnSubscribeFirstError() throws Exception {
-        expectedException.expectCause(sameInstance(DELIBERATE_EXCEPTION));
-        testContextFromSecondOnSubscribe(failed(DELIBERATE_EXCEPTION), never());
+    public void contextFromSecondOnSubscribeFirstError() {
+        assertThrowsWithDeliberateExceptionAsCause(() ->
+                testContextFromSecondOnSubscribe(failed(DELIBERATE_EXCEPTION), never()));
     }
 
     @Test
@@ -159,9 +159,9 @@ public class SingleAmbWithAsyncTest {
     }
 
     @Test
-    public void contextFromSecondOnSubscribeSecondError() throws Exception {
-        expectedException.expectCause(sameInstance(DELIBERATE_EXCEPTION));
-        testContextFromSecondOnSubscribe(never(), failed(DELIBERATE_EXCEPTION));
+    public void contextFromSecondOnSubscribeSecondError() {
+        assertThrowsWithDeliberateExceptionAsCause(() ->
+                testContextFromSecondOnSubscribe(never(), failed(DELIBERATE_EXCEPTION)));
     }
 
     private int testOffloadSecond(final Single<Integer> first, final Single<Integer> second) throws Exception {
@@ -178,7 +178,7 @@ public class SingleAmbWithAsyncTest {
                 .ambWith(second.publishOn(secondExec.executor()))
                 .beforeFinally(() ->
                         assertThat("Unexpected context value.", AsyncContext.current().get(BEFORE_SUBSCRIBE_KEY),
-                        is(BEFORE_SUBSCRIBE_KEY_VAL)))
+                                is(BEFORE_SUBSCRIBE_KEY_VAL)))
                 .<Integer>liftSync(subscriber -> {
                     AsyncContext.put(BEFORE_SUBSCRIBE_KEY, BEFORE_SUBSCRIBE_KEY_VAL);
                     return subscriber;
@@ -193,7 +193,7 @@ public class SingleAmbWithAsyncTest {
                 .beforeFinally(() ->
                         assertThat("Unexpected context value.",
                                 AsyncContext.current().get(BEFORE_ON_SUBSCRIBE_KEY),
-                        is(BEFORE_ON_SUBSCRIBE_KEY_VAL)))
+                                is(BEFORE_ON_SUBSCRIBE_KEY_VAL)))
                 .toFuture().get();
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbWithAsyncTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbWithAsyncTest.java
@@ -16,14 +16,12 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.api.AsyncContextMap.Key;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.function.Executable;
 
-import static io.servicetalk.concurrent.api.ExecutorExtension.withNamePrefix;
+import static io.servicetalk.concurrent.api.ExecutorExtension.withCachedExecutor;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.Single.never;
 import static io.servicetalk.concurrent.api.Single.succeeded;
@@ -34,7 +32,6 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SingleAmbWithAsyncTest {
     private static final String FIRST_EXECUTOR_THREAD_NAME_PREFIX = "first";
     private static final String SECOND_EXECUTOR_THREAD_NAME_PREFIX = "second";
@@ -47,9 +44,9 @@ public class SingleAmbWithAsyncTest {
     private static final int BEFORE_ON_SUBSCRIBE_KEY_VAL_2 = 3;
 
     @RegisterExtension
-    public final ExecutorExtension<Executor> firstExec = withNamePrefix(FIRST_EXECUTOR_THREAD_NAME_PREFIX);
+    final ExecutorExtension<Executor> firstExec = withCachedExecutor(FIRST_EXECUTOR_THREAD_NAME_PREFIX);
     @RegisterExtension
-    public final ExecutorExtension<Executor> secondExec = withNamePrefix(SECOND_EXECUTOR_THREAD_NAME_PREFIX);
+    final ExecutorExtension<Executor> secondExec = withCachedExecutor(SECOND_EXECUTOR_THREAD_NAME_PREFIX);
 
     @Test
     public void offloadSuccessFromFirst() throws Exception {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleExecutorPreservationTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleExecutorPreservationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,21 @@
  */
 package io.servicetalk.concurrent.api;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.time.Duration;
-
+import static java.time.Duration.ofMillis;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class SingleExecutorPreservationTest {
-    @ClassRule
-    public static final ExecutorRule EXEC = ExecutorRule.withNamePrefix("test");
+    @RegisterExtension
+    public static final ExecutorExtension EXEC = ExecutorExtension.withNamePrefix("test");
 
     private Single<String> single;
 
-    @Before
+    @BeforeEach
     public void setupSingle() {
         single = Single.<String>never().publishAndSubscribeOnOverride(EXEC.executor());
     }
@@ -38,7 +37,7 @@ public class SingleExecutorPreservationTest {
     @Test
     public void testTimeoutSingle() {
         assertSame(EXEC.executor(), single.idleTimeout(1, MILLISECONDS).executor());
-        assertSame(EXEC.executor(), single.idleTimeout(Duration.ofMillis(1)).executor());
+        assertSame(EXEC.executor(), single.idleTimeout(ofMillis(1)).executor());
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleExecutorPreservationTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleExecutorPreservationTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class SingleExecutorPreservationTest {
     @RegisterExtension
-    public static final ExecutorExtension EXEC = ExecutorExtension.withNamePrefix("test");
+    static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor("test");
 
     private Single<String> single;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleProcessorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,12 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.SingleSource.Subscriber;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
@@ -40,16 +39,14 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SingleProcessorTest {
-    @ClassRule
-    public static final ExecutorRule<Executor> EXECUTOR_RULE = ExecutorRule.newRule();
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
+    @RegisterExtension
+    public static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.newExtension();
     @Test
     public void testSuccessBeforeListen() {
         testSuccessBeforeListen("foo");

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleProcessorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleProcessorTest.java
@@ -17,11 +17,9 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.SingleSource.Subscriber;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.lang.ref.ReferenceQueue;
@@ -43,10 +41,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SingleProcessorTest {
     @RegisterExtension
-    public static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.newExtension();
+    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
     @Test
     public void testSuccessBeforeListen() {
         testSuccessBeforeListen("foo");

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleToCompletableFutureToCompletionStageWrappingTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleToCompletableFutureToCompletionStageWrappingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,10 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -29,10 +28,8 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SingleToCompletableFutureToCompletionStageWrappingTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
     @Test
     public void wrappedTerminationTerminates() throws Exception {
         CompletableFuture<String> composed = completedFuture("Hello")

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleToCompletableFutureToCompletionStageWrappingTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleToCompletableFutureToCompletionStageWrappingTest.java
@@ -15,10 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
-
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -28,7 +25,6 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SingleToCompletableFutureToCompletionStageWrappingTest {
     @Test
     public void wrappedTerminationTerminates() throws Exception {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SourceAdaptersTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SourceAdaptersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,7 @@ import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.internal.ScalarValueSubscription;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.concurrent.ExecutionException;
@@ -41,6 +39,7 @@ import static io.servicetalk.concurrent.internal.EmptySubscriptions.EMPTY_SUBSCR
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -48,9 +47,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class SourceAdaptersTest {
-
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void publisherToSourceSuccess() {
@@ -138,16 +134,15 @@ public class SourceAdaptersTest {
     }
 
     @Test
-    public void publisherFromSourceError() throws Exception {
+    public void publisherFromSourceError() {
         PublisherSource<Integer> src = s -> {
             s.onSubscribe(EMPTY_SUBSCRIPTION);
             s.onError(DELIBERATE_EXCEPTION);
         };
 
         Future<Integer> future = fromSource(src).firstOrElse(() -> null).toFuture();
-        expectedException.expect(ExecutionException.class);
-        expectedException.expectCause(sameInstance(DELIBERATE_EXCEPTION));
-        future.get();
+        Exception e = assertThrows(ExecutionException.class, () -> future.get());
+        assertThat(e.getCause(), sameInstance(DELIBERATE_EXCEPTION));
     }
 
     @Test
@@ -170,16 +165,15 @@ public class SourceAdaptersTest {
     }
 
     @Test
-    public void singleFromSourceError() throws Exception {
+    public void singleFromSourceError() {
         SingleSource<Integer> src = s -> {
             s.onSubscribe(IGNORE_CANCEL);
             s.onError(DELIBERATE_EXCEPTION);
         };
 
         Future<Integer> future = fromSource(src).toFuture();
-        expectedException.expect(ExecutionException.class);
-        expectedException.expectCause(sameInstance(DELIBERATE_EXCEPTION));
-        future.get();
+        Exception e = assertThrows(ExecutionException.class, () -> future.get());
+        assertThat(e.getCause(), sameInstance(DELIBERATE_EXCEPTION));
     }
 
     @Test
@@ -201,16 +195,15 @@ public class SourceAdaptersTest {
     }
 
     @Test
-    public void completableFromSourceError() throws Exception {
+    public void completableFromSourceError() {
         CompletableSource src = s -> {
             s.onSubscribe(IGNORE_CANCEL);
             s.onError(DELIBERATE_EXCEPTION);
         };
 
         Future<Void> future = fromSource(src).toFuture();
-        expectedException.expect(ExecutionException.class);
-        expectedException.expectCause(sameInstance(DELIBERATE_EXCEPTION));
-        future.get();
+        Exception e = assertThrows(ExecutionException.class, () -> future.get());
+        assertThat(e.getCause(), sameInstance(DELIBERATE_EXCEPTION));
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SubscribeThrowsTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SubscribeThrowsTest.java
@@ -19,10 +19,8 @@ import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.internal.SignalOffloader;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.ExecutionException;
 
@@ -34,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SubscribeThrowsTest {
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SubscribeThrowsTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SubscribeThrowsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,42 +18,35 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.SingleSource;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.internal.SignalOffloader;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.ExecutionException;
 
 import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
-import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.rules.ExpectedException.none;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SubscribeThrowsTest {
 
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExpectedException expectedException = none();
-
     @Test
-    public void publisherSubscriberThrows() throws Exception {
+    public void publisherSubscriberThrows() {
         Publisher<String> p = new Publisher<String>() {
             @Override
             protected void handleSubscribe(final Subscriber<? super String> subscriber) {
                 throw DELIBERATE_EXCEPTION;
             }
         };
-        expectedException.expect(instanceOf(ExecutionException.class));
-        expectedException.expectCause(is(DELIBERATE_EXCEPTION));
-        p.toFuture().get();
+        Exception e = assertThrows(ExecutionException.class, () -> p.toFuture().get());
+        assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
     }
 
     @Test
@@ -73,16 +66,15 @@ public class SubscribeThrowsTest {
     }
 
     @Test
-    public void singleSubscriberThrows() throws Exception {
+    public void singleSubscriberThrows() {
         Single<String> s = new Single<String>() {
             @Override
             protected void handleSubscribe(final SingleSource.Subscriber subscriber) {
                 throw DELIBERATE_EXCEPTION;
             }
         };
-        expectedException.expect(instanceOf(ExecutionException.class));
-        expectedException.expectCause(is(DELIBERATE_EXCEPTION));
-        s.toFuture().get();
+        Exception e = assertThrows(ExecutionException.class, () -> s.toFuture().get());
+        assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
     }
 
     @Test
@@ -103,16 +95,15 @@ public class SubscribeThrowsTest {
     }
 
     @Test
-    public void completableSubscriberThrows() throws Exception {
+    public void completableSubscriberThrows() {
         Completable c = new Completable() {
             @Override
             protected void handleSubscribe(final CompletableSource.Subscriber subscriber) {
                 throw DELIBERATE_EXCEPTION;
             }
         };
-        expectedException.expect(instanceOf(ExecutionException.class));
-        expectedException.expectCause(is(DELIBERATE_EXCEPTION));
-        c.toFuture().get();
+        Exception e = assertThrows(ExecutionException.class, () -> c.toFuture().get());
+        assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TakePublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TakePublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -25,7 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TakePublisherTest {
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TakeUntilPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TakeUntilPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -25,7 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TakeUntilPublisherTest {
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TakeWhilePublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TakeWhilePublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -25,7 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TakeWhilePublisherTest {
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestCompletableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -29,11 +27,10 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestCompletableTest {
-
-    @Rule
-    public final ExpectedException expected = ExpectedException.none();
 
     private final TestCompletableSubscriber subscriber1 = new TestCompletableSubscriber();
     private final TestCompletableSubscriber subscriber2 = new TestCompletableSubscriber();
@@ -51,11 +48,11 @@ public class TestCompletableTest {
         subscriber1.awaitOnComplete();
 
         source.subscribe(subscriber2);
-        expected.expect(RuntimeException.class);
-        expected.expectMessage("Unexpected exception(s) encountered");
-        expected.expectCause(allOf(instanceOf(IllegalStateException.class), hasProperty("message",
-                startsWith("Duplicate subscriber"))));
-        source.onComplete();
+
+        Exception e = assertThrows(RuntimeException.class, () -> source.onComplete());
+        assertEquals("Unexpected exception(s) encountered", e.getMessage());
+        assertThat(e.getCause(), allOf(instanceOf(IllegalStateException.class),
+                hasProperty("message", startsWith("Duplicate subscriber"))));
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestExecutorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -25,8 +25,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestExecutorTest {
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,7 @@ import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
@@ -39,11 +37,10 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestPublisherTest {
-    @Rule
-    public final ExpectedException expected = ExpectedException.none();
 
     private final TestPublisherSubscriber<String> subscriber1 = new TestPublisherSubscriber<>();
     private final TestPublisherSubscriber<String> subscriber2 = new TestPublisherSubscriber<>();
@@ -61,11 +58,12 @@ public class TestPublisherTest {
         subscriber1.awaitOnComplete();
 
         source.subscribe(subscriber2);
-        expected.expect(RuntimeException.class);
-        expected.expectMessage("Unexpected exception(s) encountered");
-        expected.expectCause(allOf(instanceOf(IllegalStateException.class), hasProperty("message",
-                startsWith("Duplicate subscriber"))));
-        source.onComplete();
+
+        Exception e = assertThrows(RuntimeException.class, () -> source.onComplete());
+        assertEquals("Unexpected exception(s) encountered", e.getMessage());
+        assertThat(e.getCause(), allOf(instanceOf(IllegalStateException.class),
+                                       hasProperty("message",
+                                                   startsWith("Duplicate subscriber"))));
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestSingleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
@@ -27,11 +25,10 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestSingleTest {
-
-    @Rule
-    public final ExpectedException expected = ExpectedException.none();
 
     private final TestSingleSubscriber<String> subscriber1 = new TestSingleSubscriber<>();
     private final TestSingleSubscriber<String> subscriber2 = new TestSingleSubscriber<>();
@@ -49,11 +46,12 @@ public class TestSingleTest {
         assertThat(subscriber1.awaitOnSuccess(), is("a"));
 
         source.subscribe(subscriber2);
-        expected.expect(RuntimeException.class);
-        expected.expectMessage("Unexpected exception(s) encountered");
-        expected.expectCause(allOf(instanceOf(IllegalStateException.class), hasProperty("message",
-                startsWith("Duplicate subscriber"))));
-        source.onSuccess("b");
+
+        Exception e = assertThrows(RuntimeException.class, () -> source.onSuccess("b"));
+        assertEquals("Unexpected exception(s) encountered", e.getMessage());
+        assertThat(e.getCause(), allOf(instanceOf(IllegalStateException.class),
+                                       hasProperty("message",
+                                                   startsWith("Duplicate subscriber"))));
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenCancelTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenCancelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,22 +17,21 @@ package io.servicetalk.concurrent.api.completable;
 
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.LegacyTestCompletable;
+import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 
 public abstract class AbstractWhenCancelTest {
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
     final TestCompletableSubscriber listener = new TestCompletableSubscriber();
 
     @Test
@@ -47,17 +46,18 @@ public abstract class AbstractWhenCancelTest {
 
     @Test
     public void testCallbackThrowsError() {
-        thrown.expect(is(sameInstance(DELIBERATE_EXCEPTION)));
-
         LegacyTestCompletable completable = new LegacyTestCompletable();
-        try {
-            toSource(doCancel(completable, () -> {
-                throw DELIBERATE_EXCEPTION;
-            })).subscribe(listener);
-            listener.awaitSubscription().cancel();
-        } finally {
-            completable.verifyCancelled();
-        }
+        DeliberateException e = assertThrows(DELIBERATE_EXCEPTION.getClass(), () -> {
+            try {
+                toSource(doCancel(completable, () -> {
+                    throw DELIBERATE_EXCEPTION;
+                })).subscribe(listener);
+                listener.awaitSubscription().cancel();
+            } finally {
+                completable.verifyCancelled();
+            }
+        });
+        assertThat(e, is(sameInstance(DELIBERATE_EXCEPTION)));
     }
 
     protected abstract Completable doCancel(Completable completable, Runnable runnable);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenCancelTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenCancelTest.java
@@ -47,7 +47,7 @@ public abstract class AbstractWhenCancelTest {
     @Test
     public void testCallbackThrowsError() {
         LegacyTestCompletable completable = new LegacyTestCompletable();
-        DeliberateException e = assertThrows(DELIBERATE_EXCEPTION.getClass(), () -> {
+        DeliberateException e = assertThrows(DeliberateException.class, () -> {
             try {
                 toSource(doCancel(completable, () -> {
                     throw DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenFinallyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,26 +18,23 @@ package io.servicetalk.concurrent.api.completable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.LegacyTestCompletable;
 import io.servicetalk.concurrent.api.TerminalSignalConsumer;
+import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 abstract class AbstractWhenFinallyTest {
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
     final TestCompletableSubscriber listener = new TestCompletableSubscriber();
     private final TerminalSignalConsumer doFinally = mock(TerminalSignalConsumer.class);
 
@@ -59,7 +56,7 @@ abstract class AbstractWhenFinallyTest {
 
     @Test
     public void testForCancelPostError() {
-        toSource(doFinally(Completable.<String>failed(DELIBERATE_EXCEPTION), doFinally)).subscribe(listener);
+        toSource(doFinally(Completable.failed(DELIBERATE_EXCEPTION), doFinally)).subscribe(listener);
         listener.awaitSubscription().cancel();
         verify(doFinally).onError(DELIBERATE_EXCEPTION);
         verifyNoMoreInteractions(doFinally);
@@ -76,7 +73,7 @@ abstract class AbstractWhenFinallyTest {
 
     @Test
     public void testForError() {
-        toSource(doFinally(Completable.<String>failed(DELIBERATE_EXCEPTION), doFinally)).subscribe(listener);
+        toSource(doFinally(Completable.failed(DELIBERATE_EXCEPTION), doFinally)).subscribe(listener);
         assertThat(listener.awaitOnError(), is(DELIBERATE_EXCEPTION));
         verify(doFinally).onError(DELIBERATE_EXCEPTION);
         verifyNoMoreInteractions(doFinally);
@@ -88,9 +85,8 @@ abstract class AbstractWhenFinallyTest {
         LegacyTestCompletable completable = new LegacyTestCompletable();
         try {
             toSource(doFinally(completable, mock)).subscribe(listener);
-            thrown.expect(is(sameInstance(DELIBERATE_EXCEPTION)));
-            listener.awaitSubscription().cancel();
-            fail();
+            Exception e = assertThrows(DeliberateException.class, () -> listener.awaitSubscription().cancel());
+            assertThat(e, is(sameInstance(DELIBERATE_EXCEPTION)));
         } finally {
             completable.verifyCancelled();
             verify(mock).cancel();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenOnCompleteTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenOnCompleteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api.completable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static org.mockito.Mockito.mock;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenOnErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenOnErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api.completable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.function.Consumer;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenOnSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenOnSubscribeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,8 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 
@@ -32,14 +30,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public abstract class AbstractWhenOnSubscribeTest {
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
     final TestCompletableSubscriber listener = new TestCompletableSubscriber();
     private Consumer<Cancellable> doOnListen;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         doOnListen = mock(Consumer.class);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenSubscriberTest.java
@@ -18,12 +18,10 @@ package io.servicetalk.concurrent.api.completable;
 import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.internal.DeliberateException;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.function.Supplier;
 
@@ -35,11 +33,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public abstract class AbstractWhenSubscriberTest {
     final TestCompletableSubscriber listener = new TestCompletableSubscriber();
     private CompletableSource.Subscriber subscriber;
-    @SuppressWarnings("unchecked")
+
     @BeforeEach
     public void setUp() {
         subscriber = mock(CompletableSource.Subscriber.class);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,12 @@ package io.servicetalk.concurrent.api.completable;
 import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.internal.DeliberateException;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.function.Supplier;
 
@@ -36,15 +35,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public abstract class AbstractWhenSubscriberTest {
     final TestCompletableSubscriber listener = new TestCompletableSubscriber();
     private CompletableSource.Subscriber subscriber;
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         subscriber = mock(CompletableSource.Subscriber.class);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterCompleteTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterCompleteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,17 +17,12 @@ package io.servicetalk.concurrent.api.completable;
 
 import io.servicetalk.concurrent.api.Completable;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 
 public class AfterCompleteTest extends AbstractWhenOnCompleteTest {
-
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
 
     @Override
     protected Completable doComplete(Completable completable, Runnable runnable) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,7 @@ package io.servicetalk.concurrent.api.completable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.internal.DeliberateException;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 
@@ -30,9 +28,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class AfterErrorTest extends AbstractWhenOnErrorTest {
-
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
 
     @Override
     protected Completable doError(Completable completable, Consumer<Throwable> consumer) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterFinallyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.TerminalSignalConsumer;
 import io.servicetalk.concurrent.internal.DeliberateException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterSubscribeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api.completable;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.Completable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeCompleteTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeCompleteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api.completable;
 
 import io.servicetalk.concurrent.api.Completable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api.completable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.internal.DeliberateException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeFinallyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.TerminalSignalConsumer;
 import io.servicetalk.concurrent.internal.DeliberateException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeSubscribeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.CompletableSource.Subscriber;
 import io.servicetalk.concurrent.api.Completable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CollectTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CollectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,10 @@
  */
 package io.servicetalk.concurrent.api.completable;
 
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -33,12 +32,10 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class CollectTest {
-
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
 
     @Test
     public void collectVarArgSuccess() throws Exception {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CollectTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CollectTest.java
@@ -15,10 +15,7 @@
  */
 package io.servicetalk.concurrent.api.completable;
 
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
-
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -34,7 +31,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class CollectTest {
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithCompletableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ import io.servicetalk.concurrent.api.TestCancellable;
 import io.servicetalk.concurrent.api.TestCompletable;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -28,8 +28,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CompletableConcatWithCompletableTest {
 
@@ -37,8 +37,8 @@ public class CompletableConcatWithCompletableTest {
     private TestCompletable source;
     private TestCompletable next;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         subscriber = new TestCompletableSubscriber();
         source = new TestCompletable();
         next = new TestCompletable();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithPublisherTest.java
@@ -19,12 +19,10 @@ import io.servicetalk.concurrent.api.TestCancellable;
 import io.servicetalk.concurrent.api.TestCompletable;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -36,7 +34,6 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class CompletableConcatWithPublisherTest {
     private TestPublisherSubscriber<Integer> subscriber;
     private TestCompletable source;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,12 @@ import io.servicetalk.concurrent.api.TestCancellable;
 import io.servicetalk.concurrent.api.TestCompletable;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -34,21 +33,19 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class CompletableConcatWithPublisherTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
     private TestPublisherSubscriber<Integer> subscriber;
     private TestCompletable source;
     private TestPublisher<Integer> next;
     private TestSubscription subscription;
     private TestCancellable cancellable;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         subscriber = new TestPublisherSubscriber<>();
         cancellable = new TestCancellable();
         source = new TestCompletable.Builder().disableAutoOnSubscribe().build();
@@ -143,17 +140,17 @@ public class CompletableConcatWithPublisherTest {
     public void sourceError() {
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
-        assertFalse("Next source subscribed unexpectedly.", next.isSubscribed());
+        assertFalse(next.isSubscribed(), "Next source subscribed unexpectedly.");
     }
 
     @Test
     public void cancelSource() {
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
-        assertTrue("Original completable not cancelled.", cancellable.isCancelled());
-        assertFalse("Next source subscribed unexpectedly.", next.isSubscribed());
+        assertTrue(cancellable.isCancelled(), "Original completable not cancelled.");
+        assertFalse(next.isSubscribed(), "Next source subscribed unexpectedly.");
         triggerNextSubscribe();
-        assertTrue("Next source not cancelled.", subscription.isCancelled());
+        assertTrue(subscription.isCancelled(), "Next source not cancelled.");
     }
 
     @Test
@@ -161,8 +158,8 @@ public class CompletableConcatWithPublisherTest {
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(1);
         subscriber.awaitSubscription().cancel();
-        assertTrue("Original completable not cancelled.", cancellable.isCancelled());
-        assertFalse("Next source subscribed unexpectedly.", next.isSubscribed());
+        assertTrue(cancellable.isCancelled(), "Original completable not cancelled.");
+        assertFalse(next.isSubscribed(), "Next source subscribed unexpectedly.");
     }
 
     @Test
@@ -170,8 +167,8 @@ public class CompletableConcatWithPublisherTest {
         triggerNextSubscribe();
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
-        assertFalse("Original completable cancelled unexpectedly.", cancellable.isCancelled());
-        assertTrue("Next source not cancelled.", subscription.isCancelled());
+        assertFalse(cancellable.isCancelled(), "Original completable cancelled unexpectedly.");
+        assertTrue(subscription.isCancelled(), "Next source not cancelled.");
     }
 
     private void triggerNextSubscribe() {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithSingleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import io.servicetalk.concurrent.api.TestCompletable;
 import io.servicetalk.concurrent.api.TestSingle;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -30,8 +30,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CompletableConcatWithSingleTest {
 
@@ -39,8 +39,8 @@ public class CompletableConcatWithSingleTest {
     private TestCompletable source;
     private TestSingle<Integer> next;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         subscriber = new TestSingleSubscriber<>();
         source = new TestCompletable();
         next = new TestSingle<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableDeferTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableDeferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package io.servicetalk.concurrent.api.completable;
 import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.api.Completable;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Supplier;
 
@@ -36,8 +36,8 @@ public class CompletableDeferTest {
 
     private Supplier<Completable> factory;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         @SuppressWarnings("unchecked")
         Supplier<Completable> mock = mock(Supplier.class);
         when(mock.get()).thenReturn(completed());
@@ -45,7 +45,7 @@ public class CompletableDeferTest {
     }
 
     @Test
-    public void testEverySubscribeCreatesNew() throws Exception {
+    public void testEverySubscribeCreatesNew() {
         Completable source = Completable.defer(factory);
         listenAndVerify(source);
         listenAndVerify(source);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToCompletionStageTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToCompletionStageTest.java
@@ -16,13 +16,11 @@
 package io.servicetalk.concurrent.api.completable;
 
 import io.servicetalk.concurrent.api.LegacyTestCompletable;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
@@ -37,7 +35,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class CompletableToCompletionStageTest {
     private static ExecutorService jdkExecutor;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToPublisherTest.java
@@ -16,14 +16,13 @@
 package io.servicetalk.concurrent.api.completable;
 
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.TestCancellable;
 import io.servicetalk.concurrent.api.TestCompletable;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -38,10 +37,9 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class CompletableToPublisherTest {
     @RegisterExtension
-    public final ExecutorExtension executorExtension = ExecutorExtension.newExtension();
+    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
 
     private TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,15 @@
 package io.servicetalk.concurrent.api.completable;
 
 import io.servicetalk.concurrent.api.Completable;
-import io.servicetalk.concurrent.api.ExecutorRule;
+import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.TestCancellable;
 import io.servicetalk.concurrent.api.TestCompletable;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
@@ -38,11 +38,10 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class CompletableToPublisherTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExecutorRule executorRule = ExecutorRule.newRule();
+    @RegisterExtension
+    public final ExecutorExtension executorExtension = ExecutorExtension.newExtension();
 
     private TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
 
@@ -78,7 +77,7 @@ public class CompletableToPublisherTest {
             }
         })
                 .afterCancel(analyzed::countDown)
-                .subscribeOn(executorRule.executor())
+                .subscribeOn(executorExtension.executor())
                 .<String>toPublisher())
                 .subscribe(subscriber);
         TestCancellable cancellable = new TestCancellable();
@@ -134,7 +133,7 @@ public class CompletableToPublisherTest {
         final Thread testThread = currentThread();
         CountDownLatch analyzed = new CountDownLatch(1);
         CountDownLatch receivedOnSubscribe = new CountDownLatch(1);
-        toSource(completable.publishOn(executorRule.executor())
+        toSource(completable.publishOn(executorExtension.executor())
                 .beforeOnComplete(() -> {
                     if (currentThread() == testThread) {
                         errors.add(new AssertionError("Invalid thread invoked onComplete " +

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToSingleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 package io.servicetalk.concurrent.api.completable;
 
 import io.servicetalk.concurrent.api.Completable;
-import io.servicetalk.concurrent.api.ExecutorRule;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.api.ExecutorExtension;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
@@ -33,11 +33,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class CompletableToSingleTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExecutorRule executorRule = ExecutorRule.newRule();
+    @RegisterExtension
+    public final ExecutorExtension executorExtension = ExecutorExtension.newExtension();
 
     private TestSingleSubscriber<Void> subscriber = new TestSingleSubscriber<>();
 
@@ -58,7 +57,7 @@ public class CompletableToSingleTest {
                         currentThread()));
             }
             analyzed.countDown();
-        }).subscribeOn(executorRule.executor()).toSingle().subscribe(__ -> { }).cancel();
+        }).subscribeOn(executorExtension.executor()).toSingle().subscribe(__ -> { }).cancel();
         analyzed.await();
         assertThat("Unexpected errors observed: " + errors, errors, hasSize(0));
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToSingleTest.java
@@ -16,12 +16,11 @@
 package io.servicetalk.concurrent.api.completable;
 
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ExecutorExtension;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -33,10 +32,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class CompletableToSingleTest {
     @RegisterExtension
-    public final ExecutorExtension executorExtension = ExecutorExtension.newExtension();
+    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
 
     private TestSingleSubscriber<Void> subscriber = new TestSingleSubscriber<>();
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/RepeatTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/RepeatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.concurrent.api.completable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.function.Function;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/RunnableCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/RunnableCompletableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.api.Completable;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 
@@ -38,8 +38,8 @@ public class RunnableCompletableTest {
 
     private Runnable factory;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         factory = mock(Runnable.class);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/SimpleSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/SimpleSubscribeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.concurrent.api.completable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.concurrent.CountDownLatch;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/SubscribeShareContextTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/SubscribeShareContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.concurrent.api.AsyncContextMap;
 import io.servicetalk.concurrent.api.Completable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/SubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/SubscribeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,15 +18,15 @@ package io.servicetalk.concurrent.api.completable;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.LegacyTestCompletable;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public final class SubscribeTest {
 
     private LegacyTestCompletable source;
     private Cancellable cancellable;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         source = new LegacyTestCompletable();
         cancellable = source.subscribe();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/TimeoutCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/TimeoutCompletableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,17 +20,17 @@ import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.CompletableSource.Subscriber;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.DelegatingExecutor;
-import io.servicetalk.concurrent.api.ExecutorRule;
+import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.TestCancellable;
 import io.servicetalk.concurrent.api.TestExecutor;
 import io.servicetalk.concurrent.api.TestSingle;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -44,23 +44,22 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class TimeoutCompletableTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExecutorRule<TestExecutor> executorRule = ExecutorRule.withTestExecutor();
+    @RegisterExtension
+    public final ExecutorExtension<TestExecutor> executorExtension = ExecutorExtension.withTestExecutor();
     private final TestCompletableSubscriber listener = new TestCompletableSubscriber();
     private final TestSingle<Integer> source = new TestSingle<>();
     private TestExecutor testExecutor;
 
-    @Before
+    @BeforeEach
     public void setup() {
-        testExecutor = executorRule.executor();
+        testExecutor = executorExtension.executor();
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/TimeoutCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/TimeoutCompletableTest.java
@@ -24,12 +24,10 @@ import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.TestCancellable;
 import io.servicetalk.concurrent.api.TestExecutor;
 import io.servicetalk.concurrent.api.TestSingle;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.TimeUnit;
@@ -49,7 +47,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class TimeoutCompletableTest {
     @RegisterExtension
     public final ExecutorExtension<TestExecutor> executorExtension = ExecutorExtension.withTestExecutor();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenCancelTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenCancelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,24 +19,21 @@ import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
+import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public abstract class AbstractWhenCancelTest {
-
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
 
     private final TestPublisher<String> publisher = new TestPublisher<>();
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
@@ -67,17 +64,19 @@ public abstract class AbstractWhenCancelTest {
 
     @Test
     public void testCallbackThrowsError() {
-        thrown.expect(is(sameInstance(DELIBERATE_EXCEPTION)));
+        Exception e = assertThrows(DeliberateException.class, () -> {
 
-        try {
-            doCancel(publisher, () -> {
-                throw DELIBERATE_EXCEPTION;
-            }).subscribe(subscriber);
-            publisher.onSubscribe(subscription);
-            subscriber.awaitSubscription().cancel();
-        } finally {
-            assertTrue(subscription.isCancelled());
-        }
+            try {
+                doCancel(publisher, () -> {
+                    throw DELIBERATE_EXCEPTION;
+                }).subscribe(subscriber);
+                publisher.onSubscribe(subscription);
+                subscriber.awaitSubscription().cancel();
+            } finally {
+                assertTrue(subscription.isCancelled());
+            }
+        });
+        assertThat(e, is(sameInstance(DELIBERATE_EXCEPTION)));
     }
 
     protected abstract <T> PublisherSource<T> doCancel(Publisher<T> publisher, Runnable runnable);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenFinallyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,28 +20,24 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TerminalSignalConsumer;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
+import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 abstract class AbstractWhenFinallyTest {
-
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
 
     final TestPublisher<String> publisher = new TestPublisher<>();
     final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
@@ -155,9 +151,8 @@ abstract class AbstractWhenFinallyTest {
         try {
             doFinally(publisher, mock).subscribe(subscriber);
             publisher.onSubscribe(subscription);
-            thrown.expect(is(sameInstance(DELIBERATE_EXCEPTION)));
-            subscriber.awaitSubscription().cancel();
-            fail();
+            Exception e = assertThrows(DeliberateException.class, () -> subscriber.awaitSubscription().cancel());
+            assertThat(e, is(sameInstance(DELIBERATE_EXCEPTION)));
         } finally {
             verify(mock).cancel();
             verifyNoMoreInteractions(mock);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenOnCompleteTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenOnCompleteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenOnErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenOnErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 
@@ -33,9 +31,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public abstract class AbstractWhenOnErrorTest {
-
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
 
     private final TestPublisher<String> publisher = new TestPublisher<>();
     final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenOnNextTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenOnNextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,7 @@ package io.servicetalk.concurrent.api.publisher;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 
@@ -32,9 +30,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public abstract class AbstractWhenOnNextTest {
-
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
 
     final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenOnSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenOnSubscribeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,8 @@ import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 
@@ -36,15 +34,12 @@ import static org.mockito.Mockito.verify;
 
 public abstract class AbstractWhenOnSubscribeTest {
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
     private Consumer<Subscription> doOnSubscribe;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         doOnSubscribe = mock(Consumer.class);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenRequestTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,10 @@ package io.servicetalk.concurrent.api.publisher;
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TestPublisher;
+import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.LongConsumer;
 
@@ -32,14 +31,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public abstract class AbstractWhenRequestTest {
-
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
 
     private final TestPublisher<String> publisher = new TestPublisher<>();
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
@@ -83,12 +80,12 @@ public abstract class AbstractWhenRequestTest {
 
     @Test
     public void testCallbackThrowsError() {
-        thrown.expect(is(sameInstance(DELIBERATE_EXCEPTION)));
-
         doRequest(Publisher.from("Hello"), n -> {
             throw DELIBERATE_EXCEPTION;
         }).subscribe(subscriber);
-        subscriber.awaitSubscription().request(1);
+
+        Exception e = assertThrows(DeliberateException.class, () -> subscriber.awaitSubscription().request(1));
+        assertThat(e, is(sameInstance(DELIBERATE_EXCEPTION)));
     }
 
     protected abstract <T> PublisherSource<T> doRequest(Publisher<T> publisher, LongConsumer consumer);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenSubscriberTest.java
@@ -18,11 +18,9 @@ package io.servicetalk.concurrent.api.publisher;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.internal.DeliberateException;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.function.Supplier;
 
@@ -36,7 +34,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public abstract class AbstractWhenSubscriberTest {
     @SuppressWarnings("unchecked")
     private final Subscriber<String> subscriber = (Subscriber<String>) mock(Subscriber.class);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,11 @@ package io.servicetalk.concurrent.api.publisher;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.internal.DeliberateException;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.function.Supplier;
 
@@ -37,9 +36,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public abstract class AbstractWhenSubscriberTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
     @SuppressWarnings("unchecked")
     private final Subscriber<String> subscriber = (Subscriber<String>) mock(Subscriber.class);
     private final TestPublisherSubscriber<String> finalSubscriber = new TestPublisherSubscriber<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,7 @@ import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.internal.DeliberateException;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 
@@ -31,9 +29,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class AfterErrorTest extends AbstractWhenOnErrorTest {
-
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
 
     @Override
     protected <T> PublisherSource<T> doError(Publisher<T> publisher, Consumer<Throwable> consumer) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterFinallyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,15 +20,15 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TerminalSignalConsumer;
 import io.servicetalk.concurrent.internal.DeliberateException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -45,9 +45,8 @@ public class AfterFinallyTest extends AbstractWhenFinallyTest {
         try {
             doFinally(publisher, mock).subscribe(subscriber);
             assertFalse(subscription.isCancelled());
-            thrown.expect(is(sameInstance(DELIBERATE_EXCEPTION)));
-            publisher.onComplete();
-            fail();
+            Exception e = assertThrows(DeliberateException.class, () -> publisher.onComplete());
+            assertThat(e, is(sameInstance(DELIBERATE_EXCEPTION)));
         } finally {
             subscriber.awaitOnComplete();
             verify(mock).onComplete();
@@ -63,9 +62,8 @@ public class AfterFinallyTest extends AbstractWhenFinallyTest {
         TerminalSignalConsumer mock = throwableMock(exception);
         try {
             doFinally(publisher, mock).subscribe(subscriber);
-            thrown.expect(is(sameInstance(exception)));
-            publisher.onError(DELIBERATE_EXCEPTION);
-            fail();
+            Exception e = assertThrows(DeliberateException.class, () -> publisher.onError(DELIBERATE_EXCEPTION));
+            assertThat(e, is(sameInstance(exception)));
         } finally {
             assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
             verify(mock).onError(DELIBERATE_EXCEPTION);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterNextTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterNextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api.publisher;
 
 import io.servicetalk.concurrent.api.Publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterSubscribeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api.publisher;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.api.Publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.internal.DeliberateException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeFinallyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TerminalSignalConsumer;
 import io.servicetalk.concurrent.internal.DeliberateException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -28,7 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeNextTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeNextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api.publisher;
 
 import io.servicetalk.concurrent.api.Publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeSubscribeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.api.Publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/ForEachTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/ForEachTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -38,7 +38,7 @@ public final class ForEachTest {
     private TestSubscription subscription = new TestSubscription();
 
     @SuppressWarnings("unchecked")
-    @Before
+    @BeforeEach
     public void setUp() {
         source = new TestPublisher.Builder<Integer>().disableAutoOnSubscribe().build();
         forEach = (Consumer<Integer>) mock(Consumer.class);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromArrayPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromArrayPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,11 @@ package io.servicetalk.concurrent.api.publisher;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class FromArrayPublisherTest extends FromInMemoryPublisherAbstractTest {
     @Override
@@ -35,11 +36,11 @@ public final class FromArrayPublisherTest extends FromInMemoryPublisherAbstractT
         };
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testEmptyInvalidRequestAfterCompleteDoesNotDeliverOnError() {
         InMemorySource source = newSource(0);
         toSource(source.publisher()).subscribe(subscriber);
         subscriber.awaitOnComplete();
-        subscriber.awaitSubscription().request(-1);
+        assertThrows(IllegalArgumentException.class, () -> subscriber.awaitSubscription().request(-1));
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromBlockingIterableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromBlockingIterableTest.java
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TestIterableToBlockingIterable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -33,7 +33,7 @@ import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FromBlockingIterableTest extends FromInMemoryPublisherAbstractTest {
     @Override

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromInMemoryPublisherAbstractTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromInMemoryPublisherAbstractTest.java
@@ -21,7 +21,7 @@ import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -40,9 +40,9 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class FromInMemoryPublisherAbstractTest {
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromSingleItemPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromSingleItemPublisherTest.java
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api.publisher;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubCompletableOrErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubCompletableOrErrorTest.java
@@ -16,11 +16,9 @@
 package io.servicetalk.concurrent.api.publisher;
 
 import io.servicetalk.concurrent.api.TestPublisher;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.Publisher.failed;
@@ -32,7 +30,6 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PubCompletableOrErrorTest {
     private final TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubCompletableOrErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubCompletableOrErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,11 @@
 package io.servicetalk.concurrent.api.publisher;
 
 import io.servicetalk.concurrent.api.TestPublisher;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.Publisher.failed;
@@ -30,12 +29,11 @@ import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PubCompletableOrErrorTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
     private final TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubFirstOrErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubFirstOrErrorTest.java
@@ -15,13 +15,12 @@
  */
 package io.servicetalk.concurrent.api.publisher;
 
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.TestPublisher;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.NoSuchElementException;
@@ -35,10 +34,9 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PubFirstOrErrorTest {
     @RegisterExtension
-    public final ExecutorExtension executorExtension = ExecutorExtension.newExtension();
+    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
     private final TestSingleSubscriber<String> listenerRule = new TestSingleSubscriber<>();
     private final TestPublisher<String> publisher = new TestPublisher<>();
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubFirstOrErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubFirstOrErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
  */
 package io.servicetalk.concurrent.api.publisher;
 
-import io.servicetalk.concurrent.api.ExecutorRule;
+import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.TestPublisher;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.NoSuchElementException;
 
@@ -35,11 +35,10 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PubFirstOrErrorTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExecutorRule executorRule = ExecutorRule.newRule();
+    @RegisterExtension
+    public final ExecutorExtension executorExtension = ExecutorExtension.newExtension();
     private final TestSingleSubscriber<String> listenerRule = new TestSingleSubscriber<>();
     private final TestPublisher<String> publisher = new TestPublisher<>();
 
@@ -58,7 +57,7 @@ public class PubFirstOrErrorTest {
     @Test
     public void asyncSingleItemCompleted() throws Exception {
         toSource(publisher.firstOrError()).subscribe(listenerRule);
-        executorRule.executor().submit(() -> {
+        executorExtension.executor().submit(() -> {
             publisher.onNext("hello");
             publisher.onComplete();
         }).toFuture().get();
@@ -68,7 +67,7 @@ public class PubFirstOrErrorTest {
     @Test
     public void asyncMultipleItemCompleted() throws Exception {
         toSource(publisher.firstOrError()).subscribe(listenerRule);
-        executorRule.executor().submit(() -> {
+        executorExtension.executor().submit(() -> {
             publisher.onNext("foo", "bar");
             publisher.onComplete();
         }).toFuture().get();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToCompletableIgnoreTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToCompletableIgnoreTest.java
@@ -17,14 +17,13 @@ package io.servicetalk.concurrent.api.publisher;
 
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.api.DeferredEmptySubscription;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.internal.TerminalNotification;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -39,10 +38,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PubToCompletableIgnoreTest {
     @RegisterExtension
-    public final ExecutorExtension executorExtension = ExecutorExtension.newExtension();
+    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
     private final TestCompletableSubscriber listenerRule = new TestCompletableSubscriber();
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToCompletableIgnoreTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToCompletableIgnoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +17,15 @@ package io.servicetalk.concurrent.api.publisher;
 
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.api.DeferredEmptySubscription;
-import io.servicetalk.concurrent.api.ExecutorRule;
+import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.internal.TerminalNotification;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
@@ -39,11 +39,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PubToCompletableIgnoreTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExecutorRule executorRule = ExecutorRule.newRule();
+    @RegisterExtension
+    public final ExecutorExtension executorExtension = ExecutorExtension.newExtension();
     private final TestCompletableSubscriber listenerRule = new TestCompletableSubscriber();
 
     @Test
@@ -98,7 +97,7 @@ public class PubToCompletableIgnoreTest {
                         currentThread()));
             }
             analyzed.countDown();
-        }).subscribeOn(executorRule.executor()).ignoreElements().toFuture().get();
+        }).subscribeOn(executorExtension.executor()).ignoreElements().toFuture().get();
         analyzed.await();
         assertThat("Unexpected errors observed: " + errors, errors, hasSize(0));
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToSingleFirstOrElseTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToSingleFirstOrElseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,17 +17,17 @@ package io.servicetalk.concurrent.api.publisher;
 
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.api.DeferredEmptySubscription;
-import io.servicetalk.concurrent.api.ExecutorRule;
+import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.internal.TerminalNotification;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -42,13 +42,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PubToSingleFirstOrElseTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExecutorRule executorRule = ExecutorRule.newRule();
+    @RegisterExtension
+    public final ExecutorExtension executorExtension = ExecutorExtension.newExtension();
     private final TestSingleSubscriber<String> listenerRule = new TestSingleSubscriber<>();
     private final TestPublisher<String> publisher = new TestPublisher<>();
     private final TestSubscription subscription = new TestSubscription();
@@ -131,7 +130,7 @@ public class PubToSingleFirstOrElseTest {
                         currentThread()));
             }
             analyzed.countDown();
-        }).subscribeOn(executorRule.executor()).firstOrElse(() -> {
+        }).subscribeOn(executorExtension.executor()).firstOrElse(() -> {
             throw new NoSuchElementException();
         }).toFuture().get();
         analyzed.await();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToSingleFirstOrElseTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToSingleFirstOrElseTest.java
@@ -17,16 +17,15 @@ package io.servicetalk.concurrent.api.publisher;
 
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.api.DeferredEmptySubscription;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
 import io.servicetalk.concurrent.internal.TerminalNotification;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.NoSuchElementException;
@@ -44,10 +43,9 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PubToSingleFirstOrElseTest {
     @RegisterExtension
-    public final ExecutorExtension executorExtension = ExecutorExtension.newExtension();
+    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
     private final TestSingleSubscriber<String> listenerRule = new TestSingleSubscriber<>();
     private final TestPublisher<String> publisher = new TestPublisher<>();
     private final TestSubscription subscription = new TestSubscription();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherAsInputStreamTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherAsInputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.internal.DeliberateException;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,15 +31,11 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Arrays.copyOfRange;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.rules.ExpectedException.none;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class PublisherAsInputStreamTest {
-
-    @Rule
-    public final ExpectedException expected = none();
 
     private final TestPublisher<String> publisher = new TestPublisher<>();
 
@@ -144,8 +138,7 @@ public final class PublisherAsInputStreamTest {
         Character[] src = {'1', '2', '3', '4'};
         InputStream stream = from(src).toInputStream(c -> new byte[]{(byte) c.charValue()});
         stream.close();
-        expected.expect(instanceOf(IOException.class));
-        stream.read();
+        assertThrows(IOException.class, () -> stream.read());
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherConcatWithCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherConcatWithCompletableTest.java
@@ -21,7 +21,7 @@ import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherConcatWithSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherConcatWithSingleTest.java
@@ -21,7 +21,7 @@ import io.servicetalk.concurrent.api.TestSingle;
 import io.servicetalk.concurrent.api.TestSubscription;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherDeferTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherDeferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package io.servicetalk.concurrent.api.publisher;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.api.Publisher;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Supplier;
 
@@ -37,14 +37,14 @@ public class PublisherDeferTest {
     private Supplier<Publisher<Integer>> factory;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         factory = mock(Supplier.class);
         when(factory.get()).thenReturn(empty());
     }
 
     @Test
-    public void testEverySubscribeCreatesNew() throws Exception {
+    public void testEverySubscribeCreatesNew() {
         Publisher<Integer> source = Publisher.defer(factory);
         subscribeAndVerify(source);
         subscribeAndVerify(source);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherToCompletionStageTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherToCompletionStageTest.java
@@ -16,12 +16,10 @@
 package io.servicetalk.concurrent.api.publisher;
 
 import io.servicetalk.concurrent.api.TestPublisher;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collection;
 import java.util.concurrent.CompletionStage;
@@ -38,7 +36,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class PublisherToCompletionStageTest {
 
     private final TestPublisher<String> publisher = new TestPublisher<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RangeIntPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RangeIntPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api.publisher;
 
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.Publisher.range;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.IntPredicate;
 
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -47,8 +47,8 @@ public class RepeatTest {
     private final IntPredicate shouldRepeat = mock(IntPredicate.class);
     private boolean shouldRepeatValue;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         when(shouldRepeat.test(anyInt())).thenAnswer(invocation -> shouldRepeatValue);
         toSource(source.repeat(shouldRepeat)).subscribe(subscriber);
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatWhenTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatWhenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@ import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.function.IntFunction;
@@ -41,8 +41,8 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -57,7 +57,7 @@ public class RepeatWhenTest {
     private LegacyTestCompletable repeatSignal;
     private Executor executor;
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (executor != null) {
             executor.closeAsync().toFuture().get();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RetryTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@ import io.servicetalk.concurrent.api.TestSubscription;
 import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -32,9 +32,9 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -51,8 +51,8 @@ public class RetryTest {
     private boolean shouldRetryValue;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         source = new TestPublisher<>();
         shouldRetry = (BiIntPredicate<Throwable>) mock(BiIntPredicate.class);
         when(shouldRetry.test(anyInt(), any())).thenAnswer(invocation -> shouldRetryValue);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/ScalarResultPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/ScalarResultPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api.publisher;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/SubscribeShareContextTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/SubscribeShareContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.concurrent.api.AsyncContextMap;
 import io.servicetalk.concurrent.api.Publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 import javax.annotation.Nullable;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/TimeoutPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/TimeoutPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,18 +21,18 @@ import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.DelegatingExecutor;
 import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.concurrent.api.ExecutorRule;
+import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TestExecutor;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
@@ -53,26 +53,25 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class TimeoutPublisherTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExecutorRule<TestExecutor> executorRule = ExecutorRule.withTestExecutor();
+    @RegisterExtension
+    public final ExecutorExtension<TestExecutor> executorExtension = ExecutorExtension.withTestExecutor();
 
     private final TestPublisher<Integer> publisher = new TestPublisher<>();
     private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
     private final TestSubscription subscription = new TestSubscription();
     private TestExecutor testExecutor;
 
-    @Before
+    @BeforeEach
     public void setup() {
-        testExecutor = executorRule.executor();
+        testExecutor = executorExtension.executor();
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/TimeoutPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/TimeoutPublisherTest.java
@@ -26,12 +26,10 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TestExecutor;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.CountDownLatch;
@@ -59,7 +57,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class TimeoutPublisherTest {
     @RegisterExtension
     public final ExecutorExtension<TestExecutor> executorExtension = ExecutorExtension.withTestExecutor();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractFutureToSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractFutureToSingleTest.java
@@ -18,12 +18,10 @@ package io.servicetalk.concurrent.api.single;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -44,7 +42,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public abstract class AbstractFutureToSingleTest {
     static ExecutorService jdkExecutor;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenFinallyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,10 @@ package io.servicetalk.concurrent.api.single;
 import io.servicetalk.concurrent.api.LegacyTestSingle;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.SingleTerminalSignalConsumer;
+import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
@@ -31,15 +30,13 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 abstract class AbstractWhenFinallyTest {
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
     final TestSingleSubscriber<String> listener = new TestSingleSubscriber<>();
 
     @SuppressWarnings("unchecked")
@@ -94,9 +91,8 @@ abstract class AbstractWhenFinallyTest {
         LegacyTestSingle<String> single = new LegacyTestSingle<>();
         try {
             toSource(doFinally(single, mock)).subscribe(listener);
-            thrown.expect(is(sameInstance(DELIBERATE_EXCEPTION)));
-            listener.awaitSubscription().cancel();
-            fail();
+            Exception e = assertThrows(DeliberateException.class, () -> listener.awaitSubscription().cancel());
+            assertThat(e, is(sameInstance(DELIBERATE_EXCEPTION)));
         } finally {
             single.verifyCancelled();
             verify(mock).cancel();
@@ -105,10 +101,10 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public abstract void testCallbackThrowsErrorOnSuccess() throws InterruptedException;
+    public abstract void testCallbackThrowsErrorOnSuccess();
 
     @Test
-    public abstract void testCallbackThrowsErrorOnError() throws InterruptedException;
+    public abstract void testCallbackThrowsErrorOnError();
 
     protected abstract <T> Single<T> doFinally(Single<T> single, SingleTerminalSignalConsumer<T> signalConsumer);
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenOnErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenOnErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.function.Consumer;
@@ -33,8 +31,6 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.verify;
 
 public abstract class AbstractWhenOnErrorTest {
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
     private final TestSingleSubscriber<String> listener = new TestSingleSubscriber<>();
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenOnSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenOnSubscribeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,8 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 
@@ -34,15 +32,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public abstract class AbstractWhenOnSubscribeTest {
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
     final TestSingleSubscriber<String> listener = new TestSingleSubscriber<>();
 
     private Consumer<Cancellable> doOnListen;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         doOnListen = mock(Consumer.class);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenOnSuccessTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenOnSuccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api.single;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.function.Consumer;
@@ -41,7 +41,7 @@ public abstract class AbstractWhenOnSuccessTest {
     }
 
     @Test
-    public abstract void testCallbackThrowsError() throws InterruptedException;
+    public abstract void testCallbackThrowsError();
 
     protected abstract <T> Single<T> doSuccess(Single<T> single, Consumer<T> consumer);
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Supplier;
 
@@ -39,8 +39,8 @@ public abstract class AbstractWhenSubscriberTest {
     private SingleSource.Subscriber<String> subscriber;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         subscriber = mock(SingleSource.Subscriber.class);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterFinallyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.SingleTerminalSignalConsumer;
 import io.servicetalk.concurrent.internal.DeliberateException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterSubscribeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api.single;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.Single;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterSuccessTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterSuccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,7 @@ package io.servicetalk.concurrent.api.single;
 
 import io.servicetalk.concurrent.api.Single;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 
@@ -29,9 +27,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class AfterSuccessTest extends AbstractWhenOnSuccessTest {
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Override
     protected <T> Single<T> doSuccess(Single<T> single, Consumer<T> consumer) {
         return single.afterOnSuccess(consumer);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeFinallyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.SingleTerminalSignalConsumer;
 import io.servicetalk.concurrent.internal.DeliberateException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeSubscribeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.SingleSource.Subscriber;
 import io.servicetalk.concurrent.api.Single;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeSuccessTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeSuccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api.single;
 
 import io.servicetalk.concurrent.api.Single;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CallableSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CallableSingleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.Single;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -41,8 +41,8 @@ public class CallableSingleTest {
     private Callable<Integer> factory;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         factory = mock(Callable.class);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CollectTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CollectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,10 @@
  */
 package io.servicetalk.concurrent.api.single;
 
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collection;
 import java.util.concurrent.ExecutionException;
@@ -35,12 +34,10 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class CollectTest {
-
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
 
     @Test
     public void collectVarArgSuccess() throws Exception {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CollectTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CollectTest.java
@@ -15,10 +15,7 @@
  */
 package io.servicetalk.concurrent.api.single;
 
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
-
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collection;
 import java.util.concurrent.ExecutionException;
@@ -36,7 +33,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class CollectTest {
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CompletionStageAsyncContextTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CompletionStageAsyncContextTest.java
@@ -17,15 +17,14 @@ package io.servicetalk.concurrent.api.single;
 
 import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.concurrent.api.AsyncContextMap.Key;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.LegacyTestSingle;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.CompletableFuture;
@@ -40,11 +39,10 @@ import static io.servicetalk.concurrent.api.Single.fromStage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class CompletionStageAsyncContextTest {
     private static final Key<Integer> K1 = newKey("k1");
     @RegisterExtension
-    public final ExecutorExtension executorExtension = ExecutorExtension.withNamePrefix(ST_THREAD_PREFIX_NAME);
+    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor(ST_THREAD_PREFIX_NAME);
     private static final String ST_THREAD_PREFIX_NAME = "st-exec-thread";
     private static final String JDK_THREAD_NAME_PREFIX = "jdk-thread";
     private static final AtomicInteger threadCount = new AtomicInteger();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CompletionStageAsyncContextTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CompletionStageAsyncContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,17 +17,16 @@ package io.servicetalk.concurrent.api.single;
 
 import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.concurrent.api.AsyncContextMap.Key;
-import io.servicetalk.concurrent.api.ExecutorRule;
+import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.LegacyTestSingle;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -38,40 +37,37 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static io.servicetalk.concurrent.api.AsyncContextMap.Key.newKey;
 import static io.servicetalk.concurrent.api.Single.fromStage;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class CompletionStageAsyncContextTest {
     private static final Key<Integer> K1 = newKey("k1");
-    @Rule
-    public final ExecutorRule executorRule = ExecutorRule.withNamePrefix(ST_THREAD_PREFIX_NAME);
+    @RegisterExtension
+    public final ExecutorExtension executorExtension = ExecutorExtension.withNamePrefix(ST_THREAD_PREFIX_NAME);
     private static final String ST_THREAD_PREFIX_NAME = "st-exec-thread";
     private static final String JDK_THREAD_NAME_PREFIX = "jdk-thread";
     private static final AtomicInteger threadCount = new AtomicInteger();
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
     private static ExecutorService jdkExecutor;
     private LegacyTestSingle<String> source;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         jdkExecutor = java.util.concurrent.Executors.newCachedThreadPool(
                 r -> new Thread(r, JDK_THREAD_NAME_PREFIX + '-' + threadCount.incrementAndGet()));
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         if (jdkExecutor != null) {
             jdkExecutor.shutdown();
         }
     }
 
-    @Before
+    @BeforeEach
     public void beforeTest() {
         AsyncContext.clear();
-        source = new LegacyTestSingle<>(executorRule.executor(), true, true);
+        source = new LegacyTestSingle<>(executorExtension.executor(), true, true);
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CompletionStageToSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CompletionStageToSingleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,16 @@ package io.servicetalk.concurrent.api.single;
 
 import io.servicetalk.concurrent.api.Single;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import static io.servicetalk.concurrent.api.Single.fromStage;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CompletionStageToSingleTest extends AbstractFutureToSingleTest {
     @Override
@@ -33,12 +35,11 @@ public class CompletionStageToSingleTest extends AbstractFutureToSingleTest {
     }
 
     @Test
-    public void failure() throws Exception {
+    public void failure() {
         CompletableFuture<String> future = new CompletableFuture<>();
         Single<String> single = from(future);
         jdkExecutor.execute(() -> future.completeExceptionally(DELIBERATE_EXCEPTION));
-        thrown.expect(ExecutionException.class);
-        thrown.expectCause(is(DELIBERATE_EXCEPTION));
-        single.toFuture().get();
+        Exception e = assertThrows(ExecutionException.class, () -> single.toFuture().get());
+        assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/ConcatWithCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/ConcatWithCompletableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,15 @@
  */
 package io.servicetalk.concurrent.api.single;
 
-import io.servicetalk.concurrent.api.ExecutorRule;
+import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.LegacyTestCompletable;
 import io.servicetalk.concurrent.api.LegacyTestSingle;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -32,11 +32,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class ConcatWithCompletableTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExecutorRule executorRule = ExecutorRule.newRule();
+    @RegisterExtension
+    public final ExecutorExtension executorExtension = ExecutorExtension.newExtension();
     private final TestSingleSubscriber<String> listener = new TestSingleSubscriber<>();
     private LegacyTestSingle<String> single = new LegacyTestSingle<>();
     private LegacyTestCompletable completable = new LegacyTestCompletable();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/ConcatWithCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/ConcatWithCompletableTest.java
@@ -15,14 +15,13 @@
  */
 package io.servicetalk.concurrent.api.single;
 
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.LegacyTestCompletable;
 import io.servicetalk.concurrent.api.LegacyTestSingle;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
@@ -32,10 +31,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class ConcatWithCompletableTest {
     @RegisterExtension
-    public final ExecutorExtension executorExtension = ExecutorExtension.newExtension();
+    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
     private final TestSingleSubscriber<String> listener = new TestSingleSubscriber<>();
     private LegacyTestSingle<String> single = new LegacyTestSingle<>();
     private LegacyTestCompletable completable = new LegacyTestCompletable();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/FutureToSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/FutureToSingleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api.single;
 
 import io.servicetalk.concurrent.api.Single;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -27,7 +27,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class FutureToSingleTest extends AbstractFutureToSingleTest {
     @Override

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/MapSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/MapSingleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.SourceAdapters;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/ReduceSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/ReduceSingleTest.java
@@ -15,14 +15,13 @@
  */
 package io.servicetalk.concurrent.api.single;
 
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.ArrayList;
@@ -40,10 +39,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class ReduceSingleTest {
     @RegisterExtension
-    public final ExecutorExtension executorExtension = ExecutorExtension.newExtension();
+    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
 
     private final TestSingleSubscriber<String> listenerRule = new TestSingleSubscriber<>();
     private final TestPublisher<String> publisher = new TestPublisher<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/RetryTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/RetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import io.servicetalk.concurrent.api.LegacyTestSingle;
 import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -29,8 +29,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -48,8 +48,8 @@ public class RetryTest {
     private boolean shouldRetryValue;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         setUp(subscriber);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithCompletableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import io.servicetalk.concurrent.api.TestCompletable;
 import io.servicetalk.concurrent.api.TestSingle;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -30,8 +30,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SingleConcatWithCompletableTest {
 
@@ -39,8 +39,8 @@ public class SingleConcatWithCompletableTest {
     private TestSingle<Integer> source;
     private TestCompletable next;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         subscriber = new TestSingleSubscriber<>();
         source = new TestSingle<>();
         next = new TestCompletable();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,13 +20,12 @@ import io.servicetalk.concurrent.api.TestCancellable;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSingle;
 import io.servicetalk.concurrent.api.TestSubscription;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
@@ -40,18 +39,16 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SingleConcatWithPublisherTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
     private TestPublisherSubscriber<Integer> subscriber;
     private TestSingle<Integer> source;
     private TestPublisher<Integer> next;
     private TestSubscription subscription;
     private TestCancellable cancellable;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         subscriber = new TestPublisherSubscriber<>();
         cancellable = new TestCancellable();
         source = new TestSingle.Builder<Integer>().disableAutoOnSubscribe().build();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
@@ -20,12 +20,10 @@ import io.servicetalk.concurrent.api.TestCancellable;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSingle;
 import io.servicetalk.concurrent.api.TestSubscription;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
@@ -39,7 +37,6 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SingleConcatWithPublisherTest {
     private TestPublisherSubscriber<Integer> subscriber;
     private TestSingle<Integer> source;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleDeferTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleDeferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package io.servicetalk.concurrent.api.single;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.Single;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Supplier;
 
@@ -37,14 +37,14 @@ public class SingleDeferTest {
     private Supplier<Single<Integer>> factory;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         factory = mock(Supplier.class);
         when(factory.get()).thenReturn(succeeded(1));
     }
 
     @Test
-    public void testEverySubscribeCreatesNew() throws Exception {
+    public void testEverySubscribeCreatesNew() {
         Single<Integer> source = Single.defer(factory);
         listenAndVerify(source);
         listenAndVerify(source);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleFlatMapCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleFlatMapCompletableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import io.servicetalk.concurrent.api.LegacyTestSingle;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Completable.failed;
@@ -38,7 +38,7 @@ public final class SingleFlatMapCompletableTest {
     private LegacyTestSingle<String> single;
     private LegacyTestCompletable completable;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         single = new LegacyTestSingle<>();
         completable = new LegacyTestCompletable();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleFlatMapPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleFlatMapPublisherTest.java
@@ -15,17 +15,16 @@
  */
 package io.servicetalk.concurrent.api.single;
 
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.LegacyTestSingle;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -48,10 +47,9 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public final class SingleFlatMapPublisherTest {
     @RegisterExtension
-    public final ExecutorExtension executorExtension = ExecutorExtension.newExtension();
+    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
 
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
     private final TestPublisher<String> publisher = new TestPublisher.Builder<String>()

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleFlatMapPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleFlatMapPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,18 @@
  */
 package io.servicetalk.concurrent.api.single;
 
-import io.servicetalk.concurrent.api.ExecutorRule;
+import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.LegacyTestSingle;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
@@ -45,14 +45,13 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public final class SingleFlatMapPublisherTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExecutorRule executorRule = ExecutorRule.newRule();
+    @RegisterExtension
+    public final ExecutorExtension executorExtension = ExecutorExtension.newExtension();
 
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
     private final TestPublisher<String> publisher = new TestPublisher.Builder<String>()
@@ -164,7 +163,7 @@ public final class SingleFlatMapPublisherTest {
                     }
                     analyzed.countDown();
                 })
-                .subscribeOn(executorRule.executor())
+                .subscribeOn(executorExtension.executor())
                 .flatMapPublisher(t -> Publisher.never())
                 .forEach(__ -> { }).cancel();
         analyzed.await();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleFlatMapSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleFlatMapSingleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ import io.servicetalk.concurrent.api.LegacyTestSingle;
 import io.servicetalk.concurrent.api.SourceAdapters;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
@@ -37,7 +37,7 @@ public final class SingleFlatMapSingleTest {
     private LegacyTestSingle<String> first;
     private LegacyTestSingle<String> second;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         first = new LegacyTestSingle<>();
         second = new LegacyTestSingle<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
  */
 package io.servicetalk.concurrent.api.single;
 
-import io.servicetalk.concurrent.api.ExecutorRule;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.api.ExecutorExtension;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
@@ -30,11 +30,10 @@ import static java.lang.Thread.currentThread;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SingleToCompletableTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExecutorRule executorRule = ExecutorRule.newRule();
+    @RegisterExtension
+    public final ExecutorExtension executorExtension = ExecutorExtension.newExtension();
 
     @Test
     public void subscribeOnOriginalIsPreserved() throws InterruptedException {
@@ -47,7 +46,7 @@ public class SingleToCompletableTest {
                         currentThread()));
             }
             analyzed.countDown();
-        }).subscribeOn(executorRule.executor()).toCompletable().subscribe().cancel();
+        }).subscribeOn(executorExtension.executor()).toCompletable().subscribe().cancel();
         analyzed.await();
         assertThat("Unexpected errors observed: " + errors, errors, hasSize(0));
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletableTest.java
@@ -15,11 +15,10 @@
  */
 package io.servicetalk.concurrent.api.single;
 
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ExecutorExtension;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -30,10 +29,9 @@ import static java.lang.Thread.currentThread;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SingleToCompletableTest {
     @RegisterExtension
-    public final ExecutorExtension executorExtension = ExecutorExtension.newExtension();
+    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
 
     @Test
     public void subscribeOnOriginalIsPreserved() throws InterruptedException {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletionStageTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletionStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,17 @@
  */
 package io.servicetalk.concurrent.api.single;
 
-import io.servicetalk.concurrent.api.ExecutorRule;
+import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.LegacyTestSingle;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -53,18 +52,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isOneOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SingleToCompletionStageTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExecutorRule executorRule = ExecutorRule.withNamePrefix(ST_THREAD_PREFIX_NAME);
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
+    @RegisterExtension
+    public final ExecutorExtension executorExtension = ExecutorExtension.withNamePrefix(ST_THREAD_PREFIX_NAME);
 
     private LegacyTestSingle<String> source;
     private static ExecutorService jdkExecutor;
@@ -73,36 +70,36 @@ public class SingleToCompletionStageTest {
     private static final String JDK_THREAD_NAME_PREFIX = "jdk-thread";
     private static final String JDK_FORK_JOIN_THREAD_NAME_PREFIX = "ForkJoinPool";
     private static final String COMPLETABLE_FUTURE_THREAD_PER_TASK_NAME_PREFIX = "Thread-";
+    private static final String JUNIT_THREAD_PREFIX = "Test worker";
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         jdkExecutor = java.util.concurrent.Executors.newCachedThreadPool(
                 r -> new Thread(r, JDK_THREAD_NAME_PREFIX + '-' + threadCount.incrementAndGet()));
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         if (jdkExecutor != null) {
             jdkExecutor.shutdown();
         }
     }
 
-    @Before
+    @BeforeEach
     public void beforeTest() {
-        source = new LegacyTestSingle<>(executorRule.executor(), true, true);
+        source = new LegacyTestSingle<>(executorExtension.executor(), true, true);
     }
 
     @Test
-    public void completableFutureFromSingleToCompletionStageToCompletableFutureFailure() throws Exception {
+    public void completableFutureFromSingleToCompletionStageToCompletableFutureFailure() {
         CompletableFuture<Long> input = new CompletableFuture<>();
         CompletableFuture<Long> output = Single.fromStage(input).toCompletionStage().toCompletableFuture()
                 .whenComplete((v, c) -> { })
                 .thenApply(l -> l + 1)
                 .whenComplete((v, c) -> { });
         input.completeExceptionally(DELIBERATE_EXCEPTION);
-        thrown.expect(ExecutionException.class);
-        thrown.expectCause(is(DELIBERATE_EXCEPTION));
-        output.get();
+        ExecutionException e = assertThrows(ExecutionException.class, () -> output.get());
+        assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
     }
 
     @Test
@@ -768,21 +765,25 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void blockingCancellationBeforeListen() throws Exception {
-        CompletionStage<String> stage = source.toCompletionStage();
-        CompletableFuture<String> future = stage.toCompletableFuture();
-        AtomicReference<Throwable> causeRef = new AtomicReference<>();
-        CountDownLatch latch = new CountDownLatch(1);
-        future.cancel(true);
-        stage.whenComplete((s, t) -> {
-            causeRef.set(t);
-            latch.countDown();
-        });
-        assertTrue(latch.await(100, MILLISECONDS));
-        assertTrue(future.isCancelled());
-        assertTrue(future.isDone());
-        thrown.expect(CancellationException.class);
-        future.get();
+    public void blockingCancellationBeforeListen() {
+        assertThrows(CancellationException.class,
+                () -> {
+
+                    CompletionStage<String> stage = source.toCompletionStage();
+
+                    CompletableFuture<String> future = stage.toCompletableFuture();
+                    AtomicReference<Throwable> causeRef = new AtomicReference<>();
+                    CountDownLatch latch = new CountDownLatch(1);
+                    future.cancel(true);
+                    stage.whenComplete((s, t) -> {
+                        causeRef.set(t);
+                        latch.countDown();
+                    });
+                    assertTrue(latch.await(100, MILLISECONDS));
+                    assertTrue(future.isCancelled());
+                    assertTrue(future.isDone());
+                    future.get();
+                });
     }
 
     @Test
@@ -802,24 +803,25 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void blockingCancellationAfterListen() throws Exception {
-        CountDownLatch cancelLatch = new CountDownLatch(1);
-        CompletionStage<String> stage = source.afterCancel(cancelLatch::countDown).toCompletionStage();
-        CompletableFuture<String> future = stage.toCompletableFuture();
-        AtomicReference<Throwable> causeRef = new AtomicReference<>();
-        CountDownLatch latch = new CountDownLatch(1);
-        stage.whenComplete((s, t) -> {
-            causeRef.set(t);
-            latch.countDown();
+    public void blockingCancellationAfterListen() {
+        assertThrows(CancellationException.class, () -> {
+            CountDownLatch cancelLatch = new CountDownLatch(1);
+            CompletionStage<String> stage = source.afterCancel(cancelLatch::countDown).toCompletionStage();
+            CompletableFuture<String> future = stage.toCompletableFuture();
+            AtomicReference<Throwable> causeRef = new AtomicReference<>();
+            CountDownLatch latch = new CountDownLatch(1);
+            stage.whenComplete((s, t) -> {
+                causeRef.set(t);
+                latch.countDown();
+            });
+            future.cancel(true);
+            latch.await();
+            assertTrue(future.isCancelled());
+            assertTrue(future.isDone());
+            assertThat(causeRef.get(), is(instanceOf(CancellationException.class)));
+            cancelLatch.await();
+            future.get();
         });
-        future.cancel(true);
-        latch.await();
-        assertTrue(future.isCancelled());
-        assertTrue(future.isDone());
-        assertThat(causeRef.get(), is(instanceOf(CancellationException.class)));
-        cancelLatch.await();
-        thrown.expect(CancellationException.class);
-        future.get();
     }
 
     @Test
@@ -829,7 +831,7 @@ public class SingleToCompletionStageTest {
         AtomicReference<Throwable> causeRef = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
         stage = stage.whenComplete((s, t) -> causeRef.compareAndSet(null, t))
-                     .whenComplete((s, t) -> causeRef.compareAndSet(null, t));
+                .whenComplete((s, t) -> causeRef.compareAndSet(null, t));
 
         stage.whenComplete((s, t) -> {
             causeRef.compareAndSet(null, t);
@@ -915,53 +917,55 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void blockingGetAsyncError() throws Exception {
+    public void blockingGetAsyncError() {
         blockingGetAsyncError(source.toCompletionStage().toCompletableFuture());
     }
 
     @Test
-    public void futureGetAsyncError() throws Exception {
+    public void futureGetAsyncError() {
         blockingGetAsyncError(source.toFuture());
     }
 
-    private void blockingGetAsyncError(Future<String> stage) throws ExecutionException, InterruptedException {
-        jdkExecutor.execute(() -> source.onError(DELIBERATE_EXCEPTION));
-        thrown.expect(ExecutionException.class);
-        thrown.expectCause(is(DELIBERATE_EXCEPTION));
-        stage.get();
+    private void blockingGetAsyncError(Future<String> stage) {
+        Exception e = assertThrows(ExecutionException.class, () -> {
+            jdkExecutor.execute(() -> source.onError(DELIBERATE_EXCEPTION));
+            stage.get();
+        });
+        assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void blockingGetSyncError() throws Exception {
+    public void blockingGetSyncError() {
         blockingGetSyncError(source.toCompletionStage().toCompletableFuture());
     }
 
     @Test
-    public void futureGetSyncError() throws Exception {
+    public void futureGetSyncError() {
         blockingGetSyncError(source.toFuture());
     }
 
-    private void blockingGetSyncError(Future<String> stage) throws ExecutionException, InterruptedException {
-        source.onError(DELIBERATE_EXCEPTION);
-        thrown.expect(ExecutionException.class);
-        thrown.expectCause(is(DELIBERATE_EXCEPTION));
-        stage.get();
+    private void blockingGetSyncError(Future<String> stage) {
+        Exception e = assertThrows(ExecutionException.class, () -> {
+            source.onError(DELIBERATE_EXCEPTION);
+            stage.get();
+        });
+        assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void blockingGetTimeoutExpire() throws Exception {
+    public void blockingGetTimeoutExpire() {
         blockingGetTimeoutExpire(source.toCompletionStage().toCompletableFuture());
     }
 
     @Test
-    public void futureGetTimeoutExpire() throws Exception {
+    public void futureGetTimeoutExpire() {
         blockingGetTimeoutExpire(source.toFuture());
     }
 
-    private void blockingGetTimeoutExpire(Future<String> stage)
-            throws InterruptedException, ExecutionException, TimeoutException {
-        thrown.expect(TimeoutException.class);
-        stage.get(10, MILLISECONDS);
+    private void blockingGetTimeoutExpire(Future<String> stage) {
+        assertThrows(TimeoutException.class, () -> {
+            stage.get(10, MILLISECONDS);
+        });
     }
 
     @Test
@@ -981,21 +985,21 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void blockingGetTimeoutError() throws Exception {
+    public void blockingGetTimeoutError() {
         blockingGetTimeoutError(source.toCompletionStage().toCompletableFuture());
     }
 
     @Test
-    public void futureGetTimeoutError() throws Exception {
+    public void futureGetTimeoutError() {
         blockingGetTimeoutError(source.toFuture());
     }
 
-    private void blockingGetTimeoutError(Future<String> stage)
-            throws InterruptedException, ExecutionException, TimeoutException {
-        jdkExecutor.execute(() -> source.onError(DELIBERATE_EXCEPTION));
-        thrown.expect(ExecutionException.class);
-        thrown.expectCause(is(DELIBERATE_EXCEPTION));
-        stage.get(1, MINUTES);
+    private void blockingGetTimeoutError(Future<String> stage) {
+        Exception e = assertThrows(ExecutionException.class, () -> {
+            jdkExecutor.execute(() -> source.onError(DELIBERATE_EXCEPTION));
+            stage.get(1, MINUTES);
+        });
+        assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
     }
 
     private static <X> void verifyListenerInvokedInJdkThread(CompletionStage<X> stage)
@@ -1003,7 +1007,7 @@ public class SingleToCompletionStageTest {
         // Derived stages from thenApplyAsync with a jdkExecutor should invoke listeners on the same jdkExecutor too!
         stage.thenCompose(v -> {
             CompletableFuture<Void> result = new CompletableFuture<>();
-            if (currentThread().getName().startsWith(ServiceTalkTestTimeout.THREAD_PREFIX)) {
+            if (currentThread().getName().startsWith(JUNIT_THREAD_PREFIX)) {
                 result.complete(null);
             } else {
                 result.completeExceptionally(
@@ -1035,7 +1039,7 @@ public class SingleToCompletionStageTest {
     }
 
     private static void verifyInJUnitThread() {
-        if (!currentThread().getName().startsWith(ServiceTalkTestTimeout.THREAD_PREFIX)) {
+        if (!currentThread().getName().startsWith(JUNIT_THREAD_PREFIX)) {
             throw new IllegalStateException("unexpected thread: " + currentThread());
         }
     }
@@ -1049,7 +1053,7 @@ public class SingleToCompletionStageTest {
 
     private static void verifyInStOrJUnitThread() {
         if (!currentThread().getName().startsWith(ST_THREAD_PREFIX_NAME) &&
-                !currentThread().getName().startsWith(ServiceTalkTestTimeout.THREAD_PREFIX)) {
+                !currentThread().getName().startsWith(JUNIT_THREAD_PREFIX)) {
             throw new IllegalStateException("unexpected thread: " + currentThread());
         }
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletionStageTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletionStageTest.java
@@ -15,16 +15,15 @@
  */
 package io.servicetalk.concurrent.api.single;
 
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.LegacyTestSingle;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.CancellationException;
@@ -58,10 +57,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SingleToCompletionStageTest {
     @RegisterExtension
-    public final ExecutorExtension executorExtension = ExecutorExtension.withNamePrefix(ST_THREAD_PREFIX_NAME);
+    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor(ST_THREAD_PREFIX_NAME);
 
     private LegacyTestSingle<String> source;
     private static ExecutorService jdkExecutor;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToFutureTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToFutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api.single;
 import io.servicetalk.concurrent.api.AbstractToFutureTest;
 import io.servicetalk.concurrent.api.TestSingle;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Future;
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToPublisherTest.java
@@ -20,11 +20,9 @@ import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.TestCancellable;
 import io.servicetalk.concurrent.api.TestSingle;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -43,11 +41,10 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SingleToPublisherTest {
 
     @RegisterExtension
-    public final ExecutorExtension<Executor> executorExtension = ExecutorExtension.newExtension();
+    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
 
     private final TestPublisherSubscriber<String> verifier = new TestPublisherSubscriber<>();
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SubscribeShareContextTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SubscribeShareContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.api.single;
 import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.concurrent.api.AsyncContextMap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SubscribeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package io.servicetalk.concurrent.api.single;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.LegacyTestSingle;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 
@@ -34,7 +34,7 @@ public final class SubscribeTest {
     private Cancellable cancellable;
 
     @SuppressWarnings("unchecked")
-    @Before
+    @BeforeEach
     public void setUp() {
         source = new LegacyTestSingle<>();
         resultConsumer = (Consumer<Integer>) mock(Consumer.class);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SupplierSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SupplierSingleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.Single;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Supplier;
@@ -41,8 +41,8 @@ public class SupplierSingleTest {
     private Supplier<Integer> factory;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         factory = mock(Supplier.class);
         when(factory.get()).thenReturn(1);
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/TimeoutSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/TimeoutSingleTest.java
@@ -23,12 +23,10 @@ import io.servicetalk.concurrent.api.LegacyTestSingle;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.TestCancellable;
 import io.servicetalk.concurrent.api.TestExecutor;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.TimeUnit;
@@ -49,7 +47,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class TimeoutSingleTest {
     @RegisterExtension
     public final ExecutorExtension<TestExecutor> executorExtension = ExecutorExtension.withTestExecutor();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/TimeoutSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/TimeoutSingleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,18 @@ package io.servicetalk.concurrent.api.single;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.SingleSource.Subscriber;
 import io.servicetalk.concurrent.api.DelegatingExecutor;
-import io.servicetalk.concurrent.api.ExecutorRule;
+import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.LegacyTestSingle;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.TestCancellable;
 import io.servicetalk.concurrent.api.TestExecutor;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -44,24 +44,23 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class TimeoutSingleTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExecutorRule<TestExecutor> executorRule = ExecutorRule.withTestExecutor();
+    @RegisterExtension
+    public final ExecutorExtension<TestExecutor> executorExtension = ExecutorExtension.withTestExecutor();
 
     private LegacyTestSingle<Integer> source = new LegacyTestSingle<>(false, false);
     public final TestSingleSubscriber<Integer> subscriber = new TestSingleSubscriber<>();
     private TestExecutor testExecutor;
 
-    @Before
+    @BeforeEach
     public void setup() {
-        testExecutor = executorRule.executor();
+        testExecutor = executorExtension.executor();
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentSubscriptionTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentSubscriptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,8 @@ package io.servicetalk.concurrent.internal;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.api.TestSubscription;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,15 +35,14 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class ConcurrentSubscriptionTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
     private final TestSubscription subscription = new TestSubscription();
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentSubscriptionTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentSubscriptionTest.java
@@ -19,7 +19,6 @@ import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.api.TestSubscription;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,7 +40,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class ConcurrentSubscriptionTest {
     private final TestSubscription subscription = new TestSubscription();
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentTerminalSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentTerminalSubscriberTest.java
@@ -23,7 +23,6 @@ import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
@@ -44,10 +43,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class ConcurrentTerminalSubscriberTest {
     @RegisterExtension
-    public final ExecutorExtension<Executor> executorExtension = ExecutorExtension.newExtension();
+    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
 
     private final TestPublisher<Integer> publisher =
             new TestPublisher.Builder<Integer>().disableAutoOnSubscribe().build();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderCompletableTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Executors.from;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -59,6 +60,7 @@ public class SignalOffloaderCompletableTest {
 
     private static final Logger LOGGER = getLogger(SignalOffloaderCompletableTest.class);
 
+    @Nullable
     private OffloaderHolder state;
 
     private void init(Supplier<OffloaderHolder> stateSupplier) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderConcurrentCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderConcurrentCompletableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,16 +21,14 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Executors;
 
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -38,6 +36,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
@@ -48,37 +47,36 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.slf4j.LoggerFactory.getLogger;
 
-@RunWith(Parameterized.class)
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SignalOffloaderConcurrentCompletableTest {
     private static final Logger LOGGER = getLogger(SignalOffloaderConcurrentCompletableTest.class);
 
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
+    private OffloaderHolder state;
 
-    public final OffloaderHolder state;
-
-    public SignalOffloaderConcurrentCompletableTest(Supplier<OffloaderHolder> state,
-                                                    @SuppressWarnings("unused") boolean supportsTermination) {
-        this.state = state.get();
+    private void init(Supplier<OffloaderHolder> stateSupplier) {
+        this.state = stateSupplier.get();
     }
 
-    @Parameterized.Parameters(name = "{index} - thread based: {1}")
-    public static Collection<Object[]> offloaders() {
-        Collection<Object[]> offloaders = new ArrayList<>();
-        offloaders.add(new Object[]{(Supplier<OffloaderHolder>) () ->
-                new OffloaderHolder(ThreadBasedSignalOffloader::new), true});
-        offloaders.add(new Object[]{(Supplier<OffloaderHolder>) () ->
-                new OffloaderHolder(TaskBasedSignalOffloader::new), false});
-        return offloaders;
+    @SuppressWarnings("unused")
+    public static Stream<Arguments> offloaders() {
+        return Stream.of(
+            Arguments.of((Supplier<OffloaderHolder>) () ->
+                new OffloaderHolder(ThreadBasedSignalOffloader::new), true),
+            Arguments.of((Supplier<OffloaderHolder>) () ->
+                new OffloaderHolder(TaskBasedSignalOffloader::new), false));
     }
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    public void tearDown() {
         state.shutdown();
     }
 
-    @Test
-    public void concurrentSignalsMultipleEntities() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void concurrentSignalsMultipleEntities(Supplier<OffloaderHolder> stateSupplier,
+                                                  @SuppressWarnings("unused") boolean supportsTermination)
+            throws Exception {
+        init(stateSupplier);
         final int entityCount = 100;
         final OffloaderHolder.SubscriberCancellablePair[] pairs =
                 new OffloaderHolder.SubscriberCancellablePair[entityCount];

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderConcurrentSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderConcurrentSingleTest.java
@@ -23,11 +23,8 @@ import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Executors;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.slf4j.Logger;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,8 +33,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
@@ -46,38 +41,40 @@ import static io.servicetalk.concurrent.internal.TerminalNotification.error;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
-import static org.slf4j.LoggerFactory.getLogger;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SignalOffloaderConcurrentSingleTest {
-    private static final Logger LOGGER = getLogger(SignalOffloaderConcurrentSingleTest.class);
-
     private OffloaderHolder state;
 
-    private void init(Supplier<OffloaderHolder> stateSupplier) {
-        this.state = stateSupplier.get();
+    private enum OffloaderTestParam {
+        THREAD_BASED {
+            @Override
+            OffloaderHolder get() {
+                return new OffloaderHolder(ThreadBasedSignalOffloader::new);
+            }
+        },
+        TASK_BASED {
+            @Override
+            OffloaderHolder get() {
+                return new OffloaderHolder(TaskBasedSignalOffloader::new);
+            }
+        };
+
+        abstract OffloaderHolder get();
     }
 
-    @SuppressWarnings("unused")
-    public static Stream<Arguments> offloaders() {
-        return Stream.of(
-            Arguments.of((Supplier<OffloaderHolder>) () ->
-                new OffloaderHolder(ThreadBasedSignalOffloader::new), true),
-            Arguments.of((Supplier<OffloaderHolder>) () ->
-                new OffloaderHolder(TaskBasedSignalOffloader::new), false));
+    private void init(OffloaderTestParam offloader) {
+        this.state = offloader.get();
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws Exception {
         state.shutdown();
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void concurrentSignalsMultipleEntities(Supplier<OffloaderHolder> stateSupplier,
-                                                  @SuppressWarnings("unused") boolean supportsTermination)
-            throws Exception {
-        init(stateSupplier);
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void concurrentSignalsMultipleEntities(OffloaderTestParam offloader) throws Exception {
+        init(offloader);
         final int entityCount = 100;
         final OffloaderHolder.SubscriberCancellablePair[] pairs =
                 new OffloaderHolder.SubscriberCancellablePair[entityCount];
@@ -112,13 +109,9 @@ public class SignalOffloaderConcurrentSingleTest {
             offloader = offloaderFactory.apply(executor);
         }
 
-        void shutdown() {
-            try {
-                executor.closeAsync().toFuture().get();
-                emitters.shutdownNow();
-            } catch (Exception e) {
-                LOGGER.warn("Failed to close the executor {}.", executor, e);
-            }
+        void shutdown() throws Exception {
+            executor.closeAsync().toFuture().get();
+            emitters.shutdownNow();
         }
 
         void awaitTermination() throws Exception {
@@ -137,13 +130,13 @@ public class SignalOffloaderConcurrentSingleTest {
 
             final SubscriberImpl subscriber;
             final CancellableImpl cancellable;
-            private SingleSource.Subscriber<? super Integer> offloadCancellable;
             private SingleSource.Subscriber<? super Integer> offloadSubscriber;
 
             SubscriberCancellablePair(SubscriberImpl subscriber, CancellableImpl cancellable) {
                 this.subscriber = subscriber;
                 this.cancellable = cancellable;
-                offloadCancellable = offloader.offloadCancellable(this.subscriber);
+                SingleSource.Subscriber<? super Integer> offloadCancellable =
+                        offloader.offloadCancellable(this.subscriber);
                 offloadSubscriber = offloader.offloadSubscriber(offloadCancellable);
             }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,23 +19,20 @@ import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.api.Executor;
 
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Executors.from;
@@ -49,7 +46,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assume.assumeThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -58,53 +56,55 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.slf4j.LoggerFactory.getLogger;
 
-@RunWith(Parameterized.class)
+@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SignalOffloaderPublisherTest {
 
     private static final Logger LOGGER = getLogger(SignalOffloaderPublisherTest.class);
 
-    @Rule
-    public final ExpectedException expected = ExpectedException.none();
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    public final OffloaderHolder state;
-    private final boolean supportsTermination;
+    private OffloaderHolder state;
 
-    public SignalOffloaderPublisherTest(Supplier<OffloaderHolder> state, boolean supportsTermination) {
-        this.state = state.get();
-        this.supportsTermination = supportsTermination;
+    private void init(Supplier<OffloaderHolder> stateSupplier) {
+        this.state = stateSupplier.get();
     }
 
-    @Parameterized.Parameters(name = "{index} - thread based: {1}")
-    public static Collection<Object[]> offloaders() {
-        Collection<Object[]> offloaders = new ArrayList<>();
-        offloaders.add(new Object[]{(Supplier<OffloaderHolder>) () ->
-                new OffloaderHolder(ThreadBasedSignalOffloader::new), true});
-        offloaders.add(new Object[]{(Supplier<OffloaderHolder>) () ->
-                new OffloaderHolder(TaskBasedSignalOffloader::new), false});
-        return offloaders;
+    @SuppressWarnings("unused")
+    public static Stream<Arguments> offloaders() {
+        return Stream.of(
+        Arguments.of((Supplier<OffloaderHolder>) () ->
+                new OffloaderHolder(ThreadBasedSignalOffloader::new), true),
+        Arguments.of((Supplier<OffloaderHolder>) () ->
+                new OffloaderHolder(TaskBasedSignalOffloader::new), false));
     }
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    public void tearDown() {
         state.shutdown();
     }
 
-    @Test
-    public void offloadSignal() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void offloadSignal(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
+        init(stateSupplier);
         state.offloadSignalAndAwait("Hello");
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void offloadSignalShouldTerminateOffloader() throws Exception {
-        assumeThat("Termination test not supported by this offloader.", supportsTermination, is(true));
-        state.offloadSignalAndAwait("Hello")
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void offloadSignalShouldTerminateOffloader(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
+        init(stateSupplier);
+        assumeTrue(supportsTermination, "Termination test not supported by this offloader.");
+        assertThrows(IllegalStateException.class, () -> state.offloadSignalAndAwait("Hello")
                 .awaitTermination()
-                .offloadSignalAndAwait("Hello1");
+                .offloadSignalAndAwait("Hello1"));
     }
 
-    @Test
-    public void offloadingSubscriberShouldNotOffloadSubscription() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void offloadingSubscriberShouldNotOffloadSubscription(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
+        init(stateSupplier);
         Subscriber<? super String> offloadSubscription = state.offloader.offloadSubscription(state.subscriber);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(offloadSubscription);
 
@@ -114,8 +114,11 @@ public class SignalOffloaderPublisherTest {
                 .awaitTermination();
     }
 
-    @Test
-    public void offloadingSubscriptionShouldNotOffloadSubscriber() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void offloadingSubscriptionShouldNotOffloadSubscriber(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
+        init(stateSupplier);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscription(state.subscriber);
 
         Subscription received = state.sendOnSubscribe(offloaded);
@@ -126,8 +129,11 @@ public class SignalOffloaderPublisherTest {
                 .awaitTermination();
     }
 
-    @Test
-    public void offloadSubscriber() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void offloadSubscriber(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
+        init(stateSupplier);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
         state.verifyOnNextOffloaded(offloaded)
@@ -135,8 +141,11 @@ public class SignalOffloaderPublisherTest {
                 .awaitTermination();
     }
 
-    @Test
-    public void cancelShouldTerminateOffloadingWithMultipleEntities() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void cancelShouldTerminateOffloadingWithMultipleEntities(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
+        init(stateSupplier);
         Subscriber<? super String> offloadedSubscription = state.offloader.offloadSubscription(state.subscriber);
         Subscriber<? super String> offloadedSubscriber = state.offloader.offloadSubscriber(offloadedSubscription);
         Subscription received = state.verifyOnSubscribeOffloaded(offloadedSubscriber);
@@ -144,24 +153,33 @@ public class SignalOffloaderPublisherTest {
                 .awaitTermination();
     }
 
-    @Test
-    public void onErrorShouldTerminateOffloadingWithMultipleEntities() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void onErrorShouldTerminateOffloadingWithMultipleEntities(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
+        init(stateSupplier);
         Subscriber<? super String> offloadedSubscription = state.offloader.offloadSubscription(state.subscriber);
         Subscriber<? super String> offloadedSubscriber = state.offloader.offloadSubscriber(offloadedSubscription);
         state.verifyOnSubscribeOffloaded(offloadedSubscriber);
         state.verifyOnErrorOffloaded(offloadedSubscriber).awaitTermination();
     }
 
-    @Test
-    public void onCompleteShouldTerminateOffloadingWithMultipleEntities() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void onCompleteShouldTerminateOffloadingWithMultipleEntities(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
+        init(stateSupplier);
         Subscriber<? super String> offloadedSubscription = state.offloader.offloadSubscription(state.subscriber);
         Subscriber<? super String> offloadedSubscriber = state.offloader.offloadSubscriber(offloadedSubscription);
         state.verifyOnSubscribeOffloaded(offloadedSubscriber);
         state.verifyOnCompleteOffloaded(offloadedSubscriber).awaitTermination();
     }
 
-    @Test
-    public void onNextSupportsNull() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void onNextSupportsNull(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
+        init(stateSupplier);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
         state.verifyOnNextOffloaded(offloaded, null)
@@ -169,16 +187,22 @@ public class SignalOffloaderPublisherTest {
                 .awaitTermination();
     }
 
-    @Test
-    public void onSubscribeThrows() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void onSubscribeThrows(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
+        init(stateSupplier);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloadedWhenThrows(offloaded);
         state.awaitTermination();
         verify(state.subscription).cancel();
     }
 
-    @Test
-    public void onNextThrows() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void onNextThrows(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
+        init(stateSupplier);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
         state.verifyOnNextOffloadedWhenThrows(offloaded);
@@ -187,55 +211,78 @@ public class SignalOffloaderPublisherTest {
         verify(state.subscription).cancel();
     }
 
-    @Test
-    public void onErrorThrows() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void onErrorThrows(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
+        init(stateSupplier);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
         state.verifyOnErrorOffloadedWhenThrows(offloaded);
         state.awaitTermination();
     }
 
-    @Test
-    public void onCompleteThrows() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void onCompleteThrows(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
+        init(stateSupplier);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
         state.verifyOnCompleteOffloadedWhenThrows(offloaded);
         state.awaitTermination();
     }
 
-    @Test
-    public void offloadPostTermination() throws Exception {
-        assumeThat("Termination test not supported by this offloader.", supportsTermination, is(true));
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void offloadPostTermination(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
+        init(stateSupplier);
+        assumeTrue(supportsTermination, "Termination test not supported by this offloader.");
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
         state.verifyOnCompleteOffloaded(offloaded);
         state.awaitTermination();
-        expected.expect(instanceOf(IllegalStateException.class));
-        state.offloader.offloadSubscriber(state.subscriber);
+        assertThrows(IllegalStateException.class, () -> state.offloader.offloadSubscriber(state.subscriber));
     }
 
-    @Test
-    public void negative1RequestIsPropagated() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void negative1RequestIsPropagated(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
+        init(stateSupplier);
         testInvalidRequestNIsPropagated(-1, Long.MIN_VALUE);
     }
 
-    @Test
-    public void negative2RequestIsPropagated() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void negative2RequestIsPropagated(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
+        init(stateSupplier);
         testInvalidRequestNIsPropagated(-2, Long.MIN_VALUE);
     }
 
-    @Test
-    public void negative3RequestIsPropagated() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void negative3RequestIsPropagated(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
+        init(stateSupplier);
         testInvalidRequestNIsPropagated(-3, -3);
     }
 
-    @Test
-    public void zeroRequestIsPropagated() throws Exception {
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void zeroRequestIsPropagated(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
+        init(stateSupplier);
         testInvalidRequestNIsPropagated(0, Long.MIN_VALUE);
     }
 
-    @Test
-    public void executorRejectsForHandleSubscribe() {
+    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
+    @MethodSource("offloaders")
+    public void executorRejectsForHandleSubscribe(Supplier<OffloaderHolder> stateSupplier,
+                              @SuppressWarnings("unused") boolean supportsTermination) {
+        init(stateSupplier);
         ThreadBasedSignalOffloader offloader = new ThreadBasedSignalOffloader(from(task -> {
             throw new RejectedExecutionException();
         }));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderPublisherTest.java
@@ -20,19 +20,14 @@ import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.api.Executor;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
-import org.slf4j.Logger;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Executors.from;
@@ -54,57 +49,74 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.slf4j.LoggerFactory.getLogger;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 public class SignalOffloaderPublisherTest {
 
-    private static final Logger LOGGER = getLogger(SignalOffloaderPublisherTest.class);
+    private enum OffloaderTestParam {
+        THREAD_BASED {
+            @Override
+            OffloaderHolder get() {
+                return new OffloaderHolder(ThreadBasedSignalOffloader::new);
+            }
 
-    private OffloaderHolder state;
+            @Override
+            boolean isSupportsTermination() {
+                return true;
+            }
+        },
+        TASK_BASED {
+            @Override
+            OffloaderHolder get() {
+                return new OffloaderHolder(TaskBasedSignalOffloader::new);
+            }
 
-    private void init(Supplier<OffloaderHolder> stateSupplier) {
-        this.state = stateSupplier.get();
+            @Override
+            boolean isSupportsTermination() {
+                return false;
+            }
+        };
+
+        abstract OffloaderHolder get();
+
+        abstract boolean isSupportsTermination();
     }
 
-    @SuppressWarnings("unused")
-    public static Stream<Arguments> offloaders() {
-        return Stream.of(
-        Arguments.of((Supplier<OffloaderHolder>) () ->
-                new OffloaderHolder(ThreadBasedSignalOffloader::new), true),
-        Arguments.of((Supplier<OffloaderHolder>) () ->
-                new OffloaderHolder(TaskBasedSignalOffloader::new), false));
+    @Nullable
+    private OffloaderHolder state;
+
+    private void init(OffloaderTestParam offloader) {
+        this.state = offloader.get();
     }
 
     @AfterEach
-    public void tearDown() {
-        state.shutdown();
+    public void tearDown() throws Exception {
+        if (state != null) {
+            state.shutdown();
+            state = null;
+        }
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void offloadSignal(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
-        init(stateSupplier);
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void offloadSignal(OffloaderTestParam offloader) throws Exception {
+        init(offloader);
         state.offloadSignalAndAwait("Hello");
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void offloadSignalShouldTerminateOffloader(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
-        init(stateSupplier);
-        assumeTrue(supportsTermination, "Termination test not supported by this offloader.");
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void offloadSignalShouldTerminateOffloader(OffloaderTestParam offloader) {
+        assumeTrue(offloader.isSupportsTermination(), "Termination test not supported by this offloader.");
+        init(offloader);
         assertThrows(IllegalStateException.class, () -> state.offloadSignalAndAwait("Hello")
                 .awaitTermination()
                 .offloadSignalAndAwait("Hello1"));
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void offloadingSubscriberShouldNotOffloadSubscription(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
-        init(stateSupplier);
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void offloadingSubscriberShouldNotOffloadSubscription(OffloaderTestParam offloader) throws Exception {
+        init(offloader);
         Subscriber<? super String> offloadSubscription = state.offloader.offloadSubscription(state.subscriber);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(offloadSubscription);
 
@@ -114,11 +126,10 @@ public class SignalOffloaderPublisherTest {
                 .awaitTermination();
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void offloadingSubscriptionShouldNotOffloadSubscriber(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
-        init(stateSupplier);
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void offloadingSubscriptionShouldNotOffloadSubscriber(OffloaderTestParam offloader) throws Exception {
+        init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscription(state.subscriber);
 
         Subscription received = state.sendOnSubscribe(offloaded);
@@ -129,11 +140,10 @@ public class SignalOffloaderPublisherTest {
                 .awaitTermination();
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void offloadSubscriber(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
-        init(stateSupplier);
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void offloadSubscriber(OffloaderTestParam offloader) throws Exception {
+        init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
         state.verifyOnNextOffloaded(offloaded)
@@ -141,11 +151,10 @@ public class SignalOffloaderPublisherTest {
                 .awaitTermination();
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void cancelShouldTerminateOffloadingWithMultipleEntities(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
-        init(stateSupplier);
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void cancelShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader) throws Exception {
+        init(offloader);
         Subscriber<? super String> offloadedSubscription = state.offloader.offloadSubscription(state.subscriber);
         Subscriber<? super String> offloadedSubscriber = state.offloader.offloadSubscriber(offloadedSubscription);
         Subscription received = state.verifyOnSubscribeOffloaded(offloadedSubscriber);
@@ -153,33 +162,30 @@ public class SignalOffloaderPublisherTest {
                 .awaitTermination();
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void onErrorShouldTerminateOffloadingWithMultipleEntities(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
-        init(stateSupplier);
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void onErrorShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader) throws Exception {
+        init(offloader);
         Subscriber<? super String> offloadedSubscription = state.offloader.offloadSubscription(state.subscriber);
         Subscriber<? super String> offloadedSubscriber = state.offloader.offloadSubscriber(offloadedSubscription);
         state.verifyOnSubscribeOffloaded(offloadedSubscriber);
         state.verifyOnErrorOffloaded(offloadedSubscriber).awaitTermination();
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void onCompleteShouldTerminateOffloadingWithMultipleEntities(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
-        init(stateSupplier);
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void onCompleteShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader) throws Exception {
+        init(offloader);
         Subscriber<? super String> offloadedSubscription = state.offloader.offloadSubscription(state.subscriber);
         Subscriber<? super String> offloadedSubscriber = state.offloader.offloadSubscriber(offloadedSubscription);
         state.verifyOnSubscribeOffloaded(offloadedSubscriber);
         state.verifyOnCompleteOffloaded(offloadedSubscriber).awaitTermination();
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void onNextSupportsNull(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
-        init(stateSupplier);
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void onNextSupportsNull(OffloaderTestParam offloader) throws Exception {
+        init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
         state.verifyOnNextOffloaded(offloaded, null)
@@ -187,22 +193,20 @@ public class SignalOffloaderPublisherTest {
                 .awaitTermination();
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void onSubscribeThrows(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
-        init(stateSupplier);
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void onSubscribeThrows(OffloaderTestParam offloader) throws Exception {
+        init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloadedWhenThrows(offloaded);
         state.awaitTermination();
         verify(state.subscription).cancel();
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void onNextThrows(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
-        init(stateSupplier);
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void onNextThrows(OffloaderTestParam offloader) throws Exception {
+        init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
         state.verifyOnNextOffloadedWhenThrows(offloaded);
@@ -211,34 +215,31 @@ public class SignalOffloaderPublisherTest {
         verify(state.subscription).cancel();
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void onErrorThrows(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
-        init(stateSupplier);
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void onErrorThrows(OffloaderTestParam offloader) throws Exception {
+        init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
         state.verifyOnErrorOffloadedWhenThrows(offloaded);
         state.awaitTermination();
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void onCompleteThrows(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
-        init(stateSupplier);
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void onCompleteThrows(OffloaderTestParam offloader) throws Exception {
+        init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
         state.verifyOnCompleteOffloadedWhenThrows(offloaded);
         state.awaitTermination();
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void offloadPostTermination(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
-        init(stateSupplier);
-        assumeTrue(supportsTermination, "Termination test not supported by this offloader.");
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void offloadPostTermination(OffloaderTestParam offloader) throws Exception {
+        assumeTrue(offloader.isSupportsTermination(), "Termination test not supported by this offloader.");
+        init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
         state.verifyOnCompleteOffloaded(offloaded);
@@ -246,47 +247,42 @@ public class SignalOffloaderPublisherTest {
         assertThrows(IllegalStateException.class, () -> state.offloader.offloadSubscriber(state.subscriber));
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void negative1RequestIsPropagated(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
-        init(stateSupplier);
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void negative1RequestIsPropagated(OffloaderTestParam offloader) throws Exception {
+        init(offloader);
         testInvalidRequestNIsPropagated(-1, Long.MIN_VALUE);
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void negative2RequestIsPropagated(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
-        init(stateSupplier);
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void negative2RequestIsPropagated(OffloaderTestParam offloader) throws Exception {
+        init(offloader);
         testInvalidRequestNIsPropagated(-2, Long.MIN_VALUE);
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void negative3RequestIsPropagated(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
-        init(stateSupplier);
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void negative3RequestIsPropagated(OffloaderTestParam offloader) throws Exception {
+        init(offloader);
         testInvalidRequestNIsPropagated(-3, -3);
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void zeroRequestIsPropagated(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) throws Exception {
-        init(stateSupplier);
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void zeroRequestIsPropagated(OffloaderTestParam offloader) throws Exception {
+        init(offloader);
         testInvalidRequestNIsPropagated(0, Long.MIN_VALUE);
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] - thread based: {1}")
-    @MethodSource("offloaders")
-    public void executorRejectsForHandleSubscribe(Supplier<OffloaderHolder> stateSupplier,
-                              @SuppressWarnings("unused") boolean supportsTermination) {
-        init(stateSupplier);
-        ThreadBasedSignalOffloader offloader = new ThreadBasedSignalOffloader(from(task -> {
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @EnumSource(OffloaderTestParam.class)
+    public void executorRejectsForHandleSubscribe(OffloaderTestParam offloader) {
+        init(offloader);
+        ThreadBasedSignalOffloader rejectedOffloader = new ThreadBasedSignalOffloader(from(task -> {
             throw new RejectedExecutionException();
         }));
-        offloader.offloadSubscribe(state.subscriber, __ -> {
+        rejectedOffloader.offloadSubscribe(state.subscriber, __ -> {
         });
         verify(state.subscriber).onSubscribe(any(Subscription.class));
         ArgumentCaptor<Throwable> errorCaptor = ArgumentCaptor.forClass(Throwable.class);
@@ -315,12 +311,8 @@ public class SignalOffloaderPublisherTest {
             subscriber = mockSubscriber();
         }
 
-        void shutdown() {
-            try {
-                executor.closeAsync().toFuture().get();
-            } catch (Exception e) {
-                LOGGER.warn("Failed to close the executor {}.", executor, e);
-            }
+        void shutdown() throws Exception {
+            executor.closeAsync().toFuture().get();
         }
 
         OffloaderHolder awaitTermination() throws Exception {

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/ExecutorExtension.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/ExecutorExtension.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
+
+import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
+import static java.lang.Thread.NORM_PRIORITY;
+
+/**
+ * An {@link org.junit.jupiter.api.extension.Extension} wrapper for an {@link Executor}.
+ * @param <E> The type of {@link Executor}.
+ */
+public final class ExecutorExtension<E extends Executor> implements BeforeEachCallback, AfterEachCallback {
+
+    private final Supplier<E> eSupplier;
+    private E executor;
+
+    private ExecutorExtension(final Supplier<E> eSupplier) {
+        this.eSupplier = eSupplier;
+    }
+
+    /**
+     * Create an {@link ExecutorExtension} with a default executor.
+     *
+     * @return a new {@link ExecutorExtension}.
+     */
+    public static ExecutorExtension<Executor> newExtension() {
+        return new ExecutorExtension<>(Executors::newCachedThreadExecutor);
+    }
+
+    /**
+     * Create an {@link ExecutorExtension} with a {@link TestExecutor}.
+     * <p>
+     * {@link #executor()} will return the {@link TestExecutor} to allow controlling the executor in tests.
+     *
+     * @return a new {@link ExecutorExtension}.
+     */
+    public static ExecutorExtension<TestExecutor> withTestExecutor() {
+        return new ExecutorExtension<>(TestExecutor::new);
+    }
+
+    /**
+     * Create an {@link ExecutorExtension} with the specified {@code executor}.
+     *
+     * @param executorSupplier The {@link Executor} {@link Supplier} to use.
+     * @return a new {@link ExecutorExtension}.
+     */
+    public static ExecutorExtension<Executor> withExecutor(Supplier<Executor> executorSupplier) {
+        return new ExecutorExtension<>(executorSupplier);
+    }
+
+    /**
+     * Create an {@link ExecutorExtension} with a default executor, configured to prefix thread names
+     * with {@code namePrefix}.
+     *
+     * @param namePrefix the name to prefix thread names with.
+     * @return a new {@link ExecutorExtension}.
+     */
+    public static ExecutorExtension<Executor> withNamePrefix(String namePrefix) {
+        return new ExecutorExtension<>(() ->
+                newCachedThreadExecutor(new DefaultThreadFactory(namePrefix, true, NORM_PRIORITY)));
+    }
+
+    /**
+     * Returns {@link Executor} created on the last call to {@link #beforeEach(ExtensionContext)} ()}.
+     *
+     * @return {@link Executor} created on the last call to {@link #beforeEach(ExtensionContext)} ()}.
+     * {@code null} if {@link #beforeEach(ExtensionContext)} ()} has
+     * not been called yet.
+     */
+    public E executor() {
+        return executor;
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        executor = eSupplier.get();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        try {
+            executor.closeAsync().toFuture().get();
+        } catch (ExecutionException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/LegacyTestCompletable.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/LegacyTestCompletable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@ import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Deprecated.
@@ -115,12 +115,12 @@ public class LegacyTestCompletable extends Completable implements CompletableSou
     }
 
     public LegacyTestCompletable verifyCancelled() {
-        assertTrue("Subscriber did not cancel.", isCancelled());
+        assertTrue(isCancelled(), "Subscriber did not cancel.");
         return this;
     }
 
     public LegacyTestCompletable verifyNotCancelled() {
-        assertFalse("Subscriber cancelled.", isCancelled());
+        assertFalse(isCancelled(), "Subscriber cancelled.");
         return this;
     }
 }

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/LegacyTestSingle.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/LegacyTestSingle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Deprecated.
@@ -142,12 +142,12 @@ public class LegacyTestSingle<T> extends Single<T> implements SingleSource.Subsc
     }
 
     public LegacyTestSingle<T> verifyCancelled() {
-        assertTrue("Subscriber did not cancel.", isCancelled());
+        assertTrue(isCancelled(), "Subscriber did not cancel.");
         return this;
     }
 
     public LegacyTestSingle<T> verifyNotCancelled() {
-        assertFalse("Subscriber cancelled.", isCancelled());
+        assertFalse(isCancelled(), "Subscriber cancelled.");
         return this;
     }
 }

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/VerificationTestUtils.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/VerificationTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import javax.annotation.Nullable;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public final class VerificationTestUtils {
     private VerificationTestUtils() {
@@ -38,7 +38,7 @@ public final class VerificationTestUtils {
                 break;
             }
         }
-        assertTrue("couldn't find suppressed cause " + expectedSuppressedCause, found);
+        assertTrue(found, () -> "couldn't find suppressed cause " + expectedSuppressedCause);
     }
 
     public static void expectThrowable(final Runnable runnable, final Class<? extends Throwable> expected) {

--- a/servicetalk-concurrent-internal/build.gradle
+++ b/servicetalk-concurrent-internal/build.gradle
@@ -34,4 +34,5 @@ dependencies {
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testFixturesImplementation "junit:junit:$junitVersion"
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  testFixturesImplementation "org.slf4j:slf4j-api:$slf4jVersion"
 }

--- a/servicetalk-concurrent-internal/build.gradle
+++ b/servicetalk-concurrent-internal/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,11 +25,13 @@ dependencies {
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation project(":servicetalk-test-resources")
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "junit:junit:$junitVersion"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 
   testFixturesImplementation project(":servicetalk-annotations")
+  testFixturesImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testFixturesImplementation "junit:junit:$junitVersion"
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
 }

--- a/servicetalk-concurrent-internal/src/testFixtures/java/io/servicetalk/concurrent/internal/ServiceTalkTestTimeout.java
+++ b/servicetalk-concurrent-internal/src/testFixtures/java/io/servicetalk/concurrent/internal/ServiceTalkTestTimeout.java
@@ -22,24 +22,15 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.junit.runners.model.TestTimedOutException;
 
-import java.lang.management.LockInfo;
-import java.lang.management.ManagementFactory;
-import java.lang.management.MonitorInfo;
-import java.lang.management.ThreadInfo;
-import java.lang.management.ThreadMXBean;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 import static java.lang.Boolean.parseBoolean;
@@ -143,7 +134,7 @@ public final class ServiceTalkTestTimeout extends Timeout {
                 // test failed; have caller re-throw the exception thrown by the test
                 return e.getCause();
             } catch (TimeoutException e) {
-                dumpAllStacks(); // dump all stacks before interrupting any thread
+                TimeoutTracingInfoExtension.dumpAllStacks(); // dump all stacks before interrupting any thread
                 onTimeout.run();
                 return createTimeoutException(thread);
             }
@@ -179,57 +170,6 @@ public final class ServiceTalkTestTimeout extends Timeout {
             void awaitStarted() throws InterruptedException {
                 startLatch.await();
             }
-        }
-
-        private static void dumpAllStacks() {
-            ThreadMXBean bean = ManagementFactory.getThreadMXBean();
-            List<ThreadInfo> threadInfos = Stream.of(bean.getThreadInfo(bean.getAllThreadIds(),
-                    bean.isObjectMonitorUsageSupported(), bean.isSynchronizerUsageSupported()))
-                    .filter(Objects::nonNull) // filter out dead threads
-                    .sorted(Comparator.comparing(ThreadInfo::getThreadName))
-                    .collect(Collectors.toList());
-            StringBuilder sb = new StringBuilder(threadInfos.size() * 4096);
-            for (ThreadInfo info : threadInfos) {
-                sb.append('"').append(info.getThreadName()).append('"');
-                sb.append(" #").append(info.getThreadId());
-                sb.append(" ").append(info.getThreadState().toString().toLowerCase());
-                if (info.getLockName() != null) {
-                    sb.append(" on ").append(info.getLockName());
-                }
-                if (info.getLockOwnerName() != null) {
-                    sb.append(" owned by \"").append(info.getLockOwnerName()).append("\" #")
-                            .append(info.getLockOwnerId());
-                }
-                if (info.isSuspended()) {
-                    sb.append(" (suspended)");
-                }
-                if (info.isInNative()) {
-                    sb.append(" (in native)");
-                }
-                sb.append("\n");
-
-                sb.append("  java.lang.Thread.State: ").append(info.getThreadState()).append("\n");
-                StackTraceElement[] stackTrace = info.getStackTrace();
-                for (int i = 0; i < stackTrace.length; ++i) {
-                    sb.append("\t  at ").append(stackTrace[i]).append("\n");
-                    for (MonitorInfo mi : info.getLockedMonitors()) {
-                        if (mi.getLockedStackDepth() == i) {
-                            sb.append("\t  - locked ").append(mi).append("\n");
-                        }
-                    }
-                }
-                sb.append("\n");
-
-                LockInfo[] locks = info.getLockedSynchronizers();
-                if (locks.length > 0) {
-                    sb.append("\t  Number of locked synchronizers = ").append(locks.length).append("\n");
-                    for (LockInfo li : locks) {
-                        sb.append("\t  - ").append(li).append("\n");
-                    }
-                    sb.append("\n");
-                }
-            }
-            System.out.println(sb.toString());
         }
     }
 }

--- a/servicetalk-concurrent-internal/src/testFixtures/java/io/servicetalk/concurrent/internal/TimeoutTracingInfoExtension.java
+++ b/servicetalk-concurrent-internal/src/testFixtures/java/io/servicetalk/concurrent/internal/TimeoutTracingInfoExtension.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.servicetalk.concurrent.internal;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.lang.management.LockInfo;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class TimeoutTracingInfoExtension implements AfterEachCallback {
+
+    public static final int DEFAULT_TIMEOUT_SECONDS = 30;
+    @Override
+    public void afterEach(ExtensionContext context) {
+        Optional<Throwable> executionException = context.getExecutionException();
+        if (executionException.isPresent() && executionException.get() instanceof TimeoutException) {
+            dumpAllStacks();
+        }
+    }
+
+    private static void dumpAllStacks() {
+        ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+        List<ThreadInfo> threadInfos = Stream.of(bean.getThreadInfo(bean.getAllThreadIds(),
+                                                                    bean.isObjectMonitorUsageSupported(),
+                                                                    bean.isSynchronizerUsageSupported()))
+            .filter(Objects::nonNull) // filter out dead threads
+            .sorted(Comparator.comparing(ThreadInfo::getThreadName))
+            .collect(Collectors.toList());
+        StringBuilder sb = new StringBuilder(threadInfos.size() * 4096);
+        for (ThreadInfo info : threadInfos) {
+            sb.append('"').append(info.getThreadName()).append('"');
+            sb.append(" #").append(info.getThreadId());
+            sb.append(" ").append(info.getThreadState().toString().toLowerCase());
+            if (info.getLockName() != null) {
+                sb.append(" on ").append(info.getLockName());
+            }
+            if (info.getLockOwnerName() != null) {
+                sb.append(" owned by \"").append(info.getLockOwnerName()).append("\" #")
+                    .append(info.getLockOwnerId());
+            }
+            if (info.isSuspended()) {
+                sb.append(" (suspended)");
+            }
+            if (info.isInNative()) {
+                sb.append(" (in native)");
+            }
+            sb.append("\n");
+
+            sb.append("  java.lang.Thread.State: ").append(info.getThreadState()).append("\n");
+            StackTraceElement[] stackTrace = info.getStackTrace();
+            for (int i = 0; i < stackTrace.length; ++i) {
+                sb.append("\t  at ").append(stackTrace[i]).append("\n");
+                for (MonitorInfo mi : info.getLockedMonitors()) {
+                    if (mi.getLockedStackDepth() == i) {
+                        sb.append("\t  - locked ").append(mi).append("\n");
+                    }
+                }
+            }
+            sb.append("\n");
+
+            LockInfo[] locks = info.getLockedSynchronizers();
+            if (locks.length > 0) {
+                sb.append("\t  Number of locked synchronizers = ").append(locks.length).append("\n");
+                for (LockInfo li : locks) {
+                    sb.append("\t  - ").append(li).append("\n");
+                }
+                sb.append("\n");
+            }
+        }
+        System.out.println(sb);
+    }
+}

--- a/servicetalk-concurrent-internal/src/testFixtures/java/io/servicetalk/concurrent/internal/TimeoutTracingInfoExtension.java
+++ b/servicetalk-concurrent-internal/src/testFixtures/java/io/servicetalk/concurrent/internal/TimeoutTracingInfoExtension.java
@@ -18,23 +18,86 @@ package io.servicetalk.concurrent.internal;
 
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.management.LockInfo;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class TimeoutTracingInfoExtension implements AfterEachCallback {
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static java.util.regex.Pattern.UNICODE_CASE;
 
-    public static final int DEFAULT_TIMEOUT_SECONDS = 30;
+/**
+ * Junit extension which will print information about all threads if unit test method throws
+ * {@link TimeoutException}.
+ */
+public final class TimeoutTracingInfoExtension implements AfterEachCallback {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private static final Pattern PATTERN = Pattern.compile("([1-9]\\d*) ?((?:[nμm]?s)|m|h|d)?",
+            CASE_INSENSITIVE | UNICODE_CASE);
+    private static final Map<String, TimeUnit> UNITS_MAP;
+
+    static {
+        Map<String, TimeUnit> unitsMap = new HashMap<>();
+        unitsMap.put("ns", NANOSECONDS);
+        unitsMap.put("μs", MICROSECONDS);
+        unitsMap.put("ms", MILLISECONDS);
+        unitsMap.put("s", SECONDS);
+        unitsMap.put("m", MINUTES);
+        unitsMap.put("h", HOURS);
+        unitsMap.put("d", DAYS);
+        UNITS_MAP = Collections.unmodifiableMap(unitsMap);
+    }
+
+    public static final long DEFAULT_TIMEOUT_SECONDS = parseSystemProperty();
+    private static final int DEFAULT_TIMEOUT_SECONDS_DEFAULT = 30;
+
+    private static long parseSystemProperty() {
+        String systemPropertyValue = System.getProperty("junit.jupiter.execution.timeout.default");
+
+        if (systemPropertyValue == null) {
+            return DEFAULT_TIMEOUT_SECONDS_DEFAULT;
+        }
+        Matcher matcher = PATTERN.matcher(systemPropertyValue);
+        if (matcher.matches()) {
+            long value = Long.parseLong(matcher.group(1));
+            String unitAbbreviation = matcher.group(2);
+            TimeUnit unit = unitAbbreviation == null ? SECONDS
+                    : UNITS_MAP.get(unitAbbreviation.toLowerCase(Locale.ENGLISH));
+            return SECONDS.convert(value, unit);
+        }
+
+        LOGGER.error("Error parsing `{}`, using default value", systemPropertyValue);
+        return DEFAULT_TIMEOUT_SECONDS_DEFAULT;
+    }
+
     @Override
     public void afterEach(ExtensionContext context) {
         Optional<Throwable> executionException = context.getExecutionException();
@@ -43,14 +106,14 @@ public class TimeoutTracingInfoExtension implements AfterEachCallback {
         }
     }
 
-    private static void dumpAllStacks() {
+    static void dumpAllStacks() {
         ThreadMXBean bean = ManagementFactory.getThreadMXBean();
         List<ThreadInfo> threadInfos = Stream.of(bean.getThreadInfo(bean.getAllThreadIds(),
-                                                                    bean.isObjectMonitorUsageSupported(),
-                                                                    bean.isSynchronizerUsageSupported()))
-            .filter(Objects::nonNull) // filter out dead threads
-            .sorted(Comparator.comparing(ThreadInfo::getThreadName))
-            .collect(Collectors.toList());
+                bean.isObjectMonitorUsageSupported(),
+                bean.isSynchronizerUsageSupported()))
+                .filter(Objects::nonNull) // filter out dead threads
+                .sorted(Comparator.comparing(ThreadInfo::getThreadName))
+                .collect(Collectors.toList());
         StringBuilder sb = new StringBuilder(threadInfos.size() * 4096);
         for (ThreadInfo info : threadInfos) {
             sb.append('"').append(info.getThreadName()).append('"');
@@ -61,7 +124,7 @@ public class TimeoutTracingInfoExtension implements AfterEachCallback {
             }
             if (info.getLockOwnerName() != null) {
                 sb.append(" owned by \"").append(info.getLockOwnerName()).append("\" #")
-                    .append(info.getLockOwnerId());
+                        .append(info.getLockOwnerId());
             }
             if (info.isSuspended()) {
                 sb.append(" (suspended)");

--- a/servicetalk-concurrent-internal/src/testFixtures/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/servicetalk-concurrent-internal/src/testFixtures/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension


### PR DESCRIPTION
Motivation:
 
- JUnit 5 leverages features from Java 8 or later, such as lambda functions, making tests more powerful and easier to maintain.
- JUnit 5 has added some very useful new features for describing, organizing, and executing tests. For instance, tests get better display names and can be organized hierarchically.
- JUnit 5 is organized into multiple libraries, so only the features you need are imported into your project. With build systems such as Maven and Gradle, including the right libraries is easy.
- JUnit 5 can use more than one extension at a time, which JUnit 4 could not (only one runner could be used at a time). This means you can easily combine the Spring extension with other extensions (such as your own custom extension).

[migrating-from-junit-4-to-junit-5-important-differences-and-benefits](https://blogs.oracle.com/javamagazine/migrating-from-junit-4-to-junit-5-important-differences-and-benefits)

Modifications:
   Updated unit tests 
   `ServiceTalkTestTimeout` junit4 Rule functionality is replaced with 
    - global timeout for all tests methods - `junit.jupiter.execution.timeout.default`
    - junit5 `@Timeout` annotation 
    - custom junit5 `TimeoutTracingInfoExtension`

Result:
   module concurrent-api is running tests using junit5 engine