### PR TITLE
Smaller max delays and retry/repeat strategies with delta jitter

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
@@ -224,8 +224,7 @@ public final class RepeatStrategies {
         final long maxDelayNanos = maxDelay.toNanos();
         final long maxInitialShift = maxShift(initialDelayNanos);
         return repeatCount -> {
-            final long baseDelayNanos = baseDelayNanos(initialDelayNanos, maxDelayNanos, maxInitialShift,
-                    repeatCount - 1);
+            final long baseDelayNanos = baseDelayNanos(initialDelayNanos, maxDelayNanos, maxInitialShift, repeatCount);
             return timerExecutor.timer(
                     current().nextLong(max(0, baseDelayNanos - jitterNanos),
                             min(maxDelayNanos, addWithOverflowProtection(baseDelayNanos, jitterNanos))),
@@ -263,8 +262,7 @@ public final class RepeatStrategies {
             if (repeatCount > maxRepeats) {
                 return terminateRepeat();
             }
-            final long baseDelayNanos = baseDelayNanos(initialDelayNanos, maxDelayNanos, maxInitialShift,
-                    repeatCount - 1);
+            final long baseDelayNanos = baseDelayNanos(initialDelayNanos, maxDelayNanos, maxInitialShift, repeatCount);
             return timerExecutor.timer(
                     current().nextLong(max(0, baseDelayNanos - jitterNanos),
                             min(maxDelayNanos, addWithOverflowProtection(baseDelayNanos, jitterNanos))),

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 import java.util.function.IntFunction;
 
 import static io.servicetalk.concurrent.api.Completable.failed;
+import static io.servicetalk.concurrent.api.RetryStrategies.baseDelayNanos;
 import static io.servicetalk.concurrent.api.RetryStrategies.checkJitterDelta;
 import static io.servicetalk.concurrent.api.RetryStrategies.checkMaxRetries;
 import static io.servicetalk.concurrent.api.RetryStrategies.maxShift;
@@ -223,7 +224,8 @@ public final class RepeatStrategies {
         final long maxDelayNanos = maxDelay.toNanos();
         final long maxInitialShift = maxShift(initialDelayNanos);
         return repeatCount -> {
-            final long baseDelayNanos = min(maxDelayNanos, initialDelayNanos << min(maxInitialShift, repeatCount - 1));
+            final long baseDelayNanos = baseDelayNanos(initialDelayNanos, maxDelayNanos, maxInitialShift,
+                    repeatCount - 1);
             return timerExecutor.timer(
                     current().nextLong(max(0, baseDelayNanos - jitterNanos),
                             min(maxDelayNanos, addWithOverflowProtection(baseDelayNanos, jitterNanos))),
@@ -261,7 +263,8 @@ public final class RepeatStrategies {
             if (repeatCount > maxRepeats) {
                 return terminateRepeat();
             }
-            final long baseDelayNanos = min(maxDelayNanos, initialDelayNanos << min(maxInitialShift, repeatCount - 1));
+            final long baseDelayNanos = baseDelayNanos(initialDelayNanos, maxDelayNanos, maxInitialShift,
+                    repeatCount - 1);
             return timerExecutor.timer(
                     current().nextLong(max(0, baseDelayNanos - jitterNanos),
                             min(maxDelayNanos, addWithOverflowProtection(baseDelayNanos, jitterNanos))),

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
@@ -167,7 +167,7 @@ public final class RepeatStrategies {
         final long maxDelayNanos = maxDelay.toNanos();
         final long maxInitialShift = maxShift(initialDelayNanos);
         return repeatCount -> timerExecutor.timer(current().nextLong(0,
-                        min(maxDelayNanos, initialDelayNanos << min(maxInitialShift, repeatCount - 1))), NANOSECONDS);
+                baseDelayNanos(initialDelayNanos, maxDelayNanos, maxInitialShift, repeatCount)), NANOSECONDS);
     }
 
     /**
@@ -197,7 +197,7 @@ public final class RepeatStrategies {
         final long maxInitialShift = maxShift(initialDelayNanos);
         return repeatCount -> repeatCount <= maxRepeats ?
                 timerExecutor.timer(current().nextLong(0,
-                        min(maxDelayNanos, initialDelayNanos << min(maxInitialShift, repeatCount - 1))), NANOSECONDS) :
+                        baseDelayNanos(initialDelayNanos, maxDelayNanos, maxInitialShift, repeatCount)), NANOSECONDS) :
                 terminateRepeat();
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
@@ -223,7 +223,7 @@ public final class RepeatStrategies {
         final long maxDelayNanos = maxDelay.toNanos();
         final long maxInitialShift = maxShift(initialDelayNanos);
         return repeatCount -> {
-            final long baseDelayNanos = initialDelayNanos << min(maxInitialShift, repeatCount - 1);
+            final long baseDelayNanos = min(maxDelayNanos, initialDelayNanos << min(maxInitialShift, repeatCount - 1));
             return timerExecutor.timer(
                     current().nextLong(max(0, baseDelayNanos - jitterNanos),
                             min(maxDelayNanos, addWithOverflowProtection(baseDelayNanos, jitterNanos))),
@@ -261,7 +261,7 @@ public final class RepeatStrategies {
             if (repeatCount > maxRepeats) {
                 return terminateRepeat();
             }
-            final long baseDelayNanos = initialDelayNanos << min(maxInitialShift, repeatCount - 1);
+            final long baseDelayNanos = min(maxDelayNanos, initialDelayNanos << min(maxInitialShift, repeatCount - 1));
             return timerExecutor.timer(
                     current().nextLong(max(0, baseDelayNanos - jitterNanos),
                             min(maxDelayNanos, addWithOverflowProtection(baseDelayNanos, jitterNanos))),

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetryStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetryStrategies.java
@@ -237,7 +237,7 @@ public final class RetryStrategies {
             if (!causeFilter.test(cause)) {
                 return failed(cause);
             }
-            final long baseDelayNanos = initialDelayNanos << min(maxInitialShift, retryCount - 1);
+            final long baseDelayNanos = min(maxDelayNanos, initialDelayNanos << min(maxInitialShift, retryCount - 1));
             return timerExecutor.timer(
                     current().nextLong(max(0, baseDelayNanos - jitterNanos),
                             min(maxDelayNanos, addWithOverflowProtection(baseDelayNanos, jitterNanos))),
@@ -278,7 +278,7 @@ public final class RetryStrategies {
             if (retryCount > maxRetries || !causeFilter.test(cause)) {
                 return failed(cause);
             }
-            final long baseDelayNanos = initialDelayNanos << min(maxInitialShift, retryCount - 1);
+            final long baseDelayNanos = min(maxDelayNanos, initialDelayNanos << min(maxInitialShift, retryCount - 1));
             return timerExecutor.timer(
                     current().nextLong(max(0, baseDelayNanos - jitterNanos),
                             min(maxDelayNanos, addWithOverflowProtection(baseDelayNanos, jitterNanos))),

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetryStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetryStrategies.java
@@ -287,8 +287,8 @@ public final class RetryStrategies {
     }
 
     static long baseDelayNanos(final long initialDelayNanos, final long maxDelayNanos, final long maxInitialShift,
-                               final int retryCount) {
-        return min(maxDelayNanos, initialDelayNanos << min(maxInitialShift, retryCount - 1));
+                               final int count) {
+        return min(maxDelayNanos, initialDelayNanos << min(maxInitialShift, count - 1));
     }
 
     static void checkMaxRetries(final int maxRetries) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RepeatStrategiesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RepeatStrategiesTest.java
@@ -19,12 +19,14 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.function.IntFunction;
+import java.util.function.UnaryOperator;
 
 import static io.servicetalk.concurrent.api.RepeatStrategies.TerminateRepeatException;
 import static io.servicetalk.concurrent.api.RepeatStrategies.repeatWithConstantBackoffDeltaJitter;
 import static io.servicetalk.concurrent.api.RepeatStrategies.repeatWithConstantBackoffFullJitter;
 import static io.servicetalk.concurrent.api.RepeatStrategies.repeatWithExponentialBackoffDeltaJitter;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static java.lang.Integer.MAX_VALUE;
 import static java.time.Duration.ofDays;
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofNanos;
@@ -78,24 +80,23 @@ public class RepeatStrategiesTest extends RedoStrategiesTest {
     }
 
     @Test
-    public void testExpBackoffWithJitter() throws Exception {
-        Duration initialDelay = ofSeconds(1);
-        Duration jitter = ofMillis(500);
-        RepeatStrategy strategy = new RepeatStrategy(repeatWithExponentialBackoffDeltaJitter(2, initialDelay, jitter,
-                ofDays(10), timerExecutor));
-        io.servicetalk.concurrent.test.internal.TestCompletableSubscriber subscriber = strategy.invokeAndListen();
-        verifyDelayWithDeltaJitter(initialDelay.toNanos(), jitter.toNanos(), 1);
+    public void testExpBackoffWithJitterLargeMaxDelayAndMaxRetries() throws Exception {
+        testExpBackoffWithJitter(2, ofSeconds(1), duration -> duration.plus(ofDays(10)));
+    }
 
-        timers.take().verifyListenCalled().onComplete();
-        subscriber.awaitOnComplete();
-        verifyNoMoreInteractions(timerExecutor);
+    @Test
+    public void testExpBackoffWithJitterLargeMaxDelayAndNoMaxRetries() throws Exception {
+        testExpBackoffWithJitter(MAX_VALUE, ofSeconds(1), duration -> duration.plus(ofDays(10)));
+    }
 
-        subscriber = strategy.invokeAndListen();
-        long nextDelay = initialDelay.toNanos() << 1;
-        verifyDelayWithDeltaJitter(nextDelay, jitter.toNanos(), 2);
-        timers.take().verifyListenCalled().onComplete();
-        subscriber.awaitOnComplete();
-        verifyNoMoreInteractions(timerExecutor);
+    @Test
+    public void testExpBackoffWithJitterSmallMaxDelayAndMaxRetries() throws Exception {
+        testExpBackoffWithJitter(2, ofSeconds(1), duration -> duration.plus(ofMillis(10)));
+    }
+
+    @Test
+    public void testExpBackoffWithJitterSmallMaxDelayAndNoMaxRetries() throws Exception {
+        testExpBackoffWithJitter(MAX_VALUE, ofSeconds(1), duration -> duration.plus(ofMillis(10)));
     }
 
     @Test
@@ -122,6 +123,30 @@ public class RepeatStrategiesTest extends RedoStrategiesTest {
         subscriber = strategy.invokeAndListen();
         verifyNoMoreInteractions(timerExecutor);
         assertThat(subscriber.awaitOnError(), instanceOf(TerminateRepeatException.class));
+    }
+
+    private void testExpBackoffWithJitter(final int maxRepeats, final Duration initialDelay,
+                                          final UnaryOperator<Duration> maxDelayFunc) throws Exception {
+        Duration jitter = ofMillis(500);
+        final IntFunction<Completable> strategyFunction = maxRepeats < MAX_VALUE ?
+                repeatWithExponentialBackoffDeltaJitter(maxRepeats, initialDelay, jitter,
+                        maxDelayFunc.apply(initialDelay), timerExecutor) :
+                repeatWithExponentialBackoffDeltaJitter(initialDelay, jitter,
+                        maxDelayFunc.apply(initialDelay), timerExecutor);
+        RepeatStrategy strategy = new RepeatStrategy(strategyFunction);
+        io.servicetalk.concurrent.test.internal.TestCompletableSubscriber subscriber = strategy.invokeAndListen();
+        verifyDelayWithDeltaJitter(initialDelay.toNanos(), jitter.toNanos(), 1);
+
+        timers.take().verifyListenCalled().onComplete();
+        subscriber.awaitOnComplete();
+        verifyNoMoreInteractions(timerExecutor);
+
+        subscriber = strategy.invokeAndListen();
+        long nextDelay = initialDelay.toNanos() << 1;
+        verifyDelayWithDeltaJitter(nextDelay, jitter.toNanos(), 2);
+        timers.take().verifyListenCalled().onComplete();
+        subscriber.awaitOnComplete();
+        verifyNoMoreInteractions(timerExecutor);
     }
 
     private static final class RepeatStrategy {


### PR DESCRIPTION
__Motivation__

When using `[retry,repeat]WithExponentialBackoffDeltaJitter()` if the `maxDelay` is closer to `initialDelay`, it may so happen that after a few retries the `baseDelayNanos` (delay before jitter) becomes greater than `maxDelayNanos`. While getting the random jitter we make sure to not exceed `maxDelayNanos` for the upper bound but lower bound may exceed `maxDelayNanos` hence making the call to `nextLong()` invalid.

__Modification__

Add a cap on `baseDelayNanos` such that it never exceeds `maxDelayNanos` and hence the call to `nextLong` always has the lower bound smaller than the upper bound.

__Result__

`[retry,repeat]WithExponentialBackoffDeltaJitter()` can work with smaller `maxDelay` values.