### PR TITLE
Reduce initial size of listeners queue in `WriteStreamSubscriber`

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -276,8 +276,10 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
          *     {@link #WRITE_BOUNDARY}, listener1, listener2, {@link #WRITE_BOUNDARY}, listener3 ...
          * </pre>
          * We assume that no listener for a write is added after that write is completed (a.k.a late listeners).
+         * Most of the messages have 3 listeners (headers, one payload body chunk, trailers). Messages with large
+         * streaming payload body may have more listeners. However, the MIN_INITIAL_CAPACITY of ArrayDeque is 8.
          */
-        private final Deque<GenericFutureListener<?>> listenersOnWriteBoundaries = new ArrayDeque<>();
+        private final Deque<GenericFutureListener<?>> listenersOnWriteBoundaries = new ArrayDeque<>(8);
         private final WriteObserver observer;
         private final UnaryOperator<Throwable> enrichProtocolError;
 


### PR DESCRIPTION
Motivation:

Most of the write HTTP messages have 3 listeners, because it consist of
headers, one payload body chunk (can be empty), and trailers. `ArrayDeque`
defines `MIN_INITIAL_CAPACITY = 8` internally. It's sufficient for most
use-cases. Messages with large streaming payload body may have more
listeners, but those messages have higher overhead anyway (flush-on-each,
etc.). Therefore, it's ok for them to resize the queue, if necessary.

Modifications:

- Define the default size of 8 for `listenersOnWriteBoundaries` in
`WriteStreamSubscriber.AllWritePromise`;

Result:

Less allocation per each message write.