### PR TITLE
Add Publisher.scanWithLifetime(ScanWithLifetimeMapper) operator

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -233,6 +233,48 @@ public abstract class Publisher<T> {
     }
 
     /**
+     * Apply a function to each {@link Subscriber#onNext(Object)} emitted by this {@link Publisher} as well as
+     * optionally concat one {@link Subscriber#onNext(Object)} signal before the terminal signal is emitted downstream.
+     * Additionally it guarantees a {@link ScanWithLifetimeMapper#onFinalize()} callback after the terminal signal is
+     * emitted downstream.
+     *
+     * <p>
+     * This method provides a data transformation in sequential programming similar to:
+     * <pre>{@code
+     *     List<R> results = ...;
+     *     ScanWithLifetimeMapper<T, R> mapper = mapperSupplier.get();
+     *     try {
+     *         try {
+     *           for (T t : resultOfThisPublisher()) {
+     *             results.add(mapper.mapOnNext(t));
+     *           }
+     *         } catch (Throwable cause) {
+     *           if (mapTerminal.test(state)) {
+     *             results.add(mapper.mapOnError(cause));
+     *             return;
+     *           }
+     *           throw cause;
+     *         }
+     *         if (mapTerminal.test(state)) {
+     *           results.add(mapper.mapOnComplete());
+     *         }
+     *     } finally {
+     *       mapper.onFinalize();
+     *     }
+     *     return results;
+     * }</pre>
+     * @param mapperSupplier Invoked on each {@link PublisherSource#subscribe(Subscriber)} and maintains any necessary
+     * state for the mapping/accumulation for each {@link Subscriber}.
+     * @param <R> Type of the items emitted by the returned {@link Publisher}.
+     * @return A {@link Publisher} that transforms elements emitted by this {@link Publisher} into a different type.
+     * @see <a href="http://reactivex.io/documentation/operators/scan.html">ReactiveX scan operator.</a>
+     */
+    public final <R> Publisher<R> scanWithLifetime(
+            Supplier<? extends ScanWithLifetimeMapper<? super T, ? extends R>> mapperSupplier) {
+        return new ScanWithLifetimePublisher<>(this, mapperSupplier, executor);
+    }
+
+    /**
      * Transform errors emitted on this {@link Publisher} into a {@link Subscriber#onComplete()} signal
      * (e.g. swallows the error).
      * <p>

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -235,8 +235,9 @@ public abstract class Publisher<T> {
     /**
      * Apply a function to each {@link Subscriber#onNext(Object)} emitted by this {@link Publisher} as well as
      * optionally concat one {@link Subscriber#onNext(Object)} signal before the terminal signal is emitted downstream.
-     * Additionally it guarantees a {@link ScanWithLifetimeMapper#onFinalize()} callback after the terminal signal is
-     * emitted downstream.
+     * Additionally the {@link ScanWithLifetimeMapper#afterFinally()} method will be invoked on terminal or cancel
+     * signals which enables cleanup of state (if required). This provides a similar lifetime management as
+     * {@link TerminalSignalConsumer}.
      *
      * <p>
      * This method provides a data transformation in sequential programming similar to:
@@ -259,7 +260,7 @@ public abstract class Publisher<T> {
      *           results.add(mapper.mapOnComplete());
      *         }
      *     } finally {
-     *       mapper.onFinalize();
+     *       mapper.afterFinally();
      *     }
      *     return results;
      * }</pre>

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithLifetimeMapper.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithLifetimeMapper.java
@@ -21,7 +21,8 @@ import java.util.function.Supplier;
 
 /**
  * Provides the ability to transform (aka map) signals emitted via
- * the {@link Publisher#scanWithLifetime(Supplier)} operator, and hooks cancellations signals.
+ * the {@link Publisher#scanWithLifetime(Supplier)} operator, as well as the ability to cleanup state
+ * via {@link #afterFinally}.
  * @param <T> Type of items emitted by the {@link Publisher} this operator is applied.
  * @param <R> Type of items emitted by this operator.
  */

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithLifetimeMapper.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithLifetimeMapper.java
@@ -30,6 +30,8 @@ public interface ScanWithLifetimeMapper<T, R> extends ScanWithMapper<T, R> {
     /**
      * Invoked after a terminal signal {@link PublisherSource.Subscriber#onError(Throwable)} or
      * {@link PublisherSource.Subscriber#onComplete()} or {@link PublisherSource.Subscription#cancel()}.
+     * No further interaction will occur with the {@link ScanWithLifetimeMapper} to prevent use-after-free
+     * on internal state.
      */
-    void onFinalize();
+    void afterFinally();
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithLifetimeMapper.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithLifetimeMapper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.PublisherSource;
+
+import java.util.function.Supplier;
+
+/**
+ * Provides the ability to transform (aka map) signals emitted via
+ * the {@link Publisher#scanWithLifetime(Supplier)} operator, and hooks cancellations signals.
+ * @param <T> Type of items emitted by the {@link Publisher} this operator is applied.
+ * @param <R> Type of items emitted by this operator.
+ */
+public interface ScanWithLifetimeMapper<T, R> extends ScanWithMapper<T, R> {
+
+    /**
+     * Invoked after a terminal signal {@link PublisherSource.Subscriber#onError(Throwable)} or
+     * {@link PublisherSource.Subscriber#onComplete()} or {@link PublisherSource.Subscription#cancel()}.
+     */
+    void onFinalize();
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithLifetimePublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithLifetimePublisher.java
@@ -1,0 +1,365 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.internal.FlowControlUtils;
+import io.servicetalk.concurrent.internal.SignalOffloader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.OnSubscribeIgnoringSubscriberForOffloading.offloadWithDummyOnSubscribe;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
+
+final class ScanWithLifetimePublisher<T, R> extends AbstractNoHandleSubscribePublisher<R> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScanWithLifetimePublisher.class);
+
+    private final Publisher<T> original;
+    private final Supplier<? extends ScanWithLifetimeMapper<? super T, ? extends R>> mapperSupplier;
+
+    ScanWithLifetimePublisher(Publisher<T> original,
+                              Supplier<? extends ScanWithLifetimeMapper<? super T, ? extends R>> mapperSupplier,
+                              Executor executor) {
+        super(executor, true);
+        this.mapperSupplier = requireNonNull(mapperSupplier);
+        this.original = original;
+    }
+
+    @Override
+    void handleSubscribe(final Subscriber<? super R> subscriber, final SignalOffloader signalOffloader,
+                         final AsyncContextMap contextMap, final AsyncContextProvider contextProvider) {
+        original.delegateSubscribe(new ScanWithSubscriber<>(subscriber, mapperSupplier.get(), signalOffloader,
+                contextMap, contextProvider), signalOffloader, contextMap, contextProvider);
+    }
+
+    private static final class ScanWithSubscriber<T, R> implements Subscriber<T> {
+        private static final int NOT_ALLOWED = -1;
+        private static final int STATE_INIT = 0;
+        private static final int STATE_IN_SIGNAL = 1;
+        private static final int STATE_INVALID_DEMAND = 2;
+        private static final int STATE_TERMINAL_PENDING = 3;
+        private static final int STATE_TERMINATED = 4;
+        private static final int STATE_TERMINATED_WITH_REQ_HANDOFF = 5;
+
+        @SuppressWarnings("rawtypes")
+        private static final AtomicIntegerFieldUpdater<ScanWithSubscriber> stateUpdater =
+                AtomicIntegerFieldUpdater.newUpdater(ScanWithSubscriber.class, "state");
+
+        @SuppressWarnings("rawtypes")
+        private static final AtomicLongFieldUpdater<ScanWithSubscriber> demandUpdater =
+                newUpdater(ScanWithSubscriber.class, "demand");
+
+        private final Subscriber<? super R> subscriber;
+        private final SignalOffloader signalOffloader;
+        private final AsyncContextMap contextMap;
+        private final AsyncContextProvider contextProvider;
+        private final ScanWithLifetimeMapper<? super T, ? extends R> mapper;
+        private volatile long demand;
+        private volatile int state = STATE_INIT;
+
+        /**
+         * Retains the {@link #onError(Throwable)} cause for use in the {@link Subscription}.
+         * Happens-before relationship with {@link #demand} means no volatile or other synchronization required.
+         */
+        @Nullable
+        private Throwable errorCause;
+
+        ScanWithSubscriber(final Subscriber<? super R> subscriber,
+                           final ScanWithLifetimeMapper<? super T, ? extends R> mapper,
+                           final SignalOffloader signalOffloader, final AsyncContextMap contextMap,
+                           final AsyncContextProvider contextProvider) {
+            this.subscriber = subscriber;
+            this.signalOffloader = signalOffloader;
+            this.contextMap = contextMap;
+            this.contextProvider = contextProvider;
+            this.mapper = requireNonNull(mapper);
+        }
+
+        @Override
+        public void onSubscribe(final Subscription subscription) {
+            subscriber.onSubscribe(new Subscription() {
+                @Override
+                public void request(final long n) {
+                    if (!isRequestNValid(n)) {
+                        handleInvalidDemand(n);
+                    } else if (demandUpdater.getAndAccumulate(ScanWithSubscriber.this, n,
+                            FlowControlUtils::addWithOverflowProtectionIfNotNegative) < 0) {
+
+                        for (;;) {
+                            int theState = stateUpdater.get(ScanWithSubscriber.this);
+                            if (theState >= STATE_TERMINATED) {
+                                return;
+                            }
+
+                            if (stateUpdater.compareAndSet(ScanWithSubscriber.this, theState,
+                                    STATE_TERMINATED_WITH_REQ_HANDOFF)) {
+                                try {
+                                    // Deliver and finalize only if the state was STATE_TERMINAL_PENDING and we won the
+                                    // CAS otherwise the SIGNAL will process both
+                                    if (theState == STATE_TERMINAL_PENDING && errorCause != null) {
+                                        deliverOnError(errorCause, newOffloadedSubscriber());
+                                    } else if (theState == STATE_TERMINAL_PENDING) {
+                                        deliverOnComplete(newOffloadedSubscriber());
+                                    }
+                                } finally {
+                                    mapper.onFinalize();
+                                }
+                            }
+                        }
+                    } else {
+                        subscription.request(n);
+                    }
+                }
+
+                @Override
+                public void cancel() {
+                    try {
+                        subscription.cancel();
+                    } finally {
+                        for (;;) {
+                            int theState = stateUpdater.get(ScanWithSubscriber.this);
+                            if (theState >= STATE_TERMINATED) {
+                                break;
+                            }
+
+                            if (stateUpdater.compareAndSet(ScanWithSubscriber.this, theState, STATE_TERMINATED)) {
+                                // Finalize only if the state was not IN_SIGNAL, otherwise handover finalization
+                                // to the signal in-progress
+                                if (theState != STATE_IN_SIGNAL) {
+                                    mapper.onFinalize();
+                                }
+
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                private void handleInvalidDemand(final long n) {
+                    demandUpdater.getAndSet(ScanWithSubscriber.this, -1);
+
+                    // If there is a terminal pending then the upstream source cannot deliver an error because
+                    // duplicate terminal signals are not allowed. otherwise we let upstream deliver the error.
+                    final int theState = stateUpdater.getAndSet(ScanWithSubscriber.this, STATE_INVALID_DEMAND);
+                    if (theState == STATE_TERMINAL_PENDING) {
+                        newOffloadedSubscriber().onError(newExceptionForInvalidRequestN(n));
+                    } else {
+                        // STATE_INVALID_DEMAND will be allowed to process signals from upstream
+                        subscription.request(n);
+                    }
+                }
+
+                private Subscriber<? super R> newOffloadedSubscriber() {
+                    return offloadWithDummyOnSubscribe(subscriber, signalOffloader, contextMap, contextProvider);
+                }
+            });
+        }
+
+        @Override
+        public void onNext(@Nullable final T t) {
+            int theState = tryAcquireSignal();
+            if (theState == NOT_ALLOWED) {
+                return;
+            }
+
+            try {
+                // If anything throws in onNext the source is responsible for catching the error,
+                // cancelling the associated subscription, and propagate an onError.
+                final R mapped = mapper.mapOnNext(t);
+                demandUpdater.decrementAndGet(this);
+                subscriber.onNext(mapped);
+            } finally {
+                releaseAndFinalizeIfNeeded(theState);
+            }
+        }
+
+        @Override
+        public void onError(final Throwable t) {
+            boolean doMap = false;
+            boolean onErrorPropagated = false;
+
+            int theState = tryAcquireSignal();
+            if (theState == NOT_ALLOWED) {
+                return;
+            }
+
+            // Done after this signal
+            theState = STATE_TERMINATED;
+
+            try {
+                errorCause = t;
+                try {
+                    doMap = mapper.mapTerminal();
+                } catch (Throwable cause) {
+                    subscriber.onError(cause);
+                    onErrorPropagated = true;
+                    return;
+                }
+
+                final long currDemand = demandUpdater.getAndDecrement(this);
+                if (doMap) {
+                    if (currDemand > 0) {
+                        onErrorPropagated = deliverOnError(t, subscriber);
+                    } else if (currDemand == 0) {
+                        theState = STATE_TERMINAL_PENDING;
+                    } else {
+                        // Either we previously saw invalid request n, or upstream has sent a duplicate
+                        // terminal event. In either circumstance we propagate the error downstream and bail.
+                        subscriber.onError(t);
+                        onErrorPropagated = true;
+                    }
+                } else {
+                    subscriber.onError(t);
+                    onErrorPropagated = true;
+                }
+            } finally {
+                releaseWithTerminalAndFinalizeIfNeeded(theState, doMap, onErrorPropagated, t);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            int theState = tryAcquireSignal();
+            if (theState == NOT_ALLOWED) {
+                return;
+            }
+
+            // Done after this signal
+            theState = STATE_TERMINATED;
+
+            boolean doMap = false;
+            boolean onErrorPropagated = false;
+            try {
+                try {
+                    doMap = mapper.mapTerminal();
+                } catch (Throwable cause) {
+                    onErrorPropagated = true;
+                    subscriber.onError(cause);
+                    return;
+                }
+
+                final long currDemand = demandUpdater.getAndDecrement(this);
+                if (doMap) {
+                    if (currDemand > 0) {
+                        onErrorPropagated = deliverOnComplete(subscriber);
+                    } else if (currDemand == 0) {
+                        theState = STATE_TERMINAL_PENDING;
+                    } else {
+                        // Either we previously saw invalid request n, or upstream has sent a duplicate terminal event.
+                        // In either circumstance we propagate the error downstream and bail.
+                        subscriber.onError(new IllegalStateException("onComplete with invalid demand: " + currDemand));
+                        onErrorPropagated = true;
+                    }
+                } else {
+                    subscriber.onComplete();
+                }
+            } finally {
+                releaseWithTerminalAndFinalizeIfNeeded(theState, doMap, onErrorPropagated, null);
+            }
+        }
+
+        private boolean deliverOnError(Throwable t, Subscriber<? super R> subscriber) {
+            try {
+                subscriber.onNext(mapper.mapOnError(t));
+            } catch (Throwable cause) {
+                subscriber.onError(cause);
+                return true;
+            }
+            subscriber.onComplete();
+            return false;
+        }
+
+        private boolean deliverOnComplete(Subscriber<? super R> subscriber) {
+            try {
+                subscriber.onNext(mapper.mapOnComplete());
+            } catch (Throwable cause) {
+                subscriber.onError(cause);
+                return true;
+            }
+            subscriber.onComplete();
+            return false;
+        }
+
+        private int tryAcquireSignal() {
+            int theState = stateUpdater.get(ScanWithSubscriber.this);
+            if (theState >= STATE_TERMINATED) {
+                return NOT_ALLOWED;
+            }
+
+            // No need to loop since the signals are guaranteed to be signalled serially,
+            // thus a CAS fail means cancellation won, so we can safely ignore it.
+            if (stateUpdater.compareAndSet(ScanWithSubscriber.this, theState, STATE_IN_SIGNAL)) {
+                return theState;
+            }
+
+            return NOT_ALLOWED;
+        }
+
+        private void releaseAndFinalizeIfNeeded(final int newState) {
+            final boolean finalizationHandedOver = !stateUpdater.compareAndSet(this, STATE_IN_SIGNAL, newState);
+            if (finalizationHandedOver || newState == STATE_TERMINATED) {
+                // state changed while we were in progress, or new state is TERMINATE
+                // finalization is our responsibility
+                try {
+                    mapper.onFinalize();
+                } catch (Throwable cause) {
+                    subscriber.onError(cause);
+                }
+            }
+        }
+
+        private void releaseWithTerminalAndFinalizeIfNeeded(final int newState, final boolean doMap,
+                                                            boolean onErrorPropagated, @Nullable final Throwable t) {
+            final boolean finalizationHandedOver = !stateUpdater.compareAndSet(this, STATE_IN_SIGNAL, newState);
+            if (finalizationHandedOver || newState == STATE_TERMINATED) {
+                // state changed while we were in progress, or new state is TERMINATE
+                // finalization is our responsibility
+
+                try {
+                    if (doMap && state == STATE_TERMINATED_WITH_REQ_HANDOFF) {
+                        // If a request came while we are in progress, setting the state to
+                        // STATE_TERMINATED_REQ_HANDOFF then we can handle the last delivery too.
+
+                        if (t == null) {
+                            onErrorPropagated = deliverOnComplete(subscriber);
+                        } else {
+                            onErrorPropagated = deliverOnError(t, subscriber);
+                        }
+                    }
+                } finally {
+                    try {
+                        mapper.onFinalize();
+                    } catch (Throwable cause) {
+                        if (onErrorPropagated) {
+                            LOGGER.error("Unexpected error occurred during finalization.", cause);
+                        } else {
+                            subscriber.onError(cause);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithMapper.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithMapper.java
@@ -35,7 +35,7 @@ public interface ScanWithMapper<T, R> {
     R mapOnNext(@Nullable T next);
 
     /**
-     * Invoked when a {@link Subscriber#onError(Throwable)} is signal received, and maps the current state into an
+     * Invoked when a {@link Subscriber#onError(Throwable)} signal is received, and maps the current state into an
      * object of type {@link R} which will be emitted downstream as {@link Subscriber#onNext(Object)}, followed by
      * {@link Subscriber#onComplete()}.
      * <p>
@@ -51,7 +51,7 @@ public interface ScanWithMapper<T, R> {
     R mapOnError(Throwable cause) throws Throwable;
 
     /**
-     * Invoked when a {@link Subscriber#onComplete()} is signal received, and maps the current state into an object of
+     * Invoked when a {@link Subscriber#onComplete()} signal is received, and maps the current state into an object of
      * type {@link R} which will be emitted downstream as {@link Subscriber#onNext(Object)}, followed by
      * {@link Subscriber#onComplete()}.
      * <p>

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithPublisher.java
@@ -156,7 +156,12 @@ final class ScanWithPublisher<T, R> extends AbstractNoHandleSubscribePublisher<R
         }
 
         /**
-         * Return true if onError0 had sufficient demand to deliver.
+         * Executes the on-error signal and returns {@code true} if demand was sufficient to deliver the result of the
+         * mapped {@code Throwable} with {@link ScanWithMapper#mapOnError(Throwable)}.
+         *
+         * @param t The throwable to propagate
+         * @return {@code true} if the demand was sufficient to deliver the result of the mapped {@code Throwable} with
+         * {@link ScanWithMapper#mapOnError(Throwable)}.
          */
         protected boolean onError0(final Throwable t) {
             errorCause = t;
@@ -191,7 +196,11 @@ final class ScanWithPublisher<T, R> extends AbstractNoHandleSubscribePublisher<R
         }
 
         /**
-         * Return true if onComplete0 had sufficient demand to deliver.
+         * Executes the on-completed signal and returns {@code true} if demand was sufficient to deliver the concat item
+         * from {@link ScanWithMapper#mapOnComplete()} downstream.
+         *
+         * @return {@code true} if demand was sufficient to deliver the concat item from
+         * {@link ScanWithMapper#mapOnComplete()} downstream.
          */
         protected boolean onComplete0() {
             final boolean doMap;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ScanWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ScanWithPublisherTest.java
@@ -404,7 +404,6 @@ public class ScanWithPublisherTest {
             }
         }));
 
-
         Thread sub = new Thread(() -> {
             TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
             source.subscribe(subscriber);

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherScanWithLifetimeTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherScanWithLifetimeTckTest.java
@@ -45,7 +45,7 @@ public class PublisherScanWithLifetimeTckTest extends AbstractPublisherOperatorT
             @Nullable
             @Override
             public String mapOnComplete() {
-                return valueOf(-1);
+                return null;
             }
 
             @Override

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherScanWithLifetimeTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherScanWithLifetimeTckTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.ScanWithLifetimeMapper;
+
+import javax.annotation.Nullable;
+
+import static java.lang.String.valueOf;
+
+public class PublisherScanWithLifetimeTckTest extends AbstractPublisherOperatorTckTest<String> {
+    @Override
+    protected Publisher<String> composePublisher(Publisher<Integer> publisher, int elements) {
+        return publisher.scanWithLifetime(() -> new ScanWithLifetimeMapper<Integer, String>() {
+            @Override
+            public void onFinalize() {
+            }
+
+            @Nullable
+            @Override
+            public String mapOnNext(@Nullable final Integer next) {
+                return valueOf(next);
+            }
+
+            @Nullable
+            @Override
+            public String mapOnError(final Throwable cause) throws Throwable {
+                return null;
+            }
+
+            @Nullable
+            @Override
+            public String mapOnComplete() {
+                return valueOf(-1);
+            }
+
+            @Override
+            public boolean mapTerminal() {
+                return false;
+            }
+        });
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherScanWithLifetimeTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherScanWithLifetimeTckTest.java
@@ -27,7 +27,7 @@ public class PublisherScanWithLifetimeTckTest extends AbstractPublisherOperatorT
     protected Publisher<String> composePublisher(Publisher<Integer> publisher, int elements) {
         return publisher.scanWithLifetime(() -> new ScanWithLifetimeMapper<Integer, String>() {
             @Override
-            public void onFinalize() {
+            public void afterFinally() {
             }
 
             @Nullable


### PR DESCRIPTION
**Motivation**:
The existing Publisher.scanWith(...) operator is not exposing cancellations to the end user. Use cases that need to control resource lifetimes (ie. clean-up), can't do so on cancel.

**Modifications**:
Add a new Publisher operator, scanWithLifetime(ScanWithLifetimeMapper), that also captures cancellation and invokes an afterFinally callback on all terminal signal (complete, error & cancel).

**Result**:
A new lifetime aware scanWith operator.