### PR TITLE
Fail parsing signed `Content-Length` header values

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -27,8 +27,6 @@ import io.servicetalk.transport.netty.internal.CloseHandler;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.codec.http2.DefaultHttp2HeadersFrame;
 import io.netty.handler.codec.http2.Http2DataFrame;
@@ -37,10 +35,12 @@ import io.netty.handler.codec.http2.Http2HeadersFrame;
 
 import javax.annotation.Nullable;
 
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
+import static io.netty.handler.codec.http.HttpHeaderNames.TRANSFER_ENCODING;
+import static io.netty.handler.codec.http.HttpHeaderValues.CHUNKED;
+import static io.netty.handler.codec.http.HttpHeaderValues.ZERO;
 import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.STATUS;
-import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
-import static io.servicetalk.http.api.HttpHeaderNames.HOST;
-import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.api.HttpRequestMethod.CONNECT;
 import static io.servicetalk.http.api.HttpResponseMetaDataFactory.newResponseMetaData;
@@ -48,7 +48,6 @@ import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATION
 import static io.servicetalk.http.netty.H2ToStH1Utils.h1HeadersToH2Headers;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h2HeadersSanitizeForH1;
 import static io.servicetalk.http.netty.HeaderUtils.canAddResponseTransferEncodingProtocol;
-import static io.servicetalk.http.netty.HeaderUtils.contentLength;
 import static io.servicetalk.http.netty.HeaderUtils.responseMayHaveContent;
 
 final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
@@ -167,15 +166,14 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
         h2HeadersSanitizeForH1(h2Headers);
         if (httpStatus != null) {
             final int statusCode = httpStatus.code();
-            final long contentLength = contentLength(h2Headers.valueIterator(HttpHeaderNames.CONTENT_LENGTH),
-                    h2Headers::getAll);
-            if (contentLength < 0) {
+            final Long contentLength = h2Headers.getLong(CONTENT_LENGTH);
+            if (contentLength == null) {
                 if (fullResponse) {
                     if (responseMayHaveContent(statusCode, method)) {
                         h2Headers.set(CONTENT_LENGTH, ZERO);
                     }
                 } else if (canAddResponseTransferEncodingProtocol(statusCode, method)) {
-                    h2Headers.add(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
+                    h2Headers.add(TRANSFER_ENCODING, CHUNKED);
                 }
             } else if (!responseMayHaveContent(statusCode, method)) {
                 throw new IllegalArgumentException("content-length (" + contentLength +

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
@@ -53,7 +53,6 @@ import static io.servicetalk.http.api.HttpRequestMethod.TRACE;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATIONAL_1XX;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
-import static java.lang.Character.isDigit;
 import static java.lang.Long.parseLong;
 
 final class HeaderUtils {
@@ -304,7 +303,8 @@ final class HeaderUtils {
         }
 
         char firstChar = firstValue.charAt(0);
-        if (!isDigit(firstChar)) {   // prevent signed content-length values: -digit or +digit
+        if (firstChar < '0' || firstChar > '9') {   // allow numbers only in ASCII or ISO-8859-1 encoding
+            // prevent signed content-length values: -digit or +digit
             throw malformedCL(firstValue);
         }
         final long value;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
@@ -33,7 +33,6 @@ import io.netty.util.AsciiString;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
@@ -54,6 +53,8 @@ import static io.servicetalk.http.api.HttpRequestMethod.TRACE;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATIONAL_1XX;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
+import static java.lang.Character.isDigit;
+import static java.lang.Long.parseLong;
 
 final class HeaderUtils {
     static final Predicate<Object> LAST_CHUNK_PREDICATE = p -> p instanceof HttpHeaders;
@@ -271,14 +272,15 @@ final class HeaderUtils {
 
     /**
      * Extracts the {@link HttpHeaderNames#CONTENT_LENGTH content-length} value from the passed values iterator.
+     * <p>
+     * This utility validates that there is no more than one {@link HttpHeaderNames#CONTENT_LENGTH content-length}
+     * header present and it has a valid number format.
      *
      * @param iterator the {@link Iterator} over content-length header values
-     * @param valuesExtractor a {@link Function} that extracts header values for exception message
      * @return the normalized content-length from the headers or {@code -1} if no content-length header is found
      * @throws IllegalArgumentException if multiple content-length header values are present
      */
-    static long contentLength(final Iterator<? extends CharSequence> iterator,
-                              final Function<CharSequence, Iterable<? extends CharSequence>> valuesExtractor) {
+    static long contentLength(final Iterator<? extends CharSequence> iterator) {
         if (!iterator.hasNext()) {
             return -1;
         }
@@ -297,11 +299,43 @@ final class HeaderUtils {
         //   containing that decimal value prior to determining the message body
         //   length or forwarding the message.
         CharSequence firstValue = iterator.next();
-        if (iterator.hasNext() || CharSequences.indexOf(firstValue, ',', 0) >= 0) {
-            throw new IllegalArgumentException("Multiple content-length values found: " +
-                    valuesExtractor.apply(CONTENT_LENGTH));
+        if (iterator.hasNext()) {
+            throw multipleCL(firstValue, iterator);
         }
-        return Long.parseLong(firstValue.toString());
+
+        char firstChar = firstValue.charAt(0);
+        if (!isDigit(firstChar)) {   // prevent signed content-length values: -digit or +digit
+            throw malformedCL(firstValue);
+        }
+        final long value;
+        try {   // optimistically assume the value can be parsed to skip indexOf check
+             value = parseLong(firstValue.toString());
+        } catch (NumberFormatException e) {
+            if (CharSequences.indexOf(firstValue, ',', 0) >= 0) {
+                throw multipleCL(firstValue, null);
+            }
+            throw malformedCL(firstValue);
+        }
+        return value;
+    }
+
+    private static IllegalArgumentException malformedCL(final CharSequence value) {
+        return new IllegalArgumentException("Malformed 'content-length' value: " + value);
+    }
+
+    private static IllegalArgumentException multipleCL(final CharSequence firstValue,
+                                                       @Nullable final Iterator<? extends CharSequence> iterator) {
+        final CharSequence allClValues;
+        if (iterator == null) {
+            allClValues = firstValue;
+        } else {
+            final StringBuilder sb = new StringBuilder(firstValue.length() + 8).append(firstValue);
+            while (iterator.hasNext()) {
+                sb.append(", ").append(iterator.next());
+            }
+            allClValues = sb;
+        }
+        return new IllegalArgumentException("Multiple content-length values found: " + allClValues);
     }
 
     @FunctionalInterface

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -885,7 +885,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
 
     private static long getContentLength(final HttpMetaData message) {
         final HttpHeaders headers = message.headers();
-        final long contentLength = HeaderUtils.contentLength(headers.valuesIterator(CONTENT_LENGTH), headers::values);
+        final long contentLength = HeaderUtils.contentLength(headers.valuesIterator(CONTENT_LENGTH));
         if (contentLength >= 0) {
             return contentLength;
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractH2DuplexHandlerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractH2DuplexHandlerTest.java
@@ -39,8 +39,6 @@ import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.util.function.Consumer;
-
 import static io.netty.buffer.ByteBufUtil.writeAscii;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpMethod.PUT;
@@ -139,41 +137,6 @@ public class AbstractH2DuplexHandlerTest {
     @Parameterized.Parameters(name = "variant = {0}")
     public static Variant[] data() {
         return Variant.values();
-    }
-
-    @Test
-    public void multipleContentLengthHeaders() {
-        final Consumer<Http2Headers> initHeaders = headers -> headers.add(CONTENT_LENGTH, "1", "2");
-        multipleContentLength(initHeaders, false);
-    }
-
-    @Test
-    public void multipleContentLengthHeadersEndStream() {
-        final Consumer<Http2Headers> initHeaders = headers -> headers.add(CONTENT_LENGTH, "1", "2");
-        multipleContentLength(initHeaders, true);
-    }
-
-    @Test
-    public void multipleContentLengthHeaderValues() {
-        final Consumer<Http2Headers> initHeaders = headers -> headers.add(CONTENT_LENGTH, "1, 2");
-        multipleContentLength(initHeaders, false);
-    }
-
-    @Test
-    public void multipleContentLengthHeaderValuesEndStream() {
-        final Consumer<Http2Headers> initHeaders = headers -> headers.add(CONTENT_LENGTH, "1, 2");
-        multipleContentLength(initHeaders, true);
-    }
-
-    private void multipleContentLength(Consumer<Http2Headers> initHeaders, boolean endStream) {
-        variant.writeOutbound(channel);
-
-        Http2Headers headers = variant.setHeaders(new DefaultHttp2Headers());
-        initHeaders.accept(headers);
-
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-                () -> channel.writeInbound(new DefaultHttp2HeadersFrame(headers, endStream)));
-        assertThat(e.getMessage(), startsWith("Multiple content-length values found"));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

`Content-Length` header values must contain only digits, according to [1].
However, our existing parser allows signed (positive or negative) CL
values, like: `+n` or `-n`.
Some servers may ignore those values and forward it as-is, some may treat
`+n` as `n`. A combination of those two servers can yield an HTTP Request
Smuggling vulnerability.

1. https://tools.ietf.org/html/rfc7230#section-3.3.2

Modifications:

- Fail HTTP messages with signed `Content-Length` header values;
- Add tests to validate this behavior;
- Fix the way `HeaderUtils.contentLength` generates an exception
message for multiple CL header values;

Result:

Signed `Content-Length` header values are prohibited and fail the message
parsing.