### PR TITLE
H2PriorKnowledgeFeatureParityTest remove exception verification workaround

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -95,7 +95,6 @@ import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.net.InetSocketAddress;
-import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -152,7 +151,6 @@ import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.function.UnaryOperator.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
@@ -686,7 +684,7 @@ public class H2PriorKnowledgeFeatureParityTest {
             }
             if (h2PriorKnowledge) {
                 assertThat(assertThrows(Throwable.class, () -> client.request(request)),
-                        either(instanceOf(Http2Exception.class)).or(instanceOf(ClosedChannelException.class)));
+                        instanceOf(Http2Exception.class));
             } else {
                 try (ReservedBlockingHttpConnection reservedConn = client.reserveConnection(request)) {
                     assertThrows(DecoderException.class, () -> {


### PR DESCRIPTION
Motivaiton:
H2PriorKnowledgeFeatureParityTest allows for ClosedChannelException in
some scenarios which should be a Http2Exception. This issue has since
been fixed in netty and the workaround can be reverted.

Modifications:
- Remove .or(instanceOf(ClosedChannelException.class)) clause in
H2PriorKnowledgeFeatureParityTest

Result:
H2PriorKnowledgeFeatureParityTest test verifies expected exception for
h2.