### PR TITLE
RangeIntPublisher add explicit cast to int

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RangeIntPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RangeIntPublisher.java
@@ -77,7 +77,7 @@ final class RangeIntPublisher extends AbstractSynchronousPublisher<Integer> {
                 return;
             }
             pendingN = addWithOverflowProtection(pendingN, n);
-            for (; pendingN > 0 && index < end; --pendingN, index += min(stride, (long) end - index)) {
+            for (; pendingN > 0 && index < end; --pendingN, index += (int) min(stride, (long) end - index)) {
                 try {
                     subscriber.onNext(index);
                 } catch (Throwable cause) {


### PR DESCRIPTION
Motivation:
RangeIntPublisher relies upon an implict case from long to int which is
gaurded by a `min(int, long)` (where the int is non-negative). CodeQL
highlights this as a warning.

Modifications:
- Add an explicit cast to int to be more clear this is intentional

Result:
CodeQL warning is resovled.