### PR TITLE
Remove 1ms connect timeout in tests

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -137,7 +137,6 @@ import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h2Default;
 import static io.servicetalk.http.netty.HttpTestExecutionStrategy.CACHED;
 import static io.servicetalk.http.netty.HttpTestExecutionStrategy.NO_OFFLOAD;
-import static io.servicetalk.transport.api.ServiceTalkSocketOptions.CONNECT_TIMEOUT;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.BuilderUtils.serverChannel;
 import static io.servicetalk.transport.netty.internal.NettyIoExecutors.createEventLoopGroup;
@@ -800,7 +799,6 @@ public class H2PriorKnowledgeFeatureParityTest {
         h1ServerContext.closeAsyncGracefully().subscribe();
 
         try (BlockingHttpClient client2 = forSingleAddress(HostAndPort.of(serverAddress))
-                .socketOption(CONNECT_TIMEOUT, 1) // windows default connect timeout is seconds, we want to fail fast.
                 .protocols(h2PriorKnowledge ? h2Default() : h1Default())
                 .executionStrategy(clientExecutionStrategy).buildBlocking()) {
             try {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
@@ -67,7 +67,6 @@ import static io.servicetalk.http.api.HttpResponseStatus.PERMANENT_REDIRECT;
 import static io.servicetalk.http.api.HttpResponseStatus.SEE_OTHER;
 import static io.servicetalk.http.api.HttpResponseStatus.UNAUTHORIZED;
 import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.globalDnsServiceDiscoverer;
-import static io.servicetalk.transport.api.ServiceTalkSocketOptions.CONNECT_TIMEOUT;
 import static io.servicetalk.transport.netty.internal.AddressUtils.hostHeader;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -104,7 +103,6 @@ public class MultiAddressUrlHttpClientTest {
 
         client = afterClassCloseables.append(HttpClients.forMultiAddressUrl()
                 .serviceDiscoverer(sdThatSupportsInvalidHostname())
-                .socketOption(CONNECT_TIMEOUT, 1) // windows default connect timeout is seconds, we want to fail fast.
                 .buildStreaming());
 
         httpService = (ctx, request, factory) -> {


### PR DESCRIPTION
Motivation:

We added `socketOption(CONNECT_TIMEOUT, 1)` in the past to make some
tests pass on Windows with a comment that Windows uses seconds for the
timeout value. However, Linux uses milliseconds and the `CONNECT_TIMEOUT`
socket option says it have to be in milliseconds. 1ms timeout makes
these tests flaky on Linux and macOS. Let's revisit when we will have
Windows CI pipeline and understand why this socket option is not consistent
on different OS.

Modifications:

- Remove `CONNECT_TIMEOUT` from `H2PriorKnowledgeFeatureParityTest`
and `MultiAddressUrlHttpClientTest`;

Result:

Fixes #1363. Tests do not fail due to 1ms connect timeout on Linux.