### PR TITLE
`FromInputStreamPublisher` should apply an upper bound to temporary buffer size

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromInputStreamPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromInputStreamPublisher.java
@@ -83,7 +83,9 @@ final class FromInputStreamPublisher extends Publisher<byte[]> implements Publis
      */
     FromInputStreamPublisher(final InputStream stream, final int readChunkSize) {
         this.stream = requireNonNull(stream);
-        this.readChunkSize = readChunkSize;
+        if (readChunkSize <= 0) {
+            throw new IllegalArgumentException("readChunkSize: " + readChunkSize + " (expected: >0)");
+        }
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromInputStreamPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromInputStreamPublisher.java
@@ -45,6 +45,7 @@ import static java.util.Objects.requireNonNull;
  */
 final class FromInputStreamPublisher extends Publisher<byte[]> implements PublisherSource<byte[]> {
     private static final Logger LOGGER = LoggerFactory.getLogger(FromInputStreamPublisher.class);
+    private static final int DEFAULT_READ_CHUNK_SIZE = 65536;
     private static final AtomicIntegerFieldUpdater<FromInputStreamPublisher> subscribedUpdater =
             AtomicIntegerFieldUpdater.newUpdater(FromInputStreamPublisher.class, "subscribed");
 
@@ -62,6 +63,7 @@ final class FromInputStreamPublisher extends Publisher<byte[]> implements Publis
     private volatile int subscribed;
 
     private final InputStream stream;
+    private final int readChunkSize;
 
     /**
      * A new instance.
@@ -69,7 +71,19 @@ final class FromInputStreamPublisher extends Publisher<byte[]> implements Publis
      * @param stream the {@link InputStream} to expose as a {@link Publisher}
      */
     FromInputStreamPublisher(final InputStream stream) {
+        this(stream, DEFAULT_READ_CHUNK_SIZE);
+    }
+
+    /**
+     * A new instance.
+     *
+     * @param stream the {@link InputStream} to expose as a {@link Publisher}
+     * @param readChunkSize the maximum length of {@code byte[]} chunks which will be read from the {@link InputStream}
+     * and emitted by the {@link Publisher}.
+     */
+    FromInputStreamPublisher(final InputStream stream, final int readChunkSize) {
         this.stream = requireNonNull(stream);
+        this.readChunkSize = readChunkSize;
     }
 
     @Override
@@ -81,7 +95,7 @@ final class FromInputStreamPublisher extends Publisher<byte[]> implements Publis
     protected void handleSubscribe(final Subscriber<? super byte[]> subscriber) {
         if (subscribedUpdater.compareAndSet(this, 0, 1)) {
             try {
-                subscriber.onSubscribe(new InputStreamPublisherSubscription(stream, subscriber));
+                subscriber.onSubscribe(new InputStreamPublisherSubscription(stream, subscriber, readChunkSize));
             } catch (Throwable t) {
                 handleExceptionFromOnSubscribe(subscriber, t);
             }
@@ -100,6 +114,7 @@ final class FromInputStreamPublisher extends Publisher<byte[]> implements Publis
 
         private final InputStream stream;
         private final Subscriber<? super byte[]> subscriber;
+        private final int readChunkSize;
         /**
          * Contains the outstanding demand or {@link #TERMINAL_SENT} indicating when {@link InputStream} and {@link
          * Subscription} are terminated.
@@ -110,9 +125,11 @@ final class FromInputStreamPublisher extends Publisher<byte[]> implements Publis
         private int writeIdx;
         private boolean ignoreRequests;
 
-        InputStreamPublisherSubscription(final InputStream stream, final Subscriber<? super byte[]> subscriber) {
+        InputStreamPublisherSubscription(final InputStream stream, final Subscriber<? super byte[]> subscriber,
+                                         final int readChunkSize) {
             this.stream = stream;
             this.subscriber = subscriber;
+            this.readChunkSize = readChunkSize;
         }
 
         @Override
@@ -168,7 +185,7 @@ final class FromInputStreamPublisher extends Publisher<byte[]> implements Publis
         // This method honors the estimated available bytes that can be read without blocking
         private int fillBufferAvoidingBlocking(int available) throws IOException {
             if (buffer == null) {
-                buffer = new byte[available];
+                buffer = new byte[min(available, readChunkSize)];
             }
             while (writeIdx != buffer.length && available > 0) {
                 int len = min(buffer.length - writeIdx, available);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromInputStreamPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromInputStreamPublisher.java
@@ -86,6 +86,7 @@ final class FromInputStreamPublisher extends Publisher<byte[]> implements Publis
         if (readChunkSize <= 0) {
             throw new IllegalArgumentException("readChunkSize: " + readChunkSize + " (expected: >0)");
         }
+        this.readChunkSize = readChunkSize;
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2913,7 +2913,7 @@ public abstract class Publisher<T> {
      * the {@link Subscription} should be "responsive". The responsiveness of the associated {@link Subscription}s will
      * depend upon the behavior of the {@code stream} below. Make sure the {@link Executor} for this execution chain
      * can tolerate this responsiveness and any blocking behavior.
-     * @param stream provides the data in the form of {@code byte[]} to be emitted to the {@link Subscriber} to the
+     * @param stream provides the data in the form of {@code byte[]} to be emitted to the {@link Subscriber} by the
      * returned {@link Publisher}. Given the blocking nature of {@link InputStream}, assume {@link
      * Subscription#request(long)} can block when the underlying {@link InputStream} blocks on {@link
      * InputStream#read(byte[], int, int)}.
@@ -2922,6 +2922,29 @@ public abstract class Publisher<T> {
      */
     public static Publisher<byte[]> fromInputStream(InputStream stream) {
         return new FromInputStreamPublisher(stream);
+    }
+
+    /**
+     * Create a new {@link Publisher} that when subscribed will emit all data from the {@link InputStream} to the
+     * {@link Subscriber} and then {@link Subscriber#onComplete()}.
+     * <p>
+     * The Reactive Streams specification provides two criteria (
+     * <a href="https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#3.4">3.4</a>, and
+     * <a href="https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#3.5">3.5</a>) stating
+     * the {@link Subscription} should be "responsive". The responsiveness of the associated {@link Subscription}s will
+     * depend upon the behavior of the {@code stream} below. Make sure the {@link Executor} for this execution chain
+     * can tolerate this responsiveness and any blocking behavior.
+     * @param stream provides the data in the form of {@code byte[]} to be emitted to the {@link Subscriber} by the
+     * returned {@link Publisher}. Given the blocking nature of {@link InputStream}, assume {@link
+     * Subscription#request(long)} can block when the underlying {@link InputStream} blocks on {@link
+     * InputStream#read(byte[], int, int)}.
+     * @param readChunkSize the maximum length of {@code byte[]} chunks which will be read from the {@link InputStream}
+     * and emitted by the returned {@link Publisher}.
+     * @return a new {@link Publisher} that when subscribed will emit all data from the {@link InputStream} to the
+     * {@link Subscriber} and then {@link Subscriber#onComplete()}.
+     */
+    public static Publisher<byte[]> fromInputStream(InputStream stream, int readChunkSize) {
+        return new FromInputStreamPublisher(stream, readChunkSize);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/FromInputStreamPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/FromInputStreamPublisherTest.java
@@ -514,4 +514,13 @@ public class FromInputStreamPublisherTest {
         }
         assertThat(complete.get(), equalTo(true));
     }
+
+    @Test
+    public void dontFailWhenInputStreamAvailableExceedsVmArraySizeLimit() throws Throwable {
+        when(inputStream.available()).thenReturn(MAX_VALUE);
+        when(inputStream.read(any(), anyInt(), anyInt())).thenReturn(-1);
+        toSource(pub).subscribe(sub1);
+        sub1.awaitSubscription().request(1);
+        sub1.awaitOnComplete();
+    }
 }


### PR DESCRIPTION
Motivation:

An `InputStream` with an arbitrary number of bytes available to be read
must be usable as a supply for payload body on a request.
However, supplying an `InputStream` with available bytes greater than
VM array size limit [1]. Results in `java.lang.OutOfMemoryError:
Requested array size exceeds VM limit` being thrown.

1. https://plumbr.io/outofmemoryerror/requested-array-size-exceeds-vm-limit

Modifications:

- Limited the max size of the buffer into which `InputStream` is read
to 64kb.

Result:

Providing an `InputStream` with available bytes greater than max VM
array size no longer results in an `OutOfMemoryError`.