### PR TITLE
Deprecate ContentCodec API with offest & length

### DIFF
--- a/servicetalk-encoding-api/src/main/java/io/servicetalk/encoding/api/AbstractZipContentCodec.java
+++ b/servicetalk-encoding-api/src/main/java/io/servicetalk/encoding/api/AbstractZipContentCodec.java
@@ -66,6 +66,11 @@ abstract class AbstractZipContentCodec extends AbstractContentCodec {
     abstract InflaterInputStream newInflaterInputStream(InputStream in) throws IOException;
 
     @Override
+    public Buffer encode(final Buffer src, final BufferAllocator allocator) {
+        return encode(src, 0, src.readableBytes(), allocator);
+    }
+
+    @Override
     public final Buffer encode(final Buffer src, final int offset, final int length, final BufferAllocator allocator) {
         if (offset < 0) {
             throw new IllegalArgumentException("Invalid offset: " + offset + " (expected >= 0)");
@@ -185,6 +190,11 @@ abstract class AbstractZipContentCodec extends AbstractContentCodec {
                         subscriber.onComplete();
                     }
                 });
+    }
+
+    @Override
+    public Buffer decode(final Buffer src, final BufferAllocator allocator) {
+        return decode(src, 0, src.readableBytes(), allocator);
     }
 
     @Override

--- a/servicetalk-encoding-api/src/main/java/io/servicetalk/encoding/api/ContentCodec.java
+++ b/servicetalk-encoding-api/src/main/java/io/servicetalk/encoding/api/ContentCodec.java
@@ -42,9 +42,7 @@ public interface ContentCodec {
      * @param allocator the {@link BufferAllocator} to use for allocating auxiliary buffers or the returned buffer
      * @return {@link Buffer} the result buffer with the content encoded
      */
-    default Buffer encode(Buffer src, BufferAllocator allocator) {
-        return encode(src, 0, src.readableBytes(), allocator);
-    }
+    Buffer encode(Buffer src, BufferAllocator allocator);
 
     /**
      * Take a {@link Buffer} and encode its contents resulting in a {@link Buffer} with the encoded contents.
@@ -56,7 +54,10 @@ public interface ContentCodec {
      * @param length the total count of bytes to read
      * @param allocator the {@link BufferAllocator} to use for allocating auxiliary buffers or the returned buffer
      * @return {@link Buffer} the result buffer with the content encoded
+     * @deprecated Use the plain {@link #encode(Buffer, BufferAllocator)} version and {@link Buffer#slice(int, int)}
+     * where needed.
      */
+    @Deprecated
     Buffer encode(Buffer src, int offset, int length, BufferAllocator allocator);
 
     /**
@@ -68,9 +69,7 @@ public interface ContentCodec {
      * @param allocator the {@link BufferAllocator} to use for allocating auxiliary buffers or the returned buffer
      * @return {@link Buffer} the result buffer with the content decoded
      */
-    default Buffer decode(Buffer src, BufferAllocator allocator) {
-        return decode(src, 0, src.readableBytes(), allocator);
-    }
+    Buffer decode(Buffer src, BufferAllocator allocator);
 
     /**
      * Take a {@link Buffer} and decode its contents resulting in a {@link Buffer} with the decoded content.
@@ -82,7 +81,10 @@ public interface ContentCodec {
      * @param length the total count of bytes to read
      * @param allocator the {@link BufferAllocator} to use for allocating auxiliary buffers or the returned buffer
      * @return {@link Buffer} the result buffer with the content decoded
+     * @deprecated Use the plain {@link #decode(Buffer, BufferAllocator)} version and {@link Buffer#slice(int, int)}
+     * where needed.
      */
+    @Deprecated
     Buffer decode(Buffer src, int offset, int length, BufferAllocator allocator);
 
     /**

--- a/servicetalk-encoding-api/src/main/java/io/servicetalk/encoding/api/IdentityContentCodec.java
+++ b/servicetalk-encoding-api/src/main/java/io/servicetalk/encoding/api/IdentityContentCodec.java
@@ -34,6 +34,16 @@ final class IdentityContentCodec implements ContentCodec {
     }
 
     @Override
+    public Buffer encode(final Buffer src, final BufferAllocator allocator) {
+        return src;
+    }
+
+    @Override
+    public Buffer decode(final Buffer src, final BufferAllocator allocator) {
+        return src;
+    }
+
+    @Override
     public Buffer encode(final Buffer src, final int offset, final int length, final BufferAllocator allocator) {
         return src;
     }

--- a/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/NettyChannelContentCodec.java
+++ b/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/NettyChannelContentCodec.java
@@ -63,6 +63,11 @@ final class NettyChannelContentCodec extends AbstractContentCodec {
     }
 
     @Override
+    public Buffer encode(final Buffer src, final BufferAllocator allocator) {
+        return encode(src, 0, src.readableBytes(), allocator);
+    }
+
+    @Override
     public Buffer encode(final Buffer src, final int offset, final int length, final BufferAllocator allocator) {
         requireNonNull(allocator);
 
@@ -175,6 +180,11 @@ final class NettyChannelContentCodec extends AbstractContentCodec {
                         subscriber.onComplete();
                     }
                 });
+    }
+
+    @Override
+    public Buffer decode(final Buffer src, final BufferAllocator allocator) {
+        return decode(src, 0, src.readableBytes(), allocator);
     }
 
     @Override

--- a/servicetalk-encoding-netty/src/test/java/io/servicetalk/encoding/netty/NettyChannelContentCodecTest.java
+++ b/servicetalk-encoding-netty/src/test/java/io/servicetalk/encoding/netty/NettyChannelContentCodecTest.java
@@ -76,41 +76,31 @@ public class NettyChannelContentCodecTest {
 
     @Test
     public void testEncode() {
-        testEncode(DEFAULT_ALLOCATOR, 0);
+        testEncode(DEFAULT_ALLOCATOR);
     }
 
     @Test
-    public void testEncodeWithOffset() {
-        testEncode(DEFAULT_ALLOCATOR, 10);
+    public void testEncodeWithReadOnlyBuffer() {
+        testEncode(DEFAULT_RO_ALLOCATOR);
     }
 
     @Test(expected = CodecEncodingException.class)
     public void testEncodeWithOffsetAndZeroLength() {
-        testEncode(DEFAULT_ALLOCATOR, 10, 0);
+        testEncode(DEFAULT_ALLOCATOR, 0);
     }
 
-    @Test(expected = CodecEncodingException.class)
-    public void testEncodeWithOffsetAndOverflowLength() {
-        testEncode(DEFAULT_ALLOCATOR, 1023, 0);
+    private void testEncode(final BufferAllocator allocator) {
+        testEncode(allocator, INPUT.length());
     }
 
-    @Test
-    public void testEncodeWithOffsetAndReadOnlyBuffer() {
-        testEncode(DEFAULT_RO_ALLOCATOR, 10);
-    }
-
-    private void testEncode(final BufferAllocator allocator, final int offset) {
-        testEncode(allocator, offset, INPUT.length() - offset);
-    }
-
-    private void testEncode(final BufferAllocator allocator, final int offset, final int length) {
+    private void testEncode(final BufferAllocator allocator, final int length) {
         Buffer source = allocator.fromAscii(INPUT);
-        Buffer encoded = codec.encode(source, offset, length, DEFAULT_ALLOCATOR);
+        Buffer encoded = codec.encode(source.readSlice(length), DEFAULT_ALLOCATOR);
 
         assertThat(encoded, notNullValue());
 
         Buffer decoded = codec.decode(encoded, DEFAULT_ALLOCATOR);
-        assertThat(decoded.toString(US_ASCII), equalTo(INPUT.substring(offset)));
+        assertThat(decoded.toString(US_ASCII), equalTo(INPUT.substring(0, length)));
     }
 
     @Test(expected = CodecDecodingException.class)

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcMessageEncodingTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcMessageEncodingTest.java
@@ -115,16 +115,13 @@ public class GrpcMessageEncodingTest {
         }
 
         @Override
-        public Buffer encode(final Buffer src, final int offset, final int length,
-                             final BufferAllocator allocator) {
-            src.readerIndex(src.readerIndex() + offset);
-
+        public Buffer encode(final Buffer src, final BufferAllocator allocator) {
             final Buffer dst = allocator.newBuffer(OUGHT_TO_BE_ENOUGH);
             DeflaterOutputStream output = null;
             try {
                 output = new GZIPOutputStream(asOutputStream(dst));
-                output.write(src.array(), src.arrayOffset() + src.readerIndex(), length);
-                src.readerIndex(src.readerIndex() + length);
+                output.write(src.array(), src.arrayOffset() + src.readerIndex(), src.readableBytes());
+                src.skipBytes(src.readableBytes());
                 output.finish();
             } catch (IOException e) {
                 throw new RuntimeException(e);
@@ -136,10 +133,12 @@ public class GrpcMessageEncodingTest {
         }
 
         @Override
-        public Buffer decode(final Buffer src, final int offset, final int length,
-                             final BufferAllocator allocator) {
-            src.readerIndex(src.readerIndex() + offset);
+        public Buffer encode(final Buffer src, final int offset, final int length, final BufferAllocator allocator) {
+            throw new UnsupportedOperationException();
+        }
 
+        @Override
+        public Buffer decode(final Buffer src, final BufferAllocator allocator) {
             final Buffer dst = allocator.newBuffer(OUGHT_TO_BE_ENOUGH);
             InflaterInputStream input = null;
             try {
@@ -154,6 +153,11 @@ public class GrpcMessageEncodingTest {
             }
 
             return dst;
+        }
+
+        @Override
+        public Buffer decode(final Buffer src, final int offset, final int length, final BufferAllocator allocator) {
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/servicetalk-grpc-protobuf/src/main/java/io/servicetalk/grpc/protobuf/ProtoBufSerializationProvider.java
+++ b/servicetalk-grpc-protobuf/src/main/java/io/servicetalk/grpc/protobuf/ProtoBufSerializationProvider.java
@@ -158,7 +158,7 @@ final class ProtoBufSerializationProvider<T extends MessageLite> implements Seri
                         Buffer buffer = toDeserialize;
                         int decodedLengthOfData = lengthOfData;
                         if (compressed) {
-                            buffer = codec.decode(toDeserialize, 0, lengthOfData, DEFAULT_ALLOCATOR);
+                            buffer = codec.decode(toDeserialize.readSlice(lengthOfData), DEFAULT_ALLOCATOR);
                             decodedLengthOfData = buffer.readableBytes();
                         }
 
@@ -306,7 +306,7 @@ final class ProtoBufSerializationProvider<T extends MessageLite> implements Seri
             Buffer serialized = DEFAULT_ALLOCATOR.newBuffer(size);
             serialize0(msg, serialized);
 
-            Buffer encoded = codec.encode(serialized, 0, serialized.readableBytes(), DEFAULT_ALLOCATOR);
+            Buffer encoded = codec.encode(serialized, DEFAULT_ALLOCATOR);
 
             destination.writeByte(FLAG_COMPRESSED);
             destination.writeInt(encoded.readableBytes());


### PR DESCRIPTION
Motivation:
Deprecate the `ContentCodec` APIs that receive offset & length. User's can slice if needed.

Modifications:
Deprecate API & relevant changes to accommodate the change.

Result:
Less API surface.