### PR TITLE
Update dependencies for site documentation

### DIFF
--- a/docs/generation/build.gradle
+++ b/docs/generation/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019,2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ buildscript {
 }
 
 plugins {
-  id "com.github.node-gradle.node" version "2.2.4"
+  id "com.github.node-gradle.node" version "3.0.1"
 }
 
 apply plugin: "base"
@@ -44,7 +44,7 @@ ext.Jsoup = org.jsoup.Jsoup
 buildDir = ".out"
 
 node {
-  version = "12.18.3" // LTS
+  version = "14.16.0" // LTS
   download = true
 }
 

--- a/docs/generation/build.gradle
+++ b/docs/generation/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019,2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/generation/gradle.properties
+++ b/docs/generation/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019,2021 Apple Inc. and the ServiceTalk project authors
+# Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/generation/gradle.properties
+++ b/docs/generation/gradle.properties
@@ -16,6 +16,6 @@
 
 # suppress inspection "UnusedProperty" for whole file
 
-antoraVersion=2.1.2
+antoraVersion=2.3.4
 jsoupVersion=1.13.1
 nuValidatorVersion=20.7.2

--- a/docs/generation/gradle.properties
+++ b/docs/generation/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+# Copyright © 2019,2021 Apple Inc. and the ServiceTalk project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,6 @@
 
 # suppress inspection "UnusedProperty" for whole file
 
-antoraVersion=2.0.0
-jsoupVersion=1.11.3
-nuValidatorVersion=18.11.5
+antoraVersion=2.1.2
+jsoupVersion=1.13.1
+nuValidatorVersion=20.7.2

--- a/docs/generation/gradle/buildSite.gradle
+++ b/docs/generation/gradle/buildSite.gradle
@@ -17,6 +17,8 @@
 def servicetalkRoot = "../../"
 
 task buildLocalSite(type: NodeTask) { task ->
+  group = "Build"
+  description = "Builds the local site with local sources"
   dependsOn installAntora
 
   def outputDir = file("$buildDir/local")
@@ -46,6 +48,8 @@ task buildLocalSite(type: NodeTask) { task ->
 }
 
 task buildRemoteSite(type: NodeTask) { task ->
+  group = "Build"
+  description = "Builds the remote site for all versions"
   dependsOn installAntora
 
   def outputDir = file("$buildDir/remote")

--- a/docs/generation/gradle/validateSite.gradle
+++ b/docs/generation/gradle/validateSite.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019,2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,6 @@ configurations {
 
 dependencies {
   nuValidator("nu.validator:validator:$nuValidatorVersion") {
-    exclude group: "org.eclipse.jetty"
     exclude group: "javax.servlet"
     exclude group: "commons-fileupload"
   }
@@ -74,7 +73,8 @@ for (location in ["local", "remote"]) {
 
     classpath = configurations.nuValidator
     main = "nu.validator.client.SimpleCommandLineValidator"
-    args "--skip-non-html" // --also-check-css doesn't work (still checks css as html), so limit to html files
+    args "--also-check-css"
+    args "--also-check-svg"
     args "--filterpattern", '(.*)Consider adding “lang=(.*)'
     args "--filterpattern", '(.*)Consider adding a “lang” attribute(.*)'
 

--- a/docs/generation/gradle/validateSite.gradle
+++ b/docs/generation/gradle/validateSite.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019,2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/generation/site-local.yml
+++ b/docs/generation/site-local.yml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+# Copyright © 2019,2021 Apple Inc. and the ServiceTalk project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ site:
   title: ServiceTalk Docs
   start_page: servicetalk::index.adoc
 content:
+  edit_url: false
   # ordered alphabetically by component name (as specified in components' antora.yml)
   # to reflect ordering of `site.components` used in .hbs
   sources:

--- a/docs/generation/site-local.yml
+++ b/docs/generation/site-local.yml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019,2021 Apple Inc. and the ServiceTalk project authors
+# Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/generation/site-remote.yml
+++ b/docs/generation/site-remote.yml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+# Copyright © 2019,2021 Apple Inc. and the ServiceTalk project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ site:
     google_analytics: 'UA-151504011-1'
   start_page: servicetalk::index.adoc
 content:
+  edit_url: false
   # ordered alphabetically by component name (as specified in components' antora.yml)
   # to reflect ordering of `site.components` used in .hbs
   # TODO: Need to configure authentication to be able to use remote URLs:

--- a/docs/generation/site-remote.yml
+++ b/docs/generation/site-remote.yml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019,2021 Apple Inc. and the ServiceTalk project authors
+# Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Motivation:
The documentation produced for the servicetalk.io website uses plugins
and tools which have been updated. Where practical recent versions of
these dependencies should be used.

Modifications:
Plugins and tool dependencies used for generating and verifying the
servicetalk.io site are updated to current or more recent versions.

Result:
Updated versions are used for generating documentation