### PR TITLE
Revert "Remove deprecated SecurityConfigurator and Builder.secure() APIs (#1438)"

### DIFF
--- a/docs/modules/ROOT/pages/performance.adoc
+++ b/docs/modules/ROOT/pages/performance.adoc
@@ -584,10 +584,11 @@ link:https://wiki.mozilla.org/Security/Server_Side_TLS[Mozilla Server Side TLS])
 
 [source, java]
 ----
-// You can force the provider to OPENSSL as demonstrated below, or don't specify the provider and OPENSSL will be used
-// if available on the classpath (currently runtime dependency of ServiceTalk).
+
+// add the netty dependency to your build, eg: "io.netty:netty-tcnative-boringssl-static:2.0.25.Final"
+
 BlockingHttpClient client = HttpClients.forSingleAddress("servicetalk.io", 443)
-        .sslConfig(new ServerSslConfigBuilder(..).provider(OPENSSL).build())
+        .secure().provider(SecurityConfigurator.SslProvider.OPENSSL).commit()
         .buildBlocking();
 HttpResponse resp = client.request(client.get("/"));
 ----

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -87,6 +87,10 @@ public abstract class GrpcClientBuilder<U, R>
     public abstract GrpcClientBuilder<U, R> appendConnectionFilter(Predicate<StreamingHttpRequest> predicate,
                                                                    StreamingHttpConnectionFilterFactory factory);
 
+    @Deprecated
+    @Override
+    public abstract GrpcClientSecurityConfigurator<U, R> secure();
+
     @Override
     public abstract GrpcClientBuilder<U, R> sslConfig(ClientSslConfig sslConfig);
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientSecurityConfigurator.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientSecurityConfigurator.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.api;
+
+import io.servicetalk.transport.api.ClientSecurityConfigurator;
+import io.servicetalk.transport.api.ClientSslConfig;
+
+import java.io.InputStream;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * A {@link ClientSecurityConfigurator} for {@link SingleAddressGrpcClientBuilder}.
+ * @deprecated Use {@link GrpcClientBuilder#sslConfig(ClientSslConfig)}.
+ * @param <U> the type of address before resolution (unresolved address)
+ * @param <R> the type of address after resolution (resolved address)
+ */
+@Deprecated
+public interface GrpcClientSecurityConfigurator<U, R> extends ClientSecurityConfigurator {
+    /**
+     * Commit configuring client security.
+     *
+     * @return Original {@link GrpcClientBuilder} that initiated the security configuration process.
+     */
+    GrpcClientBuilder<U, R> commit();
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> trustManager(Supplier<InputStream> trustCertChainSupplier);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> trustManager(TrustManagerFactory trustManagerFactory);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> protocols(String... protocols);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> ciphers(Iterable<String> ciphers);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> sessionCacheSize(long sessionCacheSize);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> sessionTimeout(long sessionTimeout);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> provider(SslProvider provider);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> hostnameVerificationAlgorithm(
+            String hostNameVerificationAlgorithm);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationAlgorithm,
+                                                              String hostNameVerificationHost);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationAlgorithm,
+                                                              String hostNameVerificationHost,
+                                                              int hostNameVerificationPort);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationHost);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationHost,
+                                                              int hostNameVerificationPort);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> sniHostname(String sniHostname);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> disableHostnameVerification();
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> keyManager(KeyManagerFactory keyManagerFactory);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> keyManager(Supplier<InputStream> keyCertChainSupplier,
+                                                    Supplier<InputStream> keySupplier);
+
+    @Override
+    GrpcClientSecurityConfigurator<U, R> keyManager(Supplier<InputStream> keyCertChainSupplier,
+                                                    Supplier<InputStream> keySupplier, String keyPassword);
+}

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -79,6 +79,16 @@ public abstract class GrpcServerBuilder {
     }
 
     /**
+     * Initiate security configuration for this server. Calling any {@code commit} method on the returned
+     * {@link GrpcServerSecurityConfigurator} will commit the configuration.
+     * @deprecated Use {@link #sslConfig(ServerSslConfig)}.
+     * @return {@link GrpcServerSecurityConfigurator} to configure security for this server. It is
+     * mandatory to call any one of the {@code commit} methods after all configuration is done.
+     */
+    @Deprecated
+    public abstract GrpcServerSecurityConfigurator secure();
+
+    /**
      * Set the SSL/TLS configuration.
      * @param config The configuration to use.
      * @return {@code this}.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerSecurityConfigurator.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerSecurityConfigurator.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.api;
+
+import io.servicetalk.transport.api.ServerSecurityConfigurator;
+import io.servicetalk.transport.api.ServerSslConfig;
+
+import java.io.InputStream;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * A {@link ServerSecurityConfigurator} for {@link GrpcServerBuilder}.
+ * @deprecated Use {@link GrpcServerBuilder#sslConfig(ServerSslConfig)}.
+ */
+@Deprecated
+public interface GrpcServerSecurityConfigurator extends ServerSecurityConfigurator {
+    @Override
+    GrpcServerSecurityConfigurator trustManager(Supplier<InputStream> trustCertChainSupplier);
+
+    @Override
+    GrpcServerSecurityConfigurator trustManager(TrustManagerFactory trustManagerFactory);
+
+    @Override
+    GrpcServerSecurityConfigurator protocols(String... protocols);
+
+    @Override
+    GrpcServerSecurityConfigurator ciphers(Iterable<String> ciphers);
+
+    @Override
+    GrpcServerSecurityConfigurator sessionCacheSize(long sessionCacheSize);
+
+    @Override
+    GrpcServerSecurityConfigurator sessionTimeout(long sessionTimeout);
+
+    @Override
+    GrpcServerSecurityConfigurator provider(SslProvider provider);
+
+    @Override
+    GrpcServerSecurityConfigurator clientAuth(ClientAuth clientAuth);
+
+    /**
+     * Commit configuring server security.
+     *
+     * @param keyManagerFactory an {@link KeyManagerFactory}.
+     * @return Original {@link GrpcServerBuilder} that initiated the security configuration process.
+     */
+    GrpcServerBuilder commit(KeyManagerFactory keyManagerFactory);
+
+    /**
+     * Commit configuring server security.
+     *
+     * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a {@code X.509} certificate
+     * chain in {@code PEM} format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a {@code KCS#8} private key in
+     * {@code PEM} format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @return Original {@link GrpcServerBuilder} that initiated the security configuration process.
+     */
+    GrpcServerBuilder commit(Supplier<InputStream> keyCertChainSupplier, Supplier<InputStream> keySupplier);
+
+    /**
+     * Commit configuring server security.
+     *
+     * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a {@code X.509} certificate
+     * chain in {@code PEM} format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a {@code KCS#8} private key in
+     * {@code PEM} format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @param keyPassword the password of the {@code keyFile}.
+     * @return Original {@link GrpcServerBuilder} that initiated the security configuration process.
+     */
+    GrpcServerBuilder commit(Supplier<InputStream> keyCertChainSupplier, Supplier<InputStream> keySupplier,
+                             String keyPassword);
+}

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/SingleAddressGrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/SingleAddressGrpcClientBuilder.java
@@ -96,6 +96,18 @@ interface SingleAddressGrpcClientBuilder<U, R,
                                                                      StreamingHttpConnectionFilterFactory factory);
 
     /**
+     * Initiate security configuration for this client. Calling
+     * {@link GrpcClientSecurityConfigurator#commit()} on the returned {@link GrpcClientSecurityConfigurator} will
+     * commit the configuration.
+     * @deprecated Use {@link #sslConfig(ClientSslConfig)}.
+     * @return {@link GrpcClientSecurityConfigurator} to configure security for this client. It is
+     * mandatory to call {@link GrpcClientSecurityConfigurator#commit() commit} after all configuration is
+     * done.
+     */
+    @Deprecated
+    GrpcClientSecurityConfigurator<U, R> secure();
+
+    /**
      * Set the SSL/TLS configuration.
      * @param sslConfig The configuration to use.
      * @return {@code this}.

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
@@ -22,11 +22,13 @@ import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.grpc.api.GrpcClientBuilder;
 import io.servicetalk.grpc.api.GrpcClientCallFactory;
+import io.servicetalk.grpc.api.GrpcClientSecurityConfigurator;
 import io.servicetalk.grpc.api.GrpcExecutionStrategy;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpLoadBalancerFactory;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.http.api.SingleAddressHttpClientSecurityConfigurator;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -112,6 +114,13 @@ final class DefaultGrpcClientBuilder<U, R> extends GrpcClientBuilder<U, R> {
             final Predicate<StreamingHttpRequest> predicate, final StreamingHttpConnectionFilterFactory factory) {
         httpClientBuilder.appendConnectionFilter(predicate, factory);
         return this;
+    }
+
+    @Deprecated
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> secure() {
+        SingleAddressHttpClientSecurityConfigurator<U, R> httpConfigurator = httpClientBuilder.secure();
+        return new DefaultGrpcClientSecurityConfigurator<>(httpConfigurator, this);
     }
 
     @Override

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientSecurityConfigurator.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientSecurityConfigurator.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.netty;
+
+import io.servicetalk.grpc.api.GrpcClientBuilder;
+import io.servicetalk.grpc.api.GrpcClientSecurityConfigurator;
+import io.servicetalk.http.api.SingleAddressHttpClientSecurityConfigurator;
+
+import java.io.InputStream;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+@Deprecated
+final class DefaultGrpcClientSecurityConfigurator<U, R> implements GrpcClientSecurityConfigurator<U, R> {
+    private final SingleAddressHttpClientSecurityConfigurator<U, R> delegate;
+    private final GrpcClientBuilder<U, R> original;
+
+    DefaultGrpcClientSecurityConfigurator(final SingleAddressHttpClientSecurityConfigurator<U, R> delegate,
+                                          final GrpcClientBuilder<U, R> original) {
+        this.delegate = delegate;
+        this.original = original;
+    }
+
+    @Override
+    public GrpcClientBuilder<U, R> commit() {
+        delegate.commit();
+        return original;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> trustManager(final Supplier<InputStream> trustCertChainSupplier) {
+        delegate.trustManager(trustCertChainSupplier);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> trustManager(final TrustManagerFactory trustManagerFactory) {
+        delegate.trustManager(trustManagerFactory);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> protocols(final String... protocols) {
+        delegate.protocols(protocols);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> ciphers(final Iterable<String> ciphers) {
+        delegate.ciphers(ciphers);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> sessionCacheSize(final long sessionCacheSize) {
+        delegate.sessionCacheSize(sessionCacheSize);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> sessionTimeout(final long sessionTimeout) {
+        delegate.sessionTimeout(sessionTimeout);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> provider(final SslProvider provider) {
+        delegate.provider(provider);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> hostnameVerificationAlgorithm(
+            final String hostNameVerificationAlgorithm) {
+        delegate.hostnameVerificationAlgorithm(hostNameVerificationAlgorithm);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> hostnameVerification(final String hostNameVerificationAlgorithm,
+                                                                     final String hostNameVerificationHost) {
+        delegate.hostnameVerification(hostNameVerificationAlgorithm, hostNameVerificationHost);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> hostnameVerification(final String hostNameVerificationAlgorithm,
+                                                                     final String hostNameVerificationHost,
+                                                                     final int hostNameVerificationPort) {
+        delegate.hostnameVerification(hostNameVerificationAlgorithm, hostNameVerificationHost,
+                hostNameVerificationPort);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> hostnameVerification(final String hostNameVerificationHost) {
+        delegate.hostnameVerification(hostNameVerificationHost);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> hostnameVerification(final String hostNameVerificationHost,
+                                                                     final int hostNameVerificationPort) {
+        delegate.hostnameVerification(hostNameVerificationHost, hostNameVerificationPort);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> sniHostname(final String sniHostname) {
+        delegate.sniHostname(sniHostname);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> disableHostnameVerification() {
+        delegate.disableHostnameVerification();
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> keyManager(final KeyManagerFactory keyManagerFactory) {
+        delegate.keyManager(keyManagerFactory);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> keyManager(final Supplier<InputStream> keyCertChainSupplier,
+                                                           final Supplier<InputStream> keySupplier) {
+        delegate.keyManager(keyCertChainSupplier, keySupplier);
+        return this;
+    }
+
+    @Override
+    public GrpcClientSecurityConfigurator<U, R> keyManager(final Supplier<InputStream> keyCertChainSupplier,
+                                                           final Supplier<InputStream> keySupplier,
+                                                           final String keyPassword) {
+        delegate.keyManager(keyCertChainSupplier, keySupplier, keyPassword);
+        return this;
+    }
+}

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -19,12 +19,14 @@ import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.grpc.api.GrpcExecutionStrategy;
 import io.servicetalk.grpc.api.GrpcServerBuilder;
+import io.servicetalk.grpc.api.GrpcServerSecurityConfigurator;
 import io.servicetalk.grpc.api.GrpcServiceFactory;
 import io.servicetalk.grpc.api.GrpcServiceFactory.ServerBinder;
 import io.servicetalk.http.api.BlockingHttpService;
 import io.servicetalk.http.api.BlockingStreamingHttpService;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpServerSecurityConfigurator;
 import io.servicetalk.http.api.HttpService;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpService;
@@ -61,6 +63,13 @@ final class DefaultGrpcServerBuilder extends GrpcServerBuilder implements Server
     public GrpcServerBuilder protocols(final HttpProtocolConfig... protocols) {
         httpServerBuilder.protocols(protocols);
         return this;
+    }
+
+    @Deprecated
+    @Override
+    public GrpcServerSecurityConfigurator secure() {
+        HttpServerSecurityConfigurator secure = httpServerBuilder.secure();
+        return new DefaultGrpcServerSecurityConfigurator(secure, this);
     }
 
     @Override

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerSecurityConfigurator.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerSecurityConfigurator.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.netty;
+
+import io.servicetalk.grpc.api.GrpcServerBuilder;
+import io.servicetalk.grpc.api.GrpcServerSecurityConfigurator;
+import io.servicetalk.http.api.HttpServerSecurityConfigurator;
+
+import java.io.InputStream;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+@Deprecated
+final class DefaultGrpcServerSecurityConfigurator implements GrpcServerSecurityConfigurator {
+    private final HttpServerSecurityConfigurator delegate;
+    private final GrpcServerBuilder original;
+
+    DefaultGrpcServerSecurityConfigurator(final HttpServerSecurityConfigurator delegate,
+                                          final GrpcServerBuilder original) {
+        this.delegate = delegate;
+        this.original = original;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator trustManager(final Supplier<InputStream> trustCertChainSupplier) {
+        delegate.trustManager(trustCertChainSupplier);
+        return this;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator trustManager(final TrustManagerFactory trustManagerFactory) {
+        delegate.trustManager(trustManagerFactory);
+        return this;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator protocols(final String... protocols) {
+        delegate.protocols(protocols);
+        return this;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator ciphers(final Iterable<String> ciphers) {
+        delegate.ciphers(ciphers);
+        return this;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator sessionCacheSize(final long sessionCacheSize) {
+        delegate.sessionCacheSize(sessionCacheSize);
+        return this;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator sessionTimeout(final long sessionTimeout) {
+        delegate.sessionTimeout(sessionTimeout);
+        return this;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator provider(final SslProvider provider) {
+        delegate.provider(provider);
+        return this;
+    }
+
+    @Override
+    public GrpcServerSecurityConfigurator clientAuth(final ClientAuth clientAuth) {
+        delegate.clientAuth(clientAuth);
+        return this;
+    }
+
+    @Override
+    public GrpcServerBuilder commit(final KeyManagerFactory keyManagerFactory) {
+        delegate.commit(keyManagerFactory);
+        return original;
+    }
+
+    @Override
+    public GrpcServerBuilder commit(final Supplier<InputStream> keyCertChainSupplier,
+                                    final Supplier<InputStream> keySupplier) {
+        delegate.commit(keyCertChainSupplier, keySupplier);
+        return original;
+    }
+
+    @Override
+    public GrpcServerBuilder commit(final Supplier<InputStream> keyCertChainSupplier,
+                                    final Supplier<InputStream> keySupplier, final String keyPassword) {
+        delegate.commit(keyCertChainSupplier, keySupplier, keyPassword);
+        return original;
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -82,6 +82,16 @@ public abstract class HttpServerBuilder {
     }
 
     /**
+     * Initiates security configuration for this server. Calling any {@code commit} method on the returned
+     * {@link HttpServerSecurityConfigurator} will commit the configuration.
+     * @deprecated Use {@link #sslConfig(ServerSslConfig)}.
+     * @return {@link HttpServerSecurityConfigurator} to configure security for this server. It is
+     * mandatory to call any one of the {@code commit} methods after all configuration is done.
+     */
+    @Deprecated
+    public abstract HttpServerSecurityConfigurator secure();
+
+    /**
      * Set the SSL/TLS configuration.
      * @param config The configuration to use.
      * @return {@code this}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerSecurityConfigurator.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerSecurityConfigurator.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.transport.api.ServerSecurityConfigurator;
+import io.servicetalk.transport.api.ServerSslConfig;
+
+import java.io.InputStream;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * A {@link ServerSecurityConfigurator} for {@link HttpServerBuilder}.
+ * @deprecated Use {@link HttpServerBuilder#sslConfig(ServerSslConfig)}.
+ */
+@Deprecated
+public interface HttpServerSecurityConfigurator extends ServerSecurityConfigurator {
+    @Override
+    HttpServerSecurityConfigurator trustManager(Supplier<InputStream> trustCertChainSupplier);
+
+    @Override
+    HttpServerSecurityConfigurator trustManager(TrustManagerFactory trustManagerFactory);
+
+    @Override
+    HttpServerSecurityConfigurator protocols(String... protocols);
+
+    @Override
+    HttpServerSecurityConfigurator ciphers(Iterable<String> ciphers);
+
+    @Override
+    HttpServerSecurityConfigurator sessionCacheSize(long sessionCacheSize);
+
+    @Override
+    HttpServerSecurityConfigurator sessionTimeout(long sessionTimeout);
+
+    @Override
+    HttpServerSecurityConfigurator provider(SslProvider provider);
+
+    @Override
+    HttpServerSecurityConfigurator clientAuth(ClientAuth clientAuth);
+
+    /**
+     * Commit configuring server security.
+     *
+     * @param keyManagerFactory an {@link KeyManagerFactory}.
+     * @return Original {@link HttpServerBuilder} that initiated the security configuration process.
+     */
+    HttpServerBuilder commit(KeyManagerFactory keyManagerFactory);
+
+    /**
+     * Commit configuring server security.
+     *
+     * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a {@code X.509} certificate
+     * chain in {@code PEM} format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a {@code KCS#8} private key in
+     * {@code PEM} format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @return Original {@link HttpServerBuilder} that initiated the security configuration process.
+     */
+    HttpServerBuilder commit(Supplier<InputStream> keyCertChainSupplier, Supplier<InputStream> keySupplier);
+
+    /**
+     * Commit configuring server security.
+     *
+     * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a {@code X.509} certificate
+     * chain in {@code PEM} format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a {@code KCS#8} private key in
+     * {@code PEM} format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @param keyPassword the password of the {@code keyFile}.
+     * @return Original {@link HttpServerBuilder} that initiated the security configuration process.
+     */
+    HttpServerBuilder commit(Supplier<InputStream> keyCertChainSupplier, Supplier<InputStream> keySupplier,
+                             String keyPassword);
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -21,9 +21,13 @@ import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.logging.api.LogLevel;
+import io.servicetalk.transport.api.ClientSecurityConfigurator;
+import io.servicetalk.transport.api.ClientSslConfig;
+import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
 
 import java.net.SocketOption;
+import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -160,6 +164,17 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
     @Deprecated
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> allowDropResponseTrailers(boolean allowDrop);
+
+    /**
+     * Sets a function that is used for configuring SSL/TLS for https requests.
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and create a
+     * {@link SingleAddressInitializer} that invokes {@link SingleAddressHttpClientBuilder#sslConfig(ClientSslConfig)}.
+     * @param sslConfigFunction The function to use for configuring SSL/TLS for https requests.
+     * @return {@code this}
+     */
+    @Deprecated
+    public abstract MultiAddressHttpClientBuilder<U, R> secure(
+            BiConsumer<HostAndPort, ClientSecurityConfigurator> sslConfigFunction);
 
     /**
      * Set a function which can customize options for each {@link StreamingHttpClient} that is built.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
@@ -25,6 +25,7 @@ import io.servicetalk.client.api.partition.PartitionMapFactory;
 import io.servicetalk.client.api.partition.PartitionedServiceDiscovererEvent;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.logging.api.LogLevel;
+import io.servicetalk.transport.api.ClientSslConfig;
 import io.servicetalk.transport.api.IoExecutor;
 
 import java.net.SocketOption;
@@ -264,6 +265,19 @@ public abstract class PartitionedHttpClientBuilder<U, R>
         return (PartitionedHttpClientBuilder<U, R>)
                 super.appendClientFilter(predicate, factory);
     }
+
+    /**
+     * Initiates security configuration for this client. Calling
+     * {@link PartitionedHttpClientSecurityConfigurator#commit()} on the returned
+     * {@link PartitionedHttpClientSecurityConfigurator} will commit the configuration.
+     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and create a {@link SingleAddressInitializer} that
+     * invokes {@link SingleAddressHttpClientBuilder#sslConfig(ClientSslConfig)}.
+     * @return {@link PartitionHttpClientBuilderConfigurator} to configure security for this client. It is
+     * mandatory to call {@link PartitionedHttpClientSecurityConfigurator#commit() commit} after all configuration is
+     * done.
+     */
+    @Deprecated
+    public abstract PartitionedHttpClientSecurityConfigurator<U, R> secure();
 
     /**
      * Sets the maximum amount of {@link ServiceDiscovererEvent} objects that will be queued for each partition.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientSecurityConfigurator.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientSecurityConfigurator.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.transport.api.ClientSecurityConfigurator;
+
+import java.io.InputStream;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * A {@link ClientSecurityConfigurator} for {@link PartitionedHttpClientSecurityConfigurator}.
+ * @deprecated Use
+ * {@link PartitionedHttpClientBuilder#appendClientBuilderFilter(PartitionHttpClientBuilderConfigurator)}.
+ * @param <U> the type of address before resolution (unresolved address)
+ * @param <R> the type of address after resolution (resolved address)
+ */
+@Deprecated
+public interface PartitionedHttpClientSecurityConfigurator<U, R> extends ClientSecurityConfigurator {
+    /**
+     * Commit configuring client security.
+     *
+     * @return Original {@link HttpServerBuilder} that initiated the security configuration process.
+     */
+    PartitionedHttpClientBuilder<U, R> commit();
+
+    @Override
+    PartitionedHttpClientSecurityConfigurator<U, R> trustManager(Supplier<InputStream> trustCertChainSupplier);
+
+    @Override
+    PartitionedHttpClientSecurityConfigurator<U, R> trustManager(TrustManagerFactory trustManagerFactory);
+
+    @Override
+    PartitionedHttpClientSecurityConfigurator<U, R> protocols(String... protocols);
+
+    @Override
+    PartitionedHttpClientSecurityConfigurator<U, R> ciphers(Iterable<String> ciphers);
+
+    @Override
+    PartitionedHttpClientSecurityConfigurator<U, R> sessionCacheSize(long sessionCacheSize);
+
+    @Override
+    PartitionedHttpClientSecurityConfigurator<U, R> sessionTimeout(long sessionTimeout);
+
+    @Override
+    PartitionedHttpClientSecurityConfigurator<U, R> provider(SslProvider provider);
+
+    @Override
+    PartitionedHttpClientSecurityConfigurator<U, R> hostnameVerificationAlgorithm(
+            String hostNameVerificationAlgorithm);
+
+    @Override
+    PartitionedHttpClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationAlgorithm,
+                                                                         String hostNameVerificationHost);
+
+    @Override
+    PartitionedHttpClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationAlgorithm,
+                                                                         String hostNameVerificationHost,
+                                                                         int hostNameVerificationPort);
+
+    @Override
+    PartitionedHttpClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationHost);
+
+    @Override
+    PartitionedHttpClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationHost,
+                                                                         int hostNameVerificationPort);
+
+    @Override
+    PartitionedHttpClientSecurityConfigurator<U, R> sniHostname(String sniHostname);
+
+    @Override
+    PartitionedHttpClientSecurityConfigurator<U, R> disableHostnameVerification();
+
+    @Override
+    PartitionedHttpClientSecurityConfigurator<U, R> keyManager(KeyManagerFactory keyManagerFactory);
+
+    @Override
+    PartitionedHttpClientSecurityConfigurator<U, R> keyManager(Supplier<InputStream> keyCertChainSupplier,
+                                                               Supplier<InputStream> keySupplier);
+
+    @Override
+    PartitionedHttpClientSecurityConfigurator<U, R> keyManager(Supplier<InputStream> keyCertChainSupplier,
+                                                               Supplier<InputStream> keySupplier, String keyPassword);
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -127,6 +127,18 @@ public abstract class SingleAddressHttpClientBuilder<U, R>
     }
 
     /**
+     * Initiates security configuration for this client. Calling
+     * {@link SingleAddressHttpClientSecurityConfigurator#commit()} on the returned
+     * {@link SingleAddressHttpClientSecurityConfigurator} will commit the configuration.
+     * @deprecated Use {@link #sslConfig(ClientSslConfig)}.
+     * @return {@link SingleAddressHttpClientSecurityConfigurator} to configure security for this client. It is
+     * mandatory to call {@link SingleAddressHttpClientSecurityConfigurator#commit() commit} after all configuration is
+     * done.
+     */
+    @Deprecated
+    public abstract SingleAddressHttpClientSecurityConfigurator<U, R> secure();
+
+    /**
      * Set the SSL/TLS configuration.
      * @param sslConfig The configuration to use.
      * @return {@code this}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientSecurityConfigurator.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientSecurityConfigurator.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.transport.api.ClientSecurityConfigurator;
+import io.servicetalk.transport.api.ClientSslConfig;
+
+import java.io.InputStream;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * A {@link ClientSecurityConfigurator} for {@link SingleAddressHttpClientBuilder}.
+ * @deprecated Use {@link SingleAddressHttpClientBuilder#sslConfig(ClientSslConfig)}.
+ * @param <U> the type of address before resolution (unresolved address)
+ * @param <R> the type of address after resolution (resolved address)
+ */
+@Deprecated
+public interface SingleAddressHttpClientSecurityConfigurator<U, R> extends ClientSecurityConfigurator {
+    /**
+     * Commit configuring client security.
+     *
+     * @return Original {@link HttpServerBuilder} that initiated the security configuration process.
+     */
+    SingleAddressHttpClientBuilder<U, R> commit();
+
+    @Override
+    SingleAddressHttpClientSecurityConfigurator<U, R> trustManager(Supplier<InputStream> trustCertChainSupplier);
+
+    @Override
+    SingleAddressHttpClientSecurityConfigurator<U, R> trustManager(TrustManagerFactory trustManagerFactory);
+
+    @Override
+    SingleAddressHttpClientSecurityConfigurator<U, R> protocols(String... protocols);
+
+    @Override
+    SingleAddressHttpClientSecurityConfigurator<U, R> ciphers(Iterable<String> ciphers);
+
+    @Override
+    SingleAddressHttpClientSecurityConfigurator<U, R> sessionCacheSize(long sessionCacheSize);
+
+    @Override
+    SingleAddressHttpClientSecurityConfigurator<U, R> sessionTimeout(long sessionTimeout);
+
+    @Override
+    SingleAddressHttpClientSecurityConfigurator<U, R> provider(SslProvider provider);
+
+    @Override
+    SingleAddressHttpClientSecurityConfigurator<U, R> hostnameVerificationAlgorithm(
+            String hostNameVerificationAlgorithm);
+
+    @Override
+    SingleAddressHttpClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationAlgorithm,
+                                                                           String hostNameVerificationHost);
+
+    @Override
+    SingleAddressHttpClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationAlgorithm,
+                                                                           String hostNameVerificationHost,
+                                                                           int hostNameVerificationPort);
+
+    @Override
+    SingleAddressHttpClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationHost);
+
+    @Override
+    SingleAddressHttpClientSecurityConfigurator<U, R> hostnameVerification(String hostNameVerificationHost,
+                                                                           int hostNameVerificationPort);
+
+    @Override
+    SingleAddressHttpClientSecurityConfigurator<U, R> sniHostname(String sniHostname);
+
+    @Override
+    SingleAddressHttpClientSecurityConfigurator<U, R> disableHostnameVerification();
+
+    @Override
+    SingleAddressHttpClientSecurityConfigurator<U, R> keyManager(KeyManagerFactory keyManagerFactory);
+
+    @Override
+    SingleAddressHttpClientSecurityConfigurator<U, R> keyManager(Supplier<InputStream> keyCertChainSupplier,
+                                                                 Supplier<InputStream> keySupplier);
+
+    @Override
+    SingleAddressHttpClientSecurityConfigurator<U, R> keyManager(Supplier<InputStream> keyCertChainSupplier,
+                                                                 Supplier<InputStream> keySupplier, String keyPassword);
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -21,6 +21,7 @@ import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpServerSecurityConfigurator;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.ConnectionAcceptor;
@@ -65,6 +66,15 @@ final class DefaultHttpServerBuilder extends HttpServerBuilder {
     public HttpServerBuilder backlog(int backlog) {
         listenSocketOption(ServiceTalkSocketOptions.SO_BACKLOG, backlog);
         return this;
+    }
+
+    @Deprecated
+    @Override
+    public HttpServerSecurityConfigurator secure() {
+        return new DefaultHttpServerSecurityConfigurator(config -> {
+            this.config.tcpConfig().sslConfig(config);
+            return DefaultHttpServerBuilder.this;
+        });
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerSecurityConfigurator.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerSecurityConfigurator.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpServerSecurityConfigurator;
+import io.servicetalk.transport.api.ServerSslConfig;
+import io.servicetalk.transport.netty.internal.ServerSecurityConfig;
+
+import java.io.InputStream;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+@Deprecated
+final class DefaultHttpServerSecurityConfigurator implements HttpServerSecurityConfigurator {
+    private final ServerSecurityConfig securityConfig = new ServerSecurityConfig();
+    private final Function<ServerSslConfig, HttpServerBuilder> configConsumer;
+
+    DefaultHttpServerSecurityConfigurator(
+            final Function<ServerSslConfig, HttpServerBuilder> configConsumer) {
+        this.configConsumer = configConsumer;
+    }
+
+    @Override
+    public HttpServerSecurityConfigurator trustManager(final Supplier<InputStream> trustCertChainSupplier) {
+        securityConfig.trustManager(trustCertChainSupplier);
+        return this;
+    }
+
+    @Override
+    public HttpServerSecurityConfigurator trustManager(final TrustManagerFactory trustManagerFactory) {
+        securityConfig.trustManager(trustManagerFactory);
+        return this;
+    }
+
+    @Override
+    public HttpServerSecurityConfigurator protocols(final String... protocols) {
+        securityConfig.protocols(protocols);
+        return this;
+    }
+
+    @Override
+    public HttpServerSecurityConfigurator ciphers(final Iterable<String> ciphers) {
+        securityConfig.ciphers(ciphers);
+        return this;
+    }
+
+    @Override
+    public HttpServerSecurityConfigurator sessionCacheSize(final long sessionCacheSize) {
+        securityConfig.sessionCacheSize(sessionCacheSize);
+        return this;
+    }
+
+    @Override
+    public HttpServerSecurityConfigurator sessionTimeout(final long sessionTimeout) {
+        securityConfig.sessionTimeout(sessionTimeout);
+        return this;
+    }
+
+    @Override
+    public HttpServerSecurityConfigurator provider(final SslProvider provider) {
+        securityConfig.provider(provider);
+        return this;
+    }
+
+    @Override
+    public HttpServerSecurityConfigurator clientAuth(final ClientAuth clientAuth) {
+        securityConfig.clientAuth(clientAuth);
+        return this;
+    }
+
+    @Override
+    public HttpServerBuilder commit(final KeyManagerFactory keyManagerFactory) {
+        securityConfig.keyManager(keyManagerFactory);
+        return configConsumer.apply(securityConfig.asSslConfig());
+    }
+
+    @Override
+    public HttpServerBuilder commit(final Supplier<InputStream> keyCertChainSupplier,
+                                    final Supplier<InputStream> keySupplier) {
+        securityConfig.keyManager(keyCertChainSupplier, keySupplier);
+        return configConsumer.apply(securityConfig.asSslConfig());
+    }
+
+    @Override
+    public HttpServerBuilder commit(final Supplier<InputStream> keyCertChainSupplier,
+                                    final Supplier<InputStream> keySupplier, final String keyPassword) {
+        securityConfig.keyManager(keyCertChainSupplier, keySupplier, keyPassword);
+        return configConsumer.apply(securityConfig.asSslConfig());
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -39,6 +39,7 @@ import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.MultiAddressHttpClientBuilder;
 import io.servicetalk.http.api.MultiAddressHttpClientFilterFactory;
 import io.servicetalk.http.api.ServiceDiscoveryRetryStrategy;
+import io.servicetalk.http.api.SingleAddressHttpClientSecurityConfigurator;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
@@ -49,6 +50,7 @@ import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.HttpClientBuildContext;
 import io.servicetalk.http.utils.RedirectingHttpRequesterFilter;
 import io.servicetalk.logging.api.LogLevel;
+import io.servicetalk.transport.api.ClientSecurityConfigurator;
 import io.servicetalk.transport.api.ClientSslConfig;
 import io.servicetalk.transport.api.ClientSslConfigBuilder;
 import io.servicetalk.transport.api.HostAndPort;
@@ -58,6 +60,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketOption;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -97,6 +100,8 @@ final class DefaultMultiAddressUrlHttpClientBuilder
     @Nullable
     private Function<HostAndPort, CharSequence> unresolvedAddressToHostFunction;
     @Nullable
+    private BiConsumer<HostAndPort, ClientSecurityConfigurator> sslConfigFunction;
+    @Nullable
     private SingleAddressInitializer<HostAndPort, InetSocketAddress> singleAddressInitializer;
 
     DefaultMultiAddressUrlHttpClientBuilder(
@@ -111,7 +116,7 @@ final class DefaultMultiAddressUrlHttpClientBuilder
             final HttpClientBuildContext<HostAndPort, InetSocketAddress> buildContext = builderTemplate.copyBuildCtx();
 
             final ClientFactory clientFactory = new ClientFactory(buildContext.builder,
-                    clientFilterFactory, unresolvedAddressToHostFunction, singleAddressInitializer);
+                    clientFilterFactory, unresolvedAddressToHostFunction, sslConfigFunction, singleAddressInitializer);
 
             final CachingKeyFactory keyFactory = closeables.prepend(new CachingKeyFactory());
             FilterableStreamingHttpClient urlClient = closeables.prepend(
@@ -226,16 +231,20 @@ final class DefaultMultiAddressUrlHttpClientBuilder
         @Nullable
         private final Function<HostAndPort, CharSequence> hostHeaderTransformer;
         @Nullable
+        private final BiConsumer<HostAndPort, ClientSecurityConfigurator> sslConfigFunction;
+        @Nullable
         private final SingleAddressInitializer<HostAndPort, InetSocketAddress> singleAddressInitializer;
 
         ClientFactory(
                 final DefaultSingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builderTemplate,
                 @Nullable final MultiAddressHttpClientFilterFactory<HostAndPort> clientFilterFactory,
                 @Nullable final Function<HostAndPort, CharSequence> hostHeaderTransformer,
+                @Nullable final BiConsumer<HostAndPort, ClientSecurityConfigurator> sslConfigFunction,
                 @Nullable final SingleAddressInitializer<HostAndPort, InetSocketAddress> singleAddressInitializer) {
             this.builderTemplate = builderTemplate;
             this.clientFilterFactory = clientFilterFactory;
             this.hostHeaderTransformer = hostHeaderTransformer;
+            this.sslConfigFunction = sslConfigFunction;
             this.singleAddressInitializer = singleAddressInitializer;
         }
 
@@ -254,7 +263,14 @@ final class DefaultMultiAddressUrlHttpClientBuilder
             }
 
             if (HTTPS_SCHEME.equalsIgnoreCase(urlKey.scheme)) {
-                buildContext.builder.sslConfig(DEFAULT_CLIENT_SSL_CONFIG);
+                if (sslConfigFunction != null) {
+                    SingleAddressHttpClientSecurityConfigurator<HostAndPort, InetSocketAddress> securityConfigurator =
+                            buildContext.builder.secure();
+                    sslConfigFunction.accept(urlKey.hostAndPort, securityConfigurator);
+                    securityConfigurator.commit();
+                } else {
+                    buildContext.builder.sslConfig(DEFAULT_CLIENT_SSL_CONFIG);
+                }
             }
 
             if (singleAddressInitializer != null) {
@@ -371,6 +387,14 @@ final class DefaultMultiAddressUrlHttpClientBuilder
     @Override
     public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> protocols(HttpProtocolConfig... protocols) {
         builderTemplate.protocols(protocols);
+        return this;
+    }
+
+    @Deprecated
+    @Override
+    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> secure(
+            final BiConsumer<HostAndPort, ClientSecurityConfigurator> sslConfigFunction) {
+        this.sslConfigFunction = requireNonNull(sslConfigFunction);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -45,6 +45,7 @@ import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.PartitionHttpClientBuilderConfigurator;
 import io.servicetalk.http.api.PartitionedHttpClientBuilder;
+import io.servicetalk.http.api.PartitionedHttpClientSecurityConfigurator;
 import io.servicetalk.http.api.ReservedStreamingHttpConnection;
 import io.servicetalk.http.api.ServiceDiscoveryRetryStrategy;
 import io.servicetalk.http.api.StreamingHttpClient;
@@ -360,6 +361,12 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
     public PartitionedHttpClientBuilder<U, R> appendClientFilter(final StreamingHttpClientFilterFactory function) {
         builderTemplate.appendClientFilter(function);
         return this;
+    }
+
+    @Deprecated
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> secure() {
+        return new DefaultPartitionedHttpClientSecurityConfigurator<>(builderTemplate.secure(), this);
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientSecurityConfigurator.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientSecurityConfigurator.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.PartitionedHttpClientBuilder;
+import io.servicetalk.http.api.PartitionedHttpClientSecurityConfigurator;
+import io.servicetalk.http.api.SingleAddressHttpClientSecurityConfigurator;
+
+import java.io.InputStream;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+@Deprecated
+final class DefaultPartitionedHttpClientSecurityConfigurator<U, R>
+        implements PartitionedHttpClientSecurityConfigurator<U, R> {
+    private final SingleAddressHttpClientSecurityConfigurator<U, R> delegate;
+    private final PartitionedHttpClientBuilder<U, R> originalBuilder;
+
+    DefaultPartitionedHttpClientSecurityConfigurator(final SingleAddressHttpClientSecurityConfigurator<U, R> delegate,
+                                                     final PartitionedHttpClientBuilder<U, R> originalBuilder) {
+        this.delegate = delegate;
+        this.originalBuilder = originalBuilder;
+    }
+
+    @Override
+    public PartitionedHttpClientBuilder<U, R> commit() {
+        delegate.commit();
+        return originalBuilder;
+    }
+
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> trustManager(
+            final Supplier<InputStream> trustCertChainSupplier) {
+        delegate.trustManager(trustCertChainSupplier);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> trustManager(final TrustManagerFactory trustManagerFactory) {
+        delegate.trustManager(trustManagerFactory);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> protocols(final String... protocols) {
+        delegate.protocols(protocols);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> ciphers(final Iterable<String> ciphers) {
+        delegate.ciphers(ciphers);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> sessionCacheSize(final long sessionCacheSize) {
+        delegate.sessionCacheSize(sessionCacheSize);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> sessionTimeout(final long sessionTimeout) {
+        delegate.sessionTimeout(sessionTimeout);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> provider(final SslProvider provider) {
+        delegate.provider(provider);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> hostnameVerificationAlgorithm(
+            final String hostNameVerificationAlgorithm) {
+        delegate.hostnameVerificationAlgorithm(hostNameVerificationAlgorithm);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> hostnameVerification(
+            final String hostNameVerificationAlgorithm, final String hostNameVerificationHost) {
+        delegate.hostnameVerification(hostNameVerificationAlgorithm, hostNameVerificationHost);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> hostnameVerification(
+            final String hostNameVerificationAlgorithm, final String hostNameVerificationHost,
+            final int hostNameVerificationPort) {
+        delegate.hostnameVerification(hostNameVerificationAlgorithm, hostNameVerificationHost,
+                hostNameVerificationPort);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> hostnameVerification(final String hostNameVerificationHost) {
+        delegate.hostnameVerification(hostNameVerificationHost);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> hostnameVerification(final String hostNameVerificationHost,
+                                                                                final int hostNameVerificationPort) {
+        delegate.hostnameVerification(hostNameVerificationHost, hostNameVerificationPort);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> sniHostname(final String sniHostname) {
+        delegate.sniHostname(sniHostname);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> disableHostnameVerification() {
+        delegate.disableHostnameVerification();
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> keyManager(final KeyManagerFactory keyManagerFactory) {
+        delegate.keyManager(keyManagerFactory);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> keyManager(final Supplier<InputStream> keyCertChainSupplier,
+                                                                      final Supplier<InputStream> keySupplier) {
+        delegate.keyManager(keyCertChainSupplier, keySupplier);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientSecurityConfigurator<U, R> keyManager(final Supplier<InputStream> keyCertChainSupplier,
+                                                                      final Supplier<InputStream> keySupplier,
+                                                                      final String keyPassword) {
+        delegate.keyManager(keyCertChainSupplier, keySupplier, keyPassword);
+        return this;
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -45,6 +45,7 @@ import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.MultiAddressHttpClientFilterFactory;
 import io.servicetalk.http.api.ServiceDiscoveryRetryStrategy;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.http.api.SingleAddressHttpClientSecurityConfigurator;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
@@ -528,6 +529,16 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
         this.loadBalancerFactory = requireNonNull(loadBalancerFactory);
         influencerChainBuilder.add(loadBalancerFactory);
         return this;
+    }
+
+    @Deprecated
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> secure() {
+        assert address != null;
+        return new DefaultSingleAddressHttpClientSecurityConfigurator<>(sslConfig -> {
+                    sslConfig(sslConfig);
+                    return DefaultSingleAddressHttpClientBuilder.this;
+                });
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientSecurityConfigurator.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientSecurityConfigurator.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.http.api.SingleAddressHttpClientSecurityConfigurator;
+import io.servicetalk.transport.api.ClientSslConfig;
+import io.servicetalk.transport.netty.internal.ClientSecurityConfig;
+
+import java.io.InputStream;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+@Deprecated
+final class DefaultSingleAddressHttpClientSecurityConfigurator<U, R>
+        implements SingleAddressHttpClientSecurityConfigurator<U, R> {
+    private final ClientSecurityConfig config;
+    private final Function<ClientSslConfig, SingleAddressHttpClientBuilder<U, R>> configConsumer;
+
+    DefaultSingleAddressHttpClientSecurityConfigurator(
+            final Function<ClientSslConfig, SingleAddressHttpClientBuilder<U, R>> configConsumer) {
+        config = new ClientSecurityConfig();
+        this.configConsumer = configConsumer;
+    }
+
+    @Override
+    public SingleAddressHttpClientBuilder<U, R> commit() {
+        return configConsumer.apply(config.asSslConfig());
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> trustManager(
+            final Supplier<InputStream> trustCertChainSupplier) {
+        config.trustManager(trustCertChainSupplier);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> trustManager(
+            final TrustManagerFactory trustManagerFactory) {
+        config.trustManager(trustManagerFactory);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> protocols(final String... protocols) {
+        config.protocols(protocols);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> ciphers(final Iterable<String> ciphers) {
+        config.ciphers(ciphers);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> sessionCacheSize(final long sessionCacheSize) {
+        config.sessionCacheSize(sessionCacheSize);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> sessionTimeout(final long sessionTimeout) {
+        config.sessionTimeout(sessionTimeout);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> provider(final SslProvider provider) {
+        config.provider(provider);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> hostnameVerificationAlgorithm(
+            final String hostNameVerificationAlgorithm) {
+        config.hostNameVerificationAlgorithm(hostNameVerificationAlgorithm);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> hostnameVerification(
+            final String hostNameVerificationAlgorithm, final String hostNameVerificationHost) {
+        config.hostNameVerification(hostNameVerificationAlgorithm, hostNameVerificationHost);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> hostnameVerification(
+            final String hostNameVerificationAlgorithm, final String hostNameVerificationHost,
+            final int hostNameVerificationPort) {
+        config.hostNameVerification(hostNameVerificationAlgorithm, hostNameVerificationHost, hostNameVerificationPort);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> hostnameVerification(
+            final String hostNameVerificationHost) {
+        config.hostNameVerification(hostNameVerificationHost);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> hostnameVerification(
+            final String hostNameVerificationHost, final int hostNameVerificationPort) {
+        config.hostNameVerification(hostNameVerificationHost, hostNameVerificationPort);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> sniHostname(final String sniHostname) {
+        config.sniHostname(sniHostname);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> disableHostnameVerification() {
+        config.disableHostnameVerification();
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> keyManager(final KeyManagerFactory keyManagerFactory) {
+        config.keyManager(keyManagerFactory);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> keyManager(
+            final Supplier<InputStream> keyCertChainSupplier, final Supplier<InputStream> keySupplier) {
+        config.keyManager(keyCertChainSupplier, keySupplier);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientSecurityConfigurator<U, R> keyManager(
+            final Supplier<InputStream> keyCertChainSupplier, final Supplier<InputStream> keySupplier,
+            final String keyPassword) {
+        config.keyManager(keyCertChainSupplier, keySupplier, keyPassword);
+        return this;
+    }
+}

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ClientSecurityConfigurator.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ClientSecurityConfigurator.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.api;
+
+import java.io.InputStream;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * A {@link SecurityConfigurator} contract for clients.
+ * @deprecated Use {@link ClientSslConfigBuilder}.
+ */
+@Deprecated
+public interface ClientSecurityConfigurator extends SecurityConfigurator {
+    @Override
+    ClientSecurityConfigurator trustManager(Supplier<InputStream> trustCertChainSupplier);
+
+    @Override
+    ClientSecurityConfigurator trustManager(TrustManagerFactory trustManagerFactory);
+
+    @Override
+    ClientSecurityConfigurator protocols(String... protocols);
+
+    @Override
+    ClientSecurityConfigurator ciphers(Iterable<String> ciphers);
+
+    @Override
+    ClientSecurityConfigurator sessionCacheSize(long sessionCacheSize);
+
+    @Override
+    ClientSecurityConfigurator sessionTimeout(long sessionTimeout);
+
+    @Override
+    ClientSecurityConfigurator provider(SslProvider provider);
+
+    /**
+     * Determines what algorithm to use for hostname verification.
+     *
+     * @param hostNameVerificationAlgorithm The algorithm to use when verifying the host name.
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#jssenames">
+     * Supported algorithm names</a>.
+     * @return {@code this}.
+     * @see SSLParameters#setEndpointIdentificationAlgorithm(String)
+     */
+    ClientSecurityConfigurator hostnameVerificationAlgorithm(String hostNameVerificationAlgorithm);
+
+    /**
+     * Determines what algorithm to use for hostname verification.
+     *
+     * @param hostNameVerificationAlgorithm The algorithm to use when verifying the host name.
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#jssenames">
+     * Supported algorithm names</a>.
+     * @param hostNameVerificationHost the host name used to verify the
+     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
+     * @return {@code this}.
+     * @see SSLParameters#setEndpointIdentificationAlgorithm(String)
+     */
+    ClientSecurityConfigurator hostnameVerification(String hostNameVerificationAlgorithm,
+                                                    String hostNameVerificationHost);
+
+    /**
+     * Determines what algorithm to use for hostname verification.
+     *
+     * @param hostNameVerificationAlgorithm The algorithm to use when verifying the host name.
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#jssenames">
+     * Supported algorithm names</a>.
+     * @param hostNameVerificationHost the host name used to verify the
+     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
+     * @param hostNameVerificationPort The port which maybe used to verify the
+     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
+     * @return {@code this}.
+     * @see SSLParameters#setEndpointIdentificationAlgorithm(String)
+     */
+    ClientSecurityConfigurator hostnameVerification(String hostNameVerificationAlgorithm,
+                                                    String hostNameVerificationHost, int hostNameVerificationPort);
+
+    /**
+     * Set the host name used to verify the <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server
+     * identity</a>.
+     *
+     * @param hostNameVerificationHost the host name used to verify the
+     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
+     * @return {@code this}.
+     */
+    ClientSecurityConfigurator hostnameVerification(String hostNameVerificationHost);
+
+    /**
+     * Set the host name and port used to verify the <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server
+     * identity</a>.
+     *
+     * @param hostNameVerificationHost the host name used to verify the
+     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
+     * @param hostNameVerificationPort The port which maybe used to verify the
+     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
+     * @return {@code this}.
+     * @see SSLParameters#setEndpointIdentificationAlgorithm(String)
+     */
+    ClientSecurityConfigurator hostnameVerification(String hostNameVerificationHost, int hostNameVerificationPort);
+
+    /**
+     * Set the <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> host name.
+     *
+     * @param sniHostname The <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> host name.
+     * @return {@code this}.
+     */
+    ClientSecurityConfigurator sniHostname(String sniHostname);
+
+    /**
+     * Disable verification of the <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
+     *
+     * @return {@code this}.
+     */
+    ClientSecurityConfigurator disableHostnameVerification();
+
+    /**
+     * Identifying certificate for this host. {@code keyManagerFactory} may be {@code null}, which disables mutual
+     * authentication. The {@link KeyManagerFactory} which take preference over any configured {@link Supplier}.
+     *
+     * @param keyManagerFactory an {@link KeyManagerFactory}.
+     * @return {@code this}.
+     */
+    ClientSecurityConfigurator keyManager(KeyManagerFactory keyManagerFactory);
+
+    /**
+     * Identifying certificate for this host. {@code keyCertChainInputStream} and {@code keyInputStream} may
+     * be {@code null}, which disables mutual authentication.
+     *
+     * @param keyCertChainSupplier a {@link Supplier} that will provide an input stream for a {@code X.509} certificate
+     * chain in {@code PEM} format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a KCS#8 private key in PEM format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @return {@code this}.
+     */
+    ClientSecurityConfigurator keyManager(Supplier<InputStream> keyCertChainSupplier,
+                                          Supplier<InputStream> keySupplier);
+
+    /**
+     * Identifying certificate for this host. {@code keyCertChainInputStream} and {@code keyInputStream} may
+     * be {@code null}, which disables mutual authentication.
+     *
+     * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a {@code X.509} certificate
+     * chain in {@code PEM} format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a KCS#8 private key in PEM format.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the {@link Supplier}.
+     * If this is not the desired behavior then wrap the {@link InputStream} and override {@link InputStream#close()}.
+     * @param keyPassword the password of the {@code keyInputStream}.
+     * @return {@code this}.
+     */
+    ClientSecurityConfigurator keyManager(Supplier<InputStream> keyCertChainSupplier, Supplier<InputStream> keySupplier,
+                                          String keyPassword);
+}

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/SecurityConfigurator.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/SecurityConfigurator.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.api;
+
+import java.io.InputStream;
+import java.util.function.Supplier;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * An abstraction to configure SSL/TLS.
+ * @deprecated Use {@link ServerSslConfigBuilder} or {@link ClientSslConfigBuilder}.
+ */
+@Deprecated
+public interface SecurityConfigurator {
+
+    /**
+     * The provider to use for {@link SSLEngine}.
+     * @deprecated Use {@link io.servicetalk.transport.api.SslProvider}.
+     */
+    @Deprecated
+    enum SslProvider {
+        /**
+         * Use the stock JDK implementation.
+         */
+        JDK,
+        /**
+         * Use the openssl implementation.
+         */
+        OPENSSL,
+        /**
+         * Auto detect which implementation to use.
+         */
+        AUTO
+    }
+
+    /**
+     * Trusted certificates for verifying the remote endpoint's certificate. The input stream should
+     * contain an {@code X.509} certificate chain in {@code PEM} format.
+     *
+     * @param trustCertChainSupplier a supplier for the certificate chain input stream.
+     * <p>
+     * The responsibility to call {@link InputStream#close()} is transferred to callers of the returned
+     * {@link Supplier}. If this is not the desired behavior then wrap the {@link InputStream} and override
+     * {@link InputStream#close()}.
+     * @return {@code this}.
+     */
+    SecurityConfigurator trustManager(Supplier<InputStream> trustCertChainSupplier);
+
+    /**
+     * Trust manager for verifying the remote endpoint's certificate.
+     * The {@link TrustManagerFactory} which take preference over any configured {@link Supplier}.
+     *
+     * @param trustManagerFactory the {@link TrustManagerFactory} to use.
+     * @return {@code this}.
+     */
+    SecurityConfigurator trustManager(TrustManagerFactory trustManagerFactory);
+
+    /**
+     * The SSL protocols to enable, in the order of preference.
+     *
+     * @param protocols the protocols to use.
+     * @return {@code this}.
+     * @see SSLEngine#setEnabledProtocols(String[])
+     */
+    SecurityConfigurator protocols(String... protocols);
+
+    /**
+     * The cipher suites to enable, in the order of preference.
+     *
+     * @param ciphers the ciphers to use.
+     * @return {@code this}.
+     */
+    SecurityConfigurator ciphers(Iterable<String> ciphers);
+
+    /**
+     * Set the size of the cache used for storing SSL session objects.
+     *
+     * @param sessionCacheSize the cache size.
+     * @return {@code this}.
+     */
+    SecurityConfigurator sessionCacheSize(long sessionCacheSize);
+
+    /**
+     * Set the timeout for the cached SSL session objects, in seconds.
+     *
+     * @param sessionTimeout the session timeout.
+     * @return {@code this}.
+     */
+    SecurityConfigurator sessionTimeout(long sessionTimeout);
+
+    /**
+     * Sets the {@link SslProvider} to use.
+     *
+     * @param provider the provider.
+     * @return {@code this}.
+     */
+    SecurityConfigurator provider(SslProvider provider);
+}

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServerSecurityConfigurator.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServerSecurityConfigurator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.api;
+
+import java.io.InputStream;
+import java.util.function.Supplier;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * A {@link SecurityConfigurator} contract for servers.
+ * @deprecated Use {@link ServerSslConfigBuilder}.
+ */
+@Deprecated
+public interface ServerSecurityConfigurator extends SecurityConfigurator {
+    /**
+     * Indicates the state of the {@link SSLEngine} with respect to client authentication.
+     * @deprecated Use {@link SslClientAuthMode}.
+     */
+    @Deprecated
+    enum ClientAuth {
+        /**
+         * Indicates that the {@link SSLEngine} will not request client authentication.
+         */
+        NONE,
+
+        /**
+         * Indicates that the {@link SSLEngine} will request client authentication.
+         */
+        OPTIONAL,
+
+        /**
+         * Indicates that the {@link SSLEngine} will <strong>require</strong> client authentication.
+         */
+        REQUIRE
+    }
+
+    @Override
+    ServerSecurityConfigurator trustManager(Supplier<InputStream> trustCertChainSupplier);
+
+    @Override
+    ServerSecurityConfigurator trustManager(TrustManagerFactory trustManagerFactory);
+
+    @Override
+    ServerSecurityConfigurator protocols(String... protocols);
+
+    @Override
+    ServerSecurityConfigurator ciphers(Iterable<String> ciphers);
+
+    @Override
+    ServerSecurityConfigurator sessionCacheSize(long sessionCacheSize);
+
+    @Override
+    ServerSecurityConfigurator sessionTimeout(long sessionTimeout);
+
+    @Override
+    ServerSecurityConfigurator provider(SslProvider provider);
+
+    /**
+     * Sets the client authentication mode.
+     *
+     * @param clientAuth the auth configuration to use.
+     * @return {@code this}.
+     */
+    ServerSecurityConfigurator clientAuth(ClientAuth clientAuth);
+}

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ClientSecurityConfig.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ClientSecurityConfig.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.servicetalk.transport.api.ClientSslConfig;
+import io.servicetalk.transport.api.ClientSslConfigBuilder;
+import io.servicetalk.transport.api.SecurityConfigurator.SslProvider;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+import static java.util.Arrays.asList;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Client security configuration.
+ * @deprecated Use {@link ClientSslConfig}.
+ */
+@Deprecated
+public class ClientSecurityConfig extends ReadOnlyClientSecurityConfig {
+    /**
+     * Determines what algorithm to use for hostname verification.
+     *
+     * @param hostNameVerificationAlgorithm The algorithm to use when verifying the host name.
+     */
+    public void hostNameVerificationAlgorithm(final String hostNameVerificationAlgorithm) {
+        this.hostnameVerificationAlgorithm = requireNonNull(hostNameVerificationAlgorithm);
+    }
+
+    /**
+     * Determines what algorithm to use for hostname verification.
+     *
+     * @param hostNameVerificationAlgorithm The algorithm to use when verifying the host name.
+     * @param hostNameVerificationHost the host name used to verify the
+     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
+     */
+    public void hostNameVerification(final String hostNameVerificationAlgorithm,
+                                     final String hostNameVerificationHost) {
+        this.hostnameVerificationAlgorithm = requireNonNull(hostNameVerificationAlgorithm);
+        this.hostNameVerificationHost = hostNameVerificationHost;
+    }
+
+    /**
+     * Determines what algorithm to use for hostname verification.
+     *
+     * @param hostNameVerificationAlgorithm The algorithm to use when verifying the host name.
+     * @param hostNameVerificationHost the host name used to verify the
+     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
+     * @param hostNameVerificationPort The port which maybe used to verify the
+     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
+     */
+    public void hostNameVerification(final String hostNameVerificationAlgorithm,
+                                     final String hostNameVerificationHost, final int hostNameVerificationPort) {
+        this.hostnameVerificationAlgorithm = requireNonNull(hostNameVerificationAlgorithm);
+        this.hostNameVerificationHost = hostNameVerificationHost;
+        this.hostNameVerificationPort = hostNameVerificationPort;
+    }
+
+    /**
+     * Set the host name used to verify the <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server
+     * identity</a>.
+     *
+     * @param hostNameVerificationHost the host name used to verify the
+     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
+     */
+    public void hostNameVerification(final String hostNameVerificationHost) {
+        this.hostNameVerificationHost = hostNameVerificationHost;
+    }
+
+    /**
+     * Set the host name and port used to verify the <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server
+     * identity</a>.
+     *
+     * @param hostNameVerificationHost the host name used to verify the
+     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
+     * @param hostNameVerificationPort The port which maybe used to verify the
+     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
+     */
+    public void hostNameVerification(final String hostNameVerificationHost, final int hostNameVerificationPort) {
+        this.hostNameVerificationHost = hostNameVerificationHost;
+        this.hostNameVerificationPort = hostNameVerificationPort;
+    }
+
+    /**
+     * Set the <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> host name.
+     *
+     * @param sniHostname The <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> host name.
+     */
+    public void sniHostname(final String sniHostname) {
+        this.sniHostname = requireNonNull(sniHostname);
+    }
+
+    /**
+     * Disable verification of the <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
+     */
+    public void disableHostnameVerification() {
+        hostnameVerificationAlgorithm = null;
+        hostNameVerificationHost = null;
+        hostNameVerificationPort = -1;
+    }
+
+    /**
+     * Trusted certificates for verifying the remote endpoint's certificate. The input stream should
+     * contain an {@code X.509} certificate chain in {@code PEM} format.
+     *
+     * @param trustCertChainSupplier a supplier for the certificate chain input stream.
+     */
+    public void trustManager(final Supplier<InputStream> trustCertChainSupplier) {
+        this.trustCertChainSupplier = requireNonNull(trustCertChainSupplier);
+    }
+
+    /**
+     * Trust manager for verifying the remote endpoint's certificate.
+     * The {@link TrustManagerFactory} which take preference over any configured {@link Supplier}.
+     *
+     * @param trustManagerFactory the {@link TrustManagerFactory} to use.
+     */
+    public void trustManager(final TrustManagerFactory trustManagerFactory) {
+        this.trustManagerFactory = requireNonNull(trustManagerFactory);
+    }
+
+    /**
+     * The SSL protocols to enable, in the order of preference.
+     *
+     * @param protocols the protocols to use.
+     */
+    public void protocols(final String... protocols) {
+        this.protocols = asList(protocols);
+    }
+
+    /**
+     * The cipher suites to enable, in the order of preference.
+     *
+     * @param ciphers the ciphers to use.
+     */
+    public void ciphers(final Iterable<String> ciphers) {
+        this.ciphers = toList(ciphers);
+    }
+
+    static <T> List<T> toList(final Iterable<T> ciphers) {
+        final List<T> list;
+        if (ciphers instanceof List) {
+            list = (List<T>) ciphers;
+        } else {
+            list = new ArrayList<>();
+            ciphers.forEach(list::add);
+        }
+        return list;
+    }
+
+    /**
+     * Set the size of the cache used for storing SSL session objects.
+     *
+     * @param sessionCacheSize the cache size.
+     */
+    public void sessionCacheSize(final long sessionCacheSize) {
+        this.sessionCacheSize = sessionCacheSize;
+    }
+
+    /**
+     * Set the timeout for the cached SSL session objects, in seconds.
+     *
+     * @param sessionTimeout the session timeout.
+     */
+    public void sessionTimeout(final long sessionTimeout) {
+        this.sessionTimeout = sessionTimeout;
+    }
+
+    /**
+     * Sets the {@link SslProvider} to use.
+     *
+     * @param provider the provider.
+     */
+    public void provider(final SslProvider provider) {
+        this.provider = requireNonNull(provider);
+    }
+
+    /**
+     * Identifying certificate for this host. {@code keyManagerFactory} may be {@code null}, which disables mutual
+     * authentication. The {@link KeyManagerFactory} which take preference over any configured {@link Supplier}.
+     *
+     * @param keyManagerFactory an {@link KeyManagerFactory}.
+     */
+    public void keyManager(final KeyManagerFactory keyManagerFactory) {
+        this.keyManagerFactory = requireNonNull(keyManagerFactory);
+    }
+
+    /**
+     * Identifying certificate for this host. {@code keyCertChainInputStream} and {@code keyInputStream} may
+     * be {@code null}, which disables mutual authentication.
+     *
+     * @param keyCertChainSupplier a {@link Supplier} that will provide an input stream for a {@code X.509} certificate
+     * chain in {@code PEM} format.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a KCS#8 private key in PEM format.
+     */
+    public void keyManager(final Supplier<InputStream> keyCertChainSupplier, final Supplier<InputStream> keySupplier) {
+        this.keyCertChainSupplier = requireNonNull(keyCertChainSupplier);
+        this.keySupplier = requireNonNull(keySupplier);
+        this.keyPassword = null;
+    }
+
+    /**
+     * Identifying certificate for this host. {@code keyCertChainInputStream} and {@code keyInputStream} may
+     * be {@code null}, which disables mutual authentication.
+     *
+     * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a {@code X.509} certificate
+     * chain in {@code PEM} format.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a KCS#8 private key in PEM format.
+     * @param keyPassword the password of the {@code keyInputStream}.
+     */
+    public void keyManager(final Supplier<InputStream> keyCertChainSupplier, final Supplier<InputStream> keySupplier,
+                           final String keyPassword) {
+        this.keyCertChainSupplier = requireNonNull(keyCertChainSupplier);
+        this.keySupplier = requireNonNull(keySupplier);
+        this.keyPassword = requireNonNull(keyPassword);
+    }
+
+    /**
+     * Returns this config as a {@link ReadOnlyClientSecurityConfig}.
+     *
+     * @return This config as a {@link ReadOnlyClientSecurityConfig}.
+     */
+    public ReadOnlyClientSecurityConfig asReadOnly() {
+        return new ReadOnlyClientSecurityConfig(this);
+    }
+
+    /**
+     * Build a new {@link ClientSslConfig}.
+     * @return a new {@link ClientSslConfig}.
+     */
+    public ClientSslConfig asSslConfig() {
+        final ClientSslConfigBuilder builder;
+        if (trustManagerFactory != null) {
+            builder = new ClientSslConfigBuilder(trustManagerFactory);
+        } else if (trustCertChainSupplier != null) {
+            builder = new ClientSslConfigBuilder(trustCertChainSupplier);
+        } else {
+            builder = new ClientSslConfigBuilder();
+        }
+
+        if (hostnameVerificationAlgorithm == null) {
+            builder.disableHostnameVerification();
+        } else {
+            builder.hostnameVerificationAlgorithm(hostnameVerificationAlgorithm);
+        }
+        if (hostNameVerificationHost != null) {
+            builder.peerHost(hostNameVerificationHost);
+            builder.peerPort(hostNameVerificationPort);
+        }
+        if (sniHostname != null) {
+            builder.sniHostname(sniHostname);
+        }
+
+        if (keyManagerFactory != null) {
+            builder.keyManager(keyManagerFactory);
+        } else if (keyCertChainSupplier != null) {
+            assert keySupplier != null;
+            builder.keyManager(keyCertChainSupplier, keySupplier, keyPassword);
+        }
+        if (protocols != null) {
+            builder.sslProtocols(protocols);
+        }
+        if (ciphers != null) {
+            builder.ciphers(ciphers);
+        }
+        builder.sessionCacheSize(sessionCacheSize);
+        builder.sessionTimeout(sessionTimeout);
+
+        if (provider == SslProvider.JDK) {
+            builder.provider(io.servicetalk.transport.api.SslProvider.JDK);
+        } else if (provider == SslProvider.OPENSSL) {
+            builder.provider(io.servicetalk.transport.api.SslProvider.OPENSSL);
+        }
+        return builder.build();
+    }
+}

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ReadOnlyClientSecurityConfig.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ReadOnlyClientSecurityConfig.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.servicetalk.transport.api.ClientSslConfig;
+
+import javax.annotation.Nullable;
+
+/**
+ * Read-only security config for clients.
+ * @deprecated Use {@link ClientSslConfig}.
+ */
+@Deprecated
+public class ReadOnlyClientSecurityConfig extends ReadOnlySecurityConfig {
+    @Nullable
+    protected String hostnameVerificationAlgorithm = "HTTPS";
+    @Nullable
+    protected String hostNameVerificationHost;
+    /**
+     * Only valid if {@link #hostNameVerificationHost} is valid.
+     */
+    protected int hostNameVerificationPort;
+    @Nullable
+    protected String sniHostname;
+
+    protected ReadOnlyClientSecurityConfig() {
+    }
+
+    /**
+     * Copy constructor.
+     *
+     * @param from {@link ReadOnlyClientSecurityConfig} to copy.
+     */
+    protected ReadOnlyClientSecurityConfig(final ReadOnlyClientSecurityConfig from) {
+        super(from);
+        hostnameVerificationAlgorithm = from.hostnameVerificationAlgorithm;
+        hostNameVerificationHost = from.hostNameVerificationHost;
+        hostNameVerificationPort = from.hostNameVerificationPort;
+        sniHostname = from.sniHostname;
+    }
+
+    /**
+     * Returns the host name verification algorithm.
+     *
+     * @return The host name verification algorithm.
+     */
+    @Nullable
+    public String hostnameVerificationAlgorithm() {
+        return hostnameVerificationAlgorithm;
+    }
+
+    /**
+     * Returns the host name verification host.
+     *
+     * @return The host name verification host.
+     */
+    @Nullable
+    public String hostnameVerificationHost() {
+        return hostNameVerificationHost;
+    }
+
+    /**
+     * Returns the host name verification port.
+     *
+     * @return The host name verification port.
+     */
+    public int hostnameVerificationPort() {
+        return hostNameVerificationPort;
+    }
+
+    /**
+     * Returns the SNI host name.
+     *
+     * @return The SNI host name.
+     */
+    @Nullable
+    public String sniHostname() {
+        return sniHostname;
+    }
+}

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ReadOnlySecurityConfig.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ReadOnlySecurityConfig.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.servicetalk.transport.api.SecurityConfigurator.SslProvider;
+import io.servicetalk.transport.api.SslConfig;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+import static java.util.Collections.unmodifiableList;
+
+/**
+ * A base security config for both client and server.
+ * @deprecated use {@link SslConfig}.
+ */
+@Deprecated
+class ReadOnlySecurityConfig {
+    @Nullable
+    Supplier<InputStream> trustCertChainSupplier;
+    @Nullable
+    TrustManagerFactory trustManagerFactory;
+    @Nullable
+    List<String> protocols;
+    @Nullable
+    List<String> ciphers;
+    long sessionCacheSize;
+    long sessionTimeout;
+    SslProvider provider = SslProvider.AUTO;
+
+    @Nullable
+    protected KeyManagerFactory keyManagerFactory;
+    @Nullable
+    protected Supplier<InputStream> keyCertChainSupplier;
+    @Nullable
+    protected Supplier<InputStream> keySupplier;
+    @Nullable
+    protected String keyPassword;
+
+    ReadOnlySecurityConfig() {
+    }
+
+    ReadOnlySecurityConfig(ReadOnlySecurityConfig from) {
+        trustCertChainSupplier = from.trustCertChainSupplier;
+        trustManagerFactory = from.trustManagerFactory;
+        protocols = from.protocols == null ? null : unmodifiableList(from.protocols);
+        ciphers = from.ciphers;
+        sessionCacheSize = from.sessionCacheSize;
+        sessionTimeout = from.sessionTimeout;
+        provider = from.provider;
+        keyManagerFactory = from.keyManagerFactory;
+        keyCertChainSupplier = from.keyCertChainSupplier;
+        keySupplier = from.keySupplier;
+        keyPassword = from.keyPassword;
+    }
+
+    @Nullable
+    Supplier<InputStream> trustCertChainSupplier() {
+        return trustCertChainSupplier;
+    }
+
+    @Nullable
+    TrustManagerFactory trustManagerFactory() {
+        return trustManagerFactory;
+    }
+
+    @Nullable
+    List<String> protocols() {
+        return protocols;
+    }
+
+    @Nullable
+    List<String> ciphers() {
+        return ciphers;
+    }
+
+    long sessionCacheSize() {
+        return sessionCacheSize;
+    }
+
+    long sessionTimeout() {
+        return sessionTimeout;
+    }
+
+    SslProvider provider() {
+        return provider;
+    }
+
+    @Nullable
+    KeyManagerFactory keyManagerFactory() {
+        return keyManagerFactory;
+    }
+
+    @Nullable
+    Supplier<InputStream> keyCertChainSupplier() {
+        return keyCertChainSupplier;
+    }
+
+    @Nullable
+    Supplier<InputStream> keySupplier() {
+        return keySupplier;
+    }
+
+    @Nullable
+    String keyPassword() {
+        return keyPassword;
+    }
+}

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ReadOnlyServerSecurityConfig.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ReadOnlyServerSecurityConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.servicetalk.transport.api.ServerSecurityConfigurator.ClientAuth;
+import io.servicetalk.transport.api.ServerSslConfig;
+
+import static io.servicetalk.transport.api.ServerSecurityConfigurator.ClientAuth.NONE;
+
+/**
+ * Read-only security config for servers.
+ * @deprecated Use {@link ServerSslConfig}.
+ */
+@Deprecated
+public class ReadOnlyServerSecurityConfig extends ReadOnlySecurityConfig {
+
+    protected ClientAuth clientAuth = NONE;
+
+    /**
+     * Creates new instance.
+     */
+    protected ReadOnlyServerSecurityConfig() {
+    }
+
+    /**
+     * Copy constructor.
+     *
+     * @param from {@link ReadOnlyServerSecurityConfig} to copy.
+     */
+    protected ReadOnlyServerSecurityConfig(final ReadOnlyServerSecurityConfig from) {
+        super(from);
+        clientAuth = from.clientAuth;
+    }
+
+    /**
+     * Returns the {@link ClientAuth} mode.
+     * @return The {@link ClientAuth} mode.
+     */
+    public ClientAuth clientAuth() {
+        return clientAuth;
+    }
+}

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ServerSecurityConfig.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ServerSecurityConfig.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.servicetalk.transport.api.SecurityConfigurator.SslProvider;
+import io.servicetalk.transport.api.ServerSecurityConfigurator.ClientAuth;
+import io.servicetalk.transport.api.ServerSslConfig;
+import io.servicetalk.transport.api.ServerSslConfigBuilder;
+import io.servicetalk.transport.api.SslClientAuthMode;
+
+import java.io.InputStream;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+import static io.servicetalk.transport.netty.internal.ClientSecurityConfig.toList;
+import static java.util.Arrays.asList;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Server security configuration.
+ * @deprecated Use {@link ServerSslConfig}.
+ */
+@Deprecated
+public class ServerSecurityConfig extends ReadOnlyServerSecurityConfig {
+
+    /**
+     * Trusted certificates for verifying the remote endpoint's certificate. The input stream should
+     * contain an {@code X.509} certificate chain in {@code PEM} format.
+     *
+     * @param trustCertChainSupplier a supplier for the certificate chain input stream.
+     */
+    public void trustManager(final Supplier<InputStream> trustCertChainSupplier) {
+        this.trustCertChainSupplier = requireNonNull(trustCertChainSupplier);
+    }
+
+    /**
+     * Trust manager for verifying the remote endpoint's certificate.
+     * The {@link TrustManagerFactory} which take preference over any configured {@link Supplier}.
+     *
+     * @param trustManagerFactory the {@link TrustManagerFactory} to use.
+     */
+    public void trustManager(final TrustManagerFactory trustManagerFactory) {
+        this.trustManagerFactory = requireNonNull(trustManagerFactory);
+    }
+
+    /**
+     * The SSL protocols to enable, in the order of preference.
+     *
+     * @param protocols the protocols to use.
+     */
+    public void protocols(final String... protocols) {
+        this.protocols = asList(protocols);
+    }
+
+    /**
+     * The cipher suites to enable, in the order of preference.
+     *
+     * @param ciphers the ciphers to use.
+     */
+    public void ciphers(final Iterable<String> ciphers) {
+        this.ciphers = toList(ciphers);
+    }
+
+    /**
+     * Set the size of the cache used for storing SSL session objects.
+     *
+     * @param sessionCacheSize the cache size.
+     */
+    public void sessionCacheSize(final long sessionCacheSize) {
+        this.sessionCacheSize = sessionCacheSize;
+    }
+
+    /**
+     * Set the timeout for the cached SSL session objects, in seconds.
+     *
+     * @param sessionTimeout the session timeout.
+     */
+    public void sessionTimeout(final long sessionTimeout) {
+        this.sessionTimeout = sessionTimeout;
+    }
+
+    /**
+     * Sets the {@link SslProvider} to use.
+     *
+     * @param provider the provider.
+     */
+    public void provider(final SslProvider provider) {
+        this.provider = requireNonNull(provider);
+    }
+
+    /**
+     * Identifying certificate for this host. {@code keyManagerFactory} may be {@code null}, which disables mutual
+     * authentication. The {@link KeyManagerFactory} which take preference over any configured {@link Supplier}.
+     *
+     * @param keyManagerFactory an {@link KeyManagerFactory}.
+     */
+    public void keyManager(final KeyManagerFactory keyManagerFactory) {
+        this.keyManagerFactory = requireNonNull(keyManagerFactory);
+    }
+
+    /**
+     * Identifying certificate for this host. {@code keyCertChainInputStream} and {@code keyInputStream} may
+     * be {@code null}, which disables mutual authentication.
+     *
+     * @param keyCertChainSupplier a {@link Supplier} that will provide an input stream for a {@code X.509} certificate
+     * chain in {@code PEM} format.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a KCS#8 private key in PEM format.
+     */
+    public void keyManager(final Supplier<InputStream> keyCertChainSupplier, final Supplier<InputStream> keySupplier) {
+        this.keyCertChainSupplier = requireNonNull(keyCertChainSupplier);
+        this.keySupplier = requireNonNull(keySupplier);
+        this.keyPassword = null;
+    }
+
+    /**
+     * Identifying certificate for this host. {@code keyCertChainInputStream} and {@code keyInputStream} may
+     * be {@code null}, which disables mutual authentication.
+     *
+     * @param keyCertChainSupplier an {@link Supplier} that will provide an input stream for a {@code X.509} certificate
+     * chain in {@code PEM} format.
+     * @param keySupplier an {@link Supplier} that will provide an input stream for a KCS#8 private key in PEM format.
+     * @param keyPassword the password of the {@code keyInputStream}.
+     */
+    public void keyManager(final Supplier<InputStream> keyCertChainSupplier, final Supplier<InputStream> keySupplier,
+                           final String keyPassword) {
+        this.keyCertChainSupplier = requireNonNull(keyCertChainSupplier);
+        this.keySupplier = requireNonNull(keySupplier);
+        this.keyPassword = requireNonNull(keyPassword);
+    }
+
+    /**
+     * Sets the client authentication mode.
+     *
+     * @param clientAuth the auth configuration to use.
+     */
+    public void clientAuth(final ClientAuth clientAuth) {
+        this.clientAuth = requireNonNull(clientAuth);
+    }
+
+    /**
+     * Returns this config as a {@link ReadOnlyServerSecurityConfig}.
+     *
+     * @return This config as a {@link ReadOnlyServerSecurityConfig}.
+     */
+    public ReadOnlyServerSecurityConfig asReadOnly() {
+        return new ReadOnlyServerSecurityConfig(this);
+    }
+
+    /**
+     * Build a new {@link ServerSslConfig}.
+     * @return a new {@link ServerSslConfig}.
+     */
+    public ServerSslConfig asSslConfig() {
+        final ServerSslConfigBuilder builder;
+        if (keyManagerFactory != null) {
+            builder = new ServerSslConfigBuilder(keyManagerFactory);
+        } else if (keyCertChainSupplier != null) {
+            assert keySupplier != null;
+            builder = new ServerSslConfigBuilder(keyCertChainSupplier, keySupplier, keyPassword);
+        } else {
+            throw new IllegalStateException("required key material not set");
+        }
+
+        if (clientAuth == ClientAuth.OPTIONAL) {
+            builder.clientAuthMode(SslClientAuthMode.OPTIONAL);
+        } else if (clientAuth == ClientAuth.REQUIRE) {
+            builder.clientAuthMode(SslClientAuthMode.REQUIRE);
+        } else if (clientAuth == ClientAuth.NONE) {
+            builder.clientAuthMode(SslClientAuthMode.NONE);
+        } else {
+            throw new IllegalStateException("unsupported ClientAuth: " + clientAuth);
+        }
+
+        if (trustManagerFactory != null) {
+            builder.trustManager(trustManagerFactory);
+        } else if (trustCertChainSupplier != null) {
+            builder.trustManager(trustCertChainSupplier);
+        }
+
+        if (protocols != null) {
+            builder.sslProtocols(protocols);
+        }
+        if (ciphers != null) {
+            builder.ciphers(ciphers);
+        }
+        builder.sessionCacheSize(sessionCacheSize);
+        builder.sessionTimeout(sessionTimeout);
+
+        if (provider == SslProvider.JDK) {
+            builder.provider(io.servicetalk.transport.api.SslProvider.JDK);
+        } else if (provider == SslProvider.OPENSSL) {
+            builder.provider(io.servicetalk.transport.api.SslProvider.OPENSSL);
+        }
+        return builder.build();
+    }
+}


### PR DESCRIPTION
Motivation:
Folks need more time to digest the deprecation and migrate to the new
APIs.

Modifications:
- This reverts commit d0324368c17c9e0271d2b018d5042c2f17332316.