### PR TITLE
Add Publisher.timeoutTerminal(Duration) operator

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -1654,6 +1654,41 @@ public abstract class Publisher<T> {
     }
 
     /**
+     * Creates a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses between subscribe and termination. The timer starts
+     * when the returned {@link Publisher} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Subscription} from
+     * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be {@link Subscription#cancel() cancelled} and
+     * the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
+     * @param duration The time duration which is allowed to elapse between {@link Subscriber#onNext(Object)} calls.
+     * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    public final Publisher<T> withTimeout(Duration duration) {
+        return withTimeout(duration, executor);
+    }
+
+    /**
+     * Creates a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses between subscribe and termination. The timer starts
+     * when the returned {@link Publisher} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Subscription} from
+     * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be {@link Subscription#cancel() cancelled} and
+     * the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
+     * @param duration The time duration which is allowed to elapse between {@link Subscriber#onNext(Object)} calls.
+     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    public final Publisher<T> withTimeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
+        return new TimeoutPublisher<>(this, executor, duration, false, timeoutExecutor);
+    }
+
+    /**
      * Emits items emitted by {@code next} {@link Publisher} after {@code this} {@link Publisher} terminates
      * successfully.
      * <p>

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -1513,7 +1513,7 @@ public abstract class Publisher<T> {
      */
     @Deprecated
     public final Publisher<T> idleTimeout(long duration, TimeUnit unit) {
-        return idleTimeout(duration, unit, executor);
+        return timeout(duration, unit);
     }
 
     /**
@@ -1533,7 +1533,7 @@ public abstract class Publisher<T> {
      */
     @Deprecated
     public final Publisher<T> idleTimeout(Duration duration) {
-        return idleTimeout(duration.toNanos(), TimeUnit.NANOSECONDS);
+        return timeout(duration);
     }
 
     /**
@@ -1555,7 +1555,7 @@ public abstract class Publisher<T> {
     @Deprecated
     public final Publisher<T> idleTimeout(long duration, TimeUnit unit,
                                           io.servicetalk.concurrent.Executor timeoutExecutor) {
-        return new TimeoutPublisher<>(this, executor, duration, unit, true, timeoutExecutor);
+        return timeout(duration, unit, timeoutExecutor);
     }
 
     /**
@@ -1575,7 +1575,7 @@ public abstract class Publisher<T> {
      */
     @Deprecated
     public final Publisher<T> idleTimeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
-        return idleTimeout(duration.toNanos(), TimeUnit.NANOSECONDS, timeoutExecutor);
+        return timeout(duration, timeoutExecutor);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutPublisher.java
@@ -140,8 +140,8 @@ final class TimeoutPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
             TimeoutSubscriber<X> s = new TimeoutSubscriber<>(parent, target, signalOffloader, contextProvider);
             try {
                 s.lastStartNS = System.nanoTime();
-                // CAS is just in case the timer fired, the run method schedule a new timer before this thread is able
-                // to set the initial timer value. in this case we don't want to overwrite the active timer.
+                // CAS is just in case the timer fired, the timerFires method schedule a new timer before this thread is
+                // able to set the initial timer value. In this case we don't want to overwrite the active timer.
                 //
                 // We rely upon the timeoutExecutor to save/restore the current context when notifying when the timer
                 // fires. An alternative would be to also wrap the Subscriber to preserve the AsyncContext but that
@@ -259,7 +259,7 @@ final class TimeoutPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
                             } else if (timerCancellableUpdater.compareAndSet(this, previousTimerCancellable,
                                     nextTimerCancellable)) {
                                 // This means that initialization sequence was such that the timer fired, and
-                                // the run method executed before the constructor set the initial value.
+                                // the timerFires method executed before the constructor set the initial value.
                                 return;
                             }
                         }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutPublisher.java
@@ -62,20 +62,14 @@ final class TimeoutPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
                      final TimeUnit unit,
                      final boolean restartAtOnNext,
                      final io.servicetalk.concurrent.Executor timeoutExecutor) {
-        this(original, publisherExecutor, unit.toNanos(duration), restartAtOnNext, timeoutExecutor);
-    }
-
-    TimeoutPublisher(final Publisher<T> original,
-                             final Executor publisherExecutor,
-                             final long durationNs,
-                             final boolean restartAtOnNext,
-                             final io.servicetalk.concurrent.Executor timeoutExecutor) {
         super(publisherExecutor);
         this.original = requireNonNull(original);
         this.timeoutExecutor = requireNonNull(timeoutExecutor);
         // We use the duration in arithmetic below to determine the expiration time for the "next timer" below. So
-        // lets cap this at 0 to simplify overflow at that time.
-        this.durationNs = max(0, durationNs);
+        // lets cap this at 0 to simplify overflow at that time. Negative duration is allowed as input as this
+        // simplifies cases where the duration is calculated and an "already timed out" result is found. The caller
+        // would otherwise have to generate the timeout exception themselves.
+        this.durationNs = max(0, unit.toNanos(duration));
         this.restartAtOnNext = restartAtOnNext;
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/TimeoutPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/TimeoutPublisherTest.java
@@ -227,8 +227,8 @@ public class TimeoutPublisherTest {
                 break;
             }
             publisher.onNext(x); // may reset timer
-            MILLISECONDS.sleep(1 * millisMultiplier);
-            testExecutor.advanceTimeBy(1 * millisMultiplier, MILLISECONDS);
+            MILLISECONDS.sleep(millisMultiplier);
+            testExecutor.advanceTimeBy(millisMultiplier, MILLISECONDS);
             assertThat(subscriber.takeOnNext(), is(x));
         }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/TimeoutPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/TimeoutPublisherTest.java
@@ -231,6 +231,7 @@ public class TimeoutPublisherTest {
             // The timer was reset so we should be able to get the last item
             assertThat(testExecutor.scheduledTasksPending(), is(1));
             assertThat(subscriber.takeOnNext(), is(3));
+            testExecutor.advanceTimeBy(2, NANOSECONDS);
         } else {
             // timer should have now fired.
             assertThat(testExecutor.scheduledTasksExecuted(), is(1));
@@ -238,7 +239,7 @@ public class TimeoutPublisherTest {
         assertThat(subscriber.awaitOnError(), instanceOf(TimeoutException.class));
 
         assertThat(testExecutor.scheduledTasksPending(), is(0));
-        assertThat(testExecutor.scheduledTasksExecuted(), is(1));
+        assertThat(testExecutor.scheduledTasksExecuted(), is(params.restartAtOnNext() ? 3 : 1) );
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/SignalOffloaders.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/SignalOffloaders.java
@@ -22,6 +22,9 @@ import io.servicetalk.concurrent.Executor;
  */
 public final class SignalOffloaders {
 
+    /**
+     * Uses {@link TaskBasedSignalOffloader} for offloading
+     */
     private static final SignalOffloaderFactory TASK_BASED_OFFLOADER_FACTORY = new SignalOffloaderFactory() {
         @Override
         public SignalOffloader newSignalOffloader(final Executor executor) {
@@ -34,6 +37,9 @@ public final class SignalOffloaders {
         }
     };
 
+    /**
+     * Uses {@link ThreadBasedSignalOffloader} for offloading
+     */
     private static final SignalOffloaderFactory THREAD_BASED_OFFLOADER_FACTORY = new SignalOffloaderFactory() {
         @Override
         public SignalOffloader newSignalOffloader(final Executor executor) {

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherTimeoutTerminalTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherTimeoutTerminalTckTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+import static java.util.concurrent.TimeUnit.HOURS;
+
+public class PublisherTimeoutTerminalTckTest extends AbstractPublisherOperatorTckTest<Integer> {
+    @Override
+    protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
+        return publisher.timeoutTerminal(1, HOURS);
+    }
+}

--- a/servicetalk-concurrent/src/main/java/io/servicetalk/concurrent/Executor.java
+++ b/servicetalk-concurrent/src/main/java/io/servicetalk/concurrent/Executor.java
@@ -69,13 +69,4 @@ public interface Executor {
     default Cancellable schedule(Runnable task, Duration delay) throws RejectedExecutionException {
         return schedule(task, delay.toNanos(), NANOSECONDS);
     }
-
-    /**
-     * Returns the current time in nanoseconds of the monotonic clock associated with this executor.
-     *
-     * @return the current time as monotonic nanoseconds
-     */
-    default long currentNanos() {
-        return System.nanoTime();
-    }
 }

--- a/servicetalk-concurrent/src/main/java/io/servicetalk/concurrent/Executor.java
+++ b/servicetalk-concurrent/src/main/java/io/servicetalk/concurrent/Executor.java
@@ -69,4 +69,13 @@ public interface Executor {
     default Cancellable schedule(Runnable task, Duration delay) throws RejectedExecutionException {
         return schedule(task, delay.toNanos(), NANOSECONDS);
     }
+
+    /**
+     * Returns the current time in nanoseconds of the monotonic clock associated with this executor.
+     *
+     * @return the current time as monotonic nanoseconds
+     */
+    default long currentNanos() {
+        return System.nanoTime();
+    }
 }


### PR DESCRIPTION
Motivation:
The existing `Publisher.timeout(Duration)` operator restarts the timer for each received item and will only timeout if no items are emitted during the timeout duration. In some cases the total time for all items to be emitted is of more interest. An operator to timeout based on the entire elapsed time since subscribe is needed.

Modifications:
Add a new Publisher operator, `timeoutTerminal(Duration)`, that terminates the Publisher with a TimeoutException if the Publisher does not terminate before the specified time duration.

Result:
A new timeout option is available.