### PR TITLE
Deprecate MultiAddress and Partitioned client builder methods

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
@@ -160,8 +160,8 @@ abstract class HttpClientBuilder<U, R, SDE extends ServiceDiscovererEvent<R>> ex
      * An example of where this maybe used is to convert the {@link U} to a default host header. It may also
      * be used in the event of proxying.
      * @deprecated Will be moved to {@link SingleAddressHttpClientBuilder} otherwise use
-     * {@link MultiAddressHttpClientBuilder.SingleAddressConfigurator} or
-     * {@link PartitionHttpClientBuilderConfigurator}.
+     * {@link MultiAddressHttpClientBuilder.SingleAddressInitializer} or
+     * {@link PartitionedHttpClientBuilder.SingleAddressInitializer}.
      * @param unresolvedAddressToHostFunction invoked to convert the {@link U} unresolved address type into a
      * {@link CharSequence} suitable for use in
      * <a href="https://tools.ietf.org/html/rfc7230#section-5.4">Host Header</a> format.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -49,12 +49,12 @@ import static java.util.Objects.requireNonNull;
 public abstract class MultiAddressHttpClientBuilder<U, R>
         extends HttpClientBuilder<U, R, ServiceDiscovererEvent<R>> {
     /**
-     * Provides a method which can customize {@link SingleAddressHttpClientBuilder} for each new client.
+     * Initializes the {@link SingleAddressHttpClientBuilder} for each new client.
      * @param <U> The unresolved address type.
      * @param <R> The resolved address type.
      */
     @FunctionalInterface
-    public interface SingleAddressConfigurator<U, R> {
+    public interface SingleAddressInitializer<U, R> {
         /**
          * Configures the passed {@link SingleAddressHttpClientBuilder} for the given {@code scheme} and
          * {@code address}.
@@ -62,32 +62,60 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
          * @param address The unresolved address.
          * @param builder The builder to customize and build a {@link StreamingHttpClient}.
          */
-        void configure(String scheme, U address, SingleAddressHttpClientBuilder<U, R> builder);
+        void initialize(String scheme, U address, SingleAddressHttpClientBuilder<U, R> builder);
 
         /**
-         * Appends the passed {@link SingleAddressConfigurator} to this {@link SingleAddressConfigurator} such that this
-         * {@link SingleAddressConfigurator} is applied first and then the passed {@link SingleAddressConfigurator}.
+         * Appends the passed {@link SingleAddressInitializer} to this {@link SingleAddressInitializer} such that this
+         * {@link SingleAddressInitializer} is applied first and then the passed {@link SingleAddressInitializer}.
          *
-         * @param toAppend {@link SingleAddressConfigurator} to append
-         * @return A composite {@link SingleAddressConfigurator} after the append operation.
+         * @param toAppend {@link SingleAddressInitializer} to append
+         * @return A composite {@link SingleAddressInitializer} after the append operation.
          */
-        default SingleAddressConfigurator<U, R> append(SingleAddressConfigurator<U, R> toAppend) {
+        default SingleAddressInitializer<U, R> append(SingleAddressInitializer<U, R> toAppend) {
             return (scheme, address, builder) -> {
-                configure(scheme, address, builder);
-                toAppend.configure(scheme, address, builder);
+                initialize(scheme, address, builder);
+                toAppend.initialize(scheme, address, builder);
             };
         }
     }
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#ioExecutor(IoExecutor)} on the last argument of
+     * {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#executionStrategy(HttpExecutionStrategy)} on the last argument of
+     * {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> executionStrategy(HttpExecutionStrategy strategy);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#bufferAllocator(BufferAllocator)} on the last argument of
+     * {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> bufferAllocator(BufferAllocator allocator);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#socketOption(SocketOption, Object)} on the last argument of
+     * {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract <T> MultiAddressHttpClientBuilder<U, R> socketOption(SocketOption<T> option, T value);
 
@@ -95,24 +123,52 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> enableWireLogging(String loggerName);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#enableWireLogging(String, LogLevel, BooleanSupplier)} on the last argument
+     * of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> enableWireLogging(String loggerName,
                                                                           LogLevel logLevel,
                                                                           BooleanSupplier logUserData);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#protocols(HttpProtocolConfig...)} on the last argument of
+     * {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> protocols(HttpProtocolConfig... protocols);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} on the last argument of
+     * {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> disableHostHeaderFallback();
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#allowDropResponseTrailers(boolean)} on the last argument of
+     * {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> allowDropResponseTrailers(boolean allowDrop);
 
     /**
      * Sets a function that is used for configuring SSL/TLS for https requests.
-     * @deprecated Use {@link #appendClientBuilderFilter(SingleAddressConfigurator)} and create a
-     * {@link SingleAddressConfigurator} that invokes {@link SingleAddressHttpClientBuilder#sslConfig(ClientSslConfig)}.
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and create a
+     * {@link SingleAddressInitializer} that invokes {@link SingleAddressHttpClientBuilder#sslConfig(ClientSslConfig)}.
      * @param sslConfigFunction The function to use for configuring SSL/TLS for https requests.
      * @return {@code this}
      */
@@ -121,51 +177,120 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
             BiConsumer<HostAndPort, ClientSecurityConfigurator> sslConfigFunction);
 
     /**
-     * Set a function which can customize options for each client that is built.
-     * @param singleAddressConfigurator Customizes the builder and returns a {@link StreamingHttpClient}.
+     * Set a function which can customize options for each {@link StreamingHttpClient} that is built.
+     * @param initializer Initializes the {@link SingleAddressHttpClientBuilder} used to build new
+     * {@link StreamingHttpClient}s.
      * @return {@code this}
      */
-    public abstract MultiAddressHttpClientBuilder<U, R> appendClientBuilderFilter(
-            SingleAddressConfigurator<U, R> singleAddressConfigurator);
+    public abstract MultiAddressHttpClientBuilder<U, R> initializer(SingleAddressInitializer<U, R> initializer);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#appendConnectionFilter(StreamingHttpConnectionFilterFactory)} on the last
+     * argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> appendConnectionFilter(
             StreamingHttpConnectionFilterFactory factory);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#appendConnectionFilter(Predicate, StreamingHttpConnectionFilterFactory)} on
+     * the last argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public MultiAddressHttpClientBuilder<U, R> appendConnectionFilter(Predicate<StreamingHttpRequest> predicate,
                                                                       StreamingHttpConnectionFilterFactory factory) {
         return (MultiAddressHttpClientBuilder<U, R>) super.appendConnectionFilter(predicate, factory);
     }
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#appendConnectionFactoryFilter(ConnectionFactoryFilter)} on the last
+     * argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> appendConnectionFactoryFilter(
             ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> factory);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#autoRetryStrategy(AutoRetryStrategyProvider)} on the last
+     * argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> autoRetryStrategy(
             AutoRetryStrategyProvider autoRetryStrategyProvider);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#serviceDiscoverer(ServiceDiscoverer)} on the last
+     * argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> serviceDiscoverer(
             ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#retryServiceDiscoveryErrors(ServiceDiscoveryRetryStrategy)} on the last
+     * argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> retryServiceDiscoveryErrors(
             ServiceDiscoveryRetryStrategy<R, ServiceDiscovererEvent<R>> retryStrategy);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#loadBalancerFactory(HttpLoadBalancerFactory)} on the last
+     * argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract
     MultiAddressHttpClientBuilder<U, R> loadBalancerFactory(HttpLoadBalancerFactory<R> loadBalancerFactory);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)} on the last
+     * argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
+     */
     @Deprecated
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> unresolvedAddressToHost(
             Function<U, CharSequence> unresolvedAddressToHostFunction);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#appendClientFilter(StreamingHttpClientFilterFactory)} on the last
+     * argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> appendClientFilter(StreamingHttpClientFilterFactory factory);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#appendClientFilter(Predicate, StreamingHttpClientFilterFactory)} on the
+     * last argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public MultiAddressHttpClientBuilder<U, R> appendClientFilter(final Predicate<StreamingHttpRequest> predicate,
                                                                   final StreamingHttpClientFilterFactory factory) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionHttpClientBuilderConfigurator.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionHttpClientBuilderConfigurator.java
@@ -21,9 +21,11 @@ import io.servicetalk.client.api.partition.PartitionAttributes;
  * If different clients used by a partitioned client created by a {@link PartitionedHttpClientBuilder} have different
  * builder configuration, this configurator helps to configure them differently.
  * <p>
+ * @deprecated Use {@link PartitionedHttpClientBuilder.SingleAddressInitializer}.
  * @param <U> the type of address before resolution (unresolved address)
  * @param <R> the type of address after resolution (resolved address)
  */
+@Deprecated
 @FunctionalInterface
 public interface PartitionHttpClientBuilderConfigurator<U, R> {
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
@@ -46,16 +46,74 @@ import java.util.function.Predicate;
  */
 public abstract class PartitionedHttpClientBuilder<U, R>
         extends BaseSingleAddressHttpClientBuilder<U, R, PartitionedServiceDiscovererEvent<R>> {
+    /**
+     * Initializes the {@link SingleAddressHttpClientBuilder} for each new client.
+     * @param <U> the type of address before resolution (unresolved address)
+     * @param <R> the type of address after resolution (resolved address)
+     */
+    @FunctionalInterface
+    public interface SingleAddressInitializer<U, R> {
+        /**
+         * Configures the passed {@link SingleAddressHttpClientBuilder} for a given set of {@link PartitionAttributes}.
+         *
+         * @param attr the {@link PartitionAttributes} for the partition
+         * @param builder {@link SingleAddressHttpClientBuilder} to configure for the given {@link PartitionAttributes}
+         */
+        void initialize(PartitionAttributes attr, SingleAddressHttpClientBuilder<U, R> builder);
 
+        /**
+         * Appends the passed {@link SingleAddressInitializer} to this
+         * {@link SingleAddressInitializer} such that this {@link SingleAddressInitializer} is
+         * applied first and then the passed {@link SingleAddressInitializer}.
+         *
+         * @param toAppend {@link SingleAddressInitializer} to append
+         * @return A composite {@link SingleAddressInitializer} after the append operation.
+         */
+        default SingleAddressInitializer<U, R> append(SingleAddressInitializer<U, R> toAppend) {
+            return (attr, builder) -> {
+                initialize(attr, builder);
+                toAppend.initialize(attr, builder);
+            };
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * @deprecated {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#ioExecutor(IoExecutor)} on the last argument of
+     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#executionStrategy(HttpExecutionStrategy)} on the last argument of
+     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> executionStrategy(HttpExecutionStrategy strategy);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#bufferAllocator(BufferAllocator)} on the last argument of
+     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> bufferAllocator(BufferAllocator allocator);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#socketOption(SocketOption, Object)} on the last argument of
+     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract <T> PartitionedHttpClientBuilder<U, R> socketOption(SocketOption<T> option, T value);
 
@@ -63,18 +121,47 @@ public abstract class PartitionedHttpClientBuilder<U, R>
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> enableWireLogging(String loggerName);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#enableWireLogging(String, LogLevel, BooleanSupplier)} on the last argument
+     * of {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> enableWireLogging(String loggerName,
                                                                          LogLevel logLevel,
                                                                          BooleanSupplier logUserData);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#protocols(HttpProtocolConfig...)} on the last argument of
+     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> protocols(HttpProtocolConfig... protocols);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#appendConnectionFilter(StreamingHttpConnectionFilterFactory)} on the last
+     * argument of {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> appendConnectionFilter(
             StreamingHttpConnectionFilterFactory factory);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#appendConnectionFilter(Predicate, StreamingHttpConnectionFilterFactory)} on
+     * the last argument of {@link SingleAddressInitializer#initialize(PartitionAttributes,
+     * SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public PartitionedHttpClientBuilder<U, R> appendConnectionFilter(Predicate<StreamingHttpRequest> predicate,
                                                                      StreamingHttpConnectionFilterFactory factory) {
@@ -82,16 +169,44 @@ public abstract class PartitionedHttpClientBuilder<U, R>
                 super.appendConnectionFilter(predicate, factory);
     }
 
+    /**
+     * {@inheritDoc}
+     * @deprecated {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#appendConnectionFactoryFilter(ConnectionFactoryFilter)} on the last
+     * argument of {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> appendConnectionFactoryFilter(
             ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> factory);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} on the last argument of
+     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> disableHostHeaderFallback();
 
+    /**
+     * {@inheritDoc}
+     * @deprecated {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#allowDropResponseTrailers(boolean)} on the last argument of
+     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> allowDropResponseTrailers(boolean allowDrop);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#autoRetryStrategy(AutoRetryStrategyProvider)} on the last argument of
+     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> autoRetryStrategy(
             AutoRetryStrategyProvider autoRetryStrategyProvider);
@@ -104,18 +219,46 @@ public abstract class PartitionedHttpClientBuilder<U, R>
     public abstract PartitionedHttpClientBuilder<U, R> retryServiceDiscoveryErrors(
             ServiceDiscoveryRetryStrategy<R, PartitionedServiceDiscovererEvent<R>> retryStrategy);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#loadBalancerFactory(HttpLoadBalancerFactory)} on the last argument of
+     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> loadBalancerFactory(
             HttpLoadBalancerFactory<R> loadBalancerFactory);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)} on the last argument of
+     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
+     */
     @Deprecated
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> unresolvedAddressToHost(
             Function<U, CharSequence> unresolvedAddressToHostFunction);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#appendClientFilter(StreamingHttpClientFilterFactory)} on the last argument
+     * of {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> appendClientFilter(StreamingHttpClientFilterFactory function);
 
+    /**
+     * {@inheritDoc}
+     * @deprecated {@link #initializer(SingleAddressInitializer)} and
+     * {@link SingleAddressHttpClientBuilder#appendClientFilter(Predicate, StreamingHttpClientFilterFactory)} on the
+     * last argument of {@link SingleAddressInitializer#initialize(PartitionAttributes,
+     * SingleAddressHttpClientBuilder)}.
+     */
+    @Deprecated
     @Override
     public PartitionedHttpClientBuilder<U, R> appendClientFilter(Predicate<StreamingHttpRequest> predicate,
                                                                  StreamingHttpClientFilterFactory factory) {
@@ -127,9 +270,8 @@ public abstract class PartitionedHttpClientBuilder<U, R>
      * Initiates security configuration for this client. Calling
      * {@link PartitionedHttpClientSecurityConfigurator#commit()} on the returned
      * {@link PartitionedHttpClientSecurityConfigurator} will commit the configuration.
-     * @deprecated Use {@link #appendClientBuilderFilter(PartitionHttpClientBuilderConfigurator)} and create a
-     * {@link PartitionHttpClientBuilderConfigurator} that invokes
-     * {@link SingleAddressHttpClientBuilder#sslConfig(ClientSslConfig)}.
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and create a {@link SingleAddressInitializer} that
+     * invokes {@link SingleAddressHttpClientBuilder#sslConfig(ClientSslConfig)}.
      * @return {@link PartitionHttpClientBuilderConfigurator} to configure security for this client. It is
      * mandatory to call {@link PartitionedHttpClientSecurityConfigurator#commit() commit} after all configuration is
      * done.
@@ -160,11 +302,20 @@ public abstract class PartitionedHttpClientBuilder<U, R>
     /**
      * Sets a function that allows customizing the {@link SingleAddressHttpClientBuilder} used to create the client for
      * a given partition based on its {@link PartitionAttributes}.
-     *
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)}.
      * @param clientFilterFunction {@link BiFunction} used to customize the {@link SingleAddressHttpClientBuilder}
      * before creating the client for the partition
      * @return {@code this}
      */
+    @Deprecated
     public abstract PartitionedHttpClientBuilder<U, R> appendClientBuilderFilter(
             PartitionHttpClientBuilderConfigurator<U, R> clientFilterFunction);
+
+    /**
+     * Set a function which can customize options for each {@link StreamingHttpClient} that is built.
+     * @param initializer Initializes the {@link SingleAddressHttpClientBuilder} used to build new
+     * {@link StreamingHttpClient}s.
+     * @return {@code this}
+     */
+    public abstract PartitionedHttpClientBuilder<U, R> initializer(SingleAddressInitializer<U, R> initializer);
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -80,6 +80,8 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
     private ServiceDiscoveryRetryStrategy<R, PartitionedServiceDiscovererEvent<R>> serviceDiscovererRetryStrategy;
     private final Function<HttpRequestMetaData, PartitionAttributesBuilder> partitionAttributesBuilderFactory;
     private final DefaultSingleAddressHttpClientBuilder<U, R> builderTemplate;
+    @Nullable
+    private SingleAddressInitializer<U, R> clientInitializer;
     private PartitionHttpClientBuilderConfigurator<U, R> clientFilterFunction = (__, ___) -> { };
     private PartitionMapFactory partitionMapFactory = PowerSetPartitionMapFactory.INSTANCE;
     private int serviceDiscoveryMaxQueueSize = 32;
@@ -109,6 +111,9 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
             DefaultSingleAddressHttpClientBuilder<U, R> builder = buildContext.builder.copyBuildCtx().builder;
             builder.serviceDiscoverer(sd);
             clientFilterFunction.configureForPartition(pa, builder);
+            if (clientInitializer != null) {
+                clientInitializer.initialize(pa, builder);
+            }
             return builder.buildStreaming();
         };
 
@@ -376,10 +381,17 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
         return this;
     }
 
+    @Deprecated
     @Override
     public PartitionedHttpClientBuilder<U, R> appendClientBuilderFilter(
             final PartitionHttpClientBuilderConfigurator<U, R> clientFilterFunction) {
         this.clientFilterFunction = this.clientFilterFunction.append(clientFilterFunction);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientBuilder<U, R> initializer(final SingleAddressInitializer<U, R> initializer) {
+        this.clientInitializer = requireNonNull(initializer);
         return this;
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PartitionedHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PartitionedHttpClientTest.java
@@ -137,8 +137,7 @@ public class PartitionedHttpClientTest {
         try (BlockingHttpClient clt = HttpClients.forPartitionedAddress(psd, "test-cluster", selector)
                 // TODO(jayv) This *hack* only works because SRV_NAME is part of the selection criteria,
                 // we need to consider adding metadata to PartitionAttributes.
-                .appendClientBuilderFilter((pa, builder) ->
-                        builder.unresolvedAddressToHost(addr -> pa.get(SRV_NAME)))
+                .initializer((pa, builder) -> builder.unresolvedAddressToHost(addr -> pa.get(SRV_NAME)))
                 .buildBlocking()) {
 
             sdPublisher.onSubscribe(new TestSubscription());
@@ -164,8 +163,7 @@ public class PartitionedHttpClientTest {
         try (BlockingHttpClient clt = HttpClients.forPartitionedAddress(psd, "test-cluster", selector)
                 // TODO(jayv) This *hack* only works because SRV_NAME is part of the selection criteria,
                 // we need to consider adding metadata to PartitionAttributes.
-                .appendClientBuilderFilter((pa, builder) ->
-                        builder.unresolvedAddressToHost(addr -> pa.get(SRV_NAME)))
+                .initializer((pa, builder) -> builder.unresolvedAddressToHost(addr -> pa.get(SRV_NAME)))
                 .buildBlocking()) {
 
             sdPublisher.onSubscribe(new TestSubscription());

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslAndNonSslConnectionsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslAndNonSslConnectionsTest.java
@@ -201,7 +201,7 @@ public class SslAndNonSslConnectionsTest {
     @Test
     public void multiAddressClientWithSslToSecureServer() throws Exception {
         try (BlockingHttpClient client = HttpClients.forMultiAddressUrl()
-                .appendClientBuilderFilter((scheme, address, builder) ->
+                .initializer((scheme, address, builder) ->
                         builder.sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
                                 .peerHost(serverPemHostname()).build()).buildStreaming())
                 .buildBlocking()) {
@@ -212,7 +212,7 @@ public class SslAndNonSslConnectionsTest {
     @Test
     public void multiAddressClientToSecureServerThenToNonSecureServer() throws Exception {
         try (BlockingHttpClient client = HttpClients.forMultiAddressUrl()
-                .appendClientBuilderFilter((scheme, address, builder) -> {
+                .initializer((scheme, address, builder) -> {
                     if (scheme.equalsIgnoreCase("https")) {
                         builder.sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
                                 .peerHost(serverPemHostname()).build());
@@ -227,7 +227,7 @@ public class SslAndNonSslConnectionsTest {
     @Test
     public void multiAddressClientToNonSecureServerThenToSecureServer() throws Exception {
         try (BlockingHttpClient client = HttpClients.forMultiAddressUrl()
-                .appendClientBuilderFilter((scheme, address, builder) -> {
+                .initializer((scheme, address, builder) -> {
                     if (scheme.equalsIgnoreCase("https")) {
                         builder.sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
                                 .peerHost(serverPemHostname()).build());


### PR DESCRIPTION
Motivation:
PartitionedHttpClientBuilder and MultiAddressHttpClientBuilder replicate
methods that exist on SingleAddressHttpClientBuilder as well as
providing a mechanism to directly access the
SingleAddressHttpClientBuilder for each new client to configure it. We
only need one of these mechanisms and the direct access to
SingleAddressHttpClientBuilder reduces duplication and is the more
flexible approach.

Modifications:
- Deprecate all methods on PartitionedHttpClientBuilder and
  MultiAddressHttpClientBuilder which can be otherwise controlled via
  appendClientBuilderFilter(..).
- Deprecate PartitionHttpClientBuilderConfigurator in favor of
  PartitionedHttpClientBuilder.SingleAddressInitializer which is now
  consistent with MultiAddressHttpClientBuilder.SingleAddressInitializer

Result:
Duplicate methods on PartitionedHttpClientBuilder and
MultiAddressHttpClientBuilder have been deprecated indicating the
preferred alternative.

Deprecated methods will be removed in a future release.