### PR TITLE
Allow client security configuration without trust material

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ClientSecurityConfig.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ClientSecurityConfig.java
@@ -252,7 +252,7 @@ public class ClientSecurityConfig extends ReadOnlyClientSecurityConfig {
         } else if (trustCertChainSupplier != null) {
             builder = new ClientSslConfigBuilder(trustCertChainSupplier);
         } else {
-            throw new IllegalStateException("required trust material not set");
+            builder = new ClientSslConfigBuilder();
         }
 
         if (hostnameVerificationAlgorithm == null) {


### PR DESCRIPTION
Motivation:

Trust material is optional for the client-side security configuration
and we should allow using the default JDK truststore.

Modifications:

- If users of deprecated `ClientSecurityConfig` did not specify a
trust material, use default `ClientSslConfigBuilder` ctor;

Result:

Users of deprecated `ClientSecurityConfig` can create a security config
with default JDK truststore.