### PR TITLE
Follow-up for debugging example added in #1459

### DIFF
--- a/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
@@ -95,7 +95,7 @@ Extends the async "Hello World" example to demonstrate some useful features avai
 [#Serialization]
 == Serialization
 
-A example similar to "Hello World" examples, which demonstrate
+An example similar to "Hello World" examples, which demonstrate
 link:{source-root}/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/async[asynchronous-aggregated],
 link:{source-root}/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/async/streaming[asynchronous-streaming],
 link:{source-root}/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/blocking[blocking-aggregated], and

--- a/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
@@ -95,7 +95,7 @@ Extends the async "Hello World" example to demonstrate some useful features avai
 [#Serialization]
 == Serialization
 
-An example similar to "Hello World" examples, which demonstrate
+An example similar to "Hello World" examples, which demonstrates
 link:{source-root}/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/async[asynchronous-aggregated],
 link:{source-root}/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/async/streaming[asynchronous-streaming],
 link:{source-root}/servicetalk-examples/http/serialization/src/main/java/io/servicetalk/examples/http/serialization/blocking[blocking-aggregated], and

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
@@ -15,12 +15,18 @@
  */
 package io.servicetalk.examples.http.debugging;
 
+import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.http.netty.H2ProtocolConfigBuilder;
 import io.servicetalk.http.netty.HttpClients;
 import io.servicetalk.http.netty.HttpProtocolConfigs;
+import io.servicetalk.logging.api.LogLevel;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.function.BooleanSupplier;
 
 import static io.servicetalk.http.api.HttpSerializationProviders.textDeserializer;
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
@@ -28,15 +34,15 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
 
 /**
  * The async "Hello World" example with debugging features enabled. Four debugging features are demonstrated:
- * <p></p><ol>
- *     <li>Disabling Async Context</li>
- *     <li>Disabling offloading</li>
- *     <li>Enabling HTTP wire logging</li>
- *     <li>Enabling HTTP/2 frame logging</li>
+ * <ol>
+ *     <li>Disabling {@link AsyncContext}</li>
+ *     <li>Disabling {@link HttpExecutionStrategy offloading}</li>
+ *     <li>Enabling {@link SingleAddressHttpClientBuilder#enableWireLogging(String, LogLevel, BooleanSupplier) HTTP wire logging}</li>
+ *     <li>Enabling {@link H2ProtocolConfigBuilder#enableFrameLogging(String, LogLevel, BooleanSupplier) HTTP/2 frame logging}</li>
  * </ol>
- * <p>The wire and frame logging features require that you configure {@link io.servicetalk.logging.api.LogLevel#TRACE}
- * logging for the logger. For this example {@code log4j.xml} is used by both the client and server and configures the
- * ({@code servicetalk-examples-wire-logger} logger.
+ * <p>The wire and frame logging features require that you configure a logger with an appropriate log level. For this
+ * example {@code log4j2.xml} is used by both the client and server and configures the
+ * ({@code servicetalk-examples-wire-logger} logger at {@link io.servicetalk.logging.api.LogLevel#TRACE TRACE} level.
  *
  * <p>When configured correctly the output should be similar to the following:
  * <pre>
@@ -50,7 +56,7 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
  * |00000000| 50 52 49 20 2a 20 48 54 54 50 2f 32 2e 30 0d 0a |PRI * HTTP/2.0..|
  * |00000010| 0d 0a 53 4d 0d 0a 0d 0a                         |..SM....        |
  * +--------+-------------------------------------------------+----------------+
- * 2021-03-26 19:42:07,013 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] OUTBOUND SETTINGS: ack=false settings={ENABLE_PUSH=0, MAX_CONCURRENT_STREAMS=0, MAX_HEADER_LIST_SIZE=8192}
+ * 2021-03-26 19:42:07,013 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] OUTBOUND SETTINGS: ack=false settings={ENABLE_PUSH=0, MAX_CONCURRENT_STREAMS=0, MAX_HEADER_LIST_SIZE=8192}
  * 2021-03-26 19:42:07,027 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] WRITE: 27B
  *          +-------------------------------------------------+
  *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
@@ -58,7 +64,7 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
  * |00000000| 00 00 12 04 00 00 00 00 00 00 02 00 00 00 00 00 |................|
  * |00000010| 03 00 00 00 00 00 06 00 00 20 00                |......... .     |
  * +--------+-------------------------------------------------+----------------+
- * 2021-03-26 19:42:07,166 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] OUTBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:authority: localhost:8080, :method: POST, :scheme: http, :path: /sayHello, content-type: text/plain; charset=UTF-8, content-length: 6] padding=0 endStream=false
+ * 2021-03-26 19:42:07,166 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] OUTBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:authority: localhost:8080, :method: POST, :scheme: http, :path: /sayHello, content-type: text/plain; charset=UTF-8, content-length: 6] padding=0 endStream=false
  * 2021-03-26 19:42:07,171 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] WRITE: 9B
  *          +-------------------------------------------------+
  *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
@@ -74,7 +80,7 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
  * |00000020| 65 78 74 2f 70 6c 61 69 6e 3b 20 63 68 61 72 73 |ext/plain; chars|
  * |00000030| 65 74 3d 55 54 46 2d 38 5c 01 36                |et=UTF-8\.6     |
  * +--------+-------------------------------------------------+----------------+
- * 2021-03-26 19:42:07,181 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] OUTBOUND DATA: streamId=3 padding=0 endStream=true length=6 bytes=47656f726765
+ * 2021-03-26 19:42:07,181 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] OUTBOUND DATA: streamId=3 padding=0 endStream=true length=6 bytes=47656f726765
  * 2021-03-26 19:42:07,181 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] WRITE: 9B
  *          +-------------------------------------------------+
  *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
@@ -100,8 +106,8 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
  * |00000040| 33 00 00 0d 00 01 00 00 00 03 48 65 6c 6c 6f 20 |3.........Hello |
  * |00000050| 47 65 6f 72 67 65 21                            |George!         |
  * +--------+-------------------------------------------------+----------------+
- * 2021-03-26 19:42:07,367 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] INBOUND SETTINGS: ack=false settings={MAX_HEADER_LIST_SIZE=8192}
- * 2021-03-26 19:42:07,369 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] OUTBOUND SETTINGS: ack=true
+ * 2021-03-26 19:42:07,367 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] INBOUND SETTINGS: ack=false settings={MAX_HEADER_LIST_SIZE=8192}
+ * 2021-03-26 19:42:07,369 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] OUTBOUND SETTINGS: ack=true
  * 2021-03-26 19:42:07,370 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] WRITE: 9B
  *          +-------------------------------------------------+
  *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
@@ -109,9 +115,9 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
  * |00000000| 00 00 00 04 01 00 00 00 00                      |.........       |
  * +--------+-------------------------------------------------+----------------+
  * 2021-03-26 19:42:07,370 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] FLUSH
- * 2021-03-26 19:42:07,370 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] INBOUND SETTINGS: ack=true
- * 2021-03-26 19:42:07,371 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] INBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:status: 200, content-type: text/plain; charset=UTF-8, content-length: 13] padding=0 endStream=false
- * 2021-03-26 19:42:07,378 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] INBOUND DATA: streamId=3 padding=0 endStream=true length=13 bytes=48656c6c6f2047656f72676521
+ * 2021-03-26 19:42:07,370 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] INBOUND SETTINGS: ack=true
+ * 2021-03-26 19:42:07,371 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] INBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:status: 200, content-type: text/plain; charset=UTF-8, content-length: 13] padding=0 endStream=false
+ * 2021-03-26 19:42:07,378 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] INBOUND DATA: streamId=3 padding=0 endStream=true length=13 bytes=48656c6c6f2047656f72676521
  * HTTP/2.0 200 OK
  * NettyH2HeadersToHttpHeaders[content-type: text/plain; charset=UTF-8
  * content-length: 13]
@@ -120,31 +126,44 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
  * 2021-03-26 19:42:07,381 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] FLUSH
  * 2021-03-26 19:42:07,381 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] FLUSH
  * 2021-03-26 19:42:07,381 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] READ_REQUEST
+ * 2021-03-26 19:42:07,394 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 - R:localhost/127.0.0.1:8080] CLOSE
+ * 2021-03-26 19:42:07,394 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 ! R:localhost/127.0.0.1:8080] INACTIVE
+ * 2021-03-26 19:42:07,395 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xf11baf09, L:/127.0.0.1:57266 ! R:localhost/127.0.0.1:8080] UNREGISTERED
  * </pre>
  */
 public final class DebuggingExampleClient {
 
     static {
-        // 1. (optional) Disables the AsyncContext associated with individual request/responses to reduce stack-trace
-        // depth and simplify execution tracing. This will disable/break some features such as request tracing,
-        // authentication, propagated timeouts, etc. that rely upon the Async context so should only be disabled when
-        // necessary for debugging
-        /* AsyncContext.disable(); */
+        /*
+         * 1. (optional) Disables the AsyncContext associated with individual request/responses to reduce stack-trace
+         * depth and simplify execution tracing. This will disable/break some features such as request tracing,
+         * authentication, propagated timeouts, etc. that rely upon the AsyncContext so should only be disabled when
+         * necessary for debugging:
+         */
+        // AsyncContext.disable();
     }
 
     public static void main(String... args) throws Exception {
         try (HttpClient client = HttpClients.forSingleAddress("localhost", 8080)
-                // 2. Disables most asynchronous offloading to simplify execution tracing. Changing this may
-                // significantly change application behavior and introduce unexpected blocking. It is most useful for
-                // being able to directly trace through situations that would normally involve a thread handoff.
-                /* .executionStrategy(HttpExecutionStrategies.noOffloadsStrategy()) */
-                // 3. Enables detailed logging of I/O and I/O states.
-                // Be sure to also enable the logger in your logging config file (log4j2.xml for this example)
+                /*
+                 * 2. Disables most asynchronous offloading to simplify execution tracing. Changing this may
+                 * significantly change application behavior and introduce unexpected blocking. It is most useful for
+                 * being able to directly trace through situations that would normally involve a thread handoff.
+                 */
+                // .executionStrategy(HttpExecutionStrategies.noOffloadsStrategy())
+
+                /*
+                 * 3. Enables detailed logging of I/O and I/O states.
+                 * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
+                 */
                 .enableWireLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
-                // 4. Enables detailed logging of HTTP2 frames.
-                // Be sure to also enable the logger in your logging config file (log4j2.xml for this example)
+
+                /*
+                 * 4. Enables detailed logging of HTTP2 frames.
+                 * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
+                 */
                 .protocols(HttpProtocolConfigs.h2()
-                        .enableFrameLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+                        .enableFrameLogging("servicetalk-examples-h2-frame-logger", TRACE, Boolean.TRUE::booleanValue)
                         .build())
                 .build()) {
             // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
@@ -15,8 +15,15 @@
  */
 package io.servicetalk.examples.http.debugging;
 
+import io.servicetalk.concurrent.api.AsyncContext;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.netty.H2ProtocolConfigBuilder;
 import io.servicetalk.http.netty.HttpProtocolConfigs;
 import io.servicetalk.http.netty.HttpServers;
+import io.servicetalk.logging.api.LogLevel;
+
+import java.util.function.BooleanSupplier;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpSerializationProviders.textDeserializer;
@@ -25,19 +32,19 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
 
 /**
  * Extends the async "Hello World" sample with debugging features. Four debugging features are demonstrated:
- * <p></p><ol>
- *     <li>Disabling Async Context</li>
- *     <li>Disabling offloading</li>
- *     <li>Enabling HTTP wire logging</li>
- *     <li>Enabling HTTP/2 frame logging</li>
+ * <ol>
+ *     <li>Disabling {@link AsyncContext}</li>
+ *     <li>Disabling {@link HttpExecutionStrategy offloading}</li>
+ *     <li>Enabling {@link HttpServerBuilder#enableWireLogging(String, LogLevel, BooleanSupplier) HTTP wire logging}</li>
+ *     <li>Enabling {@link H2ProtocolConfigBuilder#enableFrameLogging(String, LogLevel, BooleanSupplier) HTTP/2 frame logging}</li>
  * </ol>
- * <p>The wire and frame logging features require that you configure {@link io.servicetalk.logging.api.LogLevel#TRACE}
- * logging for the logger. For this example {@code log4j.xml} is used by both the client and server and configures the
- * ({@code servicetalk-examples-wire-logger} logger.
+ * <p>The wire and frame logging features require that you configure a logger with an appropriate log level. For this
+ * example {@code log4j2.xml} is used by both the client and server and configures the
+ * ({@code servicetalk-examples-wire-logger} logger at {@link io.servicetalk.logging.api.LogLevel#TRACE TRACE} level.
  *
  * <p>When configured correctly the output should be similar to the following:
  * <pre>
- * 2021-03-26 19:42:07,095 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] OUTBOUND SETTINGS: ack=false settings={MAX_HEADER_LIST_SIZE=8192}
+ * 2021-03-26 19:42:07,095 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] OUTBOUND SETTINGS: ack=false settings={MAX_HEADER_LIST_SIZE=8192}
  * 2021-03-26 19:42:07,117 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] WRITE: 15B
  *          +-------------------------------------------------+
  *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
@@ -61,17 +68,17 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
  * |00000070| 54 46 2d 38 5c 01 36 00 00 06 00 01 00 00 00 03 |TF-8\.6.........|
  * |00000080| 47 65 6f 72 67 65                               |George          |
  * +--------+-------------------------------------------------+----------------+
- * 2021-03-26 19:42:07,186 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] INBOUND SETTINGS: ack=false settings={ENABLE_PUSH=0, MAX_CONCURRENT_STREAMS=0, MAX_HEADER_LIST_SIZE=8192}
- * 2021-03-26 19:42:07,187 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] OUTBOUND SETTINGS: ack=true
+ * 2021-03-26 19:42:07,186 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] INBOUND SETTINGS: ack=false settings={ENABLE_PUSH=0, MAX_CONCURRENT_STREAMS=0, MAX_HEADER_LIST_SIZE=8192}
+ * 2021-03-26 19:42:07,187 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] OUTBOUND SETTINGS: ack=true
  * 2021-03-26 19:42:07,188 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] WRITE: 9B
  *          +-------------------------------------------------+
  *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
  * +--------+-------------------------------------------------+----------------+
  * |00000000| 00 00 00 04 01 00 00 00 00                      |.........       |
  * +--------+-------------------------------------------------+----------------+
- * 2021-03-26 19:42:07,196 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] INBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:authority: localhost:8080, :method: POST, :scheme: http, :path: /sayHello, content-type: text/plain; charset=UTF-8, content-length: 6] padding=0 endStream=false
- * 2021-03-26 19:42:07,254 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] INBOUND DATA: streamId=3 padding=0 endStream=true length=6 bytes=47656f726765
- * 2021-03-26 19:42:07,350 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] OUTBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:status: 200, content-type: text/plain; charset=UTF-8, content-length: 13] padding=0 endStream=false
+ * 2021-03-26 19:42:07,196 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] INBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:authority: localhost:8080, :method: POST, :scheme: http, :path: /sayHello, content-type: text/plain; charset=UTF-8, content-length: 6] padding=0 endStream=false
+ * 2021-03-26 19:42:07,254 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] INBOUND DATA: streamId=3 padding=0 endStream=true length=6 bytes=47656f726765
+ * 2021-03-26 19:42:07,350 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] OUTBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:status: 200, content-type: text/plain; charset=UTF-8, content-length: 13] padding=0 endStream=false
  * 2021-03-26 19:42:07,351 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] WRITE: 9B
  *          +-------------------------------------------------+
  *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
@@ -86,7 +93,7 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
  * |00000010| 68 61 72 73 65 74 3d 55 54 46 2d 38 5c 02 31 33 |harset=UTF-8\.13|
  * +--------+-------------------------------------------------+----------------+
  * 2021-03-26 19:42:07,360 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] READ_COMPLETE
- * 2021-03-26 19:42:07,362 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] OUTBOUND DATA: streamId=3 padding=0 endStream=true length=13 bytes=48656c6c6f2047656f72676521
+ * 2021-03-26 19:42:07,362 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] OUTBOUND DATA: streamId=3 padding=0 endStream=true length=13 bytes=48656c6c6f2047656f72676521
  * 2021-03-26 19:42:07,362 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] WRITE: 9B
  *          +-------------------------------------------------+
  *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
@@ -109,33 +116,47 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
  * +--------+-------------------------------------------------+----------------+
  * |00000000| 00 00 00 04 01 00 00 00 00                      |.........       |
  * +--------+-------------------------------------------------+----------------+
- * 2021-03-26 19:42:07,370 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] INBOUND SETTINGS: ack=true
+ * 2021-03-26 19:42:07,370 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] INBOUND SETTINGS: ack=true
  * 2021-03-26 19:42:07,371 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] READ_COMPLETE
  * 2021-03-26 19:42:07,371 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] FLUSH
  * 2021-03-26 19:42:07,371 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 - R:/127.0.0.1:57266] READ_REQUEST
+ * 2021-03-26 19:42:07,396 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 ! R:/127.0.0.1:57266] INACTIVE
+ * 2021-03-26 19:42:07,396 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xfdbee21a, L:/127.0.0.1:8080 ! R:/127.0.0.1:57266] UNREGISTERED
  * </pre>
  */
 public final class DebuggingExampleServer {
 
     static {
-        // 1. (optional) Disables the AsyncContext associated with individual request/responses to reduce stack-trace
-        // depth and simplify execution tracing. This will disable/break some features such as request tracing,
-        // authentication, propagated timeouts, etc. that rely upon the Async context so should only be disabled when
-        // necessary for debugging
-        /* AsyncContext.disable(); */
+        /*
+         * 1. (optional) Disables the AsyncContext associated with individual request/responses to reduce stack-trace
+         * depth and simplify execution tracing. This will disable/break some features such as request tracing,
+         * authentication, propagated timeouts, etc. that rely upon the AsyncContext so should only be disabled when
+         * necessary for debugging:
+         */
+        // AsyncContext.disable();
     }
 
     public static void main(String... args) throws Exception {
         HttpServers.forPort(8080)
-                // 2. (optional) Disables most asynchronous offloading to simplify execution tracing
-                /* .executionStrategy(HttpExecutionStrategies.noOffloadsStrategy()) */
-                // 3. Enables detailed logging of I/O and I/O states.
-                // Be sure to also enable the logger in your logging config file (log4j2.xml for this example)
+                /*
+                 * 2. Disables most asynchronous offloading to simplify execution tracing. Changing this may
+                 * significantly change application behavior and introduce unexpected blocking. It is most useful for
+                 * being able to directly trace through situations that would normally involve a thread handoff.
+                 */
+                // .executionStrategy(HttpExecutionStrategies.noOffloadsStrategy())
+
+                /*
+                 * 3. Enables detailed logging of I/O and I/O states.
+                 * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
+                 */
                 .enableWireLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
-                // 4. Enables detailed logging of HTTP2 frames.
-                // Be sure to also enable the logger in your logging config file (log4j2.xml for this example)
+
+                /*
+                 * 4. Enables detailed logging of HTTP2 frames.
+                 * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
+                 */
                 .protocols(HttpProtocolConfigs.h2()
-                        .enableFrameLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+                        .enableFrameLogging("servicetalk-examples-h2-frame-logger", TRACE, Boolean.TRUE::booleanValue)
                         .build())
                 .listenAndAwait((ctx, request, responseFactory) -> {
                     String who = request.payloadBody(textDeserializer());

--- a/servicetalk-examples/http/debugging/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/debugging/src/main/resources/log4j2.xml
@@ -21,8 +21,9 @@
     </Console>
   </Appenders>
   <Loggers>
-    <!-- Enables all wire logging messages -->
+    <!-- Enables wire logging and h2-frame logging messages -->
     <Logger name="servicetalk-examples-wire-logger" level="TRACE"/>
+    <Logger name="servicetalk-examples-h2-frame-logger" level="TRACE"/>
 
     <!-- Use `-Dservicetalk.logger.level=INFO` to change the root logger level via command line  -->
     <Root level="${sys:servicetalk.logger.level:-DEBUG}">


### PR DESCRIPTION
Motivation:

Fixing a few typos, adding links to appropriate features in javadoc,
clarifying the difference between wire-logger and h2-frame-logger.

Modifications:

- Fix typos in `index.adoc` and `log4j2.xml` name;
- Add links in javadoc for all demonstrated features;
- Use a different name for h2 frame logger;
- Use another comment style to highlight comments for demonstrated
features and let IDE use shortcut to uncomment the code line;
- Add `CLOSE/INACTIVE/UNREGISTERED` wire logger events;

Result:

More details in the example.