### PR TITLE
Remove obsolete and unproductive JVM options

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -167,8 +167,7 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
         }
 
         jvmArgs "-server", "-Xms2g", "-Xmx4g", "-dsa", "-da", "-ea:io.servicetalk...",
-            "-XX:+AggressiveOpts", "-XX:+TieredCompilation", "-XX:+UseBiasedLocking",
-                "-XX:+OptimizeStringConcat", "-XX:+HeapDumpOnOutOfMemoryError"
+                "-XX:+HeapDumpOnOutOfMemoryError"
       }
     }
   }


### PR DESCRIPTION
Motivation:
The current JVM options used for running ServiceTalk tests have not recently been updated
to reflect current recommendations.

Modifications:
Remove "-XX:+AggressiveOpts", "-XX:+TieredCompilation", "-XX:+UseBiasedLocking",
 and "-XX:+OptimizeStringConcat" options.
"-XX:+TieredCompilation" and "-XX:+OptimizeStringConcat" are now default behaviour
"-XX:+AggressiveOpts" is likely to slow performance and was removed in JDK12.
"-XX:+UseBiasedLocking" is likely to slow performance for ServiceTalk workloads and was
removed in JDK15

Result:
ServiceTalk tests executed with JVM options which more likely to reflect typical current
production usage.