### PR TITLE
Update grpc-java 1.36.0 -> 1.36.1 (compatibility testing)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -58,7 +58,7 @@ protobufVersion=3.15.3
 protoGoogleCommonProtosVersion=2.0.1
 javaPoetVersion=1.13.0
 # used for compatibility testing
-grpcVersion=1.36.0
+grpcVersion=1.36.1
 
 # Gradle Plugins
 spotbugsPluginVersion=4.6.2

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -43,11 +43,8 @@ import io.servicetalk.grpc.netty.CompatProto.Compat.ServerStreamingCallMetadata;
 import io.servicetalk.grpc.netty.CompatProto.Compat.ServiceFactory;
 import io.servicetalk.grpc.netty.CompatProto.RequestContainer.CompatRequest;
 import io.servicetalk.grpc.netty.CompatProto.ResponseContainer.CompatResponse;
-import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpServiceContext;
-import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpRequest;
-import io.servicetalk.http.api.StreamingHttpRequester;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpServiceFilter;
@@ -105,9 +102,6 @@ import static io.servicetalk.encoding.api.Identity.identity;
 import static io.servicetalk.encoding.netty.ContentCodings.gzipDefault;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.defaultStrategy;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy;
-import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
-import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
-import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.test.resources.DefaultTestCerts.loadServerKey;
 import static io.servicetalk.test.resources.DefaultTestCerts.loadServerPem;
 import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;
@@ -841,20 +835,6 @@ public class ProtocolCompatibilityTest {
             builder.sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
                     .peerHost(serverPemHostname()).build());
         }
-        // TODO(scott): remove after https://github.com/grpc/grpc-java/issues/7953 is resolved.
-        builder.appendHttpClientFilter(client -> new StreamingHttpClientFilter(client) {
-            @Override
-            protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
-                                                            final HttpExecutionStrategy strategy,
-                                                            final StreamingHttpRequest request) {
-                return Single.defer(() -> {
-                    // Force chunked transfer encoding as a workaround for grpc-java bug.
-                    request.headers().remove(CONTENT_LENGTH);
-                    request.headers().set(TRANSFER_ENCODING, CHUNKED);
-                    return delegate.request(strategy, request).subscribeShareContext();
-                });
-            }
-        });
         List<ContentCodec> codings = serviceTalkCodingsFor(compression);
         return builder.build(new Compat.ClientFactory().supportedMessageCodings(codings));
     }
@@ -862,20 +842,6 @@ public class ProtocolCompatibilityTest {
     private static GrpcServerBuilder serviceTalkServerBuilder(final ErrorMode errorMode, final boolean ssl) {
 
         final GrpcServerBuilder serverBuilder = GrpcServers.forAddress(localAddress(0))
-                // TODO(scott): remove after https://github.com/grpc/grpc-java/issues/7953 is resolved.
-                .appendHttpServiceFilter(service -> new StreamingHttpServiceFilter(service) {
-                    @Override
-                    public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
-                                                                final StreamingHttpRequest request,
-                                                                final StreamingHttpResponseFactory responseFactory) {
-                        return delegate().handle(ctx, request, responseFactory).map(response -> {
-                            // Force chunked transfer encoding as a workaround for grpc-java bug.
-                            response.headers().remove(CONTENT_LENGTH);
-                            response.headers().set(TRANSFER_ENCODING, CHUNKED);
-                            return response;
-                        });
-                    }
-                })
                 .appendHttpServiceFilter(service -> new StreamingHttpServiceFilter(service) {
                     @Override
                     public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,


### PR DESCRIPTION
Modifications:
- Remove workarounds in ProtocolCompatibilityTest for
https://github.com/grpc/grpc-java/issues/7953