### PR TITLE
Add Publisher.from(..) 2 and 3 arity overloads

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/From2Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/From2Publisher.java
@@ -55,7 +55,9 @@ final class From2Publisher<T> extends AbstractSynchronousPublisher<T> {
 
         @Override
         public void cancel() {
-            state = CANCELLED;
+            if (state != TERMINATED) {
+                state = CANCELLED;
+            }
         }
 
         @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/From2Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/From2Publisher.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
+
+final class From2Publisher<T> extends AbstractSynchronousPublisher<T> {
+    @Nullable
+    private final T v1;
+    @Nullable
+    private final T v2;
+
+    From2Publisher(@Nullable T v1, @Nullable T v2) {
+        this.v1 = v1;
+        this.v2 = v2;
+    }
+
+    @Override
+    void doSubscribe(final Subscriber<? super T> subscriber) {
+        try {
+            subscriber.onSubscribe(new TwoValueSubscription(subscriber));
+        } catch (Throwable cause) {
+            handleExceptionFromOnSubscribe(subscriber, cause);
+        }
+    }
+
+    private final class TwoValueSubscription implements Subscription {
+        private static final byte INIT = 0;
+        private static final byte DELIVERED_V1 = 1;
+        private static final byte CANCELLED = 2;
+        private static final byte TERMINATED = 3;
+        private byte state;
+        private final Subscriber<? super T> subscriber;
+
+        private TwoValueSubscription(final Subscriber<? super T> subscriber) {
+            this.subscriber = subscriber;
+        }
+
+        @Override
+        public void cancel() {
+            state = CANCELLED;
+        }
+
+        @Override
+        public void request(final long n) {
+            if (state == TERMINATED) {
+                return;
+            }
+            if (!isRequestNValid(n)) {
+                state = TERMINATED;
+                subscriber.onError(newExceptionForInvalidRequestN(n));
+                return;
+            }
+            if (state == INIT) {
+                state = DELIVERED_V1;
+                try {
+                    subscriber.onNext(v1);
+                } catch (Throwable cause) {
+                    state = TERMINATED;
+                    subscriber.onError(cause);
+                    return;
+                }
+                // We could check CANCELLED here and return, but it isn't required.
+                if (n > 1) {
+                    deliverV2();
+                }
+            } else if (state == DELIVERED_V1) {
+                deliverV2();
+            }
+        }
+
+        private void deliverV2() {
+            state = TERMINATED;
+            try {
+                subscriber.onNext(v2);
+            } catch (Throwable cause) {
+                subscriber.onError(cause);
+                return;
+            }
+            subscriber.onComplete();
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/From3Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/From3Publisher.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
+
+final class From3Publisher<T> extends AbstractSynchronousPublisher<T> {
+    @Nullable
+    private final T v1;
+    @Nullable
+    private final T v2;
+    @Nullable
+    private final T v3;
+
+    From3Publisher(@Nullable T v1, @Nullable T v2, @Nullable T v3) {
+        this.v1 = v1;
+        this.v2 = v2;
+        this.v3 = v3;
+    }
+
+    @Override
+    void doSubscribe(final Subscriber<? super T> subscriber) {
+        try {
+            subscriber.onSubscribe(new ThreeValueSubscription(subscriber));
+        } catch (Throwable cause) {
+            handleExceptionFromOnSubscribe(subscriber, cause);
+        }
+    }
+
+    private final class ThreeValueSubscription implements Subscription {
+        private static final byte INIT = 0;
+        private static final byte DELIVERED_V1 = 1;
+        private static final byte DELIVERED_V2 = 2;
+        private static final byte CANCELLED = 3;
+        private static final byte TERMINATED = 4;
+        private byte state;
+        private final Subscriber<? super T> subscriber;
+
+        private ThreeValueSubscription(final Subscriber<? super T> subscriber) {
+            this.subscriber = subscriber;
+        }
+
+        @Override
+        public void cancel() {
+            if (state != TERMINATED) {
+                state = CANCELLED;
+            }
+        }
+
+        @Override
+        public void request(final long n) {
+            if (state == TERMINATED) {
+                return;
+            }
+            if (!isRequestNValid(n)) {
+                state = TERMINATED;
+                subscriber.onError(newExceptionForInvalidRequestN(n));
+                return;
+            }
+            if (state == INIT) {
+                state = DELIVERED_V1;
+                try {
+                    subscriber.onNext(v1);
+                } catch (Throwable cause) {
+                    state = TERMINATED;
+                    subscriber.onError(cause);
+                    return;
+                }
+                // We could check CANCELLED here and return, but it isn't required.
+                if (n > 2) {
+                    deliverV2V3();
+                } else if (n == 2) {
+                    deliverV2();
+                }
+            } else if (state == DELIVERED_V1) {
+                if (n > 1) {
+                    deliverV2V3();
+                } else {
+                    deliverV2();
+                }
+            } else if (state == DELIVERED_V2) {
+                state = TERMINATED;
+                try {
+                    subscriber.onNext(v3);
+                } catch (Throwable cause) {
+                    subscriber.onError(cause);
+                    return;
+                }
+                subscriber.onComplete();
+            }
+        }
+
+        private void deliverV2() {
+            state = DELIVERED_V2;
+            try {
+                subscriber.onNext(v2);
+            } catch (Throwable cause) {
+                state = TERMINATED;
+                subscriber.onError(cause);
+            }
+        }
+
+        private void deliverV2V3() {
+            state = TERMINATED;
+            try {
+                subscriber.onNext(v2);
+                // We could check CANCELLED here and return, but it isn't required.
+                subscriber.onNext(v3);
+            } catch (Throwable cause) {
+                subscriber.onError(cause);
+                return;
+            }
+            subscriber.onComplete();
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2837,6 +2837,41 @@ public abstract class Publisher<T> {
     }
 
     /**
+     * Creates a new {@link Publisher} that emits {@code v1} and {@code v2} to its {@link Subscriber} and then
+     * {@link Subscriber#onComplete()}.
+     *
+     * @param v1 The first value that the returned {@link Publisher} will emit.
+     * @param v2 The second value that the returned {@link Publisher} will emit.
+     * @param <T> Type of items emitted by the returned {@link Publisher}.
+     *
+     * @return A new {@link Publisher} that emits {@code v1} and {@code v2} to its {@link Subscriber} and then
+     * {@link Subscriber#onComplete()}.
+     *
+     * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX just operator.</a>
+     */
+    public static <T> Publisher<T> from(@Nullable T v1, @Nullable T v2) {
+        return new From2Publisher<>(v1, v2);
+    }
+
+    /**
+     * Creates a new {@link Publisher} that emits {@code v1}, {@code v2}, and {@code v3} to its {@link Subscriber} and
+     * then {@link Subscriber#onComplete()}.
+     *
+     * @param v1 The first value that the returned {@link Publisher} will emit.
+     * @param v2 The second value that the returned {@link Publisher} will emit.
+     * @param v3 The second value that the returned {@link Publisher} will emit.
+     * @param <T> Type of items emitted by the returned {@link Publisher}.
+     *
+     * @return A new {@link Publisher} that emits {@code v1}, {@code v2}, and {@code v3} to its {@link Subscriber} and
+     * then {@link Subscriber#onComplete()}.
+     *
+     * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX just operator.</a>
+     */
+    public static <T> Publisher<T> from(@Nullable T v1, @Nullable T v2, @Nullable T v3) {
+        return new From3Publisher<>(v1, v2, v3);
+    }
+
+    /**
      * Creates a new {@link Publisher} that emits all {@code values} to its {@link Subscriber} and then
      * {@link Subscriber#onComplete()}.
      *

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/From2PublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/From2PublisherTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.PublisherSource.Subscriber;
+import io.servicetalk.concurrent.PublisherSource.Subscription;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class From2PublisherTest {
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+    private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
+
+    @Test
+    public void request2Complete() {
+        toSource(fromPublisher()).subscribe(subscriber);
+        subscriber.awaitSubscription().request(2);
+        assertThat(subscriber.takeOnNext(2), contains(1, 2));
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    public void request1Complete() {
+        toSource(fromPublisher()).subscribe(subscriber);
+        Subscription s = subscriber.awaitSubscription();
+        s.request(1);
+        assertThat(subscriber.takeOnNext(), is(1));
+        assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
+        s.request(1);
+        assertThat(subscriber.takeOnNext(), is(2));
+        subscriber.awaitOnComplete();
+        s.request(1);
+    }
+
+    @Test
+    public void request1Cancel() {
+        toSource(fromPublisher()).subscribe(subscriber);
+        Subscription s = subscriber.awaitSubscription();
+        s.request(1);
+        assertThat(subscriber.takeOnNext(), is(1));
+        assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
+        s.cancel();
+        s.request(1);
+        assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
+    }
+
+    @Test
+    public void throwFirst() {
+        throwInOnNext(1);
+    }
+
+    @Test
+    public void throwSecond() {
+        throwInOnNext(2);
+    }
+
+    private void throwInOnNext(int onNexts) {
+        @SuppressWarnings("unchecked")
+        Subscriber<Integer> mockSubscriber = mock(Subscriber.class);
+        AtomicInteger onNextCount = new AtomicInteger();
+        doAnswer((Answer<Void>) invocation -> {
+            if (onNextCount.incrementAndGet() == onNexts) {
+                throw DELIBERATE_EXCEPTION;
+            }
+            return null;
+        }).when(mockSubscriber).onNext(any());
+        doAnswer((Answer<Void>) invocation -> {
+            Subscription s = invocation.getArgument(0);
+            s.request(2);
+            return null;
+        }).when(mockSubscriber).onSubscribe(any());
+        toSource(fromPublisher()).subscribe(mockSubscriber);
+        verify(mockSubscriber).onError(eq(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    public void invalidRequestNZero() {
+        invalidRequestN(0);
+    }
+
+    @Test
+    public void invalidRequestNNeg() {
+        invalidRequestN(-1);
+    }
+
+    private void invalidRequestN(long n) {
+        toSource(fromPublisher()).subscribe(subscriber);
+        subscriber.awaitSubscription().request(n);
+        assertThat(subscriber.awaitOnError(), instanceOf(newExceptionForInvalidRequestN(n).getClass()));
+    }
+
+    private static Publisher<Integer> fromPublisher() {
+        return from(1, 2);
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/From3PublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/From3PublisherTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.PublisherSource.Subscriber;
+import io.servicetalk.concurrent.PublisherSource.Subscription;
+import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
+import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class From3PublisherTest {
+    @Rule
+    public final Timeout timeout = new ServiceTalkTestTimeout();
+    private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
+
+    @Test
+    public void request3Complete() {
+        toSource(fromPublisher()).subscribe(subscriber);
+        subscriber.awaitSubscription().request(3);
+        assertThat(subscriber.takeOnNext(3), contains(1, 2, 3));
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    public void request2FirstComplete() {
+        toSource(fromPublisher()).subscribe(subscriber);
+        Subscription s = subscriber.awaitSubscription();
+        s.request(2);
+        assertThat(subscriber.takeOnNext(2), contains(1, 2));
+        s.request(1);
+        assertThat(subscriber.takeOnNext(), is(3));
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    public void request2SecondComplete() {
+        toSource(fromPublisher()).subscribe(subscriber);
+        Subscription s = subscriber.awaitSubscription();
+        s.request(1);
+        assertThat(subscriber.takeOnNext(), is(1));
+        s.request(2);
+        assertThat(subscriber.takeOnNext(2), contains(2, 3));
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    public void request1Complete() {
+        toSource(fromPublisher()).subscribe(subscriber);
+        Subscription s = subscriber.awaitSubscription();
+        s.request(1);
+        assertThat(subscriber.takeOnNext(), is(1));
+        assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
+        s.request(1);
+        assertThat(subscriber.takeOnNext(), is(2));
+        assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
+        s.request(1);
+        assertThat(subscriber.takeOnNext(), is(3));
+        assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
+        subscriber.awaitOnComplete();
+        s.request(1);
+    }
+
+    @Test
+    public void request1Cancel() {
+        toSource(fromPublisher()).subscribe(subscriber);
+        Subscription s = subscriber.awaitSubscription();
+        s.request(1);
+        assertThat(subscriber.takeOnNext(), is(1));
+        assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
+        s.cancel();
+        s.request(1);
+        assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
+    }
+
+    @Test
+    public void request2Cancel() {
+        toSource(fromPublisher()).subscribe(subscriber);
+        Subscription s = subscriber.awaitSubscription();
+        s.request(1);
+        assertThat(subscriber.takeOnNext(), is(1));
+        assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
+        s.request(1);
+        assertThat(subscriber.takeOnNext(), is(2));
+        assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
+        s.cancel();
+        s.request(1);
+        assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
+    }
+
+    @Test
+    public void throwFirst() {
+        throwInOnNext(1);
+    }
+
+    @Test
+    public void throwSecond() {
+        throwInOnNext(2);
+    }
+
+    @Test
+    public void throwThird() {
+        throwInOnNext(3);
+    }
+
+    private void throwInOnNext(int onNexts) {
+        @SuppressWarnings("unchecked")
+        Subscriber<Integer> mockSubscriber = mock(Subscriber.class);
+        AtomicInteger onNextCount = new AtomicInteger();
+        doAnswer((Answer<Void>) invocation -> {
+            if (onNextCount.incrementAndGet() == onNexts) {
+                throw DELIBERATE_EXCEPTION;
+            }
+            return null;
+        }).when(mockSubscriber).onNext(any());
+        doAnswer((Answer<Void>) invocation -> {
+            Subscription s = invocation.getArgument(0);
+            s.request(3);
+            return null;
+        }).when(mockSubscriber).onSubscribe(any());
+        toSource(fromPublisher()).subscribe(mockSubscriber);
+        verify(mockSubscriber).onError(eq(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    public void invalidRequestNZero() {
+        invalidRequestN(0);
+    }
+
+    @Test
+    public void invalidRequestNNeg() {
+        invalidRequestN(-1);
+    }
+
+    private void invalidRequestN(long n) {
+        toSource(fromPublisher()).subscribe(subscriber);
+        subscriber.awaitSubscription().request(n);
+        assertThat(subscriber.awaitOnError(), instanceOf(newExceptionForInvalidRequestN(n).getClass()));
+    }
+
+    private static Publisher<Integer> fromPublisher() {
+        return from(1, 2, 3);
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFrom2TckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFrom2TckTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+import org.testng.annotations.Test;
+
+import static io.servicetalk.concurrent.api.Publisher.from;
+
+@Test
+public class PublisherFrom2TckTest extends AbstractPublisherTckTest<Integer> {
+    @Override
+    public Publisher<Integer> createServiceTalkPublisher(long elements) {
+        return elements == 1 ? from(1) : from(1, 2);
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 2;
+    }
+
+    @Override
+    public long boundedDepthOfOnNextAndRequestRecursion() {
+        return 2;
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFrom3TckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFrom3TckTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+import org.testng.annotations.Test;
+
+import static io.servicetalk.concurrent.api.Publisher.from;
+
+@Test
+public class PublisherFrom3TckTest extends AbstractPublisherTckTest<Integer> {
+    @Override
+    public Publisher<Integer> createServiceTalkPublisher(long elements) {
+        return elements == 1 ? from(1) : elements == 2 ? from(1, 2) : from(1, 2, 3);
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 3;
+    }
+
+    @Override
+    public long boundedDepthOfOnNextAndRequestRecursion() {
+        return 3;
+    }
+}


### PR DESCRIPTION
Motivation:
Publisher.from(..) with 2 or 3 arguments is becoming more common in
control flow, and we currently have to allocate an array in these
scenarios. Specialized implementations for this operator can avoid array
allocation and more complex index/state management.

Modifications:
- Add Publisher.from(T, T) and Publisher.from(T, T, T)

Result:
Publisher.from(..) is less resource intensive for 2 and 3 arity use
cases.