### PR TITLE
Deprecate isAsciiString and replace its internal usages

### DIFF
--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
@@ -74,7 +74,10 @@ public final class CharSequences {
      *
      * @param sequence The {@link CharSequence} to check.
      * @return {@code true} if the check passes.
+     * @deprecated Internal implementation detail that will be removed in follow-up releases. Please rely on API inside
+     * {@link CharSequences} to manipulated ascii strings.
      */
+    @Deprecated
     public static boolean isAsciiString(final CharSequence sequence) {
         return sequence.getClass() == AsciiBuffer.class;
     }
@@ -169,10 +172,10 @@ public final class CharSequences {
      * @return The index of {@code c} or {@code -1} otherwise.
      */
     public static int indexOf(final CharSequence sequence, char c, int fromIndex) {
-        if (sequence instanceof String) {
-            return ((String) sequence).indexOf(c, fromIndex);
-        } else if (isAsciiString(sequence)) {
+        if (isAsciiString(sequence)) {
             return asciiStringIndexOf(sequence, c, fromIndex);
+        } else if (sequence instanceof String) {
+            return ((String) sequence).indexOf(c, fromIndex);
         }
         for (int i = fromIndex; i < sequence.length(); ++i) {
             if (sequence.charAt(i) == c) {


### PR DESCRIPTION
Motivation:
Minimize exposed CharSequences API and don't expose internal detail.

Modifications:
Deprecate `isAsciiString` and replace it's usages.

Result:
Cleaner API.

----

Also attempted a solution with an `IndexOfExtractor` interface exposed directly from `CharSequences` and bench marked the two. The benefit was negligible (assuming that the JIT optimized for that particular case ie. `CharSequence`) so I chose to keep simple.

For reference:
```
CharSequencesBenchmark.isValidIpV4Address     thrpt    5  37734929.772 ±  935310.988  ops/s
CharSequencesBenchmark.isValidIpV4AddressNew  thrpt    5  38000362.771 ± 2153374.472  ops/s
```
_* isValidIpV4AddressNew is with the IndexOfExtractor approach_