### PR TITLE
Update Netty gradle dependencies to runtimeOnly

### DIFF
--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -51,7 +51,6 @@ dependencies {
   }
   testImplementation "io.grpc:grpc-protobuf:$grpcVersion"
   testImplementation "io.grpc:grpc-stub:$grpcVersion"
-  testImplementation "io.netty:netty-transport-native-unix-common:$nettyVersion"
   testImplementation "io.netty:netty-tcnative-boringssl-static:$tcnativeVersion"
   testImplementation "jakarta.annotation:jakarta.annotation-api:$javaxAnnotationsApiVersion"
   testImplementation "junit:junit:$junitVersion"

--- a/servicetalk-tcp-netty-internal/build.gradle
+++ b/servicetalk-tcp-netty-internal/build.gradle
@@ -42,9 +42,11 @@ dependencies {
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testFixturesImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  testFixturesImplementation "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
-  testFixturesImplementation "io.netty:netty-transport-native-epoll:$nettyVersion:linux-aarch_64"
-  testFixturesImplementation "io.netty:netty-transport-native-kqueue:$nettyVersion:osx-x86_64"
+  testFixturesImplementation "io.netty:netty-transport-native-epoll:$nettyVersion"
+  testFixturesRuntimeOnly "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
+  testFixturesRuntimeOnly "io.netty:netty-transport-native-epoll:$nettyVersion:linux-aarch_64"
+  testFixturesImplementation "io.netty:netty-transport-native-kqueue:$nettyVersion"
+  testFixturesRuntimeOnly "io.netty:netty-transport-native-kqueue:$nettyVersion:osx-x86_64"
   testFixturesImplementation "junit:junit:$junitVersion"
   testFixturesImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -29,9 +29,11 @@ dependencies {
   implementation project(":servicetalk-logging-slf4j-internal")
   implementation project(":servicetalk-utils-internal")
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
-  implementation "io.netty:netty-transport-native-epoll:$nettyVersion:linux-aarch_64"
-  implementation "io.netty:netty-transport-native-kqueue:$nettyVersion:osx-x86_64"
+  implementation "io.netty:netty-transport-native-epoll:$nettyVersion"
+  runtimeOnly "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
+  runtimeOnly "io.netty:netty-transport-native-epoll:$nettyVersion:linux-aarch_64"
+  implementation "io.netty:netty-transport-native-kqueue:$nettyVersion"
+  runtimeOnly "io.netty:netty-transport-native-kqueue:$nettyVersion:osx-x86_64"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))


### PR DESCRIPTION
Motivation:
We currently have `implementation` dependencies on Netty's native
transport modules with the architecture qualifier. However we only need
a runtime dependency on these artifacts. This isn't expected to change
behavior from an end user perspective but will allow for local Netty
development on one specific architecture without having all native
artifacts (e.g. local snapshot builds).

Modifications:
- All `implementation` scoped dependencies on Netty's native modules
  are divided into two dependencies. An `implementation` which has no
  scope/architecture qualifier (for java compilation), and a
  `runtimeOnly` which does have the scope/architecture qualifier.

Result:
Gradle dependencies on Netty's native modules are more correct, allowing
for easier local Netty development.