### PR TITLE
Update JMH 1.28 -> 1.29 and me.champeau.jmh plugin 0.5.3 -> 0.6.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ jaxRsVersion=2.1.6
 jerseyVersion=2.32
 jsonUnitVersion=2.8.1
 
-jmhCoreVersion=1.28
+jmhCoreVersion=1.29
 junitVersion=4.13.2
 junit5Version=5.7.1
 testngVersion=6.14.3

--- a/servicetalk-benchmarks/build.gradle
+++ b/servicetalk-benchmarks/build.gradle
@@ -16,7 +16,7 @@
 
 plugins {
   id "com.github.johnrengelman.shadow" version "6.1.0"
-  id "me.champeau.gradle.jmh" version "0.5.3"
+  id "me.champeau.jmh" version "0.6.3"
 }
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
@@ -43,11 +43,11 @@ dependencies {
 }
 
 jmh {
-  include = ".*Benchmark"
+  includes = [".*Benchmark"]
   jmhVersion = "$jmhCoreVersion"
-  jvmArgsPrepend = "-Dio.netty.maxDirectMemory=9223372036854775807 " +
-                   "-Djmh.executor=CUSTOM " +
-                   "-Djmh.executor.class=io.servicetalk.benchmark.concurrent.AsyncContextFriendlyExecutor"
+  jvmArgsPrepend = ["-Dio.netty.maxDirectMemory=9223372036854775807 " +
+                    "-Djmh.executor=CUSTOM " +
+                    "-Djmh.executor.class=io.servicetalk.benchmark.concurrent.AsyncContextFriendlyExecutor"]
 }
 
 jmhJar {


### PR DESCRIPTION
Motivation:

0.5.x plugin version can not run newer JMH versions.