### PR TITLE
Ensure that onError with timeout is called after subscription cancel

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutSingle.java
@@ -184,13 +184,16 @@ final class TimeoutSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
                                 contextProvider.contextMap()));
                 // The timer is started before onSubscribe so the oldCancellable may actually be null at this time.
                 if (oldCancellable != null) {
-                    oldCancellable.cancel();
-
                     // We already know that this.onSubscribe was called because we have a valid Cancellable. We need to
                     // know that the call to target.onSubscribe completed so we don't interact with the Subscriber
                     // concurrently.
-                    if (subscriberStateUpdater.getAndSet(this, STATE_TIMED_OUT_ERROR) == STATE_ON_SUBSCRIBE_DONE) {
-                        offloadedTarget.onError(newTimeoutException());
+                    int stateWas = subscriberStateUpdater.getAndSet(this, STATE_TIMED_OUT_ERROR);
+                    try {
+                        oldCancellable.cancel();
+                    } finally {
+                        if (stateWas == STATE_ON_SUBSCRIBE_DONE) {
+                            offloadedTarget.onError(newTimeoutException());
+                        }
                     }
                 } else {
                     // If there is no Cancellable, that means this.onSubscribe wasn't called before the timeout. In this


### PR DESCRIPTION
Motivation:
In some cases the `cancel()` which resulted from a timeout did not
result in the `onError()` also being called with the timeout exception
because the cancel operation changed the subscriber state.

Modifications:
If the operator had not completed at the time of the timeout then the
`onError()` should be called regardless of the state changes which
happen during `cancel()`.

Result:
The reason for the cancel is exposed via the `onError()`.