### PR TITLE
H1SpecExceptions add option to allow LF without proceeding CR

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1SpecExceptions.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1SpecExceptions.java
@@ -21,9 +21,12 @@ package io.servicetalk.http.netty;
 public final class H1SpecExceptions {
 
     private final boolean allowPrematureClosureBeforePayloadBody;
+    private final boolean allowLFWithoutCR;
 
-    private H1SpecExceptions(final boolean allowPrematureClosureBeforePayloadBody) {
+    private H1SpecExceptions(final boolean allowPrematureClosureBeforePayloadBody,
+                             final boolean allowLFWithoutCR) {
         this.allowPrematureClosureBeforePayloadBody = allowPrematureClosureBeforePayloadBody;
+        this.allowLFWithoutCR = allowLFWithoutCR;
     }
 
     /**
@@ -38,20 +41,63 @@ public final class H1SpecExceptions {
     }
 
     /**
+     * Allow {@code LF} without a proceeding {@code CR} as described in
+     * <a href="https://tools.ietf.org/html/rfc7230#section-3.5">HTTP/1.x Message Parsing Robustness</a>:
+     * <pre>
+     *   Although the line terminator for the start-line and header fields is
+     *    the sequence CRLF, a recipient MAY recognize a single LF as a line
+     *    terminator and ignore any preceding CR.
+     * </pre>
+     * @return {@code true} to allow {@code LF} without a proceeding {@code CR}.
+     */
+    public boolean allowLFWithoutCR() {
+        return allowLFWithoutCR;
+    }
+
+    /**
      * Builder for {@link H1SpecExceptions}.
      */
     public static final class Builder {
 
         private boolean allowPrematureClosureBeforePayloadBody;
+        private boolean allowLFWithoutCR;
 
         /**
          * Allows interpreting connection closures as the end of HTTP/1.1 messages if the receiver did not receive any
          * part of the payload body before the connection closure.
-         *
+         * @deprecated Use {@link #prematureClosureBeforePayloadBody(boolean)}.
          * @return {@code this}
          */
+        @Deprecated
         public Builder allowPrematureClosureBeforePayloadBody() {
-            this.allowPrematureClosureBeforePayloadBody = true;
+            return prematureClosureBeforePayloadBody(true);
+        }
+
+        /**
+         * Allows interpreting connection closures as the end of HTTP/1.1 messages if the receiver did not receive any
+         * part of the payload body before the connection closure.
+         * @param allow {@code true} if the receiver should interpret connection closures as the end of HTTP/1.1
+         * messages if it did not receive any part of the payload body before the connection closure.
+         * @return {@code this}
+         */
+        public Builder prematureClosureBeforePayloadBody(boolean allow) {
+            this.allowPrematureClosureBeforePayloadBody = allow;
+            return this;
+        }
+
+        /**
+         * Allow {@code LF} without a proceeding {@code CR} as described in
+         * <a href="https://tools.ietf.org/html/rfc7230#section-3.5">HTTP/1.x Message Parsing Robustness</a>:
+         * <pre>
+         *   Although the line terminator for the start-line and header fields is
+         *    the sequence CRLF, a recipient MAY recognize a single LF as a line
+         *    terminator and ignore any preceding CR.
+         * </pre>
+         * @param allow {@code true} to allow {@code LF} without a proceeding {@code CR}.
+         * @return {@code this}
+         */
+        public Builder lfWithoutCR(boolean allow) {
+            this.allowLFWithoutCR = allow;
             return this;
         }
 
@@ -61,7 +107,7 @@ public final class H1SpecExceptions {
          * @return a new {@link H1SpecExceptions}
          */
         public H1SpecExceptions build() {
-            return new H1SpecExceptions(allowPrematureClosureBeforePayloadBody);
+            return new H1SpecExceptions(allowPrematureClosureBeforePayloadBody, allowLFWithoutCR);
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1SpecExceptions.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1SpecExceptions.java
@@ -45,8 +45,8 @@ public final class H1SpecExceptions {
      * <a href="https://tools.ietf.org/html/rfc7230#section-3.5">HTTP/1.x Message Parsing Robustness</a>:
      * <pre>
      *   Although the line terminator for the start-line and header fields is
-     *    the sequence CRLF, a recipient MAY recognize a single LF as a line
-     *    terminator and ignore any preceding CR.
+     *   the sequence CRLF, a recipient MAY recognize a single LF as a line
+     *   terminator and ignore any preceding CR.
      * </pre>
      * @return {@code true} to allow {@code LF} without a proceeding {@code CR}.
      */
@@ -65,12 +65,12 @@ public final class H1SpecExceptions {
         /**
          * Allows interpreting connection closures as the end of HTTP/1.1 messages if the receiver did not receive any
          * part of the payload body before the connection closure.
-         * @deprecated Use {@link #prematureClosureBeforePayloadBody(boolean)}.
+         * @deprecated Use {@link #allowPrematureClosureBeforePayloadBody(boolean)}.
          * @return {@code this}
          */
         @Deprecated
         public Builder allowPrematureClosureBeforePayloadBody() {
-            return prematureClosureBeforePayloadBody(true);
+            return allowPrematureClosureBeforePayloadBody(true);
         }
 
         /**
@@ -80,7 +80,7 @@ public final class H1SpecExceptions {
          * messages if it did not receive any part of the payload body before the connection closure.
          * @return {@code this}
          */
-        public Builder prematureClosureBeforePayloadBody(boolean allow) {
+        public Builder allowPrematureClosureBeforePayloadBody(boolean allow) {
             this.allowPrematureClosureBeforePayloadBody = allow;
             return this;
         }
@@ -90,13 +90,13 @@ public final class H1SpecExceptions {
          * <a href="https://tools.ietf.org/html/rfc7230#section-3.5">HTTP/1.x Message Parsing Robustness</a>:
          * <pre>
          *   Although the line terminator for the start-line and header fields is
-         *    the sequence CRLF, a recipient MAY recognize a single LF as a line
-         *    terminator and ignore any preceding CR.
+         *   the sequence CRLF, a recipient MAY recognize a single LF as a line
+         *   terminator and ignore any preceding CR.
          * </pre>
          * @param allow {@code true} to allow {@code LF} without a proceeding {@code CR}.
          * @return {@code this}
          */
-        public Builder lfWithoutCR(boolean allow) {
+        public Builder allowLFWithoutCR(boolean allow) {
             this.allowLFWithoutCR = allow;
             return this;
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientChannelInitializer.java
@@ -47,7 +47,8 @@ final class HttpClientChannelInitializer implements ChannelInitializer {
             final ChannelPipeline pipeline = channel.pipeline();
             pipeline.addLast(new HttpResponseDecoder(methodQueue, alloc, config.headersFactory(),
                     config.maxStartLineLength(), config.maxHeaderFieldLength(),
-                    config.specExceptions().allowPrematureClosureBeforePayloadBody(), closeHandler));
+                    config.specExceptions().allowPrematureClosureBeforePayloadBody(),
+                    config.specExceptions().allowLFWithoutCR(), closeHandler));
             pipeline.addLast(new HttpRequestEncoder(methodQueue,
                     config.headersEncodedSizeEstimate(), config.trailersEncodedSizeEstimate(), closeHandler));
         });

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -426,8 +426,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                 if (longLFIndex < 0) {
                     return;
                 }
-                final int lfIndex = crlfIndex(longLFIndex);
-                consumeCRLF(buffer, lfIndex);
+                consumeCRLF(buffer, crlfIndex(longLFIndex));
                 currentState = State.READ_CHUNK_SIZE;
                 break;
             }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -132,6 +132,15 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
     private final HttpHeadersFactory headersFactory;
     private final CloseHandler closeHandler;
     private final boolean allowPrematureClosureBeforePayloadBody;
+    /**
+     * <a href="https://tools.ietf.org/html/rfc7230#section-3.5>HTTP/1.x Message Parsing Robustness</a>
+     * <pre>
+     *   Although the line terminator for the start-line and header fields is
+     *    the sequence CRLF, a recipient MAY recognize a single LF as a line
+     *    terminator and ignore any preceding CR.
+     * </pre>
+     */
+    private final boolean allowLFWithoutCR;
     @Nullable
     private T message;
     @Nullable
@@ -166,9 +175,10 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
     /**
      * Creates a new instance with the specified parameters.
      */
-    protected HttpObjectDecoder(final ByteBufAllocator alloc, final HttpHeadersFactory headersFactory,
-                                final int maxStartLineLength, final int maxHeaderFieldLength,
-                                final boolean allowPrematureClosureBeforePayloadBody, final CloseHandler closeHandler) {
+    HttpObjectDecoder(final ByteBufAllocator alloc, final HttpHeadersFactory headersFactory,
+                      final int maxStartLineLength, final int maxHeaderFieldLength,
+                      final boolean allowPrematureClosureBeforePayloadBody, final boolean allowLFWithoutCR,
+                      final CloseHandler closeHandler) {
         super(alloc);
         this.closeHandler = requireNonNull(closeHandler);
         if (maxStartLineLength <= 0) {
@@ -181,6 +191,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         this.maxStartLineLength = maxStartLineLength;
         this.maxHeaderFieldLength = maxHeaderFieldLength;
         this.allowPrematureClosureBeforePayloadBody = allowPrematureClosureBeforePayloadBody;
+        this.allowLFWithoutCR = allowLFWithoutCR;
     }
 
     final HttpHeadersFactory headersFactory() {
@@ -231,8 +242,8 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                 currentState = State.READ_INITIAL;
             }
             case READ_INITIAL: {
-                final int lfIndex = findCRLF(buffer, maxStartLineLength);
-                if (lfIndex < 0) {
+                final long longLFIndex = findCRLF(buffer, maxStartLineLength, allowLFWithoutCR);
+                if (longLFIndex < 0) {
                     handlePartialInitialLine(ctx, buffer);
                     return;
                 }
@@ -242,7 +253,8 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                 // request-line = method SP request-target SP HTTP-version CRLF
                 // https://tools.ietf.org/html/rfc7230#section-3.1.2
                 // status-line = HTTP-version SP status-code SP reason-phrase CRLF
-                final int nonControlIndex = lfIndex - 2;
+                final int lfIndex = crlfIndex(longLFIndex);
+                final int nonControlIndex = crlfBeforeIndex(longLFIndex);
                 final int aStart = buffer.readerIndex();    // We already skipped all preface control chars
                 // Look only for a WS, other checks will be done later by request/response decoder
                 final int aEnd = buffer.forEachByte(aStart + 1, nonControlIndex - aStart, FIND_WS);
@@ -375,10 +387,11 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
             // everything else after this point takes care of reading chunked content. basically, read chunk size,
             // read chunk, read and ignore the CRLF and repeat until 0
             case READ_CHUNK_SIZE: {
-                int lfIndex = findCRLF(buffer, MAX_HEX_CHARS_FOR_LONG);
-                if (lfIndex < 0) {
+                final long longLFIndex = findCRLF(buffer, MAX_HEX_CHARS_FOR_LONG, false);
+                if (longLFIndex < 0) {
                     return;
                 }
+                final int lfIndex = crlfIndex(longLFIndex);
                 long chunkSize = getChunkSize(buffer, lfIndex);
                 consumeCRLF(buffer, lfIndex);
                 this.chunkSize = chunkSize;
@@ -409,10 +422,11 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
             }
             case READ_CHUNK_DELIMITER: {
                 // Read the chunk delimiter
-                int lfIndex = findCRLF(buffer, CHUNK_DELIMETER_SIZE);
-                if (lfIndex < 0) {
+                final long longLFIndex = findCRLF(buffer, CHUNK_DELIMETER_SIZE, false);
+                if (longLFIndex < 0) {
                     return;
                 }
+                final int lfIndex = crlfIndex(longLFIndex);
                 consumeCRLF(buffer, lfIndex);
                 currentState = State.READ_CHUNK_SIZE;
                 break;
@@ -592,8 +606,8 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         }
     }
 
-    private void parseHeaderLine(final HttpHeaders headers, final ByteBuf buffer, final int lfIndex)
-            throws DecoderException {
+    private void parseHeaderLine(final HttpHeaders headers, final ByteBuf buffer, final int lfIndex,
+                                 final int nonControlIndex) throws DecoderException {
         // https://tools.ietf.org/html/rfc7230#section-3.2
         // header-field   = field-name ":" OWS field-value OWS
         //
@@ -613,7 +627,6 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         //    security vulnerabilities in request routing and response handling.
         // Additional checks will be done by header validator
 
-        final int nonControlIndex = lfIndex - 2;
         final int nameStart = buffer.readerIndex();
         final int nameEnd = buffer.forEachByte(nameStart, nonControlIndex - nameStart + 1, FIND_COLON);
         if (nameEnd < 0) {
@@ -665,13 +678,13 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
 
     @Nullable
     private State readHeaders(final ByteBuf buffer) {
-        int lfIndex = findCRLF(buffer, maxHeaderFieldLength);
-        if (lfIndex < 0) {
+        final long longLFIndex = findCRLF(buffer, maxHeaderFieldLength, allowLFWithoutCR);
+        if (longLFIndex < 0) {
             return null;
         }
         final T message = this.message;
         assert message != null;
-        if (!parseAllHeaders(buffer, message.headers(), lfIndex, maxHeaderFieldLength)) {
+        if (!parseAllHeaders(buffer, message.headers(), longLFIndex)) {
             return null;
         }
 
@@ -705,20 +718,20 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
 
     @Nullable
     private HttpHeaders readTrailingHeaders(final ByteBuf buffer) {
-        final int lfIndex = findCRLF(buffer, maxHeaderFieldLength);
-        if (lfIndex < 0) {
+        final long longLFIndex = findCRLF(buffer, maxHeaderFieldLength, allowLFWithoutCR);
+        if (longLFIndex < 0) {
             return null;
         }
-        if (lfIndex - 2 > buffer.readerIndex()) {
+        if (crlfBeforeIndex(longLFIndex) > buffer.readerIndex()) {
             HttpHeaders trailer = this.trailer;
             if (trailer == null) {
                 trailer = this.trailer = headersFactory.newTrailers();
             }
 
-            return parseAllHeaders(buffer, trailer, lfIndex, maxHeaderFieldLength) ? trailer : null;
+            return parseAllHeaders(buffer, trailer, longLFIndex) ? trailer : null;
         }
 
-        consumeCRLF(buffer, lfIndex);
+        consumeCRLF(buffer, crlfIndex(longLFIndex));
         // The RFC says the trailers are optional [1] so use an empty trailers instance from the headers factory.
         // [1] https://tools.ietf.org/html/rfc7230.html#section-4.1
         return trailer != null ? trailer : headersFactory.newEmptyTrailers();
@@ -729,29 +742,23 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
      *
      * @param buffer source of the headers
      * @param headers destination for parsed headers
-     * @param lfIndex the end of the current line
-     * @param maxHeaderFieldLength limit to the length of the headers
+     * @param longLFIndex result of {@link #findCRLF(ByteBuf, int, int, int, boolean)}
      * @return true if complete headers were processed otherwise false indicates incomplete parsing or error.
      */
-    private boolean parseAllHeaders(final ByteBuf buffer, final HttpHeaders headers, int lfIndex,
-                                    final int maxHeaderFieldLength) {
+    private boolean parseAllHeaders(final ByteBuf buffer, final HttpHeaders headers, long longLFIndex) {
         for (;;) {
-            if (lfIndex - 1 == buffer.readerIndex()) {
+            final int lfIndex = crlfIndex(longLFIndex);
+            final int nonControlIndex = crlfBeforeIndex(longLFIndex);
+            if (nonControlIndex < buffer.readerIndex()) {
                 consumeCRLF(buffer, lfIndex);
                 return true;
             }
-            final int nextLFIndex = findCRLF(buffer, lfIndex + 1, maxHeaderFieldLength, parsingLine);
-            parseHeaderLine(headers, buffer, lfIndex);
-            if (nextLFIndex < 0) {
+            longLFIndex = findCRLF(buffer, lfIndex + 1, maxHeaderFieldLength, parsingLine, allowLFWithoutCR);
+            parseHeaderLine(headers, buffer, lfIndex, nonControlIndex);
+            if (longLFIndex < 0) {
                 return false;
             }
             ++parsingLine;
-            if (nextLFIndex - 2 == lfIndex) {
-                // CRLF followed by CRLF, we are done.
-                consumeCRLF(buffer, nextLFIndex);
-                return true;
-            }
-            lfIndex = nextLFIndex;
         }
     }
 
@@ -795,16 +802,18 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         }
     }
 
-    private int findCRLF(final ByteBuf buffer, final int maxLineSize) {
+    private long findCRLF(final ByteBuf buffer, final int maxLineSize, final boolean allowLFWithoutCR) {
         if (cumulationIndex < 0) {
             cumulationIndex = buffer.readerIndex();
         }
-        final int lfIndex = findCRLF(buffer, cumulationIndex, maxLineSize, parsingLine);
-        cumulationIndex = lfIndex < 0 ? min(buffer.writerIndex(), cumulationIndex + maxLineSize) : lfIndex;
-        if (lfIndex >= 0) {
+        final long longLFIndex = findCRLF(buffer, cumulationIndex, maxLineSize, parsingLine, allowLFWithoutCR);
+        if (longLFIndex < 0) {
+            cumulationIndex = min(buffer.writerIndex(), cumulationIndex + maxLineSize);
+        } else {
+            cumulationIndex = crlfIndex(longLFIndex);
             ++parsingLine;
         }
-        return lfIndex;
+        return longLFIndex;
     }
 
     /**
@@ -815,15 +824,23 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
      * @param startIndex initial scanning index
      * @param maxLineSize maximum length of a line
      * @param parsingLine line count for error messages.
-     * @return the offset of the CRLF or < 0 if no CRLF found
+     * @param allowLFWithoutCR allow a LF without a proceeding CR to signify "end of line".
+     * @return
+     * <ul>
+     *     <li>{@code <0} if no [CR]?LF found</li>
+     *     <li>Use {@link #crlfIndex(long)} to extract the offset of the [CR]?LF and {@link #crlfBeforeIndex(long)}
+     *     to get the index immediately preceding the [CR]?LF</li>
+     * </ul>
      * @throws DecoderException if no LF or found in buffer
      * @throws TooLongFrameException if the line exceeds the permitted maximum
      */
-    private static int findCRLF(final ByteBuf buffer, int startIndex, final int maxLineSize, final int parsingLine) {
+    private static long findCRLF(final ByteBuf buffer, int startIndex, final int maxLineSize, final int parsingLine,
+                                final boolean allowLFWithoutCR) {
         final int maxToIndex = startIndex + maxLineSize;
         for (;;) {
             final int toIndex = min(buffer.writerIndex(), maxToIndex);
             final int lfIndex = findLF(buffer, startIndex, toIndex);
+            final boolean foundCR;
             if (lfIndex == -1) {
                 if (toIndex - startIndex == maxLineSize) {
                     throw new DecoderException("Could not find CRLF (0x0d0a) within " + maxLineSize +
@@ -831,10 +848,13 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                 }
                 return -2;
             } else if (lfIndex == buffer.readerIndex()) {
+                if (allowLFWithoutCR) {
+                    return ((long) lfIndex) << 32 | lfIndex;
+                }
                 buffer.skipBytes(1);
                 ++startIndex;
-            } else if (buffer.getByte(lfIndex - 1) == CR) {
-                return lfIndex;
+            } else if ((foundCR = buffer.getByte(lfIndex - 1) == CR) || allowLFWithoutCR) {
+                return foundCR ? ((long) lfIndex - 1) << 32 | lfIndex : ((long) lfIndex) << 32 | lfIndex;
             } else if (lfIndex != maxToIndex) {
                 throw new DecoderException("Found LF (0x0a) but no CR (0x0d) before, while parsing line " +
                         parsingLine);
@@ -843,6 +863,14 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                         " bytes");
             }
         }
+    }
+
+    private static int crlfIndex(long index) {
+        return (int) index;
+    }
+
+    private static int crlfBeforeIndex(long index) {
+        return ((int) (index >>> 32)) - 1;
     }
 
     private static int findLF(final ByteBuf buffer, final int fromIndex, final int toIndex) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -31,7 +31,6 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.buffer.api.Buffer;
-import io.servicetalk.concurrent.internal.FlowControlUtils;
 import io.servicetalk.http.api.EmptyHttpHeaders;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpHeadersFactory;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestDecoder.java
@@ -54,15 +54,15 @@ final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> {
                        final HttpHeadersFactory headersFactory, final int maxStartLineLength,
                        final int maxHeaderFieldLength) {
         this(methodQueue, alloc, headersFactory, maxStartLineLength, maxHeaderFieldLength,
-                false, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER);
+                false, false, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER);
     }
 
     HttpRequestDecoder(final Queue<HttpRequestMethod> methodQueue, final ByteBufAllocator alloc,
                        final HttpHeadersFactory headersFactory, final int maxStartLineLength,
                        final int maxHeaderFieldLength, final boolean allowPrematureClosureBeforePayloadBody,
-                       final CloseHandler closeHandler) {
+                       final boolean allowLFWithoutCR, final CloseHandler closeHandler) {
         super(alloc, headersFactory, maxStartLineLength, maxHeaderFieldLength, allowPrematureClosureBeforePayloadBody,
-                closeHandler);
+                allowLFWithoutCR, closeHandler);
         this.methodQueue = requireNonNull(methodQueue);
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseDecoder.java
@@ -66,14 +66,15 @@ final class HttpResponseDecoder extends HttpObjectDecoder<HttpResponseMetaData> 
     HttpResponseDecoder(final Queue<HttpRequestMethod> methodQueue, final ByteBufAllocator alloc,
                         final HttpHeadersFactory headersFactory, int maxStartLineLength, int maxHeaderFieldLength) {
         this(methodQueue, alloc, headersFactory, maxStartLineLength, maxHeaderFieldLength,
-                false, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER);
+                false, false, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER);
     }
 
     HttpResponseDecoder(final Queue<HttpRequestMethod> methodQueue, final ByteBufAllocator alloc,
                         final HttpHeadersFactory headersFactory, final int maxStartLineLength, int maxHeaderFieldLength,
-                        final boolean allowPrematureClosureBeforePayloadBody, final CloseHandler closeHandler) {
+                        final boolean allowPrematureClosureBeforePayloadBody, final boolean allowLFWithoutCR,
+                        final CloseHandler closeHandler) {
         super(alloc, headersFactory, maxStartLineLength, maxHeaderFieldLength, allowPrematureClosureBeforePayloadBody,
-                closeHandler);
+                allowLFWithoutCR, closeHandler);
         this.methodQueue = requireNonNull(methodQueue);
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -173,7 +173,8 @@ final class NettyHttpServer {
             final ChannelPipeline pipeline = channel.pipeline();
             pipeline.addLast(new HttpRequestDecoder(methodQueue, alloc, config.headersFactory(),
                     config.maxStartLineLength(), config.maxHeaderFieldLength(),
-                    config.specExceptions().allowPrematureClosureBeforePayloadBody(), closeHandler));
+                    config.specExceptions().allowPrematureClosureBeforePayloadBody(),
+                    config.specExceptions().allowLFWithoutCR(), closeHandler));
             pipeline.addLast(new HttpResponseEncoder(methodQueue, config.headersEncodedSizeEstimate(),
                     config.trailersEncodedSizeEstimate(), closeHandler));
         });

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -65,57 +65,92 @@ abstract class HttpObjectDecoderTest {
                 channel().close().get();
             }
         } finally {
-            channel().releaseInbound();
-            channel().releaseOutbound();
+            try {
+                if (channelSpecException().isOpen()) {
+                    channelSpecException().close().get();
+                }
+            } finally {
+                channel().releaseInbound();
+                channel().releaseOutbound();
+                channelSpecException().releaseInbound();
+                channelSpecException().releaseOutbound();
+            }
         }
     }
 
     abstract EmbeddedChannel channel();
 
+    abstract EmbeddedChannel channelSpecException();
+
     abstract String startLine();
 
-    abstract HttpMetaData assertStartLine();
+    abstract HttpMetaData assertStartLine(EmbeddedChannel channel);
 
     abstract String startLineForContent();
 
-    abstract HttpMetaData assertStartLineForContent();
+    abstract HttpMetaData assertStartLineForContent(EmbeddedChannel channel);
+
+    final HttpMetaData assertStartLineForContent() {
+        return assertStartLineForContent(channel());
+    }
 
     final void writeMsg(String msg) {
+        writeMsg(msg, channel());
+    }
+
+    final void writeMsg(String msg, EmbeddedChannel channel) {
         assertThat("writeInbound(msg) did not produce something for readInbound()",
-                channel().writeInbound(fromAscii(msg)), is(true));
+                channel.writeInbound(fromAscii(msg)), is(true));
     }
 
     final void writeContent(int length) {
-        assertThat("writeInbound(content) did not produce something for readInbound()",
-                channel().writeInbound(content(length)), is(true));
+        writeContent(length, channel());
     }
 
-    final void writeChunkSize(int length) {
-        writeMsg(toHexString(length) + "\r\n");
+    final void writeContent(int length, EmbeddedChannel channel) {
+        assertThat("writeInbound(content) did not produce something for readInbound()",
+                channel.writeInbound(content(length)), is(true));
+    }
+
+    final void writeChunkSize(int length, EmbeddedChannel channel) {
+        writeMsg(toHexString(length) + "\r\n", channel);
     }
 
     final void writeChunk(int length) {
-        if (length == 0) {
-            writeMsg("0\r\n");
-            return;
-        }
-        writeChunkSize(length);
-        writeContent(length);
-        writeMsg("\r\n");
+        writeChunk(length, channel());
     }
 
-    final void writeLastChunk() {
-        writeMsg("0\r\n\r\n");
+    final void writeChunk(int length, EmbeddedChannel channel) {
+        if (length == 0) {
+            writeMsg("0\r\n", channel);
+            return;
+        }
+        writeChunkSize(length, channel);
+        writeContent(length, channel);
+        writeMsg("\r\n", channel);
+    }
+
+    final void writeLastChunk(EmbeddedChannel channel) {
+        writeMsg("0\r\n\r\n", channel);
     }
 
     final void assertDecoderException(String msg, String expectedExceptionMsg) {
-        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg));
+        assertDecoderException(msg, expectedExceptionMsg, channel());
+    }
+
+    final void assertDecoderException(String msg, String expectedExceptionMsg, EmbeddedChannel channel) {
+        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
         assertThat(e.getMessage(), startsWith(expectedExceptionMsg));
         assertThat(channel().inboundMessages(), is(empty()));
     }
 
     final void assertDecoderExceptionWithCause(String msg, String expectedExceptionMsg) {
-        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg));
+        assertDecoderExceptionWithCause(msg, expectedExceptionMsg, channel());
+    }
+
+    final void assertDecoderExceptionWithCause(String msg, String expectedExceptionMsg,
+                                               EmbeddedChannel channel) {
+        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
         assertThat(e.getMessage(), startsWith(expectedExceptionMsg));
         assertThat(e.getCause(), is(instanceOf(IllegalCharacterException.class)));
         assertThat(e.getCause().getMessage(), not(isEmptyString()));
@@ -123,40 +158,49 @@ abstract class HttpObjectDecoderTest {
     }
 
     final HttpMetaData validateWithContent(int expectedContentLength, boolean containsTrailers) {
-        HttpMetaData metaData = assertStartLineForContent();
+        return validateWithContent(expectedContentLength, containsTrailers, channel());
+    }
+
+    final HttpMetaData validateWithContent(int expectedContentLength, boolean containsTrailers,
+        EmbeddedChannel channel) {
+        HttpMetaData metaData = assertStartLineForContent(channel);
         assertStandardHeaders(metaData.headers());
         if (expectedContentLength > 0) {
             assertSingleHeaderValue(metaData.headers(), CONTENT_LENGTH, String.valueOf(expectedContentLength));
-            HttpHeaders trailers = assertPayloadSize(expectedContentLength);
+            HttpHeaders trailers = assertPayloadSize(expectedContentLength, channel);
             assertThat("Trailers are not empty", trailers.isEmpty(), is(true));
         } else if (expectedContentLength == 0) {
             if (containsTrailers) {
                 assertSingleHeaderValue(metaData.headers(), TRANSFER_ENCODING, CHUNKED);
-                HttpHeaders trailers = channel().readInbound();
+                HttpHeaders trailers = channel.readInbound();
                 assertSingleHeaderValue(trailers, "TrailerStatus", "good");
             } else {
                 assertSingleHeaderValue(metaData.headers(), CONTENT_LENGTH, "0");
-                assertEmptyTrailers(channel());
+                assertEmptyTrailers(channel);
             }
         } else {
             assertThat("No 'transfer-encoding: chunked' header",
                     isTransferEncodingChunked(metaData.headers()), is(true));
-            HttpHeaders trailers = assertPayloadSize(-expectedContentLength);
+            HttpHeaders trailers = assertPayloadSize(-expectedContentLength, channel);
             if (containsTrailers) {
                 assertSingleHeaderValue(trailers, "TrailerStatus", "good");
             } else {
                 assertThat("Trailers are not empty", trailers.isEmpty(), is(true));
             }
         }
-        assertFalse(channel().finishAndReleaseAll());
+        assertFalse(channel.finishAndReleaseAll());
         return metaData;
     }
 
     final HttpHeaders assertPayloadSize(int expectedPayloadSize) {
+        return assertPayloadSize(expectedPayloadSize, channel());
+    }
+
+    final HttpHeaders assertPayloadSize(int expectedPayloadSize, EmbeddedChannel channel) {
         int actualPayloadSize = 0;
         Object item;
         for (;;) {
-            item = channel().readInbound();
+            item = channel.readInbound();
             if (item instanceof Buffer) {
                 actualPayloadSize += ((Buffer) item).readableBytes();
             } else {
@@ -196,93 +240,186 @@ abstract class HttpObjectDecoderTest {
         return wrappedBuffer(content);
     }
 
+    private EmbeddedChannel channel(boolean crlf) {
+        return crlf ? channel() : channelSpecException();
+    }
+
+    private static String br(boolean crlf) {
+        return crlf ? "\r\n" : "\n";
+    }
+
     @Test
     public void startLineWithoutCR() {
         assertDecoderException(startLine() + '\n', "Found LF (0x0a) but no CR (0x0d) before");
     }
 
     @Test
+    public void startLineWithoutCRSpecException() {
+        writeMsg(startLine() + "\n" + "\n", channelSpecException());
+        assertStartLine(channelSpecException());
+        assertEmptyTrailers(channelSpecException());
+        assertFalse(channelSpecException().finishAndReleaseAll());
+    }
+
+    @Test
     public void validStartLine() {
-        writeMsg(startLine() + "\r\n" + "\r\n");
-        assertStartLine();
-        assertEmptyTrailers(channel());
-        assertFalse(channel().finishAndReleaseAll());
+        validStartLine(true);
+        validStartLine(false);
+    }
+
+    private void validStartLine(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        writeMsg(startLine() + br + br, channel);
+        assertStartLine(channel);
+        assertEmptyTrailers(channel);
+        assertFalse(channel.finishAndReleaseAll());
     }
 
     @Test
     public void validStartLineInThreeFrames() {
-        assertFalse(channel().writeInbound(fromAscii(startLine())));
-        assertFalse(channel().writeInbound(fromAscii("\r\n")));
-        assertTrue(channel().writeInbound(fromAscii("\r\n")));
-        assertStartLine();
-        assertEmptyTrailers(channel());
-        assertFalse(channel().finishAndReleaseAll());
+        validStartLineInThreeFrames(true);
+        validStartLineInThreeFrames(false);
+    }
+
+    private void validStartLineInThreeFrames(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        assertFalse(channel.writeInbound(fromAscii(startLine())));
+        assertFalse(channel.writeInbound(fromAscii(br)));
+        assertTrue(channel.writeInbound(fromAscii(br)));
+        assertStartLine(channel);
+        assertEmptyTrailers(channel);
+        assertFalse(channel.finishAndReleaseAll());
     }
 
     @Test
     public void validStartLineInFourFrames() {
-        assertFalse(channel().writeInbound(fromAscii(startLine().substring(0, 3))));
-        assertFalse(channel().writeInbound(fromAscii(startLine().substring(3))));
-        assertFalse(channel().writeInbound(fromAscii("\r\n")));
-        assertTrue(channel().writeInbound(fromAscii("\r\n")));
-        assertStartLine();
-        assertEmptyTrailers(channel());
-        assertFalse(channel().finishAndReleaseAll());
+        validStartLineInFourFrames(true);
+        validStartLineInFourFrames(false);
+    }
+
+    private void validStartLineInFourFrames(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        assertFalse(channel.writeInbound(fromAscii(startLine().substring(0, 3))));
+        assertFalse(channel.writeInbound(fromAscii(startLine().substring(3))));
+        assertFalse(channel.writeInbound(fromAscii(br)));
+        assertTrue(channel.writeInbound(fromAscii(br)));
+        assertStartLine(channel);
+        assertEmptyTrailers(channel);
+        assertFalse(channel.finishAndReleaseAll());
     }
 
     @Test
     public void validStartLineAfterPrefaceCRLF() {
-        writeMsg("\r\n" + startLine() + "\r\n" + "\r\n");
-        assertStartLine();
-        assertEmptyTrailers(channel());
-        assertFalse(channel().finishAndReleaseAll());
+        validStartLineAfterPrefaceCRLF(true);
+        validStartLineAfterPrefaceCRLF(false);
+    }
+
+    private void validStartLineAfterPrefaceCRLF(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        writeMsg("\r\n" + startLine() + br + br, channel);
+        assertStartLine(channel);
+        assertEmptyTrailers(channel);
+        assertFalse(channel.finishAndReleaseAll());
     }
 
     @Test
     public void validStartLineAfterPrefaceCRLFInSeparateFrame() {
-        assertFalse(channel().writeInbound(fromAscii("\r\n")));   // write control characters first
-        writeMsg(startLine() + "\r\n" + "\r\n");
-        assertStartLine();
-        assertEmptyTrailers(channel());
-        assertFalse(channel().finishAndReleaseAll());
+        validStartLineAfterPrefaceCRLFInSeparateFrame(true);
+        validStartLineAfterPrefaceCRLFInSeparateFrame(false);
+    }
+
+    private void validStartLineAfterPrefaceCRLFInSeparateFrame(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        assertFalse(channel.writeInbound(fromAscii("\r\n")));   // write control characters first
+        writeMsg(startLine() + br + br, channel);
+        assertStartLine(channel);
+        assertEmptyTrailers(channel);
+        assertFalse(channel.finishAndReleaseAll());
     }
 
     @Test
     public void tooManyPrefaceCharacters() {
+        tooManyPrefaceCharacters(true);
+        tooManyPrefaceCharacters(false);
+    }
+
+    private void tooManyPrefaceCharacters(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
         DecoderException ex = assertThrows(DecoderException.class,
-                () -> writeMsg("\r\n\r\n\r\n" + startLine() + "\r\n" + "\r\n"));
+                () -> writeMsg("\r\n\r\n\r\n" + startLine() + br + br, channel));
         assertThat(ex.getMessage(), startsWith("Too many prefacing CRLF (0x0d0a) characters"));
-        assertThat(channel().inboundMessages(), is(empty()));
+        assertThat(channel.inboundMessages(), is(empty()));
     }
 
     @Test
     public void whitespaceNotAllowedBeforeHeaderFieldName() {
-        assertDecoderExceptionWithCause(startLine() + "\r\n" +
-                " Host: servicetalk.io" + "\r\n" + "\r\n", "Invalid header name");
+        whitespaceNotAllowedBeforeHeaderFieldName(true);
+        whitespaceNotAllowedBeforeHeaderFieldName(false);
+    }
+
+    private void whitespaceNotAllowedBeforeHeaderFieldName(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        assertDecoderExceptionWithCause(startLine() + br +
+                " Host: servicetalk.io" + br + br, "Invalid header name", channel);
     }
 
     @Test
     public void whitespaceNotAllowedBetweenHeaderFieldNameAndColon() {
-        assertDecoderExceptionWithCause(startLine() + "\r\n" +
-                "Host : servicetalk.io" + "\r\n" + "\r\n", "Invalid header name");
+        whitespaceNotAllowedBetweenHeaderFieldNameAndColon(true);
+        whitespaceNotAllowedBetweenHeaderFieldNameAndColon(false);
+    }
+
+    private void whitespaceNotAllowedBetweenHeaderFieldNameAndColon(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        assertDecoderExceptionWithCause(startLine() + br +
+                "Host : servicetalk.io" + br + br, "Invalid header name", channel);
     }
 
     @Test
     public void controlCharNotAllowedBeforeHeaderFieldValue() {
-        assertDecoderExceptionWithCause(startLine() + "\r\n" +
-                "Host: \fservicetalk.io" + "\r\n" + "\r\n", "Invalid value for the header");
+        controlCharNotAllowedBeforeHeaderFieldValue(true);
+        controlCharNotAllowedBeforeHeaderFieldValue(false);
+    }
+
+    private void controlCharNotAllowedBeforeHeaderFieldValue(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        assertDecoderExceptionWithCause(startLine() + br +
+                "Host: \fservicetalk.io" + br + br, "Invalid value for the header", channel);
     }
 
     @Test
     public void noEndOfHeaderName() {
-        assertDecoderException(startLine() + "\r\n" +
-                "Host" + "\r\n" + "\r\n", "Unable to find end of a header name");
+        noEndOfHeaderName(true);
+        noEndOfHeaderName(false);
+    }
+
+    private void noEndOfHeaderName(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        assertDecoderException(startLine() + br +
+                "Host" + br + br, "Unable to find end of a header name", channel);
     }
 
     @Test
     public void emptyHeaderName() {
-        assertDecoderException(startLine() + "\r\n" +
-                ": some-value" + "\r\n" + "\r\n", "Empty header name");
+        emptyHeaderName(true);
+        emptyHeaderName(false);
+    }
+
+    private void emptyHeaderName(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        assertDecoderException(startLine() + br +
+                ": some-value" + br + br, "Empty header name", channel);
     }
 
     @Test
@@ -306,20 +443,41 @@ abstract class HttpObjectDecoderTest {
     }
 
     private void testBadHeaderName(String badHeader) {
-        assertDecoderException(startLine() + "\r\n" +
-                badHeader + ": 3" + "\r\n" + "\r\n", "Invalid header name");
+        testBadHeaderName(badHeader, true);
+        testBadHeaderName(badHeader, false);
+    }
+
+    private void testBadHeaderName(String badHeader, boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        assertDecoderException(startLine() + br +
+                badHeader + ": 3" + br + br, "Invalid header name", channel);
     }
 
     @Test
     public void headerNameWithControlChar() {
-        assertDecoderExceptionWithCause(startLine() + "\r\n" +
-                "H\0st: servicetalk.io" + "\r\n" + "\r\n", "Invalid header name");
+        headerNameWithControlChar(true);
+        headerNameWithControlChar(false);
+    }
+
+    private void headerNameWithControlChar(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        assertDecoderExceptionWithCause(startLine() + br +
+                "H\0st: servicetalk.io" + br + br, "Invalid header name", channel);
     }
 
     @Test
     public void headerNameWithObsText() {
-        assertDecoderExceptionWithCause(startLine() + "\r\n" +
-                "Hóst: servicetalk.io" + "\r\n" + "\r\n", "Invalid header name");
+        headerNameWithObsText(true);
+        headerNameWithObsText(false);
+    }
+
+    private void headerNameWithObsText(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        assertDecoderExceptionWithCause(startLine() + br +
+                "Hóst: servicetalk.io" + br + br, "Invalid header name", channel);
     }
 
     @Test
@@ -367,20 +525,34 @@ abstract class HttpObjectDecoderTest {
     }
 
     private void testHeaderFiledValue(String fieldValue, String expectedFieldValue) {
-        writeMsg(startLine() + "\r\n" +
-                "Host:" + fieldValue + "\r\n" + "\r\n");
-        HttpMetaData metaData = assertStartLine();
+        testHeaderFiledValue(fieldValue, expectedFieldValue, true);
+        testHeaderFiledValue(fieldValue, expectedFieldValue, false);
+    }
+
+    private void testHeaderFiledValue(String fieldValue, String expectedFieldValue, boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        writeMsg(startLine() + br +
+                "Host:" + fieldValue + br + br, channel);
+        HttpMetaData metaData = assertStartLine(channel);
         assertSingleHeaderValue(metaData.headers(), HOST, expectedFieldValue);
-        assertEmptyTrailers(channel());
+        assertEmptyTrailers(channel);
     }
 
     @Test
     public void multipleHeaderFiledValues() {
-        writeMsg(startLine() + "\r\n" +
-                "Accept-Encoding: gzip" + "\r\n" +
-                "Accept-Encoding: compress" + "\r\n" +
-                "Accept-Encoding: deflate" + "\r\n" + "\r\n");
-        HttpMetaData metaData = assertStartLine();
+        multipleHeaderFiledValues(true);
+        multipleHeaderFiledValues(false);
+    }
+
+    private void multipleHeaderFiledValues(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        writeMsg(startLine() + br +
+                "Accept-Encoding: gzip" + br +
+                "Accept-Encoding: compress" + br +
+                "Accept-Encoding: deflate" + br + br, channel);
+        HttpMetaData metaData = assertStartLine(channel);
         List<String> headerValues = new ArrayList<>();
         Iterator<? extends CharSequence> itr = metaData.headers().valuesIterator(ACCEPT_ENCODING);
         while (itr.hasNext()) {
@@ -388,297 +560,410 @@ abstract class HttpObjectDecoderTest {
         }
         assertThat("Unable to find header name 'Accept-Encoding'", headerValues, hasSize(3));
         assertThat(headerValues, containsInAnyOrder("gzip", "compress", "deflate"));
-        assertEmptyTrailers(channel());
-        assertFalse(channel().finishAndReleaseAll());
+        assertEmptyTrailers(channel);
+        assertFalse(channel.finishAndReleaseAll());
     }
 
     @Test
     public void zeroContentLength() {
-        writeMsg(startLineForContent() + "\r\n" +
-                "Host: servicetalk.io" + "\r\n" +
-                "Connection: keep-alive" + "\r\n" +
-                "Content-Length: 0" + "\r\n" + "\r\n");
-        validateWithContent(0, false);
+        zeroContentLength(true);
+        zeroContentLength(false);
+    }
+
+    private void zeroContentLength(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Connection: keep-alive" + br +
+                "Content-Length: 0" + br + br, channel);
+        validateWithContent(0, false, channel);
     }
 
     @Test
     public void contentLengthNoTrailers() {
+        contentLengthNoTrailers(true);
+        contentLengthNoTrailers(false);
+    }
+
+    private void contentLengthNoTrailers(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
         int contentLength = 128;
-        writeMsg(startLineForContent() + "\r\n" +
-                "Host: servicetalk.io" + "\r\n" +
-                "Connection: keep-alive" + "\r\n" +
-                "Content-Length: " + contentLength + "\r\n" + "\r\n");
-        writeContent(contentLength);
-        validateWithContent(contentLength, false);
+        writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Connection: keep-alive" + br +
+                "Content-Length: " + contentLength + br + br, channel);
+        writeContent(contentLength, channel);
+        validateWithContent(contentLength, false, channel);
     }
 
     @Test
     public void chunkedNoTrailersChunkSizeWithoutSemicolon() {
-        chunkedNoTrailers(false);
+        chunkedNoTrailers(false, true);
+        chunkedNoTrailers(false, false);
     }
 
     @Test
     public void chunkedNoTrailersChunkSizeWithSemicolon() {
-        chunkedNoTrailers(true);
+        chunkedNoTrailers(true, true);
+        chunkedNoTrailers(true, false);
     }
 
-    private void chunkedNoTrailers(boolean addSemicolon) {
+    private void chunkedNoTrailers(boolean addSemicolon, boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
         int chunkSize = 128;
-        writeMsg(startLineForContent() + "\r\n" +
-                "Host: servicetalk.io" + "\r\n" +
-                "Connection: keep-alive" + "\r\n" +
-                "Transfer-Encoding: chunked" + "\r\n" + "\r\n");
-        writeMsg(toHexString(chunkSize) + (addSemicolon ? ";" : "") + "\r\n");
-        writeContent(chunkSize);
-        writeMsg("\r\n");
-        writeLastChunk();
-        validateWithContent(-chunkSize, false);
+        writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Connection: keep-alive" + br +
+                "Transfer-Encoding: chunked" + br + br, channel);
+        writeMsg(toHexString(chunkSize) + (addSemicolon ? ";" : "") + "\r\n", channel);
+        writeContent(chunkSize, channel);
+        writeMsg("\r\n", channel);
+        writeLastChunk(channel);
+        validateWithContent(-chunkSize, false, channel);
     }
 
     @Test
     public void chunkedWithContentLength() {
+        chunkedWithContentLength(true);
+        chunkedWithContentLength(false);
+    }
+
+    private void chunkedWithContentLength(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
         int chunkSize = 128;
         int chunkedContentLength = 2 + 2 + chunkSize + 2 + 5;
-        writeMsg(startLineForContent() + "\r\n" +
-                "Host: servicetalk.io" + "\r\n" +
-                "Connection: keep-alive" + "\r\n" +
-                "Content-Length: " + chunkedContentLength + "\r\n" +
-                "Transfer-Encoding: chunked" + "\r\n" + "\r\n");
-        writeChunk(chunkSize);
-        writeLastChunk();
-        HttpMetaData metaData = validateWithContent(-chunkSize, false);
+        writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Connection: keep-alive" + br +
+                "Content-Length: " + chunkedContentLength + br +
+                "Transfer-Encoding: chunked" + br + br, channel);
+        writeChunk(chunkSize, channel);
+        writeLastChunk(channel);
+        HttpMetaData metaData = validateWithContent(-chunkSize, false, channel);
         assertThat("Unexpected content-length header(s)",
                 metaData.headers().valuesIterator(CONTENT_LENGTH).hasNext(), is(false));
     }
 
     @Test
     public void chunkedNoTrailersMultipleLargeContent() {
+        chunkedNoTrailersMultipleLargeContent(true);
+        chunkedNoTrailersMultipleLargeContent(false);
+    }
+
+    private void chunkedNoTrailersMultipleLargeContent(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
         int chunkSize = 4096;
         int numChunks = 5;
-        writeMsg(startLineForContent() + "\r\n" +
-                "Host: servicetalk.io" + "\r\n" +
-                "Connection: keep-alive" + "\r\n" +
-                "Transfer-Encoding: chunked" + "\r\n" + "\r\n");
+        writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Connection: keep-alive" + br +
+                "Transfer-Encoding: chunked" + br + br, channel);
         for (int i = 0; i < numChunks; ++i) {
-            writeChunk(chunkSize);
+            writeChunk(chunkSize, channel);
         }
-        writeLastChunk();
-        validateWithContent(-(chunkSize * numChunks), false);
+        writeLastChunk(channel);
+        validateWithContent(-(chunkSize * numChunks), false, channel);
     }
 
     @Test
     public void chunkedNoTrailersNoChunkSize() {
-        writeMsg(startLineForContent() + "\r\n" +
-                "Host: servicetalk.io" + "\r\n" +
-                "Connection: keep-alive" + "\r\n" +
-                "Transfer-Encoding: chunked" + "\r\n" + "\r\n");
+        chunkedNoTrailersNoChunkSize(true);
+        chunkedNoTrailersNoChunkSize(false);
+    }
+
+    private void chunkedNoTrailersNoChunkSize(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Connection: keep-alive" + br +
+                "Transfer-Encoding: chunked" + br + br, channel);
         // we omit writing the chunk-size intentionally, write only \r\n
-        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg("\r\n"));
+        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg("\r\n", channel));
         assertThat(e.getMessage(), startsWith("Chunked encoding specified but chunk-size not found"));
-        assertThat(channel().inboundMessages(), is(not(empty())));
+        assertThat(channel.inboundMessages(), is(not(empty())));
     }
 
     @Test
     public void chunkedNoTrailersInvalidChunkSize() {
-        writeMsg(startLineForContent() + "\r\n" +
-                "Host: servicetalk.io" + "\r\n" +
-                "Connection: keep-alive" + "\r\n" +
-                "Transfer-Encoding: chunked" + "\r\n" + "\r\n");
+        chunkedNoTrailersInvalidChunkSize(true);
+        chunkedNoTrailersInvalidChunkSize(false);
+    }
+
+    private void chunkedNoTrailersInvalidChunkSize(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Connection: keep-alive" + br +
+                "Transfer-Encoding: chunked" + br + br, channel);
         // write illegal characters instead of chunk-size
-        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg("text\r\n"));
+        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg("text\r\n", channel));
         assertThat(e.getCause(), is(instanceOf(NumberFormatException.class)));
-        assertThat(channel().inboundMessages(), is(not(empty())));
+        assertThat(channel.inboundMessages(), is(not(empty())));
     }
 
     @Test
     public void chunkedNoTrailersNoChunkCRLF() {
+        chunkedNoTrailersNoChunkCRLF(true);
+        chunkedNoTrailersNoChunkCRLF(false);
+    }
+
+    private void chunkedNoTrailersNoChunkCRLF(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
         int chunkSize = 128;
-        writeMsg(startLineForContent() + "\r\n" +
-                "Host: servicetalk.io" + "\r\n" +
-                "Connection: keep-alive" + "\r\n" +
-                "Transfer-Encoding: chunked" + "\r\n" + "\r\n");
-        writeChunkSize(chunkSize);
-        writeContent(chunkSize);
+        writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Connection: keep-alive" + br +
+                "Transfer-Encoding: chunked" + br + br, channel);
+        writeChunkSize(chunkSize, channel);
+        writeContent(chunkSize, channel);
         // we omit writing the "\r\n" after chunk-data intentionally
-        DecoderException e = assertThrows(DecoderException.class, this::writeLastChunk);
+        DecoderException e = assertThrows(DecoderException.class, () -> writeLastChunk(channel));
         assertThat(e.getMessage(), startsWith("Could not find CRLF"));
-        assertThat(channel().inboundMessages(), is(not(empty())));
+        assertThat(channel.inboundMessages(), is(not(empty())));
     }
 
     @Test
     public void chunkedNoContentWithTrailers() {
-        writeMsg(startLineForContent() + "\r\n" +
-                "Host: servicetalk.io" + "\r\n" +
-                "Connection: keep-alive" + "\r\n" +
-                "Transfer-Encoding: chunked" + "\r\n" + "\r\n" +
+        chunkedNoContentWithTrailers(true);
+        chunkedNoContentWithTrailers(false);
+    }
+
+    private void chunkedNoContentWithTrailers(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Connection: keep-alive" + br +
+                "Transfer-Encoding: chunked" + br + br +
                 "0\r\n" +
-                "TrailerStatus: good" + "\r\n" + "\r\n");
-        validateWithContent(0, true);
+                "TrailerStatus: good" + br + br, channel);
+        validateWithContent(0, true, channel);
     }
 
     @Test
     public void chunkedContentWithTrailers() {
+        chunkedContentWithTrailers(true);
+        chunkedContentWithTrailers(false);
+    }
+
+    private void chunkedContentWithTrailers(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
         int chunkSize = 128;
-        writeMsg(startLineForContent() + "\r\n" +
-                "Host: servicetalk.io" + "\r\n" +
-                "Connection: keep-alive" + "\r\n" +
-                "Transfer-Encoding: chunked" + "\r\n" + "\r\n");
-        writeChunk(chunkSize);
-        writeMsg("0\r\n" + "TrailerStatus: good" + "\r\n" + "\r\n");
-        validateWithContent(-chunkSize, true);
+        writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Connection: keep-alive" + br +
+                "Transfer-Encoding: chunked" + br + br, channel);
+        writeChunk(chunkSize, channel);
+        writeMsg("0\r\n" + "TrailerStatus: good" + br + br, channel);
+        validateWithContent(-chunkSize, true, channel);
     }
 
     @Test
     public void chunkedNoContentNoTrailers() {
-        writeMsg(startLineForContent() + "\r\n" +
-                "Host: servicetalk.io" + "\r\n" +
-                "Connection: keep-alive" + "\r\n" +
-                "Transfer-Encoding: chunked" + "\r\n" + "\r\n");
-        writeLastChunk();
+        chunkedNoContentNoTrailers(true);
+        chunkedNoContentNoTrailers(false);
+    }
 
-        HttpMetaData metaData = assertStartLineForContent();
+    private void chunkedNoContentNoTrailers(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Connection: keep-alive" + br +
+                "Transfer-Encoding: chunked" + br + br, channel);
+        writeLastChunk(channel);
+
+        HttpMetaData metaData = assertStartLineForContent(channel);
         assertStandardHeaders(metaData.headers());
-        assertEmptyTrailers(channel());
-        assertFalse(channel().finishAndReleaseAll());
+        assertEmptyTrailers(channel);
+        assertFalse(channel.finishAndReleaseAll());
     }
 
     @Test
     public void unexpectedTrailersAfterContentLength() {
+        unexpectedTrailersAfterContentLength(true);
+        unexpectedTrailersAfterContentLength(false);
+    }
+
+    private void unexpectedTrailersAfterContentLength(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
         int contentLength = 128;
-        writeMsg(startLineForContent() + "\r\n" +
-                "Host: servicetalk.io" + "\r\n" +
-                "Connection: keep-alive" + "\r\n" +
-                "Content-Length:" + contentLength + "\r\n" + "\r\n");
-        writeContent(contentLength);
+        writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Connection: keep-alive" + br +
+                "Content-Length:" + contentLength + br + br, channel);
+        writeContent(contentLength, channel);
         // Note that trailers are not allowed when content-length is specified
         // https://tools.ietf.org/html/rfc7230#section-3.3
         DecoderException e = assertThrows(DecoderException.class,
-                () -> writeMsg("TrailerStatus: good" + "\r\n" + "\r\n"));
+                () -> writeMsg("TrailerStatus: good" + br + br, channel));
         assertThat(e.getMessage(), startsWith("Invalid start-line"));
-        assertThat(channel().inboundMessages(), is(not(empty())));
+        assertThat(channel.inboundMessages(), is(not(empty())));
     }
 
     @Test
     public void smuggleBeforeZeroContentLengthHeader() {
-        smuggleZeroContentLength(true);
+        smuggleZeroContentLength(true, false);
+        smuggleZeroContentLength(true, true);
     }
 
     @Test
     public void smuggleAfterZeroContentLengthHeader() {
-        smuggleZeroContentLength(false);
+        smuggleZeroContentLength(false, false);
+        smuggleZeroContentLength(false, true);
     }
 
-    private void smuggleZeroContentLength(boolean smuggleBeforeContentLength) {
-        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(startLine() + "\r\n" +
-                "Host: servicetalk.io" + "\r\n" +
+    private void smuggleZeroContentLength(boolean smuggleBeforeContentLength, boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(startLine() + br +
+                "Host: servicetalk.io" + br +
                 // Smuggled requests injected into a header will terminate the current request due to valid \r\n\r\n
                 // framing terminating the request with no content-length or transfer-encoding, or with known zero
                 // content-length [1].
                 // [1] https://tools.ietf.org/html/rfc7230#section-3.3.3
                 (smuggleBeforeContentLength ?
-                        "Smuggled: " + startLine() + "\r\n\r\n" + "Content-Length: 0" + "\r\n" :
-                        "Content-Length: 0" + "\r\n" + "Smuggled: " + startLine() + "\r\n\r\n") +
-                "Connection: keep-alive" + "\r\n\r\n"));
+                        "Smuggled: " + startLine() + br + br + "Content-Length: 0" + br :
+                        "Content-Length: 0" + br + "Smuggled: " + startLine() + br + br) +
+                "Connection: keep-alive" + br + br, channel));
         assertThat(e.getMessage(), startsWith("Invalid start-line"));
 
-        HttpMetaData metaData = assertStartLine();
+        HttpMetaData metaData = assertStartLine(channel);
         assertSingleHeaderValue(metaData.headers(), HOST, "servicetalk.io");
         assertSingleHeaderValue(metaData.headers(), "Smuggled", startLine());
-        assertEmptyTrailers(channel());
+        assertEmptyTrailers(channel);
     }
 
     @Test
     public void smuggleAfterTransferEncodingHeader() {
-        smuggleTransferEncoding(false);
+        smuggleTransferEncoding(false, false);
+        smuggleTransferEncoding(false, true);
     }
 
-    protected void smuggleTransferEncoding(boolean smuggleBeforeTransferEncoding) {
-        assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + "\r\n" +
-                "Host: servicetalk.io" + "\r\n" +
+    protected void smuggleTransferEncoding(boolean smuggleBeforeTransferEncoding, boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
                 // Smuggled requests injected into a header will terminate the current request due to valid \r\n\r\n
                 // framing terminating the request with no content-length or transfer-encoding, or with known zero
                 // content-length [1].
                 // [1] https://tools.ietf.org/html/rfc7230#section-3.3.3
                 (smuggleBeforeTransferEncoding ?
-                        "Smuggled: " + startLine() + "\r\n\r\n" + TRANSFER_ENCODING + ":" + CHUNKED + "\r\n" :
-                        TRANSFER_ENCODING + ":" + CHUNKED + "\r\n" + "Smuggled: " + startLine() + "\r\n\r\n") +
-                "Connection: keep-alive" + "\r\n\r\n"));
+                        "Smuggled: " + startLine() + br + br + TRANSFER_ENCODING + ":" + CHUNKED + br :
+                        TRANSFER_ENCODING + ":" + CHUNKED + br + "Smuggled: " + startLine() + br + br) +
+                "Connection: keep-alive" + br + br, channel));
 
-        HttpMetaData metaData = assertStartLineForContent();
+        HttpMetaData metaData = assertStartLineForContent(channel);
         assertSingleHeaderValue(metaData.headers(), HOST, "servicetalk.io");
         assertSingleHeaderValue(metaData.headers(), "Smuggled", startLine());
     }
 
     @Test
     public void smuggleNameBeforeNonZeroContentLengthHeader() {
-        smuggleNameZeroContentLengthHeader(true);
+        smuggleNameZeroContentLengthHeader(true, false);
+        smuggleNameZeroContentLengthHeader(true, true);
     }
 
     @Test
     public void smuggleNameAfterNonZeroContentLengthHeader() {
-        smuggleNameZeroContentLengthHeader(false);
+        smuggleNameZeroContentLengthHeader(false, false);
+        smuggleNameZeroContentLengthHeader(false, true);
     }
 
-    private void smuggleNameZeroContentLengthHeader(boolean smuggleBeforeContentLength) {
-        assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + "\r\n" +
-                "Host: servicetalk.io" + "\r\n" +
+    private void smuggleNameZeroContentLengthHeader(boolean smuggleBeforeContentLength, boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
                         (smuggleBeforeContentLength ?
-                                startLine() + "\r\n\r\n" + "Content-Length: 0" + "\r\n" :
-                                "Content-Length: 0" + "\r\n" + startLine() + "\r\n\r\n") +
-                "Connection: keep-alive" + "\r\n\r\n"));
+                                startLine() + br + br + "Content-Length: 0" + br :
+                                "Content-Length: 0" + br + startLine() + br + br) +
+                "Connection: keep-alive" + br + br, channel));
     }
 
     @Test
     public void multipleContentLengthHeaders() {
-        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + "\r\n" +
-                "Host: servicetalk.io" + "\r\n" +
-                "Content-Length: 1" + "\r\n" +
-                "Content-Length: 2" + "\r\n" +
-                "Connection: keep-alive" + "\r\n\r\n"));
+        multipleContentLengthHeaders(true);
+        multipleContentLengthHeaders(false);
+    }
+
+    private void multipleContentLengthHeaders(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Content-Length: 1" + br +
+                "Content-Length: 2" + br +
+                "Connection: keep-alive" + br + br, channel));
         assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
         assertThat(e.getCause().getMessage(), startsWith("Multiple content-length values found"));
     }
 
     @Test
     public void multipleContentLengthHeaderValues() {
-        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + "\r\n" +
-                "Host: servicetalk.io" + "\r\n" +
-                "Content-Length: 1, 2" + "\r\n" +
-                "Connection: keep-alive" + "\r\n\r\n"));
+        multipleContentLengthHeaderValues(true);
+        multipleContentLengthHeaderValues(false);
+    }
+
+    private void multipleContentLengthHeaderValues(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Content-Length: 1, 2" + br +
+                "Connection: keep-alive" + br + br, channel));
         assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
         assertThat(e.getCause().getMessage(), startsWith("Multiple content-length values found"));
     }
 
     @Test
     public void signedPositiveContentLengthHeaderValues() {
-        malformedContentLengthHeaderValue("+1");
+        malformedContentLengthHeaderValue("+1", true);
+        malformedContentLengthHeaderValue("+1", false);
     }
 
     @Test
     public void signedNegativeContentLengthHeaderValues() {
-        malformedContentLengthHeaderValue("-1");
+        malformedContentLengthHeaderValue("-1", true);
+        malformedContentLengthHeaderValue("-1", false);
     }
 
     @Test
     public void malformedContentLengthHeaderValueWithSP() {
-        malformedContentLengthHeaderValue("1 2");
+        malformedContentLengthHeaderValue("1 2", true);
+        malformedContentLengthHeaderValue("1 2", false);
     }
 
     @Test
     public void malformedContentLengthHeaderValueWithLetter() {
-        malformedContentLengthHeaderValue("1a2");
+        malformedContentLengthHeaderValue("1a2", true);
+        malformedContentLengthHeaderValue("1a2", false);
     }
 
     @Test
     public void malformedContentLengthHeaderValueWithSymbol() {
-        malformedContentLengthHeaderValue("1-2");
+        malformedContentLengthHeaderValue("1-2", true);
+        malformedContentLengthHeaderValue("1-2", false);
     }
 
-    public void malformedContentLengthHeaderValue(String value) {
-        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + "\r\n" +
-                "Host: servicetalk.io" + "\r\n" +
-                "Content-Length: " + value + "\r\n" +
-                "Connection: keep-alive" + "\r\n\r\n"));
+    public void malformedContentLengthHeaderValue(String value, boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Content-Length: " + value + br +
+                "Connection: keep-alive" + br + br, channel));
         assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
         assertThat(e.getCause().getMessage(), startsWith("Malformed 'content-length' value"));
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
@@ -49,11 +49,14 @@ import static org.junit.Assert.assertThrows;
 
 public class HttpRequestDecoderTest extends HttpObjectDecoderTest {
 
-    private final EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder(new ArrayDeque<>(),
-            getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE, 8192, 8192));
-    private final EmbeddedChannel channelSpecException = new EmbeddedChannel(new HttpRequestDecoder(new ArrayDeque<>(),
-            getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE, 8192, 8192, false, true,
-            UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
+    private final EmbeddedChannel channel = newChannel(false);
+    private final EmbeddedChannel channelSpecException = newChannel(true);
+
+    private static EmbeddedChannel newChannel(boolean allowLFWithoutCR) {
+        return new EmbeddedChannel(new HttpRequestDecoder(new ArrayDeque<>(), getByteBufAllocator(DEFAULT_ALLOCATOR),
+                DefaultHttpHeadersFactory.INSTANCE, 8192, 8192, false, allowLFWithoutCR,
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
+    }
 
     @Override
     EmbeddedChannel channel() {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
@@ -76,11 +76,14 @@ public class HttpResponseDecoderTest extends HttpObjectDecoderTest {
 
     private final Queue<HttpRequestMethod> methodQueue = new ArrayDeque<>();
 
-    private final EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder(methodQueue,
-            getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE, 8192, 8192));
-    private final EmbeddedChannel channelSpecException = new EmbeddedChannel(new HttpResponseDecoder(methodQueue,
-            getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE, 8192, 8192,
-            false, true, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
+    private final EmbeddedChannel channel = newChannel(false);
+    private final EmbeddedChannel channelSpecException = newChannel(true);
+
+    private EmbeddedChannel newChannel(boolean allowLFWithoutCR) {
+        return new EmbeddedChannel(new HttpResponseDecoder(methodQueue,
+                getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE, 8192, 8192,
+                false, allowLFWithoutCR, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
+    }
 
     @Override
     protected EmbeddedChannel channel() {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
@@ -61,6 +61,7 @@ import static io.servicetalk.http.api.HttpRequestMethod.CONNECT;
 import static io.servicetalk.http.api.HttpResponseStatus.BAD_REQUEST;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
 import static java.lang.Integer.toHexString;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -77,10 +78,18 @@ public class HttpResponseDecoderTest extends HttpObjectDecoderTest {
 
     private final EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder(methodQueue,
             getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE, 8192, 8192));
+    private final EmbeddedChannel channelSpecException = new EmbeddedChannel(new HttpResponseDecoder(methodQueue,
+            getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE, 8192, 8192,
+            false, true, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
 
     @Override
     protected EmbeddedChannel channel() {
         return channel;
+    }
+
+    @Override
+    EmbeddedChannel channelSpecException() {
+        return channelSpecException;
     }
 
     @Override
@@ -89,8 +98,8 @@ public class HttpResponseDecoderTest extends HttpObjectDecoderTest {
     }
 
     @Override
-    HttpMetaData assertStartLine() {
-        return assertResponseLine(HTTP_1_1, NO_CONTENT);
+    HttpMetaData assertStartLine(EmbeddedChannel channel) {
+        return assertResponseLine(HTTP_1_1, NO_CONTENT, channel);
     }
 
     @Override
@@ -99,8 +108,8 @@ public class HttpResponseDecoderTest extends HttpObjectDecoderTest {
     }
 
     @Override
-    HttpMetaData assertStartLineForContent() {
-        return assertResponseLine(HTTP_1_1, OK);
+    HttpMetaData assertStartLineForContent(final EmbeddedChannel channel) {
+        return assertResponseLine(HTTP_1_1, OK, channel);
     }
 
     @Test
@@ -360,6 +369,11 @@ public class HttpResponseDecoderTest extends HttpObjectDecoderTest {
 
     private HttpResponseMetaData assertResponseLine(HttpProtocolVersion expectedVersion,
                                                     HttpResponseStatus expectedStatus) {
+        return assertResponseLine(expectedVersion, expectedStatus, channel());
+    }
+
+    private static HttpResponseMetaData assertResponseLine(HttpProtocolVersion expectedVersion,
+                                                           HttpResponseStatus expectedStatus, EmbeddedChannel channel) {
         HttpResponseMetaData response = channel.readInbound();
         assertThat(response.version(), equalTo(expectedVersion));
         assertThat(response.status().code(), is(expectedStatus.code()));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PrematureClosureBeforeResponsePayloadBodyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PrematureClosureBeforeResponsePayloadBodyTest.java
@@ -115,8 +115,8 @@ public class PrematureClosureBeforeResponsePayloadBodyTest {
         client = HttpClients.forSingleAddress(HostAndPort.of(server.localAddress()))
                 .enableWireLogging("servicetalk-tests-wire-logger", LogLevel.TRACE, () -> true)
                 .protocols(h1()
-                        .specExceptions(new H1SpecExceptions.Builder().allowPrematureClosureBeforePayloadBody(true).build())
-                        .build())
+                    .specExceptions(new H1SpecExceptions.Builder().allowPrematureClosureBeforePayloadBody(true).build())
+                    .build())
                 .buildBlocking();
         connection = client.reserveConnection(client.get("/"));
         connection.connectionContext().onClose().whenFinally(connectionClosedLatch::countDown).subscribe();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PrematureClosureBeforeResponsePayloadBodyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PrematureClosureBeforeResponsePayloadBodyTest.java
@@ -115,7 +115,7 @@ public class PrematureClosureBeforeResponsePayloadBodyTest {
         client = HttpClients.forSingleAddress(HostAndPort.of(server.localAddress()))
                 .enableWireLogging("servicetalk-tests-wire-logger", LogLevel.TRACE, () -> true)
                 .protocols(h1()
-                        .specExceptions(new H1SpecExceptions.Builder().allowPrematureClosureBeforePayloadBody().build())
+                        .specExceptions(new H1SpecExceptions.Builder().prematureClosureBeforePayloadBody(true).build())
                         .build())
                 .buildBlocking();
         connection = client.reserveConnection(client.get("/"));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PrematureClosureBeforeResponsePayloadBodyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PrematureClosureBeforeResponsePayloadBodyTest.java
@@ -115,7 +115,7 @@ public class PrematureClosureBeforeResponsePayloadBodyTest {
         client = HttpClients.forSingleAddress(HostAndPort.of(server.localAddress()))
                 .enableWireLogging("servicetalk-tests-wire-logger", LogLevel.TRACE, () -> true)
                 .protocols(h1()
-                        .specExceptions(new H1SpecExceptions.Builder().prematureClosureBeforePayloadBody(true).build())
+                        .specExceptions(new H1SpecExceptions.Builder().allowPrematureClosureBeforePayloadBody(true).build())
                         .build())
                 .buildBlocking();
         connection = client.reserveConnection(client.get("/"));


### PR DESCRIPTION
Motivation:
The HTTP/1.x spec allows for optional support to accept LF without
proceeding CR as a valid separator in some scenarios [1]. Some older
implementations rely upon this behavior and interoperability would be
improved by allowing opt-in support.

[1] https://tools.ietf.org/html/rfc7230#section-3.5
Although the line terminator for the start-line and header fields is
the sequence CRLF, a recipient MAY recognize a single LF as a line
terminator and ignore any preceding CR.

Modifications:
- Update HttpObjectDecoder to support LF without CR

Result:
H1SpecExceptions allows for opt-in support for  LF without proceeding
CR.