### PR TITLE
Github Actions Remove --max-workers gradle param

### DIFF
--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           CI: true
           JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
-        run: ./gradlew --parallel --max-workers=4 clean test
+        run: ./gradlew --parallel clean test
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-prq.yml
+++ b/.github/workflows/ci-prq.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build with Gradle
         env:
           CI: true
-        run: ./gradlew --parallel --max-workers=4 clean quality
+        run: ./gradlew --parallel clean quality
       - name: Upload CheckStyle Results
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -62,7 +62,7 @@ jobs:
           fi
 
           # Execute the gradlew command to publish the build
-          ./gradlew --parallel --max-workers=4 -PreleaseBuild=true$FIRST_GRADLE_TARGETS && ./gradlew -PreleaseBuild=true$SECOND_GRADLE_TARGETS
+          ./gradlew --parallel -PreleaseBuild=true$FIRST_GRADLE_TARGETS && ./gradlew -PreleaseBuild=true$SECOND_GRADLE_TARGETS
       - name: Publish Test Results
         if: always()
         uses: scacap/action-surefire-report@fd75ee04fbef040d0198e50ad153fcf997a0cf78

--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -63,7 +63,7 @@ jobs:
           fi
 
           # Execute the gradlew command to publish the build
-          ./gradlew --parallel --max-workers=4$FIRST_GRADLE_TARGETS && ./gradlew$SECOND_GRADLE_TARGETS
+          ./gradlew --parallel$FIRST_GRADLE_TARGETS && ./gradlew$SECOND_GRADLE_TARGETS
       - name: Publish Test Results
         if: always()
         uses: scacap/action-surefire-report@fd75ee04fbef040d0198e50ad153fcf997a0cf78

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,6 @@ jobs:
         with:
           languages: ${{ matrix.language }}
       - name: Execute gradle build
-        run: ./gradlew --parallel --max-workers=4 clean assemble
+        run: ./gradlew --parallel clean assemble
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
Motivation:
Our github action scripts explicitly set --max-workers but gradle can
automatically infer the value based upon number of processors [1].

[1] https://docs.gradle.org/current/userguide/command_line_interface.html
> Default is number of processors.

Modifications:
- Remove --max-workers param from github action scripts

Result:
Gradle will automatically determine the number of workers to use based
upon available processors.