### PR TITLE
Add a ServiceTalk debugging utilities example

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ if (!repositories) {
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-root"
 
 task validateLocalDocSite(type: Exec) {
+  group 'Documentation'
+  description 'Generate and validate servicetalk.io site documentation'
   workingDir 'docs/generation'
   commandLine './gradlew', 'clean', 'validateLocalSite'
 }

--- a/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
@@ -2,6 +2,7 @@
 * xref:{page-version}@servicetalk-examples::http/index.adoc[HTTP]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#HelloWorld[Hello World]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#Compression[Compression]
+** xref:{page-version}@servicetalk-examples::http/index.adoc#Debugging[Debugging]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#Serialization[Serialization]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#JAXRS[JAX-RS]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#MetaData[MetaData]

--- a/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
@@ -82,19 +82,20 @@ receives a response greeting the posted name as a single content.
 [#Debugging]
 == Debugging
 
-Extends the async "Hello World" example to demonstrate some debugging features available
- for debugging ServiceTalk applications.
+Extends the async "Hello World" example to demonstrate some useful features available
+ for debugging ServiceTalk applications. You should read and understand the async "Hello World"
+ example first to understand the additions this example adds. No separate example is needed
+ for the other API variants as the usage of the debugging features are the same for all API
+ styles.
 
-* link:{source-root}/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java[DebuggingExampleServer] - a server that demonstrates
-the asynchronous API and responds with a simple `Hello World!` response body, optionally customized for a specific name for `POST` requests, as a `text/plain`.
-* link:{source-root}/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java[DebuggingExampleClient.java] - a client that
-sends a `POST` request containing a name to the link:{source-root}/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java[server] and
-receives a response greeting the posted name as a single content.
+* link:{source-root}/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java[DebuggingExampleServer] - the async `Hello World!`
+ server enhanced with debugging capabilities.
+* link:{source-root}/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java[DebuggingExampleClient.java] - the async `Hello World!` client enhanced with debugging capabilities.
 
 [#Serialization]
 == Serialization
 
-A similar to "Hello World" examples, which demonstrate
+A example similar to "Hello World" examples, which demonstrate
 link:{source-root}/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/async[asynchronous-aggregated],
 link:{source-root}/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/async/streaming[asynchronous-streaming],
 link:{source-root}/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/blocking[blocking-aggregated], and

--- a/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
@@ -73,10 +73,22 @@ blocking iterable stream of buffers.
 Extends the async "Hello World" example to demonstrate content encoding compression filters. No separate example is
 needed for the other API variants as the usage of content encoding filters is the same for all API styles.
 
-* link:{source-root}/servicetalk-examples/http/compression/src/main/java/io/servicetalk/examples/http/compression/CompressionFilterExampleServer.java[CompressionFilterExampleServer] - a server that demonstrates 
+* link:{source-root}/servicetalk-examples/http/compression/src/main/java/io/servicetalk/examples/http/compression/CompressionFilterExampleServer.java[CompressionFilterExampleServer] - a server that demonstrates
 the asynchronous API and responds with a simple `Hello World!` response body, optionally customized for a specific name for `POST` requests, as a `text/plain`.
 * link:{source-root}/servicetalk-examples/http/compression/src/main/java/io/servicetalk/examples/http/compression/CompressionFilterExampleClient.java[CompressionFilterExampleClient.java] - a client that
-sends a `POST` request containing a name to the link:{source-root}/servicetalk-examples/http/compression/src/main/java/io/servicetalk/examples/http/compression/CompressionFilterExampleServer.java[server] and 
+sends a `POST` request containing a name to the link:{source-root}/servicetalk-examples/http/compression/src/main/java/io/servicetalk/examples/http/compression/CompressionFilterExampleServer.java[server] and
+receives a response greeting the posted name as a single content.
+
+[#Debugging]
+== Debugging
+
+Extends the async "Hello World" example to demonstrate some debugging features available
+ for debugging ServiceTalk applications.
+
+* link:{source-root}/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java[DebuggingExampleServer] - a server that demonstrates
+the asynchronous API and responds with a simple `Hello World!` response body, optionally customized for a specific name for `POST` requests, as a `text/plain`.
+* link:{source-root}/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java[DebuggingExampleClient.java] - a client that
+sends a `POST` request containing a name to the link:{source-root}/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java[server] and
 receives a response greeting the posted name as a single content.
 
 [#Serialization]
@@ -120,7 +132,7 @@ link:{source-root}/servicetalk-examples/http/jaxrs/src/main/java/io/servicetalk/
 [#MetaData]
 == MetaData
 
-This example demonstrates some of the basic functionality of the
+This example demonstrates some basic functionality of the
 link:{source-root}/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpMetaData.java[HttpMetaData] classes:
 
 - Setting and getting response status.

--- a/servicetalk-examples/http/debugging/build.gradle
+++ b/servicetalk-examples/http/debugging/build.gradle
@@ -18,8 +18,6 @@ apply plugin: "java"
 apply from: "../../gradle/idea.gradle"
 
 dependencies {
-  implementation project(":servicetalk-annotations")
-  implementation project(":servicetalk-encoding-netty")
   implementation project(":servicetalk-http-netty")
 
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/servicetalk-examples/http/debugging/build.gradle
+++ b/servicetalk-examples/http/debugging/build.gradle
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: "java"
+apply from: "../../gradle/idea.gradle"
+
+dependencies {
+  implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-encoding-netty")
+  implementation project(":servicetalk-http-netty")
+
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+}

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
@@ -20,6 +20,7 @@ import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.api.HttpExecutionStrategies;
 import io.servicetalk.http.api.HttpRequest;
 import io.servicetalk.http.netty.HttpClients;
+import io.servicetalk.http.netty.HttpProtocolConfigs;
 
 import java.util.concurrent.CountDownLatch;
 
@@ -29,6 +30,90 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
 
 /**
  * The async "Hello World" example with debugging features enabled.
+ *
+ * <p>When configured correctly the output should be similar to the following:
+ * <pre>
+ * 2021-03-26 19:42:07,000 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09] REGISTERED
+ * 2021-03-26 19:42:07,002 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09] CONNECT: localhost/127.0.0.1:8080
+ * 2021-03-26 19:42:07,005 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] ACTIVE
+ * 2021-03-26 19:42:07,006 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] WRITE: 24B
+ *          +-------------------------------------------------+
+ *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 50 52 49 20 2a 20 48 54 54 50 2f 32 2e 30 0d 0a |PRI * HTTP/2.0..|
+ * |00000010| 0d 0a 53 4d 0d 0a 0d 0a                         |..SM....        |
+ * +--------+-------------------------------------------------+----------------+
+ * 2021-03-26 19:42:07,013 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] OUTBOUND SETTINGS: ack=false settings={ENABLE_PUSH=0, MAX_CONCURRENT_STREAMS=0, MAX_HEADER_LIST_SIZE=8192}
+ * 2021-03-26 19:42:07,027 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] WRITE: 27B
+ *          +-------------------------------------------------+
+ *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 12 04 00 00 00 00 00 00 02 00 00 00 00 00 |................|
+ * |00000010| 03 00 00 00 00 00 06 00 00 20 00                |......... .     |
+ * +--------+-------------------------------------------------+----------------+
+ * 2021-03-26 19:42:07,166 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] OUTBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:authority: localhost:8080, :method: POST, :scheme: http, :path: /sayHello, content-type: text/plain; charset=UTF-8, content-length: 6] padding=0 endStream=false
+ * 2021-03-26 19:42:07,171 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] WRITE: 9B
+ *          +-------------------------------------------------+
+ *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 3b 01 04 00 00 00 03                      |..;......       |
+ * +--------+-------------------------------------------------+----------------+
+ * 2021-03-26 19:42:07,171 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] WRITE: 59B
+ *          +-------------------------------------------------+
+ *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 41 0e 6c 6f 63 61 6c 68 6f 73 74 3a 38 30 38 30 |A.localhost:8080|
+ * |00000010| 83 86 44 09 2f 73 61 79 48 65 6c 6c 6f 5f 19 74 |..D./sayHello_.t|
+ * |00000020| 65 78 74 2f 70 6c 61 69 6e 3b 20 63 68 61 72 73 |ext/plain; chars|
+ * |00000030| 65 74 3d 55 54 46 2d 38 5c 01 36                |et=UTF-8\.6     |
+ * +--------+-------------------------------------------------+----------------+
+ * 2021-03-26 19:42:07,181 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] OUTBOUND DATA: streamId=3 padding=0 endStream=true length=6 bytes=47656f726765
+ * 2021-03-26 19:42:07,181 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] WRITE: 9B
+ *          +-------------------------------------------------+
+ *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 06 00 01 00 00 00 03                      |.........       |
+ * +--------+-------------------------------------------------+----------------+
+ * 2021-03-26 19:42:07,181 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] WRITE: 6B
+ *          +-------------------------------------------------+
+ *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 47 65 6f 72 67 65                               |George          |
+ * +--------+-------------------------------------------------+----------------+
+ * 2021-03-26 19:42:07,183 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] FLUSH
+ * 2021-03-26 19:42:07,185 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] READ_REQUEST
+ * 2021-03-26 19:42:07,365 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] READ: 87B
+ *          +-------------------------------------------------+
+ *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 06 04 00 00 00 00 00 00 06 00 00 20 00 00 |............. ..|
+ * |00000010| 00 00 04 01 00 00 00 00 00 00 20 01 04 00 00 00 |.......... .....|
+ * |00000020| 03 88 5f 19 74 65 78 74 2f 70 6c 61 69 6e 3b 20 |.._.text/plain; |
+ * |00000030| 63 68 61 72 73 65 74 3d 55 54 46 2d 38 5c 02 31 |charset=UTF-8\.1|
+ * |00000040| 33 00 00 0d 00 01 00 00 00 03 48 65 6c 6c 6f 20 |3.........Hello |
+ * |00000050| 47 65 6f 72 67 65 21                            |George!         |
+ * +--------+-------------------------------------------------+----------------+
+ * 2021-03-26 19:42:07,367 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] INBOUND SETTINGS: ack=false settings={MAX_HEADER_LIST_SIZE=8192}
+ * 2021-03-26 19:42:07,369 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] OUTBOUND SETTINGS: ack=true
+ * 2021-03-26 19:42:07,370 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] WRITE: 9B
+ *          +-------------------------------------------------+
+ *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 00 04 01 00 00 00 00                      |.........       |
+ * +--------+-------------------------------------------------+----------------+
+ * 2021-03-26 19:42:07,370 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] FLUSH
+ * 2021-03-26 19:42:07,370 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] INBOUND SETTINGS: ack=true
+ * 2021-03-26 19:42:07,371 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] INBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:status: 200, content-type: text/plain; charset=UTF-8, content-length: 13] padding=0 endStream=false
+ * 2021-03-26 19:42:07,378 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] INBOUND DATA: streamId=3 padding=0 endStream=true length=13 bytes=48656c6c6f2047656f72676521
+ * HTTP/2.0 200 OK
+ * NettyH2HeadersToHttpHeaders[content-type: text/plain; charset=UTF-8
+ * content-length: 13]
+ * Hello George!
+ * 2021-03-26 19:42:07,381 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] READ_COMPLETE
+ * 2021-03-26 19:42:07,381 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] FLUSH
+ * 2021-03-26 19:42:07,381 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] FLUSH
+ * 2021-03-26 19:42:07,381 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] READ_REQUEST
+ * </pre>
  */
 public final class DebuggingExampleClient {
 
@@ -46,6 +131,11 @@ public final class DebuggingExampleClient {
                 // Enables detailed logging of I/O and I/O states.
                 // Be sure to also enable the logger in your logging config file (log4j2.xml for this example)
                 .enableWireLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+                // Enables detailed logging of HTTP2 frames.
+                // Be sure to also enable the logger in your logging config file (log4j2.xml for this example)
+                .protocols(HttpProtocolConfigs.h2()
+                        .enableFrameLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+                        .build())
                 .build()) {
             // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
             // before the response has been processed. This isn't typical usage for a streaming API but is useful for

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.debugging;
+
+import io.servicetalk.concurrent.api.AsyncContext;
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.HttpExecutionStrategies;
+import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.http.netty.HttpClients;
+
+import java.util.concurrent.CountDownLatch;
+
+import static io.servicetalk.http.api.HttpSerializationProviders.textDeserializer;
+import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
+import static io.servicetalk.logging.api.LogLevel.TRACE;
+
+/**
+ * The async "Hello World" example with debugging features enabled.
+ */
+public final class DebuggingExampleClient {
+
+    static {
+        // Enables visibility for all wire log messages
+        System.setProperty("servicetalk.logger.wireLogLevel", "TRACE");
+        // Disables the context associated with individual request/responses to simplify execution tracing
+        AsyncContext.disable();
+    }
+
+    public static void main(String... args) throws Exception {
+        try (HttpClient client = HttpClients.forSingleAddress("localhost", 8080)
+                // Disables asynchronous offloading to simplify execution tracing
+                .executionStrategy(HttpExecutionStrategies.noOffloadsStrategy())
+                // Enables detailed logging of I/O and I/O states.
+                // Be sure to also enable the logger in your logging config file (log4j2.xml for this example)
+                .enableWireLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+                .build()) {
+            // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
+            // before the response has been processed. This isn't typical usage for a streaming API but is useful for
+            // demonstration purposes.
+            CountDownLatch responseProcessedLatch = new CountDownLatch(2);
+
+            // Make a request with a payload.
+            HttpRequest request = client.post("/sayHello")
+                    .payloadBody("George", textSerializer());
+            client.request(request)
+                    .afterFinally(responseProcessedLatch::countDown)
+                    .subscribe(resp -> {
+                        System.out.println(resp.toString((name, value) -> value));
+                        System.out.println(resp.payloadBody(textDeserializer()));
+                    });
+
+            responseProcessedLatch.await();
+        }
+    }
+}

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
@@ -34,7 +34,9 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
  *     <li>Enabling HTTP wire logging</li>
  *     <li>Enabling HTTP/2 frame logging</li>
  * </ol>
- *
+ * <p>The wire and frame logging features require that you configure {@link io.servicetalk.logging.api.LogLevel#TRACE}
+ * logging for the logger. For this example {@code log4j.xml} is used by both the client and server and configures the
+ * ({@code servicetalk-examples-wire-logger} logger.
  *
  * <p>When configured correctly the output should be similar to the following:
  * <pre>

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
@@ -15,8 +15,6 @@
  */
 package io.servicetalk.examples.http.debugging;
 
-import io.servicetalk.concurrent.api.AsyncContext;
-import io.servicetalk.http.api.HttpExecutionStrategies;
 import io.servicetalk.http.netty.HttpProtocolConfigs;
 import io.servicetalk.http.netty.HttpServers;
 
@@ -26,7 +24,13 @@ import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
 import static io.servicetalk.logging.api.LogLevel.TRACE;
 
 /**
- * Extends the async "Hello World" sample with debugging features enabled.
+ * Extends the async "Hello World" sample with debugging features. Four debugging features are demonstrated:
+ * <p></p><ol>
+ *     <li>Disabling Async Context</li>
+ *     <li>Disabling offloading</li>
+ *     <li>Enabling HTTP wire logging</li>
+ *     <li>Enabling HTTP/2 frame logging</li>
+ * </ol>
  *
  * <p>When configured correctly the output should be similar to the following:
  * <pre>
@@ -111,20 +115,21 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
 public final class DebuggingExampleServer {
 
     static {
-        // Enables visibility for all wire log messages
-        System.setProperty("servicetalk.logger.wireLogLevel", "TRACE");
-        // Disables the context associated with individual request/responses to simplify execution tracing
-        AsyncContext.disable();
+        // 1. (optional) Disables the AsyncContext associated with individual request/responses to reduce stack-trace
+        // depth and simplify execution tracing. This will disable/break some features such as request tracing,
+        // authentication, propagated timeouts, etc. that rely upon the Async context so should only be disabled when
+        // necessary for debugging
+        /* AsyncContext.disable(); */
     }
 
     public static void main(String... args) throws Exception {
         HttpServers.forPort(8080)
-                // Disables asynchronous offloading to simplify execution tracing
-                .executionStrategy(HttpExecutionStrategies.noOffloadsStrategy())
-                // Enables detailed logging of I/O and I/O states.
+                // 2. (optional) Disables most asynchronous offloading to simplify execution tracing
+                /* .executionStrategy(HttpExecutionStrategies.noOffloadsStrategy()) */
+                // 3. Enables detailed logging of I/O and I/O states.
                 // Be sure to also enable the logger in your logging config file (log4j2.xml for this example)
                 .enableWireLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
-                // Enables detailed logging of HTTP2 frames.
+                // 4. Enables detailed logging of HTTP2 frames.
                 // Be sure to also enable the logger in your logging config file (log4j2.xml for this example)
                 .protocols(HttpProtocolConfigs.h2()
                         .enableFrameLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
@@ -31,6 +31,9 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
  *     <li>Enabling HTTP wire logging</li>
  *     <li>Enabling HTTP/2 frame logging</li>
  * </ol>
+ * <p>The wire and frame logging features require that you configure {@link io.servicetalk.logging.api.LogLevel#TRACE}
+ * logging for the logger. For this example {@code log4j.xml} is used by both the client and server and configures the
+ * ({@code servicetalk-examples-wire-logger} logger.
  *
  * <p>When configured correctly the output should be similar to the following:
  * <pre>

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.debugging;
+
+import io.servicetalk.concurrent.api.AsyncContext;
+import io.servicetalk.http.api.HttpExecutionStrategies;
+import io.servicetalk.http.netty.HttpServers;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.api.HttpSerializationProviders.textDeserializer;
+import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
+import static io.servicetalk.logging.api.LogLevel.TRACE;
+
+/**
+ * Extends the async "Hello World" sample with debugging features enabled.
+ */
+public final class DebuggingExampleServer {
+
+    static {
+        // Enables visibility for all wire log messages
+        System.setProperty("servicetalk.logger.wireLogLevel", "TRACE");
+        // Disables the context associated with individual request/responses to simplify execution tracing
+        AsyncContext.disable();
+    }
+
+    public static void main(String... args) throws Exception {
+        HttpServers.forPort(8080)
+                // Disables asynchronous offloading to simplify execution tracing
+                .executionStrategy(HttpExecutionStrategies.noOffloadsStrategy())
+                // Enables detailed logging of I/O and I/O states.
+                // Be sure to also enable the logger in your logging config file (log4j2.xml for this example)
+                .enableWireLogging("servicetalk-test-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+                .listenAndAwait((ctx, request, responseFactory) -> {
+                    String who = request.payloadBody(textDeserializer());
+                    return succeeded(responseFactory.ok().payloadBody("Hello " + who + "!", textSerializer()));
+                })
+                .awaitShutdown();
+    }
+}

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
@@ -17,6 +17,7 @@ package io.servicetalk.examples.http.debugging;
 
 import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.http.api.HttpExecutionStrategies;
+import io.servicetalk.http.netty.HttpProtocolConfigs;
 import io.servicetalk.http.netty.HttpServers;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
@@ -26,6 +27,86 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
 
 /**
  * Extends the async "Hello World" sample with debugging features enabled.
+ *
+ * <p>When configured correctly the output should be similar to the following:
+ * <pre>
+ * 2021-03-26 19:42:07,095 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] OUTBOUND SETTINGS: ack=false settings={MAX_HEADER_LIST_SIZE=8192}
+ * 2021-03-26 19:42:07,117 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] WRITE: 15B
+ *          +-------------------------------------------------+
+ *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 06 04 00 00 00 00 00 00 06 00 00 20 00    |............. . |
+ * +--------+-------------------------------------------------+----------------+
+ * 2021-03-26 19:42:07,119 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] REGISTERED
+ * 2021-03-26 19:42:07,120 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] ACTIVE
+ * 2021-03-26 19:42:07,120 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] READ_REQUEST
+ * 2021-03-26 19:42:07,184 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] READ: 134B
+ *          +-------------------------------------------------+
+ *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 50 52 49 20 2a 20 48 54 54 50 2f 32 2e 30 0d 0a |PRI * HTTP/2.0..|
+ * |00000010| 0d 0a 53 4d 0d 0a 0d 0a 00 00 12 04 00 00 00 00 |..SM............|
+ * |00000020| 00 00 02 00 00 00 00 00 03 00 00 00 00 00 06 00 |................|
+ * |00000030| 00 20 00 00 00 3b 01 04 00 00 00 03 41 0e 6c 6f |. ...;......A.lo|
+ * |00000040| 63 61 6c 68 6f 73 74 3a 38 30 38 30 83 86 44 09 |calhost:8080..D.|
+ * |00000050| 2f 73 61 79 48 65 6c 6c 6f 5f 19 74 65 78 74 2f |/sayHello_.text/|
+ * |00000060| 70 6c 61 69 6e 3b 20 63 68 61 72 73 65 74 3d 55 |plain; charset=U|
+ * |00000070| 54 46 2d 38 5c 01 36 00 00 06 00 01 00 00 00 03 |TF-8\.6.........|
+ * |00000080| 47 65 6f 72 67 65                               |George          |
+ * +--------+-------------------------------------------------+----------------+
+ * 2021-03-26 19:42:07,186 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] INBOUND SETTINGS: ack=false settings={ENABLE_PUSH=0, MAX_CONCURRENT_STREAMS=0, MAX_HEADER_LIST_SIZE=8192}
+ * 2021-03-26 19:42:07,187 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] OUTBOUND SETTINGS: ack=true
+ * 2021-03-26 19:42:07,188 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] WRITE: 9B
+ *          +-------------------------------------------------+
+ *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 00 04 01 00 00 00 00                      |.........       |
+ * +--------+-------------------------------------------------+----------------+
+ * 2021-03-26 19:42:07,196 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] INBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:authority: localhost:8080, :method: POST, :scheme: http, :path: /sayHello, content-type: text/plain; charset=UTF-8, content-length: 6] padding=0 endStream=false
+ * 2021-03-26 19:42:07,254 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] INBOUND DATA: streamId=3 padding=0 endStream=true length=6 bytes=47656f726765
+ * 2021-03-26 19:42:07,350 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] OUTBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:status: 200, content-type: text/plain; charset=UTF-8, content-length: 13] padding=0 endStream=false
+ * 2021-03-26 19:42:07,351 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] WRITE: 9B
+ *          +-------------------------------------------------+
+ *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 20 01 04 00 00 00 03                      |.. ......       |
+ * +--------+-------------------------------------------------+----------------+
+ * 2021-03-26 19:42:07,351 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] WRITE: 32B
+ *          +-------------------------------------------------+
+ *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 88 5f 19 74 65 78 74 2f 70 6c 61 69 6e 3b 20 63 |._.text/plain; c|
+ * |00000010| 68 61 72 73 65 74 3d 55 54 46 2d 38 5c 02 31 33 |harset=UTF-8\.13|
+ * +--------+-------------------------------------------------+----------------+
+ * 2021-03-26 19:42:07,360 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] READ_COMPLETE
+ * 2021-03-26 19:42:07,362 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] OUTBOUND DATA: streamId=3 padding=0 endStream=true length=13 bytes=48656c6c6f2047656f72676521
+ * 2021-03-26 19:42:07,362 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] WRITE: 9B
+ *          +-------------------------------------------------+
+ *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 0d 00 01 00 00 00 03                      |.........       |
+ * +--------+-------------------------------------------------+----------------+
+ * 2021-03-26 19:42:07,363 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] WRITE: 13B
+ *          +-------------------------------------------------+
+ *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 48 65 6c 6c 6f 20 47 65 6f 72 67 65 21          |Hello George!   |
+ * +--------+-------------------------------------------------+----------------+
+ * 2021-03-26 19:42:07,364 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] FLUSH
+ * 2021-03-26 19:42:07,364 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] FLUSH
+ * 2021-03-26 19:42:07,364 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] FLUSH
+ * 2021-03-26 19:42:07,365 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] READ_REQUEST
+ * 2021-03-26 19:42:07,370 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] READ: 9B
+ *          +-------------------------------------------------+
+ *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 00 04 01 00 00 00 00                      |.........       |
+ * +--------+-------------------------------------------------+----------------+
+ * 2021-03-26 19:42:07,370 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] INBOUND SETTINGS: ack=true
+ * 2021-03-26 19:42:07,371 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] READ_COMPLETE
+ * 2021-03-26 19:42:07,371 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] FLUSH
+ * 2021-03-26 19:42:07,371 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] READ_REQUEST
+ * </pre>
  */
 public final class DebuggingExampleServer {
 
@@ -42,7 +123,12 @@ public final class DebuggingExampleServer {
                 .executionStrategy(HttpExecutionStrategies.noOffloadsStrategy())
                 // Enables detailed logging of I/O and I/O states.
                 // Be sure to also enable the logger in your logging config file (log4j2.xml for this example)
-                .enableWireLogging("servicetalk-test-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+                .enableWireLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+                // Enables detailed logging of HTTP2 frames.
+                // Be sure to also enable the logger in your logging config file (log4j2.xml for this example)
+                .protocols(HttpProtocolConfigs.h2()
+                        .enableFrameLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+                        .build())
                 .listenAndAwait((ctx, request, responseFactory) -> {
                     String who = request.payloadBody(textDeserializer());
                     return succeeded(responseFactory.ok().payloadBody("Hello " + who + "!", textSerializer()));

--- a/servicetalk-examples/http/debugging/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/debugging/src/main/resources/log4j2.xml
@@ -21,17 +21,11 @@
     </Console>
   </Appenders>
   <Loggers>
-    <!-- Prints server start and shutdown -->
-    <Logger name="io.servicetalk.http.netty.NettyHttpServer" level="DEBUG"/>
-
     <!-- Enables all wire logging messages -->
     <Logger name="servicetalk-examples-wire-logger" level="TRACE"/>
 
-    <!-- Prints default subscriber errors-->
-    <Logger name="io.servicetalk.concurrent.api" level="DEBUG"/>
-
-    <!-- Use `-Dservicetalk.logger.level=DEBUG` to change the root logger level via command line  -->
-    <Root level="${sys:servicetalk.logger.level:-INFO}">
+    <!-- Use `-Dservicetalk.logger.level=INFO` to change the root logger level via command line  -->
+    <Root level="${sys:servicetalk.logger.level:-DEBUG}">
       <AppenderRef ref="Console"/>
     </Root>
   </Loggers>

--- a/servicetalk-examples/http/debugging/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/debugging/src/main/resources/log4j2.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="info">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d %30t [%-5level] %-30logger{1} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <!-- Prints server start and shutdown -->
+    <Logger name="io.servicetalk.http.netty.NettyHttpServer" level="DEBUG"/>
+
+    <!-- Enables all wire logging messages -->
+    <Logger name="servicetalk-examples-wire-logger" level="TRACE"/>
+
+    <!-- Prints default subscriber errors-->
+    <Logger name="io.servicetalk.concurrent.api" level="DEBUG"/>
+
+    <!-- Use `-Dservicetalk.logger.level=DEBUG` to change the root logger level via command line  -->
+    <Root level="${sys:servicetalk.logger.level:-INFO}">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
@@ -16,6 +16,8 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.Executors;
+import io.servicetalk.transport.api.ExecutionContext;
 
 import javax.annotation.Nullable;
 
@@ -70,9 +72,15 @@ public final class HttpExecutionStrategies {
     }
 
     /**
-     * A {@link HttpExecutionStrategy} that disables all offloads.
+     * A {@link HttpExecutionStrategy} that disables all offloads on the request-response path.
      *
-     * @return {@link HttpExecutionStrategy} that disables all offloads.
+     * <p>The default offloading executor will still be used inside {@link ExecutionContext} and for all places where
+     * it is referenced. To ensure that the default offloading executor is never used configure it with
+     * {@link Executors#immediate()} executor explicitly: <pre>
+     *     HttpExecutionStrategies.customStrategyBuilder().offloadNone().executor(immediate()).build()
+     * </pre>
+     *
+     * @return {@link HttpExecutionStrategy} that disables all request-response path offloads.
      */
     public static HttpExecutionStrategy noOffloadsStrategy() {
         return NO_OFFLOADS_NO_EXECUTOR;

--- a/settings.gradle
+++ b/settings.gradle
@@ -52,6 +52,7 @@ include "servicetalk-annotations",
         "servicetalk-examples:http:service-composition",
         "servicetalk-examples:http:uds",
         "servicetalk-examples:http:compression",
+        "servicetalk-examples:http:debugging",
         "servicetalk-gradle-plugin-internal",
         "servicetalk-grpc-api",
         "servicetalk-grpc-netty",
@@ -95,6 +96,7 @@ project(":servicetalk-examples:grpc:compression").name = "servicetalk-examples-g
 project(":servicetalk-examples:grpc:errors").name = "servicetalk-examples-grpc-errors"
 project(":servicetalk-examples:http:http2").name = "servicetalk-examples-http-http2"
 project(":servicetalk-examples:http:helloworld").name = "servicetalk-examples-http-helloworld"
+project(":servicetalk-examples:http:debugging").name = "servicetalk-examples-http-debugging"
 project(":servicetalk-examples:http:jaxrs").name = "servicetalk-examples-http-jaxrs"
 project(":servicetalk-examples:http:metadata").name = "servicetalk-examples-http-metadata"
 project(":servicetalk-examples:http:serialization").name = "servicetalk-examples-http-serialization"


### PR DESCRIPTION
Motivation:
ServiceTalk has purpose-built features for improving the debugging
experience for both applications and for ServiceTalk itself. An example
with explanatory comments would improve exposure of these features.

Modifications:
A new HTTP debugging example is provided demonstrating wire logging,
disabling offloading, disabling async context.

Result:
ServiceTalk debugging features are more visible.