### PR TITLE
CharSequences.newAsciiString accept CharSequence

### DIFF
--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
@@ -59,10 +59,10 @@ public final class CharSequences {
      * Create a new {@link CharSequence} from the specified {@code input}, supporting only 8-bit ASCII characters, and
      * with a case-insensitive {@code hashCode}.
      *
-     * @param input a string containing only 8-bit ASCII characters.
+     * @param input a character sequence containing only 8-bit ASCII characters.
      * @return a {@link CharSequence}
      */
-    public static CharSequence newAsciiString(final String input) {
+    public static CharSequence newAsciiString(final CharSequence input) {
         return newAsciiString(DEFAULT_RO_ALLOCATOR.fromAscii(input));
     }
 
@@ -89,7 +89,7 @@ public final class CharSequences {
 
     /**
      * Check if the provided {@link CharSequence} is an AsciiString,
-     * result of a call to {@link #newAsciiString(String)}.
+     * result of a call to {@link #newAsciiString(CharSequence)}.
      *
      * @param sequence The {@link CharSequence} to check.
      * @return {@code true} if the check passes.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
@@ -352,7 +352,7 @@ final class GrpcUtils {
 
         if (builder.length() > CONTENT_ENCODING_SEPARATOR.length()) {
             builder.setLength(builder.length() - CONTENT_ENCODING_SEPARATOR.length());
-            return newAsciiString(builder.toString());
+            return newAsciiString(builder);
         }
 
         return null;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpRequesterFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpRequesterFilter.java
@@ -126,7 +126,7 @@ public final class ContentCodingHttpRequesterFilter
             builder.append(enc.name());
         }
 
-        return builder.length() > 0 ? newAsciiString(builder.toString()) : null;
+        return builder.length() > 0 ? newAsciiString(builder) : null;
     }
 
     private static void encodePayloadContentIfAvailable(final StreamingHttpRequest request,


### PR DESCRIPTION
Motivation:
Currently the method `CharSequences.newAsciiString` takes a String
argument but the implementation is fine with any CharSequence. Allowing
the method to accept CharSquence avoids some cases of unncessary
conversion to String.

Modifications:
The String argument is replaced with a more general CharSequence.
Existing code using this method will need to be recompiled.

Result:
CharSequences.newAsciiString() generality is improved.