### PR TITLE
Run JUnit 4 based tests using junit-vintage-engine

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -69,7 +69,3 @@ shadowPluginVersion=4.0.4
 # https://issues.sonatype.org/browse/MVNCENTRAL-5276
 # https://issues.apache.org/jira/browse/INFRA-14923
 systemProp.org.gradle.internal.publish.checksums.insecure=true
-
-# Test properties
-# expected format for timeout: <number>[ns|μs|ms|s|m|h|d])
-junit5DefaultTimeout=30s

--- a/servicetalk-concurrent-api/build.gradle
+++ b/servicetalk-concurrent-api/build.gradle
@@ -16,14 +16,6 @@
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
-test {
-  useJUnitPlatform()
-  def junit5TimeoutParamName = "junit.jupiter.execution.timeout.default"
-  def junit5Timeout = System.getProperty(junit5TimeoutParamName, "$junit5DefaultTimeout")
-  systemProperty junit5TimeoutParamName, "$junit5Timeout"
-  systemProperty "junit.jupiter.extensions.autodetection.enabled", "true"
-}
-
 dependencies {
   api project(":servicetalk-concurrent")
 

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -163,7 +163,7 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
       test {
         useJUnitPlatform()
         // expected format for timeout: <number>[ns|μs|ms|s|m|h|d])
-        def junit5DefaultTimeout = "true".equalsIgnoreCase(System.getenv("CI")) ? "30s" : "10s"
+        def junit5DefaultTimeout = Boolean.valueOf(System.getenv("CI") ?: "false") ? "30s" : "10s"
         def junit5TimeoutParamName = "junit.jupiter.execution.timeout.default"
         def junit5Timeout = System.getProperty(junit5TimeoutParamName, "$junit5DefaultTimeout")
         systemProperty junit5TimeoutParamName, "$junit5Timeout"

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -162,8 +162,11 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
     project.configure(project) {
       test {
         useJUnitPlatform()
+        // expected format for timeout: <number>[ns|μs|ms|s|m|h|d])
+        def junit5DefaultTimeout = System.getProperty("CI") ? "30s" : "10s"
         def junit5TimeoutParamName = "junit.jupiter.execution.timeout.default"
         def junit5Timeout = System.getProperty(junit5TimeoutParamName, "$junit5DefaultTimeout")
+        System.out.println("my timeout = $junit5DefaultTimeout")
         systemProperty junit5TimeoutParamName, "$junit5Timeout"
         systemProperty "junit.jupiter.extensions.autodetection.enabled", "true"
 

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -163,7 +163,7 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
       test {
         useJUnitPlatform()
         // expected format for timeout: <number>[ns|μs|ms|s|m|h|d])
-        def junit5DefaultTimeout = System.getProperty("CI") ? "30s" : "10s"
+        def junit5DefaultTimeout = "true".equalsIgnoreCase(System.getenv("CI")) ? "30s" : "10s"
         def junit5TimeoutParamName = "junit.jupiter.execution.timeout.default"
         def junit5Timeout = System.getProperty(junit5TimeoutParamName, "$junit5DefaultTimeout")
         systemProperty junit5TimeoutParamName, "$junit5Timeout"

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -166,7 +166,6 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
         def junit5DefaultTimeout = System.getProperty("CI") ? "30s" : "10s"
         def junit5TimeoutParamName = "junit.jupiter.execution.timeout.default"
         def junit5Timeout = System.getProperty(junit5TimeoutParamName, "$junit5DefaultTimeout")
-        System.out.println("my timeout = $junit5DefaultTimeout")
         systemProperty junit5TimeoutParamName, "$junit5Timeout"
         systemProperty "junit.jupiter.extensions.autodetection.enabled", "true"
 

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -161,6 +161,12 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
   private static void configureTests(Project project) {
     project.configure(project) {
       test {
+        useJUnitPlatform()
+        def junit5TimeoutParamName = "junit.jupiter.execution.timeout.default"
+        def junit5Timeout = System.getProperty(junit5TimeoutParamName, "$junit5DefaultTimeout")
+        systemProperty junit5TimeoutParamName, "$junit5Timeout"
+        systemProperty "junit.jupiter.extensions.autodetection.enabled", "true"
+
         testLogging {
           events "passed", "skipped", "failed"
           showStandardStreams = true
@@ -169,6 +175,13 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
         jvmArgs "-server", "-Xms2g", "-Xmx4g", "-dsa", "-da", "-ea:io.servicetalk...",
                 "-XX:+HeapDumpOnOutOfMemoryError"
       }
+
+      dependencies {
+        testRuntimeOnly("org.junit.vintage:junit-vintage-engine:$junit5Version") {
+          because 'allows JUnit 3 and JUnit 4 tests to run'
+        }
+      }
+
     }
   }
 


### PR DESCRIPTION
Motivation:
   Let developers to create new JUnit 5 tests in modules not yet converted to JUnit5

Modifications:
  added dependency on  `org.junit.vintage:junit-vintage-engine`

Result:
   JUnit 4 and JUnit 5 tests can be mixed in one module 
   To add new JUnit 5 tests to non converted test module,  the following dependencies news to be present:

  `testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"`
  `testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"`  (optional if using parameterized tests)
  `testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"`