### PR TITLE
Skip grpc-accept-encoding when the only option is identity

### DIFF
--- a/servicetalk-encoding-api-internal/src/main/java/io/servicetalk/encoding/api/internal/HeaderUtils.java
+++ b/servicetalk-encoding-api-internal/src/main/java/io/servicetalk/encoding/api/internal/HeaderUtils.java
@@ -17,7 +17,7 @@ package io.servicetalk.encoding.api.internal;
 
 import io.servicetalk.buffer.api.CharSequences;
 import io.servicetalk.encoding.api.ContentCodec;
-import io.servicetalk.encoding.api.ContentCodings;
+import io.servicetalk.encoding.api.Identity;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -43,13 +43,13 @@ public final class HeaderUtils {
      * <p>
      * If no supported encodings are configured then the result is always {@code null}
      * If no accepted encodings are present in the request then the result is always {@code null}
-     * In all other cases, the first matching encoding (that is NOT {@link ContentCodings#identity()}) is preferred,
+     * In all other cases, the first matching encoding (that is NOT {@link Identity#identity()}) is preferred,
      * otherwise {@code null} is returned.
      *
      * @param acceptEncodingHeaderValue The accept encoding header value.
      * @param serverSupportedEncodings The server supported codings as configured.
      * @return The {@link ContentCodec} that satisfies both client and server needs,
-     * null if none found or matched to {@link ContentCodings#identity()}
+     * null if none found or matched to {@link Identity#identity()}
      */
     @Nullable
     public static ContentCodec negotiateAcceptedEncoding(@Nullable final CharSequence acceptEncodingHeaderValue,
@@ -71,13 +71,13 @@ public final class HeaderUtils {
      * on the server side and the incoming header on the request.
      * <p>
      * If no supported encodings are passed then the result is always {@code null}
-     * Otherwise, the first matching encoding (that is NOT {@link ContentCodings#identity()}) is preferred,
+     * Otherwise, the first matching encoding (that is NOT {@link Identity#identity()}) is preferred,
      * or {@code null} is returned.
      *
      * @param clientSupportedEncodings The client supported codings as found in the HTTP header.
      * @param serverSupportedEncodings The server supported codings as configured.
      * @return The {@link ContentCodec} that satisfies both client and server needs,
-     * null if none found or matched to {@link ContentCodings#identity()}
+     * null if none found or matched to {@link Identity#identity()}
      */
     @Nullable
     public static ContentCodec negotiateAcceptedEncoding(final List<ContentCodec> clientSupportedEncodings,
@@ -120,7 +120,7 @@ public final class HeaderUtils {
      * Returns the {@link ContentCodec} that matches the {@code name} within the {@code allowedList}.
      * if {@code name} is {@code null} or empty it results in {@code null} .
      * If {@code name} is {@code 'identity'} this will always result in
-     * {@link ContentCodings#identity()} regardless of its presence in the {@code allowedList}.
+     * {@link Identity#identity()} regardless of its presence in the {@code allowedList}.
      *
      * @param allowedList the source list to find a matching codec from.
      * @param name the codec name used for the equality predicate.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientFactory.java
@@ -16,6 +16,7 @@
 package io.servicetalk.grpc.api;
 
 import io.servicetalk.encoding.api.ContentCodec;
+import io.servicetalk.encoding.api.Identity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -110,7 +111,7 @@ public abstract class GrpcClientFactory<Client extends GrpcClient<BlockingClient
 
     /**
      * Sets the supported message encodings for this client factory.
-     * By default only {@link io.servicetalk.encoding.api.ContentCodings#identity()} is supported
+     * By default only {@link Identity#identity()} is supported
      *
      * @param codings The supported encodings {@link ContentCodec}s for this client.
      * @return {@code this}

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
@@ -19,7 +19,7 @@ import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.encoding.api.ContentCodec;
-import io.servicetalk.encoding.api.ContentCodings;
+import io.servicetalk.encoding.api.Identity;
 import io.servicetalk.encoding.api.internal.HeaderUtils;
 import io.servicetalk.http.api.HttpDeserializer;
 import io.servicetalk.http.api.HttpHeaders;
@@ -61,7 +61,6 @@ import static io.servicetalk.http.api.HttpHeaderNames.USER_AGENT;
 import static io.servicetalk.http.api.HttpHeaderValues.TRAILERS;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
 import static java.lang.String.valueOf;
-import static java.util.Collections.singletonList;
 
 final class GrpcUtils {
     private static final CharSequence GRPC_CONTENT_TYPE = newAsciiString("application/grpc");
@@ -73,7 +72,6 @@ final class GrpcUtils {
     private static final CharSequence GRPC_MESSAGE_ENCODING_KEY = newAsciiString("grpc-encoding");
     private static final CharSequence GRPC_ACCEPT_ENCODING_KEY = newAsciiString("grpc-accept-encoding");
     private static final GrpcStatus STATUS_OK = GrpcStatus.fromCodeValue(GrpcStatusCode.OK.value());
-    private static final List<ContentCodec> GRPC_ACCEPT_ENCODING_NONE = singletonList(identity());
     private static final ConcurrentMap<List<ContentCodec>, CharSequence> ENCODINGS_HEADER_CACHE =
             new ConcurrentHashMap<>();
 
@@ -96,7 +94,10 @@ final class GrpcUtils {
         headers.set(USER_AGENT, GRPC_USER_AGENT);
         headers.set(TE, TRAILERS);
         headers.set(CONTENT_TYPE, GRPC_CONTENT_TYPE);
-        headers.set(GRPC_ACCEPT_ENCODING_KEY, acceptedEncodingsHeaderValueOrCached(supportedEncodings));
+        final CharSequence acceptedEncoding = acceptedEncodingsHeaderValueOrCached(supportedEncodings);
+        if (acceptedEncoding != null) {
+            headers.set(GRPC_ACCEPT_ENCODING_KEY, acceptedEncoding);
+        }
     }
 
     static <T> StreamingHttpResponse newResponse(final StreamingHttpResponseFactory responseFactory,
@@ -263,7 +264,7 @@ final class GrpcUtils {
      * <p>
      * If no supported codings are configured then the result is always {@code identity}
      * If no accepted codings are present in the request then the result is always {@code identity}
-     * In all other cases, the first matching encoding (that is NOT {@link ContentCodings#identity()}) is preferred,
+     * In all other cases, the first matching encoding (that is NOT {@link Identity#identity()}) is preferred,
      * otherwise {@code identity} is returned.
      *
      * @param httpMetaData The client metadata to extract relevant headers from.
@@ -284,9 +285,10 @@ final class GrpcUtils {
         final HttpHeaders headers = response.headers();
         headers.set(SERVER, GRPC_USER_AGENT);
         headers.set(CONTENT_TYPE, GRPC_CONTENT_TYPE);
-        if (context != null) {
-            headers.set(GRPC_ACCEPT_ENCODING_KEY,
-                    acceptedEncodingsHeaderValueOrCached(context.supportedMessageCodings()));
+        final CharSequence acceptedEncoding = context == null ? null :
+                acceptedEncodingsHeaderValueOrCached(context.supportedMessageCodings());
+        if (acceptedEncoding != null) {
+            headers.set(GRPC_ACCEPT_ENCODING_KEY, acceptedEncoding);
         }
     }
 
@@ -324,15 +326,18 @@ final class GrpcUtils {
     }
 
     /**
-     * Construct the gRPC header {@code grpc-accept-encoding} representation of the given codings.
+     * Construct the gRPC header {@code grpc-accept-encoding} representation of the given context.
      *
      * @param codings the list of codings to be used in the string representation.
-     * @return a comma separated string representation of the codings for use as a header value
+     * @return a comma separated string representation of the codings for use as a header value or {@code null} if
+     * the only supported coding is {@link Identity#identity()}.
      */
+    @Nullable
     private static CharSequence acceptedEncodingsHeaderValueOrCached(final List<ContentCodec> codings) {
         return ENCODINGS_HEADER_CACHE.computeIfAbsent(codings, (__) -> acceptedEncodingsHeaderValue0(codings));
     }
 
+    @Nullable
     private static CharSequence acceptedEncodingsHeaderValue0(final List<ContentCodec> codings) {
         StringBuilder builder = new StringBuilder();
         for (ContentCodec codec : codings) {
@@ -347,7 +352,7 @@ final class GrpcUtils {
             builder.append(codec.name());
         }
 
-        return newAsciiString(builder.toString());
+        return builder.length() > 0 ? newAsciiString(builder.toString()) : null;
     }
 
     @SuppressWarnings("unchecked")

--- a/servicetalk-grpc-protobuf/src/main/java/io/servicetalk/grpc/protobuf/ProtoBufSerializationProviderBuilder.java
+++ b/servicetalk-grpc-protobuf/src/main/java/io/servicetalk/grpc/protobuf/ProtoBufSerializationProviderBuilder.java
@@ -65,7 +65,7 @@ public final class ProtoBufSerializationProviderBuilder {
     /**
      * Set the supported message encodings for the serializers and deserializers.
      * The encodings will be advertised on the endpoint's headers and also used to validate each encoded message
-     * {@link io.servicetalk.encoding.api.ContentCodings#identity()} is always supported regardless of the config passed
+     * {@link io.servicetalk.encoding.api.Identity#identity()} is always supported regardless of the config passed
      *
      * @param supportedCodings the set of allowed encodings
      * @param <T> Type of {@link MessageLite} to register.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -17,7 +17,7 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.ByteProcessor;
 import io.servicetalk.encoding.api.ContentCodec;
-import io.servicetalk.encoding.api.ContentCodings;
+import io.servicetalk.encoding.api.Identity;
 import io.servicetalk.serialization.api.SerializationException;
 import io.servicetalk.utils.internal.IllegalCharacterException;
 
@@ -666,7 +666,7 @@ public final class HeaderUtils {
      * header of a request or a response.
      * If the name can not be matched to any of the supported encodings on this endpoint, then
      * a {@link UnsupportedContentEncodingException} is thrown.
-     * If the matched encoding is {@link ContentCodings#identity()} then this returns {@code null}.
+     * If the matched encoding is {@link Identity#identity()} then this returns {@code null}.
      *
      * @param headers The headers to read the encoding name from
      * @param allowedEncodings The supported encodings for this endpoint

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpMetaData.java
@@ -16,7 +16,7 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.encoding.api.ContentCodec;
-import io.servicetalk.encoding.api.ContentCodings;
+import io.servicetalk.encoding.api.Identity;
 
 import java.util.function.BiFunction;
 import javax.annotation.Nullable;
@@ -57,7 +57,7 @@ public interface HttpMetaData {
      * by calling this method.
      *
      * Any encoding passed here, takes precedence. In other words, a compressed response, can
-     * be disabled by passing {@link ContentCodings#identity()}.
+     * be disabled by passing {@link Identity#identity()}.
      *
      * @param encoding The {@link ContentCodec} used for the encoding of the payload.
      * @return {@code this}.


### PR DESCRIPTION
Motivation:
`grpc-accept-encoding` and `grpc-encoding` headers can be skipped when the only value associated with is `identity`. The spec allows this relaxation and we can save processing and wire time.

Modifications:
Skip the relevant headers when the value is only `identity`.

Result:
Less headers and less processing done to handle unnecessary data.