### PR TITLE
Github Actions dawidd6/action-download-artifact set workflow_conclusion

### DIFF
--- a/.github/workflows/ci-prb-reports.yml
+++ b/.github/workflows/ci-prb-reports.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: ${{ github.event.workflow_run.workflow_id }}
+          workflow_conclusion: completed
           commit: ${{ github.event.workflow_run.head_commit.id }}
           # File location set in ci-prb.yml and must be coordinated.
           name: test-results-${{ matrix.os }}-${{ matrix.java }}

--- a/.github/workflows/ci-prq-reports.yml
+++ b/.github/workflows/ci-prq-reports.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: ${{ github.event.workflow_run.workflow_id }}
+          workflow_conclusion: completed
           commit: ${{ github.event.workflow_run.head_commit.id }}
           name: checkstyle-results-${{ matrix.java }}
       - name: Publish Checkstyle Report
@@ -38,6 +39,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: ${{ github.event.workflow_run.workflow_id }}
+          workflow_conclusion: completed
           commit: ${{ github.event.workflow_run.head_commit.id }}
           name: pmd-results-${{ matrix.java }}
       - name: Publish PMD Report
@@ -60,6 +62,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: ${{ github.event.workflow_run.workflow_id }}
+          workflow_conclusion: completed
           commit: ${{ github.event.workflow_run.head_commit.id }}
           name: spotbugs-results-${{ matrix.java }}
       - name: Publish SpotBugs Report


### PR DESCRIPTION
Motivation:
ec26d27e0212e1449e163dec90194bc24e1acb6b updated
dawidd6/action-download-artifact which changed the default behavior of
workflow_conclusion from "completed" to "completed,success". This may
result in failure of downloading test results for pull request builder.

Modifications:
- explicitly set workflow_conclusion to "completed"

Result:
Unit test and quality results  are downloaded to generate reports.