### PR TITLE
Fix NPE when `TRACE` request doesn't have content-length header for HTTP/2

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -175,7 +175,7 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
                     }
                 }
             } else if (!responseMayHaveContent(statusCode, method)) {
-                throw new IllegalArgumentException("content-length (" + h2Headers.getLong(CONTENT_LENGTH) +
+                throw new IllegalArgumentException("content-length (" + h2Headers.get(CONTENT_LENGTH) +
                         ") header is not expected for status code " + statusCode + " in response to " + method.name() +
                         " request");
             }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
@@ -47,6 +47,7 @@ import static io.servicetalk.http.api.HttpRequestMethod.Properties.NONE;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h1HeadersToH2Headers;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h2HeadersSanitizeForH1;
 import static io.servicetalk.http.netty.HeaderUtils.clientMaySendPayloadBodyFor;
+import static io.servicetalk.http.netty.HeaderUtils.shouldAddZeroContentLength;
 
 final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
     private boolean readHeaders;
@@ -134,17 +135,17 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
         h2Headers.remove(Http2Headers.PseudoHeaderName.SCHEME.value());
         h2HeadersSanitizeForH1(h2Headers);
         if (httpMethod != null) {
-            final Long contentLength = h2Headers.getLong(CONTENT_LENGTH);
+            final boolean containsContentLength = h2Headers.contains(CONTENT_LENGTH);
             if (clientMaySendPayloadBodyFor(httpMethod)) {
-                if (contentLength == null) {
-                    if (fullRequest) {
+                if (!containsContentLength) {
+                    if (fullRequest && shouldAddZeroContentLength(httpMethod)) {
                         h2Headers.set(CONTENT_LENGTH, ZERO);
                     } else {
                         h2Headers.add(TRANSFER_ENCODING, CHUNKED);
                     }
                 }
-            } else if (contentLength != null) {
-                throw new IllegalArgumentException("content-length (" + contentLength +
+            } else if (containsContentLength) {
+                throw new IllegalArgumentException("content-length (" + h2Headers.getLong(CONTENT_LENGTH) +
                         ") header is not expected for " + httpMethod.name() + " request");
             }
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
@@ -143,7 +143,7 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
                         h2Headers.add(TRANSFER_ENCODING, CHUNKED);
                     }
                 }
-            } else if (contentLength >= 0L) {
+            } else if (contentLength != null) {
                 throw new IllegalArgumentException("content-length (" + contentLength +
                         ") header is not expected for " + httpMethod.name() + " request");
             }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
@@ -145,7 +145,7 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
                     }
                 }
             } else if (containsContentLength) {
-                throw new IllegalArgumentException("content-length (" + h2Headers.getLong(CONTENT_LENGTH) +
+                throw new IllegalArgumentException("content-length (" + h2Headers.get(CONTENT_LENGTH) +
                         ") header is not expected for " + httpMethod.name() + " request");
             }
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
@@ -82,10 +82,7 @@ final class HeaderUtils {
 
     static boolean canAddResponseContentLength(final StreamingHttpResponse response,
                                                final HttpRequestMethod requestMethod) {
-        return canAddContentLength(response) && responseMayHaveContent(response.status().code(), requestMethod)
-                // HEAD requests should either have the content-length already set (= what GET will return) or
-                // have the header omitted when unknown, but never have any payload anyway so don't try to infer it
-                && !HEAD.equals(requestMethod);
+        return canAddContentLength(response) && serverMaySendPayloadBodyFor(response.status().code(), requestMethod);
     }
 
     static boolean clientMaySendPayloadBodyFor(final HttpRequestMethod requestMethod) {
@@ -94,8 +91,7 @@ final class HeaderUtils {
         return !TRACE.equals(requestMethod);
     }
 
-    static boolean canAddResponseTransferEncodingProtocol(final int statusCode,
-                                                          final HttpRequestMethod requestMethod) {
+    static boolean serverMaySendPayloadBodyFor(final int statusCode, final HttpRequestMethod requestMethod) {
         // (for HEAD) the server MUST NOT send a message body in the response.
         // https://tools.ietf.org/html/rfc7231#section-4.3.2
         return !HEAD.equals(requestMethod) && !isEmptyResponseStatus(statusCode)
@@ -229,7 +225,7 @@ final class HeaderUtils {
 
     static void addResponseTransferEncodingIfNecessary(final StreamingHttpResponse response,
                                                        final HttpRequestMethod requestMethod) {
-        if (canAddResponseTransferEncodingProtocol(response.status().code(), requestMethod) &&
+        if (serverMaySendPayloadBodyFor(response.status().code(), requestMethod) &&
                 canAddTransferEncodingChunked(response)) {
             response.headers().add(TRANSFER_ENCODING, CHUNKED);
         }


### PR DESCRIPTION
Motivation:

`H2ToStH1ServerDuplexHandler` uses incorrect `>=` check instead of `!= null`
for the nullable `Long` content-length variable.

Modifications:

- Reproduce the scenario in the test;
- Use `contains` to verify if the CL header is present;
- Rename `canAddResponseTransferEncodingProtocol` -> `serverMaySendPayloadBodyFor`;
- In `AbstractH2DuplexHandler` implementations do not add `content-length: 0`
- when it's not expected;

Result:

No NPE when HTTP/2 server receives `TRACE` request.