### PR TITLE
Publisher, Single, Completable rename idleTimeout -> timeout

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncCloseables.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncCloseables.java
@@ -46,7 +46,7 @@ public final class AsyncCloseables {
      * @return A {@link Completable} that is notified once the close is complete.
      */
     public static Completable closeAsyncGracefully(AsyncCloseable closable, long timeout, TimeUnit timeoutUnit) {
-        return closable.closeAsyncGracefully().idleTimeout(timeout, timeoutUnit).onErrorResume(
+        return closable.closeAsyncGracefully().timeout(timeout, timeoutUnit).onErrorResume(
                 t -> t instanceof TimeoutException ? closable.closeAsync() : failed(t)
         );
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -282,24 +282,6 @@ public abstract class Completable {
      * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
      * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
      * {@link Subscriber#onError(Throwable) terminated}.
-     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onComplete()}.
-     * @param unit The units for {@code duration}.
-     * @return a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate with
-     * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
-     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
-     */
-    public final Completable timeout(long duration, TimeUnit unit) {
-        return timeout(duration, unit, executor);
-    }
-
-    /**
-     * Creates a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate
-     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and termination.
-     * The timer starts when the returned {@link Completable} is subscribed.
-     * <p>
-     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
-     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
-     * {@link Subscriber#onError(Throwable) terminated}.
      * @deprecated Use {@link #timeout(long, TimeUnit)}.
      * @param duration The time duration which is allowed to elapse before {@link Subscriber#onComplete()}.
      * @param unit The units for {@code duration}.
@@ -310,26 +292,6 @@ public abstract class Completable {
     @Deprecated
     public final Completable idleTimeout(long duration, TimeUnit unit) {
         return timeout(duration, unit, executor);
-    }
-
-    /**
-     * Creates a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate
-     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and termination.
-     * The timer starts when the returned {@link Completable} is subscribed.
-     * <p>
-     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
-     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
-     * {@link Subscriber#onError(Throwable) terminated}.
-     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onComplete()}.
-     * @param unit The units for {@code duration}.
-     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
-     * @return a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate with
-     * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
-     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
-     */
-    public final Completable timeout(long duration, TimeUnit unit,
-                                     io.servicetalk.concurrent.Executor timeoutExecutor) {
-        return new TimeoutCompletable(this, duration, unit, timeoutExecutor);
     }
 
     /**
@@ -362,23 +324,6 @@ public abstract class Completable {
      * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
      * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
      * {@link Subscriber#onError(Throwable) terminated}.
-     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onComplete()}.
-     * @return a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate with
-     * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
-     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
-     */
-    public final Completable timeout(Duration duration) {
-        return timeout(duration, executor);
-    }
-
-    /**
-     * Creates a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate
-     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and termination.
-     * The timer starts when the returned {@link Completable} is subscribed.
-     * <p>
-     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
-     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
-     * {@link Subscriber#onError(Throwable) terminated}.
      * @deprecated Use {@link #timeout(Duration)}.
      * @param duration The time duration which is allowed to elapse before {@link Subscriber#onComplete()}.
      * @return a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate with
@@ -398,13 +343,15 @@ public abstract class Completable {
      * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
      * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
      * {@link Subscriber#onError(Throwable) terminated}.
+     * @deprecated Use {@link #timeout(Duration, io.servicetalk.concurrent.Executor)}.
      * @param duration The time duration which is allowed to elapse before {@link Subscriber#onComplete()}.
      * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
      * @return a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate with
      * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    public final Completable timeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
+    @Deprecated
+    public final Completable idleTimeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
         return new TimeoutCompletable(this, duration, timeoutExecutor);
     }
 
@@ -416,15 +363,68 @@ public abstract class Completable {
      * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
      * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
      * {@link Subscriber#onError(Throwable) terminated}.
-     * @deprecated Use {@link #timeout(Duration, io.servicetalk.concurrent.Executor)}.
+     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onComplete()}.
+     * @param unit The units for {@code duration}.
+     * @return a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate with
+     * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    public final Completable timeout(long duration, TimeUnit unit) {
+        return timeout(duration, unit, executor);
+    }
+
+    /**
+     * Creates a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate
+     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and termination.
+     * The timer starts when the returned {@link Completable} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
+     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
+     * {@link Subscriber#onError(Throwable) terminated}.
+     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onComplete()}.
+     * @param unit The units for {@code duration}.
+     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @return a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate with
+     * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    public final Completable timeout(long duration, TimeUnit unit,
+                                     io.servicetalk.concurrent.Executor timeoutExecutor) {
+        return new TimeoutCompletable(this, duration, unit, timeoutExecutor);
+    }
+
+    /**
+     * Creates a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate
+     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and termination.
+     * The timer starts when the returned {@link Completable} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
+     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
+     * {@link Subscriber#onError(Throwable) terminated}.
+     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onComplete()}.
+     * @return a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate with
+     * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    public final Completable timeout(Duration duration) {
+        return timeout(duration, executor);
+    }
+
+    /**
+     * Creates a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate
+     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and termination.
+     * The timer starts when the returned {@link Completable} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
+     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
+     * {@link Subscriber#onError(Throwable) terminated}.
      * @param duration The time duration which is allowed to elapse before {@link Subscriber#onComplete()}.
      * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
      * @return a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate with
      * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    @Deprecated
-    public final Completable idleTimeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
+    public final Completable timeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
         return new TimeoutCompletable(this, duration, timeoutExecutor);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -288,8 +288,28 @@ public abstract class Completable {
      * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
+    public final Completable timeout(long duration, TimeUnit unit) {
+        return timeout(duration, unit, executor);
+    }
+
+    /**
+     * Creates a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate
+     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and termination.
+     * The timer starts when the returned {@link Completable} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
+     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
+     * {@link Subscriber#onError(Throwable) terminated}.
+     * @deprecated Use {@link #timeout(long, TimeUnit)}.
+     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onComplete()}.
+     * @param unit The units for {@code duration}.
+     * @return a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate with
+     * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    @Deprecated
     public final Completable idleTimeout(long duration, TimeUnit unit) {
-        return idleTimeout(duration, unit, executor);
+        return timeout(duration, unit, executor);
     }
 
     /**
@@ -307,6 +327,28 @@ public abstract class Completable {
      * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
+    public final Completable timeout(long duration, TimeUnit unit,
+                                     io.servicetalk.concurrent.Executor timeoutExecutor) {
+        return new TimeoutCompletable(this, duration, unit, timeoutExecutor);
+    }
+
+    /**
+     * Creates a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate
+     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and termination.
+     * The timer starts when the returned {@link Completable} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
+     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
+     * {@link Subscriber#onError(Throwable) terminated}.
+     * @deprecated Use {@link #timeout(long, TimeUnit, io.servicetalk.concurrent.Executor)}.
+     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onComplete()}.
+     * @param unit The units for {@code duration}.
+     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @return a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate with
+     * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    @Deprecated
     public final Completable idleTimeout(long duration, TimeUnit unit,
                                          io.servicetalk.concurrent.Executor timeoutExecutor) {
         return new TimeoutCompletable(this, duration, unit, timeoutExecutor);
@@ -325,8 +367,27 @@ public abstract class Completable {
      * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
+    public final Completable timeout(Duration duration) {
+        return timeout(duration, executor);
+    }
+
+    /**
+     * Creates a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate
+     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and termination.
+     * The timer starts when the returned {@link Completable} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
+     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
+     * {@link Subscriber#onError(Throwable) terminated}.
+     * @deprecated Use {@link #timeout(Duration)}.
+     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onComplete()}.
+     * @return a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate with
+     * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    @Deprecated
     public final Completable idleTimeout(Duration duration) {
-        return idleTimeout(duration, executor);
+        return timeout(duration, executor);
     }
 
     /**
@@ -343,6 +404,26 @@ public abstract class Completable {
      * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
+    public final Completable timeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
+        return new TimeoutCompletable(this, duration, timeoutExecutor);
+    }
+
+    /**
+     * Creates a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate
+     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and termination.
+     * The timer starts when the returned {@link Completable} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
+     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
+     * {@link Subscriber#onError(Throwable) terminated}.
+     * @deprecated Use {@link #timeout(Duration, io.servicetalk.concurrent.Executor)}.
+     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onComplete()}.
+     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @return a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate with
+     * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    @Deprecated
     public final Completable idleTimeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
         return new TimeoutCompletable(this, duration, timeoutExecutor);
     }
@@ -1510,10 +1591,10 @@ public abstract class Completable {
      * offloading if necessary, and also offloading if {@link Cancellable#cancel()} will be called if this operation may
      * block.
      * <p>
-     * To apply a timeout see {@link #idleTimeout(long, TimeUnit)} and related methods.
+     * To apply a timeout see {@link #timeout(long, TimeUnit)} and related methods.
      * @param future The {@link Future} to convert.
      * @return A {@link Completable} that derives results from {@link Future}.
-     * @see #idleTimeout(long, TimeUnit)
+     * @see #timeout(long, TimeUnit)
      */
     public static Completable fromFuture(Future<?> future) {
         return Single.fromFuture(future).toCompletable();

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -1177,8 +1177,29 @@ public abstract class Publisher<T> {
      * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
      * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
-     * @see #idleTimeout(long, TimeUnit, io.servicetalk.concurrent.Executor)
+     * @see #timeout(long, TimeUnit, io.servicetalk.concurrent.Executor)
      */
+    public final Publisher<T> timeout(long duration, TimeUnit unit) {
+        return new TimeoutPublisher<>(this, executor, duration, unit);
+    }
+
+    /**
+     * Creates a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses between adjacent {@link Subscriber#onNext(Object)}
+     * calls. The timer starts when the returned {@link Publisher} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Subscription} from
+     * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be {@link Subscription#cancel() cancelled} and
+     * the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
+     * @deprecated Use {@link #timeout(long, TimeUnit)}.
+     * @param duration The time duration which is allowed to elapse between {@link Subscriber#onNext(Object)} calls.
+     * @param unit The units for {@code duration}.
+     * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     * @see #timeout(long, TimeUnit, io.servicetalk.concurrent.Executor)
+     */
+    @Deprecated
     public final Publisher<T> idleTimeout(long duration, TimeUnit unit) {
         return new TimeoutPublisher<>(this, executor, duration, unit);
     }
@@ -1195,8 +1216,28 @@ public abstract class Publisher<T> {
      * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
      * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
-     * @see #idleTimeout(long, TimeUnit, io.servicetalk.concurrent.Executor)
+     * @see #timeout(long, TimeUnit, io.servicetalk.concurrent.Executor)
      */
+    public final Publisher<T> timeout(Duration duration) {
+        return new TimeoutPublisher<>(this, executor, duration);
+    }
+
+    /**
+     * Creates a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses between adjacent {@link Subscriber#onNext(Object)}
+     * calls. The timer starts when the returned {@link Publisher} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Subscription} from
+     * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be {@link Subscription#cancel() cancelled}
+     * and the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
+     * @deprecated Use {@link #timeout(Duration)}
+     * @param duration The time duration which is allowed to elapse between {@link Subscriber#onNext(Object)} calls.
+     * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     * @see #timeout(long, TimeUnit, io.servicetalk.concurrent.Executor)
+     */
+    @Deprecated
     public final Publisher<T> idleTimeout(Duration duration) {
         return new TimeoutPublisher<>(this, executor, duration);
     }
@@ -1216,8 +1257,30 @@ public abstract class Publisher<T> {
      * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
+    public final Publisher<T> timeout(long duration, TimeUnit unit,
+                                      io.servicetalk.concurrent.Executor timeoutExecutor) {
+        return new TimeoutPublisher<>(this, executor, duration, unit, timeoutExecutor);
+    }
+
+    /**
+     * Creates a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses between adjacent {@link Subscriber#onNext(Object)}
+     * calls. The timer starts when the returned {@link Publisher} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Subscription} from
+     * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be {@link Subscription#cancel() cancelled} and
+     * the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
+     * @deprecated Use {@link #timeout(long, TimeUnit, io.servicetalk.concurrent.Executor)}.
+     * @param duration The time duration which is allowed to elapse between {@link Subscriber#onNext(Object)} calls.
+     * @param unit The units for {@code duration}.
+     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    @Deprecated
     public final Publisher<T> idleTimeout(long duration, TimeUnit unit,
-                                          io.servicetalk.concurrent.Executor timeoutExecutor) {
+                                      io.servicetalk.concurrent.Executor timeoutExecutor) {
         return new TimeoutPublisher<>(this, executor, duration, unit, timeoutExecutor);
     }
 
@@ -1235,6 +1298,26 @@ public abstract class Publisher<T> {
      * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
+    public final Publisher<T> timeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
+        return new TimeoutPublisher<>(this, executor, duration, timeoutExecutor);
+    }
+
+    /**
+     * Creates a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses between adjacent {@link Subscriber#onNext(Object)}
+     * calls. The timer starts when the returned {@link Publisher} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Subscription} from
+     * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be {@link Subscription#cancel() cancelled} and
+     * the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
+     * @deprecated Use {@link #timeout(Duration, io.servicetalk.concurrent.Executor)}.
+     * @param duration The time duration which is allowed to elapse between {@link Subscriber#onNext(Object)} calls.
+     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    @Deprecated
     public final Publisher<T> idleTimeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
         return new TimeoutPublisher<>(this, executor, duration, timeoutExecutor);
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -1172,25 +1172,6 @@ public abstract class Publisher<T> {
      * In the event of timeout any {@link Subscription} from
      * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be {@link Subscription#cancel() cancelled} and
      * the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
-     * @param duration The time duration which is allowed to elapse between {@link Subscriber#onNext(Object)} calls.
-     * @param unit The units for {@code duration}.
-     * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
-     * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
-     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
-     * @see #timeout(long, TimeUnit, io.servicetalk.concurrent.Executor)
-     */
-    public final Publisher<T> timeout(long duration, TimeUnit unit) {
-        return new TimeoutPublisher<>(this, executor, duration, unit);
-    }
-
-    /**
-     * Creates a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
-     * {@link TimeoutException} if time {@code duration} elapses between adjacent {@link Subscriber#onNext(Object)}
-     * calls. The timer starts when the returned {@link Publisher} is subscribed.
-     * <p>
-     * In the event of timeout any {@link Subscription} from
-     * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be {@link Subscription#cancel() cancelled} and
-     * the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
      * @deprecated Use {@link #timeout(long, TimeUnit)}.
      * @param duration The time duration which is allowed to elapse between {@link Subscriber#onNext(Object)} calls.
      * @param unit The units for {@code duration}.
@@ -1212,14 +1193,77 @@ public abstract class Publisher<T> {
      * In the event of timeout any {@link Subscription} from
      * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be {@link Subscription#cancel() cancelled}
      * and the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
+     * @deprecated Use {@link #timeout(Duration)}
      * @param duration The time duration which is allowed to elapse between {@link Subscriber#onNext(Object)} calls.
      * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
      * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      * @see #timeout(long, TimeUnit, io.servicetalk.concurrent.Executor)
      */
-    public final Publisher<T> timeout(Duration duration) {
+    @Deprecated
+    public final Publisher<T> idleTimeout(Duration duration) {
         return new TimeoutPublisher<>(this, executor, duration);
+    }
+
+    /**
+     * Creates a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses between adjacent {@link Subscriber#onNext(Object)}
+     * calls. The timer starts when the returned {@link Publisher} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Subscription} from
+     * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be {@link Subscription#cancel() cancelled} and
+     * the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
+     * @deprecated Use {@link #timeout(long, TimeUnit, io.servicetalk.concurrent.Executor)}.
+     * @param duration The time duration which is allowed to elapse between {@link Subscriber#onNext(Object)} calls.
+     * @param unit The units for {@code duration}.
+     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    @Deprecated
+    public final Publisher<T> idleTimeout(long duration, TimeUnit unit,
+                                          io.servicetalk.concurrent.Executor timeoutExecutor) {
+        return new TimeoutPublisher<>(this, executor, duration, unit, timeoutExecutor);
+    }
+
+    /**
+     * Creates a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses between adjacent {@link Subscriber#onNext(Object)}
+     * calls. The timer starts when the returned {@link Publisher} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Subscription} from
+     * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be {@link Subscription#cancel() cancelled} and
+     * the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
+     * @deprecated Use {@link #timeout(Duration, io.servicetalk.concurrent.Executor)}.
+     * @param duration The time duration which is allowed to elapse between {@link Subscriber#onNext(Object)} calls.
+     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    @Deprecated
+    public final Publisher<T> idleTimeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
+        return new TimeoutPublisher<>(this, executor, duration, timeoutExecutor);
+    }
+
+    /**
+     * Creates a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses between adjacent {@link Subscriber#onNext(Object)}
+     * calls. The timer starts when the returned {@link Publisher} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Subscription} from
+     * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be {@link Subscription#cancel() cancelled} and
+     * the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
+     * @param duration The time duration which is allowed to elapse between {@link Subscriber#onNext(Object)} calls.
+     * @param unit The units for {@code duration}.
+     * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     * @see #timeout(long, TimeUnit, io.servicetalk.concurrent.Executor)
+     */
+    public final Publisher<T> timeout(long duration, TimeUnit unit) {
+        return new TimeoutPublisher<>(this, executor, duration, unit);
     }
 
     /**
@@ -1230,15 +1274,13 @@ public abstract class Publisher<T> {
      * In the event of timeout any {@link Subscription} from
      * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be {@link Subscription#cancel() cancelled}
      * and the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
-     * @deprecated Use {@link #timeout(Duration)}
      * @param duration The time duration which is allowed to elapse between {@link Subscriber#onNext(Object)} calls.
      * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
      * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      * @see #timeout(long, TimeUnit, io.servicetalk.concurrent.Executor)
      */
-    @Deprecated
-    public final Publisher<T> idleTimeout(Duration duration) {
+    public final Publisher<T> timeout(Duration duration) {
         return new TimeoutPublisher<>(this, executor, duration);
     }
 
@@ -1270,28 +1312,6 @@ public abstract class Publisher<T> {
      * In the event of timeout any {@link Subscription} from
      * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be {@link Subscription#cancel() cancelled} and
      * the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
-     * @deprecated Use {@link #timeout(long, TimeUnit, io.servicetalk.concurrent.Executor)}.
-     * @param duration The time duration which is allowed to elapse between {@link Subscriber#onNext(Object)} calls.
-     * @param unit The units for {@code duration}.
-     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
-     * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
-     * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
-     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
-     */
-    @Deprecated
-    public final Publisher<T> idleTimeout(long duration, TimeUnit unit,
-                                      io.servicetalk.concurrent.Executor timeoutExecutor) {
-        return new TimeoutPublisher<>(this, executor, duration, unit, timeoutExecutor);
-    }
-
-    /**
-     * Creates a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
-     * {@link TimeoutException} if time {@code duration} elapses between adjacent {@link Subscriber#onNext(Object)}
-     * calls. The timer starts when the returned {@link Publisher} is subscribed.
-     * <p>
-     * In the event of timeout any {@link Subscription} from
-     * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be {@link Subscription#cancel() cancelled} and
-     * the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
      * @param duration The time duration which is allowed to elapse between {@link Subscriber#onNext(Object)} calls.
      * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
      * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
@@ -1299,26 +1319,6 @@ public abstract class Publisher<T> {
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
     public final Publisher<T> timeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
-        return new TimeoutPublisher<>(this, executor, duration, timeoutExecutor);
-    }
-
-    /**
-     * Creates a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
-     * {@link TimeoutException} if time {@code duration} elapses between adjacent {@link Subscriber#onNext(Object)}
-     * calls. The timer starts when the returned {@link Publisher} is subscribed.
-     * <p>
-     * In the event of timeout any {@link Subscription} from
-     * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be {@link Subscription#cancel() cancelled} and
-     * the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
-     * @deprecated Use {@link #timeout(Duration, io.servicetalk.concurrent.Executor)}.
-     * @param duration The time duration which is allowed to elapse between {@link Subscriber#onNext(Object)} calls.
-     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
-     * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
-     * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
-     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
-     */
-    @Deprecated
-    public final Publisher<T> idleTimeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
         return new TimeoutPublisher<>(this, executor, duration, timeoutExecutor);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -411,8 +411,28 @@ public abstract class Single<T> {
      * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
+    public final Single<T> timeout(long duration, TimeUnit unit) {
+        return timeout(duration, unit, executor);
+    }
+
+    /**
+     * Creates a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
+     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and
+     * termination. The timer starts when the returned {@link Single} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
+     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
+     * {@link Subscriber#onError(Throwable) terminated}.
+     * @deprecated Use {@link #timeout(long, TimeUnit)}.
+     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onSuccess(Object)}.
+     * @param unit The units for {@code duration}.
+     * @return a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    @Deprecated
     public final Single<T> idleTimeout(long duration, TimeUnit unit) {
-        return idleTimeout(duration, unit, executor);
+        return timeout(duration, unit, executor);
     }
 
     /**
@@ -430,6 +450,28 @@ public abstract class Single<T> {
      * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
+    public final Single<T> timeout(long duration, TimeUnit unit,
+                                   io.servicetalk.concurrent.Executor timeoutExecutor) {
+        return new TimeoutSingle<>(this, duration, unit, timeoutExecutor);
+    }
+
+    /**
+     * Creates a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
+     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and
+     * termination. The timer starts when the returned {@link Single} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
+     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
+     * {@link Subscriber#onError(Throwable) terminated}.
+     * @deprecated Use {@link #timeout(Duration, io.servicetalk.concurrent.Executor)}.
+     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onSuccess(Object)}.
+     * @param unit The units for {@code duration}.
+     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @return a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    @Deprecated
     public final Single<T> idleTimeout(long duration, TimeUnit unit,
                                        io.servicetalk.concurrent.Executor timeoutExecutor) {
         return new TimeoutSingle<>(this, duration, unit, timeoutExecutor);
@@ -449,8 +491,28 @@ public abstract class Single<T> {
      * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
+    public final Single<T> timeout(Duration duration) {
+        return timeout(duration, executor);
+    }
+
+    /**
+     * Creates a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
+     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and
+     * termination. The timer starts when the returned {@link Single} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
+     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
+     * {@link Subscriber#onError(Throwable) terminated}.
+     * {@link Subscriber} will via {@link Subscriber#onError(Throwable) terminated}.
+     * @deprecated Use {@link #timeout(Duration)}.
+     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onSuccess(Object)}.
+     * @return a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    @Deprecated
     public final Single<T> idleTimeout(Duration duration) {
-        return idleTimeout(duration, executor);
+        return timeout(duration, executor);
     }
 
     /**
@@ -467,6 +529,26 @@ public abstract class Single<T> {
      * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
+    public final Single<T> timeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
+        return new TimeoutSingle<>(this, duration, timeoutExecutor);
+    }
+
+    /**
+     * Creates a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
+     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and termination.
+     * The timer starts when the returned {@link Single} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
+     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
+     * {@link Subscriber#onError(Throwable) terminated}.
+     * @deprecated Use {@link #timeout(Duration, io.servicetalk.concurrent.Executor)}.
+     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onSuccess(Object)}.
+     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @return a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    @Deprecated
     public final Single<T> idleTimeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
         return new TimeoutSingle<>(this, duration, timeoutExecutor);
     }
@@ -1453,11 +1535,11 @@ public abstract class Single<T> {
      * results will block. The caller of subscribe is responsible for offloading if necessary, and also offloading if
      * {@link Cancellable#cancel()} will be called and this operation may block.
      * <p>
-     * To apply a timeout see {@link #idleTimeout(long, TimeUnit)} and related methods.
+     * To apply a timeout see {@link #timeout(long, TimeUnit)} and related methods.
      * @param future The {@link Future} to convert.
      * @param <T> The data type the {@link Future} provides when complete.
      * @return A {@link Single} that derives results from {@link Future}.
-     * @see #idleTimeout(long, TimeUnit)
+     * @see #timeout(long, TimeUnit)
      */
     public static <T> Single<T> fromFuture(Future<? extends T> future) {
         return new FutureToSingle<>(future);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -405,24 +405,6 @@ public abstract class Single<T> {
      * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
      * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
      * {@link Subscriber#onError(Throwable) terminated}.
-     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onSuccess(Object)}.
-     * @param unit The units for {@code duration}.
-     * @return a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
-     * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
-     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
-     */
-    public final Single<T> timeout(long duration, TimeUnit unit) {
-        return timeout(duration, unit, executor);
-    }
-
-    /**
-     * Creates a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
-     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and
-     * termination. The timer starts when the returned {@link Single} is subscribed.
-     * <p>
-     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
-     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
-     * {@link Subscriber#onError(Throwable) terminated}.
      * @deprecated Use {@link #timeout(long, TimeUnit)}.
      * @param duration The time duration which is allowed to elapse before {@link Subscriber#onSuccess(Object)}.
      * @param unit The units for {@code duration}.
@@ -433,26 +415,6 @@ public abstract class Single<T> {
     @Deprecated
     public final Single<T> idleTimeout(long duration, TimeUnit unit) {
         return timeout(duration, unit, executor);
-    }
-
-    /**
-     * Creates a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
-     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and
-     * termination. The timer starts when the returned {@link Single} is subscribed.
-     * <p>
-     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
-     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
-     * {@link Subscriber#onError(Throwable) terminated}.
-     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onSuccess(Object)}.
-     * @param unit The units for {@code duration}.
-     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
-     * @return a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
-     * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
-     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
-     */
-    public final Single<T> timeout(long duration, TimeUnit unit,
-                                   io.servicetalk.concurrent.Executor timeoutExecutor) {
-        return new TimeoutSingle<>(this, duration, unit, timeoutExecutor);
     }
 
     /**
@@ -486,24 +448,6 @@ public abstract class Single<T> {
      * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
      * {@link Subscriber#onError(Throwable) terminated}.
      * {@link Subscriber} will via {@link Subscriber#onError(Throwable) terminated}.
-     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onSuccess(Object)}.
-     * @return a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
-     * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
-     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
-     */
-    public final Single<T> timeout(Duration duration) {
-        return timeout(duration, executor);
-    }
-
-    /**
-     * Creates a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
-     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and
-     * termination. The timer starts when the returned {@link Single} is subscribed.
-     * <p>
-     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
-     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
-     * {@link Subscriber#onError(Throwable) terminated}.
-     * {@link Subscriber} will via {@link Subscriber#onError(Throwable) terminated}.
      * @deprecated Use {@link #timeout(Duration)}.
      * @param duration The time duration which is allowed to elapse before {@link Subscriber#onSuccess(Object)}.
      * @return a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
@@ -523,14 +467,72 @@ public abstract class Single<T> {
      * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
      * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
      * {@link Subscriber#onError(Throwable) terminated}.
+     * @deprecated Use {@link #timeout(Duration, io.servicetalk.concurrent.Executor)}.
      * @param duration The time duration which is allowed to elapse before {@link Subscriber#onSuccess(Object)}.
      * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
      * @return a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
      * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    public final Single<T> timeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
+    @Deprecated
+    public final Single<T> idleTimeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
         return new TimeoutSingle<>(this, duration, timeoutExecutor);
+    }
+
+    /**
+     * Creates a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
+     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and
+     * termination. The timer starts when the returned {@link Single} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
+     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
+     * {@link Subscriber#onError(Throwable) terminated}.
+     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onSuccess(Object)}.
+     * @param unit The units for {@code duration}.
+     * @return a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    public final Single<T> timeout(long duration, TimeUnit unit) {
+        return timeout(duration, unit, executor);
+    }
+
+    /**
+     * Creates a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
+     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and
+     * termination. The timer starts when the returned {@link Single} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
+     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
+     * {@link Subscriber#onError(Throwable) terminated}.
+     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onSuccess(Object)}.
+     * @param unit The units for {@code duration}.
+     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @return a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    public final Single<T> timeout(long duration, TimeUnit unit,
+                                   io.servicetalk.concurrent.Executor timeoutExecutor) {
+        return new TimeoutSingle<>(this, duration, unit, timeoutExecutor);
+    }
+
+    /**
+     * Creates a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
+     * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and
+     * termination. The timer starts when the returned {@link Single} is subscribed.
+     * <p>
+     * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
+     * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
+     * {@link Subscriber#onError(Throwable) terminated}.
+     * {@link Subscriber} will via {@link Subscriber#onError(Throwable) terminated}.
+     * @param duration The time duration which is allowed to elapse before {@link Subscriber#onSuccess(Object)}.
+     * @return a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
+     * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
+     * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
+     */
+    public final Single<T> timeout(Duration duration) {
+        return timeout(duration, executor);
     }
 
     /**
@@ -541,15 +543,13 @@ public abstract class Single<T> {
      * In the event of timeout any {@link Cancellable} from {@link Subscriber#onSubscribe(Cancellable)} will be
      * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
      * {@link Subscriber#onError(Throwable) terminated}.
-     * @deprecated Use {@link #timeout(Duration, io.servicetalk.concurrent.Executor)}.
      * @param duration The time duration which is allowed to elapse before {@link Subscriber#onSuccess(Object)}.
      * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
      * @return a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
      * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
-    @Deprecated
-    public final Single<T> idleTimeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
+    public final Single<T> timeout(Duration duration, io.servicetalk.concurrent.Executor timeoutExecutor) {
         return new TimeoutSingle<>(this, duration, timeoutExecutor);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableExecutorPreservationTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableExecutorPreservationTest.java
@@ -38,8 +38,8 @@ public class CompletableExecutorPreservationTest {
 
     @Test
     public void testTimeoutCompletable() {
-        assertSame(EXEC.executor(), completable.idleTimeout(1, MILLISECONDS).executor());
-        assertSame(EXEC.executor(), completable.idleTimeout(Duration.ofMillis(1)).executor());
+        assertSame(EXEC.executor(), completable.timeout(1, MILLISECONDS).executor());
+        assertSame(EXEC.executor(), completable.timeout(Duration.ofMillis(1)).executor());
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleExecutorPreservationTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleExecutorPreservationTest.java
@@ -36,8 +36,8 @@ public class SingleExecutorPreservationTest {
 
     @Test
     public void testTimeoutSingle() {
-        assertSame(EXEC.executor(), single.idleTimeout(1, MILLISECONDS).executor());
-        assertSame(EXEC.executor(), single.idleTimeout(ofMillis(1)).executor());
+        assertSame(EXEC.executor(), single.timeout(1, MILLISECONDS).executor());
+        assertSame(EXEC.executor(), single.timeout(ofMillis(1)).executor());
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/TimeoutCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/TimeoutCompletableTest.java
@@ -61,7 +61,7 @@ public class TimeoutCompletableTest {
 
     @Test
     public void executorScheduleThrows() {
-        toSource(source.ignoreElement().idleTimeout(1, NANOSECONDS, new DelegatingExecutor(testExecutor) {
+        toSource(source.ignoreElement().timeout(1, NANOSECONDS, new DelegatingExecutor(testExecutor) {
             @Override
             public Cancellable schedule(final Runnable task, final long delay, final TimeUnit unit) {
                 throw DELIBERATE_EXCEPTION;
@@ -140,7 +140,7 @@ public class TimeoutCompletableTest {
     }
 
     private void init(Completable source, boolean expectOnSubscribe) {
-        toSource(source.idleTimeout(1, NANOSECONDS, testExecutor)).subscribe(listener);
+        toSource(source.timeout(1, NANOSECONDS, testExecutor)).subscribe(listener);
         assertThat(testExecutor.scheduledTasksPending(), is(1));
         if (expectOnSubscribe) {
             assertThat(listener.pollTerminal(10, MILLISECONDS), is(nullValue()));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/TimeoutPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/TimeoutPublisherTest.java
@@ -73,7 +73,7 @@ public class TimeoutPublisherTest {
 
     @Test
     public void executorScheduleThrows() {
-        toSource(publisher.idleTimeout(1, NANOSECONDS, new DelegatingExecutor(testExecutor) {
+        toSource(publisher.timeout(1, NANOSECONDS, new DelegatingExecutor(testExecutor) {
             @Override
             public Cancellable schedule(final Runnable task, final long delay, final TimeUnit unit) {
                 throw DELIBERATE_EXCEPTION;
@@ -217,7 +217,7 @@ public class TimeoutPublisherTest {
         // the run() method.
         // Just in case the timer fires earlier than expected (after the first timer) we countdown the latch so the
         // test won't fail.
-        toSource(publisher.idleTimeout(10, MILLISECONDS, new Executor() {
+        toSource(publisher.timeout(10, MILLISECONDS, new Executor() {
             private final AtomicInteger timerCount = new AtomicInteger();
 
             @Override
@@ -286,7 +286,7 @@ public class TimeoutPublisherTest {
     }
 
     private void init(Publisher<Integer> publisher, boolean expectOnSubscribe) {
-        toSource(publisher.idleTimeout(1, NANOSECONDS, testExecutor)).subscribe(subscriber);
+        toSource(publisher.timeout(1, NANOSECONDS, testExecutor)).subscribe(subscriber);
         assertThat(testExecutor.scheduledTasksPending(), is(1));
         if (expectOnSubscribe) {
             subscriber.awaitSubscription();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractFutureToSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractFutureToSingleTest.java
@@ -70,7 +70,7 @@ public abstract class AbstractFutureToSingleTest {
     @Test
     public void timeout() {
         CompletableFuture<String> future = new CompletableFuture<>();
-        Single<String> single = from(future).idleTimeout(1, MILLISECONDS);
+        Single<String> single = from(future).timeout(1, MILLISECONDS);
         Exception e = assertThrows(ExecutionException.class, () -> single.toFuture().get());
         assertThat(e.getCause(), is(instanceOf(TimeoutException.class)));
         assertTrue(future.isCancelled());

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/TimeoutSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/TimeoutSingleTest.java
@@ -62,7 +62,7 @@ public class TimeoutSingleTest {
 
     @Test
     public void executorScheduleThrows() {
-        toSource(source.idleTimeout(1, NANOSECONDS, new DelegatingExecutor(testExecutor) {
+        toSource(source.timeout(1, NANOSECONDS, new DelegatingExecutor(testExecutor) {
             @Override
             public Cancellable schedule(final Runnable task, final long delay, final TimeUnit unit) {
                 throw DELIBERATE_EXCEPTION;
@@ -144,7 +144,7 @@ public class TimeoutSingleTest {
     }
 
     private void init(final Single<Integer> source, final boolean expectOnSubscribe) {
-        toSource(source.idleTimeout(1, NANOSECONDS, testExecutor)).subscribe(subscriber);
+        toSource(source.timeout(1, NANOSECONDS, testExecutor)).subscribe(subscriber);
         assertThat(testExecutor.scheduledTasksPending(), is(1));
         if (expectOnSubscribe) {
             subscriber.awaitSubscription();

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherTimeoutTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherTimeoutTckTest.java
@@ -22,6 +22,6 @@ import static java.util.concurrent.TimeUnit.HOURS;
 public class PublisherTimeoutTckTest extends AbstractPublisherOperatorTckTest<Integer> {
     @Override
     protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
-        return publisher.idleTimeout(1, HOURS);
+        return publisher.timeout(1, HOURS);
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionDrainTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionDrainTest.java
@@ -189,7 +189,7 @@ public class NettyHttpServerConnectionDrainTest {
                 // Without draining the request is expected to hang, don't wait too long unless on CI
                 int timeoutSeconds = CI ? 15 : 1;
                 awaitTermination(serverContext.closeAsyncGracefully()
-                        .idleTimeout(timeoutSeconds, SECONDS)
+                        .timeout(timeoutSeconds, SECONDS)
                         .onErrorResume(t -> serverContext.closeAsync().concat(Completable.failed(t))).toFuture());
             }
         };

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilter.java
@@ -68,8 +68,8 @@ public final class TimeoutHttpRequesterFilter implements StreamingHttpClientFilt
     private Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                   final HttpExecutionStrategy strategy,
                                                   final StreamingHttpRequest request) {
-        return timeoutExecutor != null ? delegate.request(strategy, request).idleTimeout(duration, timeoutExecutor) :
-                delegate.request(strategy, request).idleTimeout(duration);
+        return timeoutExecutor != null ? delegate.request(strategy, request).timeout(duration, timeoutExecutor) :
+                delegate.request(strategy, request).timeout(duration);
     }
 
     @Override


### PR DESCRIPTION
Motivation:
Publisher, Single, Completable have an idleTimeout operator. The "idle"
was meant to highlight that the timeout applies to any signals (e.g. not
time to terminal event). However other rx implementations (reactor,
rxjava) just use "timeout" for this operator name which is consistent
with the [1] reactivex operator naming convention. Using the "idle"
makes the operator more difficult to discover for folks familiar with
existing concepts.

[1] http://reactivex.io/documentation/operators/timeout.html

Modifications:
- Rename idleTimeout to timeout, deprecate idleTimeout

Result:
More consistent operator naming for timeout operator.