### PR TITLE
Implement `CharSequences#parseLong(CharSequence)`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ jaxRsVersion=2.1.6
 jerseyVersion=2.32
 jsonUnitVersion=2.8.1
 
-jmhCoreVersion=1.28
+jmhCoreVersion=1.29
 junitVersion=4.13.2
 junit5Version=5.7.1
 testngVersion=6.14.3

--- a/servicetalk-benchmarks/build.gradle
+++ b/servicetalk-benchmarks/build.gradle
@@ -16,7 +16,7 @@
 
 plugins {
   id "com.github.johnrengelman.shadow" version "6.1.0"
-  id "me.champeau.gradle.jmh" version "0.5.3"
+  id "me.champeau.jmh" version "0.6.3"
 }
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
@@ -43,11 +43,11 @@ dependencies {
 }
 
 jmh {
-  include = ".*Benchmark"
+  includes = [".*Benchmark"]
   jmhVersion = "$jmhCoreVersion"
-  jvmArgsPrepend = "-Dio.netty.maxDirectMemory=9223372036854775807 " +
-                   "-Djmh.executor=CUSTOM " +
-                   "-Djmh.executor.class=io.servicetalk.benchmark.concurrent.AsyncContextFriendlyExecutor"
+  jvmArgsPrepend = ["-Dio.netty.maxDirectMemory=9223372036854775807 " +
+                    "-Djmh.executor=CUSTOM " +
+                    "-Djmh.executor.class=io.servicetalk.benchmark.concurrent.AsyncContextFriendlyExecutor"]
 }
 
 jmhJar {

--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/buffer/api/CharSequencesParseLongBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/buffer/api/CharSequencesParseLongBenchmark.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.buffer.api;
+
+import io.netty.util.AsciiString;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.nio.charset.StandardCharsets;
+
+import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
+
+/*
+ * This benchmark compares CharSequences#parseLong(CharSequence) and Long.parseLong(String):
+ *
+ * Benchmark                              (value)   Mode  Cnt         Score         Error  Units
+ * javaParseLongString       -9223372036854775808  thrpt    5  24524373.658 ±  490417.495  ops/s
+ *   stParseLongString       -9223372036854775808  thrpt    5  19168467.144 ±  594280.502  ops/s
+ *
+ * javaParseLongString        9223372036854775807  thrpt    5  15573374.506 ± 1049847.936  ops/s
+ *   stParseLongString        9223372036854775807  thrpt    5  16697590.692 ±  231851.871  ops/s
+ *
+ * javaParseLongAsciiBuffer  -9223372036854775808  thrpt    5  10066121.790 ±  117298.619  ops/s
+ *   stParseLongAsciiBuffer  -9223372036854775808  thrpt    5  18155698.684 ±  436706.324  ops/s
+ *
+ * javaParseLongAsciiBuffer   9223372036854775807  thrpt    5  10730908.955 ±  116656.679  ops/s
+ *   stParseLongAsciiBuffer   9223372036854775807  thrpt    5  19615079.368 ±  459852.132  ops/s
+ *
+ * javaParseLongAsciiString  -9223372036854775808  thrpt    5  17546166.613 ±  444219.547  ops/s
+ *   stParseLongAsciiString  -9223372036854775808  thrpt    5  19169592.065 ±  499213.146  ops/s
+ *
+ * javaParseLongAsciiString   9223372036854775807  thrpt    5  22611841.803 ±  503643.380  ops/s
+ *   stParseLongAsciiString   9223372036854775807  thrpt    5  21140372.163 ± 2921605.423  ops/s
+ *
+ *
+ *
+ * javaParseLongString                      -8192  thrpt    5  69974528.501 ± 6167380.442  ops/s
+ *   stParseLongString                      -8192  thrpt    5  73735070.747 ± 2968101.803  ops/s
+ *
+ * javaParseLongString                       8192  thrpt    5  70138556.799 ±  918507.526  ops/s
+ *   stParseLongString                       8192  thrpt    5  66549636.755 ± 1023126.881  ops/s
+ *
+ * javaParseLongAsciiBuffer                 -8192  thrpt    5  15418127.631 ±  271577.020  ops/s
+ *   stParseLongAsciiBuffer                 -8192  thrpt    5  58372951.121 ±  920176.976  ops/s
+ *
+ * javaParseLongAsciiBuffer                  8192  thrpt    5  15203126.170 ±  289559.904  ops/s
+ *   stParseLongAsciiBuffer                  8192  thrpt    5  56709314.826 ±  813985.642  ops/s
+ *
+ * javaParseLongAsciiString                 -8192  thrpt    5  70984579.239 ± 1614728.648  ops/s
+ *   stParseLongAsciiString                 -8192  thrpt    5  68602480.185 ± 1052183.360  ops/s
+ *
+ * javaParseLongAsciiString                  8192  thrpt    5  75324292.593 ±  592329.213  ops/s
+ *   stParseLongAsciiString                  8192  thrpt    5  80748587.669 ± 1076241.647  ops/s
+ */
+@Fork(value = 1)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 3)
+@Measurement(iterations = 5, time = 3)
+@BenchmarkMode(Mode.Throughput)
+public class CharSequencesParseLongBenchmark {
+
+    @Param({"-9223372036854775808", "9223372036854775807", "-8192", "8192"})
+    private String value;
+
+    private CharSequence asciiBuffer;
+    private CharSequence asciiString;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        asciiBuffer = newAsciiString(value);
+        asciiString = new AsciiString(value.getBytes(StandardCharsets.US_ASCII));
+    }
+
+    @Benchmark
+    public long javaParseLongString() {
+        return Long.parseLong(value);
+    }
+
+    @Benchmark
+    public long stParseLongString() {
+        return CharSequences.parseLong(value);
+    }
+
+    @Benchmark
+    public long javaParseLongAsciiBuffer() {
+        return Long.parseLong(asciiBuffer.toString());
+    }
+
+    @Benchmark
+    public long stParseLongAsciiBuffer() {
+        return CharSequences.parseLong(asciiBuffer);
+    }
+
+    @Benchmark
+    public long javaParseAsciiString() {
+        return Long.parseLong(asciiString.toString());
+    }
+
+    @Benchmark
+    public long stParseLongAsciiString() {
+        return CharSequences.parseLong(asciiString);
+    }
+}

--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/buffer/api/CharSequencesParseLongBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/buffer/api/CharSequencesParseLongBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ public class CharSequencesParseLongBenchmark {
     }
 
     @Benchmark
-    public long javaParseAsciiString() {
+    public long javaParseLongAsciiString() {
         return Long.parseLong(asciiString.toString());
     }
 

--- a/servicetalk-buffer-api/build.gradle
+++ b/servicetalk-buffer-api/build.gradle
@@ -22,6 +22,8 @@ dependencies {
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
 
   testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
+  testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testFixturesImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
@@ -443,7 +443,8 @@ public final class CharSequences {
     /**
      * Parses the {@link CharSequence} argument as a signed decimal {@code long}.
      *
-     * <p> This is the equivalent of {@link Long#parseLong(String)} that does not require to {@link String} conversion.
+     * <p> This is the equivalent of {@link Long#parseLong(String)} that does not require to
+     * {@link CharSequence#toString()} conversion.
      *
      * @param cs a {@code CharSequence} containing the {@code long} value to be parsed
      * @return {code long} representation of the passed {@link CharSequence}

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
@@ -13,6 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.servicetalk.buffer.api;
 
 import java.util.ArrayList;
@@ -23,6 +38,7 @@ import static io.servicetalk.buffer.api.AsciiBuffer.EMPTY_ASCII_BUFFER;
 import static io.servicetalk.buffer.api.AsciiBuffer.hashCodeAscii;
 import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.DEFAULT_RO_ALLOCATOR;
 import static java.lang.Character.toUpperCase;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 
@@ -419,5 +435,75 @@ public final class CharSequences {
             }
         }
         return true;
+    }
+
+    /**
+     * Parses the {@link CharSequence} argument as a signed decimal {@code long}.
+     *
+     * <p> This is the equivalent of {@link Long#parseLong(String)} that does not require to {@link String} conversion.
+     *
+     * @param cs a {@code CharSequence} containing the {@code long} value to be parsed
+     * @return {code long} representation of the passed {@link CharSequence}
+     * @throws NumberFormatException if the passed {@link CharSequence} cannot be parsed into {@code long}
+     */
+    public static long parseLong(final CharSequence cs) throws NumberFormatException {
+        if (isAsciiString(cs)) {
+            return parseLong(((AsciiBuffer) cs).unwrap());
+        } else if (cs.getClass() == String.class) {
+            return Long.parseLong(cs.toString());
+        } else {
+            return Long.parseLong(cs.toString());
+        }
+    }
+
+    private static long parseLong(final Buffer buffer) {
+        final int length = buffer.readableBytes();
+        if (length <= 0) {
+            throw new NumberFormatException("Illegal length of the CharSequence: " + length + " (expected > 0)");
+        }
+
+        final int start = buffer.readerIndex();
+        final int end = buffer.writerIndex();
+
+        int i = start;
+        final byte firstCh = buffer.getByte(i);
+        final boolean negative = firstCh == '-';
+        if ((negative || firstCh == '+') && ++i == end) {
+            throw illegalInput(buffer);
+        }
+
+        return parseLong(buffer, i, end, 10, negative);
+    }
+
+    private static long parseLong(final Buffer buffer, final int start, final int end, final int radix,
+                                  final boolean negative) {
+        final long min = Long.MIN_VALUE / radix;
+        long result = 0;
+        int currOffset = start;
+        while (currOffset < end) {
+            final int digit = Character.digit((char) (buffer.getByte(currOffset++) & 0xFF), radix);
+            if (digit < 0) {
+                throw illegalInput(buffer);
+            }
+            if (min > result) {
+                throw illegalInput(buffer);
+            }
+            long next = result * radix - digit;
+            if (next > result) {
+                throw illegalInput(buffer);
+            }
+            result = next;
+        }
+        if (!negative) {
+            result = -result;
+            if (result < 0) {
+                throw illegalInput(buffer);
+            }
+        }
+        return result;
+    }
+
+    private static NumberFormatException illegalInput(final Buffer buffer) {
+        return new NumberFormatException("Illegal input: " + buffer.toString(US_ASCII));
     }
 }

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
@@ -449,8 +449,6 @@ public final class CharSequences {
     public static long parseLong(final CharSequence cs) throws NumberFormatException {
         if (isAsciiString(cs)) {
             return parseLong(((AsciiBuffer) cs).unwrap());
-        } else if (cs.getClass() == String.class) {
-            return Long.parseLong(cs.toString());
         } else {
             return Long.parseLong(cs.toString());
         }
@@ -462,9 +460,10 @@ public final class CharSequences {
             throw new NumberFormatException("Illegal length of the CharSequence: " + length + " (expected > 0)");
         }
 
-        final int start = buffer.readerIndex();
-        final int end = buffer.writerIndex();
+        return parseLong(buffer, buffer.readerIndex(), buffer.writerIndex(), 10);
+    }
 
+    private static long parseLong(final Buffer buffer, final int start, final int end, final int radix) {
         int i = start;
         final byte firstCh = buffer.getByte(i);
         final boolean negative = firstCh == '-';
@@ -472,16 +471,10 @@ public final class CharSequences {
             throw illegalInput(buffer);
         }
 
-        return parseLong(buffer, i, end, 10, negative);
-    }
-
-    private static long parseLong(final Buffer buffer, final int start, final int end, final int radix,
-                                  final boolean negative) {
         final long min = Long.MIN_VALUE / radix;
         long result = 0;
-        int currOffset = start;
-        while (currOffset < end) {
-            final int digit = Character.digit((char) (buffer.getByte(currOffset++) & 0xFF), radix);
+        while (i < end) {
+            final int digit = Character.digit((char) (buffer.getByte(i++) & 0xFF), radix);
             if (digit < 0) {
                 throw illegalInput(buffer);
             }

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
@@ -15,14 +15,19 @@
  */
 package io.servicetalk.buffer.api;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.function.Function;
 
+import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.buffer.api.CharSequences.split;
+import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.DEFAULT_RO_ALLOCATOR;
 import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
 
 public class CharSequencesTest {
 
@@ -151,5 +156,32 @@ public class CharSequencesTest {
     @Test
     public void splitAsciiWithTrim() {
         splitWithTrim(CharSequences::newAsciiString);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = { Long.MIN_VALUE, Long.MIN_VALUE + 1,
+            -101, -100, -99, -11, -10, -9, -1, 0, 1, 9, 10, 11, 99, 100, 101,
+            Long.MAX_VALUE - 1, Long.MAX_VALUE })
+    public void parseLong(final long value) {
+        final String strValue = String.valueOf(value);
+        assertThat("Unexpected value for String representation", CharSequences.parseLong(strValue), is(value));
+        assertThat("Unexpected value for AsciiBuffer representation",
+                CharSequences.parseLong(newAsciiString(strValue)), is(value));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "-0", "+0", "+1", "+10" })
+    public void parseLongSigned(final String value) {
+        assertThat("Unexpected value for String representation",
+                CharSequences.parseLong(value), is(Long.parseLong(value)));
+        assertThat("Unexpected value for AsciiBuffer representation",
+                CharSequences.parseLong(newAsciiString(value)), is(Long.parseLong(value)));
+    }
+
+    @Test
+    public void parseLongFromSlice() {
+        Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("text42text");
+        assertThat("Unexpected value for AsciiBuffer representation",
+                CharSequences.parseLong(newAsciiString(buffer.slice(4, 2))), is(42L));
     }
 }

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
@@ -28,6 +28,7 @@ import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CharSequencesTest {
 
@@ -176,6 +177,13 @@ public class CharSequencesTest {
                 CharSequences.parseLong(value), is(Long.parseLong(value)));
         assertThat("Unexpected value for AsciiBuffer representation",
                 CharSequences.parseLong(newAsciiString(value)), is(Long.parseLong(value)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "-", "+" })
+    public void parseLongSignOnly(final String value) {
+        assertThrows(NumberFormatException.class, () -> CharSequences.parseLong(value));
+        assertThrows(NumberFormatException.class, () -> CharSequences.parseLong(newAsciiString(value)));
     }
 
     @Test

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
@@ -181,7 +181,10 @@ public class CharSequencesTest {
     @Test
     public void parseLongFromSlice() {
         Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("text42text");
+        // FIXME: ReadOnlyByteBuffer#slice() does not account for the slice offset
+        // assertThat("Unexpected value for AsciiBuffer representation",
+        //         CharSequences.parseLong(newAsciiString(buffer.slice(4, 2))), is(42L));
         assertThat("Unexpected value for AsciiBuffer representation",
-                CharSequences.parseLong(newAsciiString(buffer.slice(4, 2))), is(42L));
+                CharSequences.parseLong(newAsciiString(buffer).subSequence(4, 6)), is(42L));
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
@@ -24,12 +24,12 @@ import static io.servicetalk.buffer.api.CharSequences.contentEquals;
 import static io.servicetalk.buffer.api.CharSequences.contentEqualsIgnoreCase;
 import static io.servicetalk.buffer.api.CharSequences.equalsIgnoreCaseLower;
 import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
+import static io.servicetalk.buffer.api.CharSequences.parseLong;
 import static io.servicetalk.http.api.HeaderUtils.validateCookieNameAndValue;
 import static io.servicetalk.http.api.HeaderUtils.validateCookieTokenAndHeaderName;
 import static io.servicetalk.http.api.HttpSetCookie.SameSite.Lax;
 import static io.servicetalk.http.api.HttpSetCookie.SameSite.None;
 import static io.servicetalk.http.api.HttpSetCookie.SameSite.Strict;
-import static java.lang.Long.parseLong;
 
 /**
  * Default implementation of {@link HttpSetCookie}.
@@ -230,7 +230,7 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                             expires = setCookieString.subSequence(begin, i);
                             break;
                         case ParsingMaxAge:
-                            maxAge = parseLong(setCookieString.subSequence(begin, i).toString());
+                            maxAge = parseLong(setCookieString.subSequence(begin, i));
                             break;
                         case ParsingSameSite:
                             sameSite = fromSequence(setCookieString, begin, i);
@@ -280,7 +280,7 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                     sameSite = fromSequence(setCookieString, begin, i);
                     break;
                 case ParsingMaxAge:
-                    maxAge = parseLong(setCookieString.subSequence(begin, i).toString());
+                    maxAge = parseLong(setCookieString.subSequence(begin, i));
                     break;
                 default:
                     if (name == null) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponseStatus.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponseStatus.java
@@ -19,6 +19,7 @@ import io.servicetalk.buffer.api.Buffer;
 
 import javax.annotation.Nullable;
 
+import static io.servicetalk.buffer.api.CharSequences.parseLong;
 import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.PREFER_HEAP_RO_ALLOCATOR;
 import static io.servicetalk.http.api.BufferUtils.writeReadOnlyBuffer;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.fromStatusCode;
@@ -508,7 +509,7 @@ public final class HttpResponseStatus {
      * @return a {@link HttpResponseStatus} representation of {@code statusCode}.
      */
     public static HttpResponseStatus of(final CharSequence statusCode) {
-        int statusCodeInt = Integer.parseInt(statusCode.toString());
+        int statusCodeInt = (int) parseLong(statusCode);
         final HttpResponseStatus cached = valueOf(statusCodeInt);
         return cached != null ? cached : new HttpResponseStatus(statusCodeInt, "unknown");
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.buffer.api.CharSequences.parseLong;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Publisher.fromIterable;
 import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
@@ -53,7 +54,6 @@ import static io.servicetalk.http.api.HttpRequestMethod.TRACE;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATIONAL_1XX;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
-import static java.lang.Long.parseLong;
 
 final class HeaderUtils {
     static final Predicate<Object> LAST_CHUNK_PREDICATE = p -> p instanceof HttpHeaders;
@@ -305,7 +305,7 @@ final class HeaderUtils {
         }
         final long value;
         try {   // optimistically assume the value can be parsed to skip indexOf check
-             value = parseLong(firstValue.toString());
+             value = parseLong(firstValue);
         } catch (NumberFormatException e) {
             if (CharSequences.indexOf(firstValue, ',', 0) >= 0) {
                 throw multipleCL(firstValue, null);


### PR DESCRIPTION
Motivation:

Our `HttpHeaders` API uses `CharSequence`. In order for users to parse
the value (like, `Content-Length`) they have to convert `CharSequence`
to `String` for `Long.parseLong(String)` API. This approach does an extra
copy of data from underlying `Buffer`. We can avoid it.

Modifications:

- Add `CharSequences#parseLong(CharSequence)` API that does not force
`CharSequence#toString()` conversion;
- Add tests to validate new API;
- Use the new API in all places when we parse an `AsciiBuffer` or
`AsciiString`;

Result:

Less allocations of `String`.

This PR depends on #1468 (ignore first commit).