### PR TITLE
Remove HTTP/2 content-length header validation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@
 group=io.servicetalk
 version=0.38.0-SNAPSHOT
 
-nettyVersion=4.1.59.Final
+nettyVersion=4.1.60.Final
 tcnativeVersion=2.0.36.Final
 jsr305Version=3.0.2
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -43,8 +43,11 @@ import io.servicetalk.grpc.netty.CompatProto.Compat.ServerStreamingCallMetadata;
 import io.servicetalk.grpc.netty.CompatProto.Compat.ServiceFactory;
 import io.servicetalk.grpc.netty.CompatProto.RequestContainer.CompatRequest;
 import io.servicetalk.grpc.netty.CompatProto.ResponseContainer.CompatResponse;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequester;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpServiceFilter;
@@ -100,6 +103,9 @@ import static io.servicetalk.encoding.api.ContentCodings.gzipDefault;
 import static io.servicetalk.encoding.api.ContentCodings.identity;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.defaultStrategy;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
+import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
+import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.test.resources.DefaultTestCerts.loadServerKey;
 import static io.servicetalk.test.resources.DefaultTestCerts.loadServerPem;
 import static io.servicetalk.transport.api.SecurityConfigurator.SslProvider.OPENSSL;
@@ -832,6 +838,20 @@ public class ProtocolCompatibilityTest {
             builder.secure().disableHostnameVerification().provider(OPENSSL)
                     .trustManager(DefaultTestCerts::loadServerCAPem).commit();
         }
+        // TODO(scott): remove after https://github.com/grpc/grpc-java/issues/7953 is resolved.
+        builder.appendHttpClientFilter(client -> new StreamingHttpClientFilter(client) {
+            @Override
+            protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
+                                                            final HttpExecutionStrategy strategy,
+                                                            final StreamingHttpRequest request) {
+                return Single.defer(() -> {
+                    // Force chunked transfer encoding as a workaround for grpc-java bug.
+                    request.headers().remove(CONTENT_LENGTH);
+                    request.headers().set(TRANSFER_ENCODING, CHUNKED);
+                    return delegate.request(strategy, request).subscribeShareContext();
+                });
+            }
+        });
         List<ContentCodec> codings = serviceTalkCodingsFor(compression);
         return builder.build(new Compat.ClientFactory().supportedMessageCodings(codings));
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -66,6 +66,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
+import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http2.DefaultHttp2DataFrame;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
@@ -82,6 +83,7 @@ import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -93,6 +95,7 @@ import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.net.InetSocketAddress;
+import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -124,6 +127,7 @@ import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.COOKIE;
 import static io.servicetalk.http.api.HttpHeaderNames.EXPECT;
 import static io.servicetalk.http.api.HttpHeaderNames.SET_COOKIE;
+import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderValues.CONTINUE;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
@@ -147,9 +151,11 @@ import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.function.UnaryOperator.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.notNullValue;
@@ -159,6 +165,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
@@ -432,6 +439,126 @@ public class H2PriorKnowledgeFeatureParityTest {
                 .executionStrategy(clientExecutionStrategy).buildBlocking()) {
             assertThat(client.request(client.get("/").payloadBody("", textSerializer()))
                     .payloadBody(textDeserializer()), isEmptyString());
+        }
+    }
+
+    @Test
+    public void clientSendsLargerContentLength() throws Exception {
+        assumeTrue(h2PriorKnowledge); // http/1.x will timeout waiting for more payload.
+        clientSendsInvalidContentLength(1, false);
+    }
+
+    @Test
+    public void clientSendsLargerContentLengthTrailers() throws Exception {
+        assumeTrue(h2PriorKnowledge); // http/1.x will timeout waiting for more payload.
+        clientSendsInvalidContentLength(1, true);
+    }
+
+    @Test
+    public void clientSendsSmallerContentLength() throws Exception {
+        clientSendsInvalidContentLength(-1, false);
+    }
+
+    @Test
+    public void clientSendsSmallerContentLengthTrailers() throws Exception {
+        clientSendsInvalidContentLength(-1, true);
+    }
+
+    private void clientSendsInvalidContentLength(int contentLengthAdder, boolean addTrailers) throws Exception {
+        InetSocketAddress serverAddress = bindHttpEchoServer();
+        try (BlockingHttpClient client = forSingleAddress(HostAndPort.of(serverAddress))
+                .protocols(h2PriorKnowledge ? h2Default() : h1Default())
+                .executionStrategy(clientExecutionStrategy)
+                .appendClientFilter(client1 -> new StreamingHttpClientFilter(client1) {
+                    @Override
+                    protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
+                                                                    final HttpExecutionStrategy strategy,
+                                                                    final StreamingHttpRequest request) {
+                        return request.toRequest().map(req -> {
+                            req.headers().remove(TRANSFER_ENCODING);
+                            req.headers().set(CONTENT_LENGTH,
+                                    String.valueOf(req.payloadBody().readableBytes() + contentLengthAdder));
+                            return req.toStreamingRequest();
+                        }).flatMap(req -> delegate.request(strategy, req));
+                    }
+                }).buildBlocking()) {
+            HttpRequest request = client.get("/").payloadBody("a", textSerializer());
+            if (addTrailers) {
+                request.trailers().set("mytrailer", "myvalue");
+            }
+            if (h2PriorKnowledge) {
+                assertThrows(Http2Exception.H2StreamResetException.class, () -> client.request(request));
+            } else {
+                ReservedBlockingHttpConnection reservedConn = client.reserveConnection(request);
+                try {
+                    reservedConn.request(request);
+                    assertThrows(ClosedChannelException.class, () ->
+                            reservedConn.request(client.get("/").payloadBody("a", textSerializer())));
+                } finally {
+                    assertThrows(IllegalStateException.class, reservedConn::release);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void serverSendsLargerContentLength() throws Exception {
+        assumeTrue(h2PriorKnowledge); // http/1.x will timeout waiting for more payload.
+        serverSendsInvalidContentLength(1, false);
+    }
+
+    @Test
+    public void serverSendsLargerContentLengthTrailers() throws Exception {
+        assumeTrue(h2PriorKnowledge); // http/1.x will timeout waiting for more payload.
+        serverSendsInvalidContentLength(1, true);
+    }
+
+    @Test
+    public void serverSendsSmallerContentLength() throws Exception {
+        serverSendsInvalidContentLength(-1, false);
+    }
+
+    @Test
+    public void serverSendsSmallerContentLengthTrailers() throws Exception {
+        serverSendsInvalidContentLength(-1, true);
+    }
+
+    private void serverSendsInvalidContentLength(int contentLengthAdder, boolean addTrailers) throws Exception {
+        InetSocketAddress serverAddress = bindHttpEchoServer(service -> new StreamingHttpServiceFilter(service) {
+            @Override
+            public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
+                                                        final StreamingHttpRequest request,
+                                                        final StreamingHttpResponseFactory responseFactory) {
+                return delegate().handle(ctx, request, responseFactory).flatMap(resp ->
+                        resp.toResponse().map(aggResp -> {
+                            aggResp.headers().remove(TRANSFER_ENCODING);
+                            aggResp.headers().set(CONTENT_LENGTH,
+                                    String.valueOf(aggResp.payloadBody().readableBytes() + contentLengthAdder));
+                            return aggResp.toStreamingResponse();
+                        }));
+            }
+        });
+        try (BlockingHttpClient client = forSingleAddress(HostAndPort.of(serverAddress))
+                .protocols(h2PriorKnowledge ? h2Default() : h1Default())
+                .executionStrategy(clientExecutionStrategy)
+                .buildBlocking()) {
+            HttpRequest request = client.get("/").payloadBody("a", textSerializer());
+            if (addTrailers) {
+                request.trailers().set("mytrailer", "myvalue");
+            }
+            if (h2PriorKnowledge) {
+                assertThat(invokeThrowableRunnable(() -> client.request(request)),
+                        either(instanceOf(Http2Exception.class)).or(instanceOf(ClosedChannelException.class)));
+            } else {
+                ReservedBlockingHttpConnection reservedConn = client.reserveConnection(request);
+                try {
+                    reservedConn.request(request);
+                    assertThrows(DecoderException.class, () ->
+                            reservedConn.request(client.get("/").payloadBody("a", textSerializer())));
+                } finally {
+                    invokeThrowableRunnable(reservedConn::release);
+                }
+            }
         }
     }
 
@@ -1431,5 +1558,15 @@ public class H2PriorKnowledgeFeatureParityTest {
             trailers.add(trailerName, Integer.toString(contentSize.get()));
             return trailers;
         }
+    }
+
+    @Nullable
+    private static Throwable invokeThrowableRunnable(ThrowingRunnable runnable) {
+        try {
+            runnable.run();
+        } catch (Throwable cause) {
+            return cause;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Motivation:
Netty recently added content-length header validation [1]. ServiceTalk's
content-length validation is now duplicate logic and no longer
necessary.

[1] netty/netty@89c241e

Modifications:
- Remove AbstractH2DuplexHandler state and logic related to validation
  of the content-length header
- Remove `io.servicetalk.http2.allowInvalidContentLength` system
  property. Note that Netty has `io.netty.http2.validateContentLength`
  which serves a similar purpose (and also likely to be removed in a
  release).

Result:
HTTP/2 content-length validation is enforced in a single spot.