### PR TITLE
Optimize HTTP messages with empty payload body

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractDelegatingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractDelegatingHttpRequest.java
@@ -174,6 +174,11 @@ abstract class AbstractDelegatingHttpRequest implements PayloadInfo, HttpRequest
     }
 
     @Override
+    public boolean isEmpty() {
+        return original.isEmpty();
+    }
+
+    @Override
     public boolean isSafeToAggregate() {
         return original.isSafeToAggregate();
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractDelegatingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractDelegatingHttpResponse.java
@@ -46,6 +46,11 @@ abstract class AbstractDelegatingHttpResponse implements HttpResponseMetaData, P
     }
 
     @Override
+    public boolean isEmpty() {
+        return original.isEmpty();
+    }
+
+    @Override
     public boolean isSafeToAggregate() {
         return original.isSafeToAggregate();
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
@@ -186,7 +186,8 @@ final class DefaultHttpRequest extends AbstractDelegatingHttpRequest
 
     @Override
     public Buffer payloadBody() {
-        if (payloadBody == EMPTY_BUFFER) {
+        if (payloadBody == EMPTY_BUFFER) {  // default value after aggregation,
+            // override with a new empty buffer to allow users expand it with more data:
             payloadBody = original.payloadHolder().allocator().newBuffer(0, false);
             // The correct DefaultPayloadInfo#setEmpty(...) flag will be set in toStreamingRequest()
         }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
@@ -234,18 +234,15 @@ final class DefaultHttpRequest extends AbstractDelegatingHttpRequest
 
     @Override
     public StreamingHttpRequest toStreamingRequest() {
-        final DefaultPayloadInfo payloadInfo;
-        final Publisher<Object> payload;
         final boolean emptyPayloadBody = payloadBody.readableBytes() == 0;
+        final Publisher<Object> payload;
         if (trailers != null) {
             payload = emptyPayloadBody ? from(trailers) : from(payloadBody, trailers);
-            payloadInfo = new DefaultPayloadInfo(this).setEmpty(emptyPayloadBody)
-                    .setMayHaveTrailersAndGenericTypeBuffer(true);
         } else {
             payload = emptyPayloadBody ? empty() : from(payloadBody);
-            payloadInfo = new DefaultPayloadInfo(this).setEmpty(emptyPayloadBody)
-                    .setMayHaveTrailersAndGenericTypeBuffer(false);
         }
+        final DefaultPayloadInfo payloadInfo = new DefaultPayloadInfo(this).setEmpty(emptyPayloadBody)
+                .setMayHaveTrailersAndGenericTypeBuffer(trailers != null);
         return new DefaultStreamingHttpRequest(method(), requestTarget(), version(), headers(), encoding(),
                 original.payloadHolder().allocator(), payload, payloadInfo, original.payloadHolder().headersFactory());
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
@@ -22,7 +22,6 @@ import io.servicetalk.encoding.api.ContentCodec;
 import java.nio.charset.Charset;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static java.util.Objects.requireNonNull;
 
@@ -235,11 +234,12 @@ final class DefaultHttpRequest extends AbstractDelegatingHttpRequest
     @Override
     public StreamingHttpRequest toStreamingRequest() {
         final boolean emptyPayloadBody = payloadBody.readableBytes() == 0;
+        @Nullable
         final Publisher<Object> payload;
         if (trailers != null) {
             payload = emptyPayloadBody ? from(trailers) : from(payloadBody, trailers);
         } else {
-            payload = emptyPayloadBody ? empty() : from(payloadBody);
+            payload = emptyPayloadBody ? null : from(payloadBody);
         }
         final DefaultPayloadInfo payloadInfo = new DefaultPayloadInfo(this).setEmpty(emptyPayloadBody)
                 .setMayHaveTrailersAndGenericTypeBuffer(trailers != null);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
@@ -22,6 +22,7 @@ import io.servicetalk.encoding.api.ContentCodec;
 import java.nio.charset.Charset;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.buffer.api.EmptyBuffer.EMPTY_BUFFER;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static java.util.Objects.requireNonNull;
 
@@ -184,6 +185,10 @@ final class DefaultHttpRequest extends AbstractDelegatingHttpRequest
 
     @Override
     public Buffer payloadBody() {
+        if (payloadBody == EMPTY_BUFFER) {
+            payloadBody = original.payloadHolder().allocator().newBuffer(0, false);
+            // The correct DefaultPayloadInfo#setEmpty(...) flag will be set in toStreamingRequest()
+        }
         return payloadBody;
     }
 
@@ -233,7 +238,7 @@ final class DefaultHttpRequest extends AbstractDelegatingHttpRequest
 
     @Override
     public StreamingHttpRequest toStreamingRequest() {
-        final boolean emptyPayloadBody = payloadBody.readableBytes() == 0;
+        final boolean emptyPayloadBody = payloadBody == EMPTY_BUFFER;
         @Nullable
         final Publisher<Object> payload;
         if (trailers != null) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
@@ -22,6 +22,7 @@ import io.servicetalk.encoding.api.ContentCodec;
 import java.nio.charset.Charset;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static java.util.Objects.requireNonNull;
 
@@ -237,11 +238,11 @@ final class DefaultHttpRequest extends AbstractDelegatingHttpRequest
         final Publisher<Object> payload;
         final boolean emptyPayloadBody = payloadBody.readableBytes() == 0;
         if (trailers != null) {
-            payload = from(payloadBody, trailers);
+            payload = emptyPayloadBody ? from(trailers) : from(payloadBody, trailers);
             payloadInfo = new DefaultPayloadInfo(this).setEmpty(emptyPayloadBody)
                     .setMayHaveTrailersAndGenericTypeBuffer(true);
         } else {
-            payload = from(payloadBody);
+            payload = emptyPayloadBody ? empty() : from(payloadBody);
             payloadInfo = new DefaultPayloadInfo(this).setEmpty(emptyPayloadBody)
                     .setMayHaveTrailersAndGenericTypeBuffer(false);
         }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
@@ -235,12 +235,15 @@ final class DefaultHttpRequest extends AbstractDelegatingHttpRequest
     public StreamingHttpRequest toStreamingRequest() {
         final DefaultPayloadInfo payloadInfo;
         final Publisher<Object> payload;
+        final boolean emptyPayloadBody = payloadBody.readableBytes() == 0;
         if (trailers != null) {
             payload = from(payloadBody, trailers);
-            payloadInfo = new DefaultPayloadInfo(this).setMayHaveTrailersAndGenericTypeBuffer(true);
+            payloadInfo = new DefaultPayloadInfo(this).setEmpty(emptyPayloadBody)
+                    .setMayHaveTrailersAndGenericTypeBuffer(true);
         } else {
             payload = from(payloadBody);
-            payloadInfo = new DefaultPayloadInfo(this).setMayHaveTrailersAndGenericTypeBuffer(false);
+            payloadInfo = new DefaultPayloadInfo(this).setEmpty(emptyPayloadBody)
+                    .setMayHaveTrailersAndGenericTypeBuffer(false);
         }
         return new DefaultStreamingHttpRequest(method(), requestTarget(), version(), headers(), encoding(),
                 original.payloadHolder().allocator(), payload, payloadInfo, original.payloadHolder().headersFactory());

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.buffer.api.EmptyBuffer.EMPTY_BUFFER;
 import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.http.api.HttpDataSourceTransformations.isAlwaysEmpty;
 import static java.util.Objects.requireNonNull;
 
 final class DefaultHttpRequest extends AbstractDelegatingHttpRequest
@@ -238,7 +239,7 @@ final class DefaultHttpRequest extends AbstractDelegatingHttpRequest
 
     @Override
     public StreamingHttpRequest toStreamingRequest() {
-        final boolean emptyPayloadBody = payloadBody == EMPTY_BUFFER;
+        final boolean emptyPayloadBody = isAlwaysEmpty(payloadBody);
         @Nullable
         final Publisher<Object> payload;
         if (trailers != null) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponse.java
@@ -59,7 +59,8 @@ final class DefaultHttpResponse extends AbstractDelegatingHttpResponse
 
     @Override
     public Buffer payloadBody() {
-        if (payloadBody == EMPTY_BUFFER) {
+        if (payloadBody == EMPTY_BUFFER) {  // default value after aggregation,
+            // override with a new empty buffer to allow users expand it with more data:
             payloadBody = original.payloadHolder().allocator().newBuffer(0, false);
             // The correct DefaultPayloadInfo#setEmpty(...) flag will be set in toStreamingRequest()
         }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponse.java
@@ -77,18 +77,15 @@ final class DefaultHttpResponse extends AbstractDelegatingHttpResponse
 
     @Override
     public StreamingHttpResponse toStreamingResponse() {
-        final DefaultPayloadInfo payloadInfo;
-        final Publisher<Object> payload;
         final boolean emptyPayloadBody = payloadBody.readableBytes() == 0;
+        final Publisher<Object> payload;
         if (trailers != null) {
             payload = emptyPayloadBody ? from(trailers) : from(payloadBody, trailers);
-            payloadInfo = new DefaultPayloadInfo(this).setEmpty(emptyPayloadBody)
-                    .setMayHaveTrailersAndGenericTypeBuffer(true);
         } else {
             payload = emptyPayloadBody ? empty() : from(payloadBody);
-            payloadInfo = new DefaultPayloadInfo(this).setEmpty(emptyPayloadBody)
-                    .setMayHaveTrailersAndGenericTypeBuffer(false);
         }
+        final DefaultPayloadInfo payloadInfo = new DefaultPayloadInfo(this).setEmpty(emptyPayloadBody)
+                .setMayHaveTrailersAndGenericTypeBuffer(trailers != null);
         return new DefaultStreamingHttpResponse(status(), version(), headers(), original.payloadHolder().allocator(),
                 payload, payloadInfo, original.payloadHolder().headersFactory());
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponse.java
@@ -21,6 +21,7 @@ import io.servicetalk.encoding.api.ContentCodec;
 
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static java.util.Objects.requireNonNull;
 
@@ -80,11 +81,11 @@ final class DefaultHttpResponse extends AbstractDelegatingHttpResponse
         final Publisher<Object> payload;
         final boolean emptyPayloadBody = payloadBody.readableBytes() == 0;
         if (trailers != null) {
-            payload = from(payloadBody, trailers);
+            payload = emptyPayloadBody ? from(trailers) : from(payloadBody, trailers);
             payloadInfo = new DefaultPayloadInfo(this).setEmpty(emptyPayloadBody)
                     .setMayHaveTrailersAndGenericTypeBuffer(true);
         } else {
-            payload = from(payloadBody);
+            payload = emptyPayloadBody ? empty() : from(payloadBody);
             payloadInfo = new DefaultPayloadInfo(this).setEmpty(emptyPayloadBody)
                     .setMayHaveTrailersAndGenericTypeBuffer(false);
         }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponse.java
@@ -78,12 +78,15 @@ final class DefaultHttpResponse extends AbstractDelegatingHttpResponse
     public StreamingHttpResponse toStreamingResponse() {
         final DefaultPayloadInfo payloadInfo;
         final Publisher<Object> payload;
+        final boolean emptyPayloadBody = payloadBody.readableBytes() == 0;
         if (trailers != null) {
             payload = from(payloadBody, trailers);
-            payloadInfo = new DefaultPayloadInfo(this).setMayHaveTrailersAndGenericTypeBuffer(true);
+            payloadInfo = new DefaultPayloadInfo(this).setEmpty(emptyPayloadBody)
+                    .setMayHaveTrailersAndGenericTypeBuffer(true);
         } else {
             payload = from(payloadBody);
-            payloadInfo = new DefaultPayloadInfo(this).setMayHaveTrailersAndGenericTypeBuffer(false);
+            payloadInfo = new DefaultPayloadInfo(this).setEmpty(emptyPayloadBody)
+                    .setMayHaveTrailersAndGenericTypeBuffer(false);
         }
         return new DefaultStreamingHttpResponse(status(), version(), headers(), original.payloadHolder().allocator(),
                 payload, payloadInfo, original.payloadHolder().headersFactory());

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponse.java
@@ -21,6 +21,7 @@ import io.servicetalk.encoding.api.ContentCodec;
 
 import javax.annotation.Nullable;
 
+import static io.servicetalk.buffer.api.EmptyBuffer.EMPTY_BUFFER;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static java.util.Objects.requireNonNull;
 
@@ -57,6 +58,10 @@ final class DefaultHttpResponse extends AbstractDelegatingHttpResponse
 
     @Override
     public Buffer payloadBody() {
+        if (payloadBody == EMPTY_BUFFER) {
+            payloadBody = original.payloadHolder().allocator().newBuffer(0, false);
+            // The correct DefaultPayloadInfo#setEmpty(...) flag will be set in toStreamingRequest()
+        }
         return payloadBody;
     }
 
@@ -76,7 +81,7 @@ final class DefaultHttpResponse extends AbstractDelegatingHttpResponse
 
     @Override
     public StreamingHttpResponse toStreamingResponse() {
-        final boolean emptyPayloadBody = payloadBody.readableBytes() == 0;
+        final boolean emptyPayloadBody = payloadBody == EMPTY_BUFFER;
         @Nullable
         final Publisher<Object> payload;
         if (trailers != null) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponse.java
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.buffer.api.EmptyBuffer.EMPTY_BUFFER;
 import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.http.api.HttpDataSourceTransformations.isAlwaysEmpty;
 import static java.util.Objects.requireNonNull;
 
 final class DefaultHttpResponse extends AbstractDelegatingHttpResponse
@@ -81,7 +82,7 @@ final class DefaultHttpResponse extends AbstractDelegatingHttpResponse
 
     @Override
     public StreamingHttpResponse toStreamingResponse() {
-        final boolean emptyPayloadBody = payloadBody == EMPTY_BUFFER;
+        final boolean emptyPayloadBody = isAlwaysEmpty(payloadBody);
         @Nullable
         final Publisher<Object> payload;
         if (trailers != null) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponse.java
@@ -21,7 +21,6 @@ import io.servicetalk.encoding.api.ContentCodec;
 
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static java.util.Objects.requireNonNull;
 
@@ -78,11 +77,12 @@ final class DefaultHttpResponse extends AbstractDelegatingHttpResponse
     @Override
     public StreamingHttpResponse toStreamingResponse() {
         final boolean emptyPayloadBody = payloadBody.readableBytes() == 0;
+        @Nullable
         final Publisher<Object> payload;
         if (trailers != null) {
             payload = emptyPayloadBody ? from(trailers) : from(payloadBody, trailers);
         } else {
-            payload = emptyPayloadBody ? empty() : from(payloadBody);
+            payload = emptyPayloadBody ? null : from(payloadBody);
         }
         final DefaultPayloadInfo payloadInfo = new DefaultPayloadInfo(this).setEmpty(emptyPayloadBody)
                 .setMayHaveTrailersAndGenericTypeBuffer(trailers != null);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultPayloadInfo.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultPayloadInfo.java
@@ -23,6 +23,7 @@ final class DefaultPayloadInfo implements PayloadInfo {
     private static final byte SAFE_TO_AGGREGATE = 1;
     private static final byte MAY_HAVE_TRAILERS = 2;
     private static final byte GENERIC_TYPE_BUFFER = 4;
+    private static final byte EMPTY = 8;
 
     private byte flags;
 
@@ -33,10 +34,16 @@ final class DefaultPayloadInfo implements PayloadInfo {
         if (from instanceof DefaultPayloadInfo) {
             this.flags = ((DefaultPayloadInfo) from).flags;
         } else {
+            setEmpty(from.isEmpty());
             setSafeToAggregate(from.isSafeToAggregate());
             setMayHaveTrailers(from.mayHaveTrailers());
             setGenericTypeBuffer(from.isGenericTypeBuffer());
         }
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return isSet(EMPTY);
     }
 
     @Override
@@ -52,6 +59,10 @@ final class DefaultPayloadInfo implements PayloadInfo {
     @Override
     public boolean isGenericTypeBuffer() {
         return isSet(GENERIC_TYPE_BUFFER);
+    }
+
+    DefaultPayloadInfo setEmpty(boolean empty) {
+        return set(EMPTY, empty);
     }
 
     DefaultPayloadInfo setSafeToAggregate(boolean safeToAggregate) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpRequest.java
@@ -203,6 +203,11 @@ final class DefaultStreamingHttpRequest extends DefaultHttpRequestMetaData
     }
 
     @Override
+    public boolean isEmpty() {
+        return payloadHolder.isEmpty();
+    }
+
+    @Override
     public boolean isSafeToAggregate() {
         return payloadHolder.isSafeToAggregate();
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpRequest.java
@@ -190,11 +190,7 @@ final class DefaultStreamingHttpRequest extends DefaultHttpRequestMetaData
 
     @Override
     public Single<HttpRequest> toRequest() {
-        return payloadHolder.aggregate()
-                .map(pair -> {
-                    assert pair.payload != null;
-                    return new DefaultHttpRequest(this, pair.payload, pair.trailers);
-                });
+        return payloadHolder.aggregate().map(pair -> new DefaultHttpRequest(this, pair.payload, pair.trailers));
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpResponse.java
@@ -120,6 +120,11 @@ final class DefaultStreamingHttpResponse extends DefaultHttpResponseMetaData
     }
 
     @Override
+    public boolean isEmpty() {
+        return payloadHolder.isEmpty();
+    }
+
+    @Override
     public boolean isSafeToAggregate() {
         return payloadHolder.isSafeToAggregate();
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpResponse.java
@@ -107,11 +107,7 @@ final class DefaultStreamingHttpResponse extends DefaultHttpResponseMetaData
 
     @Override
     public Single<HttpResponse> toResponse() {
-        return payloadHolder.aggregate()
-                .map(pair -> {
-                    assert pair.payload != null;
-                    return new DefaultHttpResponse(this, pair.payload, pair.trailers);
-                });
+        return payloadHolder.aggregate().map(pair -> new DefaultHttpResponse(this, pair.payload, pair.trailers));
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpApiConversions.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpApiConversions.java
@@ -184,6 +184,16 @@ public final class HttpApiConversions {
     }
 
     /**
+     * Checks whether a request/response payload body is empty.
+     *
+     * @param metadata The request/response to check.
+     * @return {@code true} is the request/response payload body is empty, {@code false} otherwise.
+     */
+    public static boolean isPayloadEmpty(HttpMetaData metadata) {
+        return (metadata instanceof PayloadInfo && ((PayloadInfo) metadata).isEmpty());
+    }
+
+    /**
      * Checks whether a request/response payload is safe to aggregate, which may allow for writing a `content-length`
      * header.
      *

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpDataSourceTransformations.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpDataSourceTransformations.java
@@ -303,7 +303,7 @@ final class HttpDataSourceTransformations {
             if (nextItem instanceof Buffer) {
                 try {
                     Buffer buffer = (Buffer) nextItem;
-                    if (pair.payload == EMPTY_BUFFER) {
+                    if (isAlwaysEmpty(pair.payload)) {
                         pair.payload = buffer;
                     } else if (pair.payload instanceof CompositeBuffer) {
                         ((CompositeBuffer) pair.payload).addBuffer(buffer);
@@ -323,7 +323,7 @@ final class HttpDataSourceTransformations {
             }
             return pair;
         }).map(pair -> {
-            if (pair.payload == EMPTY_BUFFER) {
+            if (isAlwaysEmpty(pair.payload)) {
                 payloadInfo.setEmpty(true);
             }
             if (pair.trailers == null) {
@@ -331,5 +331,9 @@ final class HttpDataSourceTransformations {
             }
             return pair;
         });
+    }
+
+    static boolean isAlwaysEmpty(final Buffer buffer) {
+        return buffer == EMPTY_BUFFER || (buffer.isReadOnly() && buffer.readableBytes() == 0);
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PayloadInfo.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PayloadInfo.java
@@ -24,6 +24,15 @@ import io.servicetalk.concurrent.api.Publisher;
  */
 interface PayloadInfo {
     /**
+     * Returns {@code true} if and only if, the payload body {@link Publisher} was never assigned, changed, or modified,
+     * and therefore remains empty.
+     *
+     * @return {@code true} if and only if, the payload body {@link Publisher} was never assigned, changed, or modified
+     * and therefore remains empty.
+     */
+    boolean isEmpty();
+
+    /**
      * Returns {@code true} if and only if, the {@link Publisher} associated with this {@link PayloadInfo} can be safely
      * aggregated to bring all data in memory. Inputs to this decision is left to the user of the API.
      *
@@ -43,9 +52,10 @@ interface PayloadInfo {
 
     /**
      * Returns {@code true} if and only if, the {@link Publisher} associated with this {@link PayloadInfo} can be
-     * safely cast to {@link Publisher}&lt;{@link Buffer}&gt;
+     * safely cast to {@link Publisher}&lt;{@link Buffer}&gt;.
+     *
      * @return {@code true} if and only if, the {@link Publisher} associated with this {@link PayloadInfo} can be
-     * safely cast to {@link Publisher}&lt;{@link Buffer}&gt;
+     * safely cast to {@link Publisher}&lt;{@link Buffer}&gt;.
      */
     boolean isGenericTypeBuffer();
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequest.java
@@ -129,9 +129,11 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
      * payload body concatenated with the <a href="https://tools.ietf.org/html/rfc7230#section-4.1.2">trailer</a> (if
      * present).
      * <p>
-     * The transformation is not expected to change the presence of trailers in the message body. For example behavior
-     * is undefined if a {@link HttpHeaders} object is inserted to or removed from to the returned {@link Publisher}.
-     * To add trailers use {@link #transform(TrailersTransformer)}.
+     * The transformation is not expected to change the content of the message body {@link Publisher} or presence of
+     * trailers in it. For example, behavior is undefined if a content is altered (added/removed/resized) or
+     * {@link HttpHeaders trailers} are inserted to or removed from to the returned {@link Publisher}. To alter the
+     * payload body content use {@link #transformPayloadBody(UnaryOperator)} method, its overloads, or
+     * {@link #transform(TrailersTransformer)} method which can also be used to modify trailers.
      * @param transformer Responsible for transforming the message-body.
      * @return {@code this}.
      */

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpResponse.java
@@ -128,9 +128,11 @@ public interface StreamingHttpResponse extends HttpResponseMetaData {
      * payload body concatenated with the <a href="https://tools.ietf.org/html/rfc7230#section-4.1.2">trailer</a> (if
      * present).
      * <p>
-     * The transformation is not expected to change the presence of trailers in the message body. For example behavior
-     * is undefined if a {@link HttpHeaders} object is inserted to or removed from to the returned {@link Publisher}.
-     * To add or clear trailers use {@link #transform(TrailersTransformer)}.
+     * The transformation is not expected to change the content of the message body {@link Publisher} or presence of
+     * trailers in it. For example, behavior is undefined if a content is altered (added/removed/resized) or
+     * {@link HttpHeaders trailers} are inserted to or removed from to the returned {@link Publisher}. To alter the
+     * payload body content use {@link #transformPayloadBody(UnaryOperator)} method, its overloads, or
+     * {@link #transform(TrailersTransformer)} method which can also be used to modify trailers.
      * @param transformer Responsible for transforming the message-body.
      * @return {@code this}.
      */

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -43,6 +43,7 @@ import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.api.HttpApiConversions.isPayloadEmpty;
 import static io.servicetalk.http.api.HttpApiConversions.isSafeToAggregate;
 import static io.servicetalk.http.api.StreamingHttpResponses.newTransportResponse;
 import static io.servicetalk.http.netty.HeaderUtils.addRequestTransferEncodingIfNecessary;
@@ -119,7 +120,7 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
     @Nullable
     static FlushStrategy determineFlushStrategyForApi(final HttpMetaData request) {
         // For non-aggregated, don't change the flush strategy, keep the default.
-        return isSafeToAggregate(request) ? flushOnEnd() : null;
+        return isPayloadEmpty(request) || isSafeToAggregate(request) ? flushOnEnd() : null;
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
@@ -37,14 +37,17 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.buffer.api.CharSequences.parseLong;
+import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Publisher.fromIterable;
 import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
+import static io.servicetalk.http.api.HttpApiConversions.isPayloadEmpty;
 import static io.servicetalk.http.api.HttpApiConversions.isSafeToAggregate;
 import static io.servicetalk.http.api.HttpApiConversions.mayHaveTrailers;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
+import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpRequestMethod.CONNECT;
 import static io.servicetalk.http.api.HttpRequestMethod.HEAD;
 import static io.servicetalk.http.api.HttpRequestMethod.PATCH;
@@ -99,18 +102,19 @@ final class HeaderUtils {
     }
 
     private static boolean canAddContentLength(final HttpMetaData metadata) {
-        return isSafeToAggregate(metadata) && (metadata.version().major() > 1 || !mayHaveTrailers(metadata)) &&
+        return (isPayloadEmpty(metadata) || isSafeToAggregate(metadata)) &&
+                (metadata.version().major() > 1 || !mayHaveTrailers(metadata)) &&
                 !hasContentHeaders(metadata.headers());
     }
 
     static Publisher<Object> setRequestContentLength(final StreamingHttpRequest request) {
         return setContentLength(request, request.messageBody(),
-                shouldAddZeroContentLength(request.method()) ? HeaderUtils::updateRequestContentLength :
+                shouldAddZeroContentLength(request.method()) ? HeaderUtils::updateContentLength :
                         HeaderUtils::updateRequestContentLengthNonZero);
     }
 
     static Publisher<Object> setResponseContentLength(final StreamingHttpResponse response) {
-        return setContentLength(response, response.messageBody(), HeaderUtils::updateResponseContentLength);
+        return setContentLength(response, response.messageBody(), HeaderUtils::updateContentLength);
     }
 
     private static void updateRequestContentLengthNonZero(final int contentLength, final HttpHeaders headers) {
@@ -119,9 +123,9 @@ final class HeaderUtils {
         }
     }
 
-    private static void updateRequestContentLength(final int contentLength, final HttpHeaders headers) {
+    private static void updateContentLength(final int contentLength, final HttpHeaders headers) {
         assert contentLength >= 0;
-        headers.set(CONTENT_LENGTH, Integer.toString(contentLength));
+        headers.set(CONTENT_LENGTH, contentLength == 0 ? ZERO : Integer.toString(contentLength));
     }
 
     static boolean shouldAddZeroContentLength(final HttpRequestMethod requestMethod) {
@@ -168,13 +172,13 @@ final class HeaderUtils {
         };
     }
 
-    private static void updateResponseContentLength(final int contentLength, final HttpHeaders headers) {
-        headers.set(CONTENT_LENGTH, Integer.toString(contentLength));
-    }
-
     private static Publisher<Object> setContentLength(final HttpMetaData metadata,
                                                       final Publisher<Object> messageBody,
                                                       final BiIntConsumer<HttpHeaders> contentLengthUpdater) {
+        if (messageBody == empty() || (isPayloadEmpty(metadata) && !mayHaveTrailers(metadata))) {
+            contentLengthUpdater.apply(0, metadata.headers());
+            return from(metadata, EmptyHttpHeaders.INSTANCE);
+        }
         return messageBody.collect(() -> null, (reduction, item) -> {
             if (reduction == null) {
                 // avoid allocating a list if the Publisher emits only a single Buffer

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
@@ -132,13 +132,13 @@ public class ContentHeadersTest extends AbstractNettyHttpServerTest {
                 new RequestTest(aggregatedRequest(GET), trailers(), HAVE_TRANSFER_ENCODING_CHUNKED),
                 new RequestTest(aggregatedRequestAsStreaming(GET), transform(), HAVE_TRANSFER_ENCODING_CHUNKED),
                 new RequestTest(streamingRequest(GET), defaults(), HAVE_TRANSFER_ENCODING_CHUNKED),
-                new RequestTest(streamingRequest(GET), withoutPayload(), HAVE_TRANSFER_ENCODING_CHUNKED),
+                new RequestTest(streamingRequest(GET), withoutPayload(), HAVE_NEITHER),
 
                 new BlockingRequestTest(aggregatedRequest(GET), defaults(), HAVE_CONTENT_LENGTH),
                 new BlockingRequestTest(aggregatedRequestAsStreaming(GET), defaults(), HAVE_CONTENT_LENGTH),
                 new BlockingRequestTest(streamingRequest(GET), defaults(), HAVE_TRANSFER_ENCODING_CHUNKED),
                 new BlockingRequestTest(aggregatedRequest(GET), trailers(), HAVE_TRANSFER_ENCODING_CHUNKED),
-                new BlockingRequestTest(streamingRequest(GET), withoutPayload(), HAVE_TRANSFER_ENCODING_CHUNKED),
+                new BlockingRequestTest(streamingRequest(GET), withoutPayload(), HAVE_NEITHER),
 
                 // ----- Response -----
                 new ResponseTest(aggregatedResponse(OK), GET, defaults(), HAVE_CONTENT_LENGTH),
@@ -181,7 +181,7 @@ public class ContentHeadersTest extends AbstractNettyHttpServerTest {
                 new ResponseTest(aggregatedResponse(INTERNAL_SERVER_ERROR), CONNECT, defaults(), HAVE_CONTENT_LENGTH),
                 new ResponseTest(aggregatedResponseAsStreaming(OK), GET, transform(), HAVE_TRANSFER_ENCODING_CHUNKED),
                 new ResponseTest(streamingResponse(OK), GET, defaults(), HAVE_TRANSFER_ENCODING_CHUNKED),
-                new ResponseTest(streamingResponse(OK), GET, withoutPayload(), HAVE_TRANSFER_ENCODING_CHUNKED),
+                new ResponseTest(streamingResponse(OK), GET, withoutPayload(), HAVE_CONTENT_LENGTH_ZERO),
 
                 new BlockingResponseTest(aggregatedResponse(OK), GET, defaults(), HAVE_CONTENT_LENGTH),
                 new BlockingResponseTest(aggregatedResponseAsStreaming(OK), GET, defaults(), HAVE_CONTENT_LENGTH),

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentLengthTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentLengthTest.java
@@ -24,7 +24,6 @@ import io.servicetalk.http.api.HttpRequest;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.HttpResponse;
 import io.servicetalk.http.api.StreamingHttpRequest;
-import io.servicetalk.http.api.StreamingHttpRequests;
 import io.servicetalk.http.api.StreamingHttpResponse;
 
 import org.hamcrest.Matcher;
@@ -50,8 +49,8 @@ import static io.servicetalk.http.api.HttpRequestMethod.TRACE;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializationProviders.textDeserializer;
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
+import static io.servicetalk.http.api.StreamingHttpRequests.newRequest;
 import static io.servicetalk.http.api.StreamingHttpResponses.newResponse;
-import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED;
 import static io.servicetalk.http.netty.HeaderUtils.setRequestContentLength;
 import static io.servicetalk.http.netty.HeaderUtils.setResponseContentLength;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -61,13 +60,9 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
 
-public class ContentLengthTest extends AbstractNettyHttpServerTest {
+public class ContentLengthTest {
 
     private static final DefaultHttpHeadersFactory headersFactory = new DefaultHttpHeadersFactory(false, false);
-
-    public ContentLengthTest() {
-        super(CACHED, CACHED);
-    }
 
     @Test
     public void shouldNotCalculateRequestContentLengthFromEmptyPublisher() throws Exception {
@@ -174,18 +169,18 @@ public class ContentLengthTest extends AbstractNettyHttpServerTest {
         setResponseContentLengthAndVerify(response, contentEqualTo("12"));
     }
 
-    private static HttpRequest newAggregatedRequest() {
+    private static HttpRequest newAggregatedRequest() throws Exception {
         return newAggregatedRequest(GET);
     }
 
-    private static HttpRequest newAggregatedRequest(HttpRequestMethod method) {
-        return awaitSingleIndefinitelyNonNull(StreamingHttpRequests.newRequest(method, "/", HTTP_1_1,
-                headersFactory.newHeaders(), DEFAULT_ALLOCATOR, headersFactory).toRequest());
+    private static HttpRequest newAggregatedRequest(HttpRequestMethod method) throws Exception {
+        return newRequest(method, "/", HTTP_1_1, headersFactory.newHeaders(), DEFAULT_ALLOCATOR, headersFactory)
+                .toRequest().toFuture().get();
     }
 
-    private static HttpResponse newAggregatedResponse() {
-        return awaitSingleIndefinitelyNonNull(newResponse(OK, HTTP_1_1, headersFactory.newHeaders(),
-                DEFAULT_ALLOCATOR, headersFactory).toResponse());
+    private static HttpResponse newAggregatedResponse() throws Exception {
+        return newResponse(OK, HTTP_1_1, headersFactory.newHeaders(), DEFAULT_ALLOCATOR, headersFactory)
+                .toResponse().toFuture().get();
     }
 
     private static void setRequestContentLengthAndVerify(final StreamingHttpRequest request,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentLengthTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentLengthTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import java.util.Collection;
 import java.util.Iterator;
 
+import static io.servicetalk.buffer.api.Matchers.contentEqualTo;
 import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.DEFAULT_RO_ALLOCATOR;
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
@@ -54,10 +55,10 @@ import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupp
 import static io.servicetalk.http.netty.HeaderUtils.setRequestContentLength;
 import static io.servicetalk.http.netty.HeaderUtils.setResponseContentLength;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class ContentLengthTest extends AbstractNettyHttpServerTest {
@@ -69,7 +70,7 @@ public class ContentLengthTest extends AbstractNettyHttpServerTest {
     }
 
     @Test
-    public void shouldNotCalculateRequestContentLengthFromEmptyPublisherForGetRequest() throws Exception {
+    public void shouldNotCalculateRequestContentLengthFromEmptyPublisher() throws Exception {
         shouldNotCalculateRequestContentLengthFromEmptyPublisher(GET);
         shouldNotCalculateRequestContentLengthFromEmptyPublisher(HEAD);
         shouldNotCalculateRequestContentLengthFromEmptyPublisher(DELETE);
@@ -86,7 +87,7 @@ public class ContentLengthTest extends AbstractNettyHttpServerTest {
     }
 
     @Test
-    public void shouldCalculateRequestContentLengthFromEmptyPublisherForPostRequest() throws Exception {
+    public void shouldCalculateRequestContentLengthFromEmptyPublisher() throws Exception {
         shouldCalculateRequestContentLengthFromEmptyPublisher(POST);
         shouldCalculateRequestContentLengthFromEmptyPublisher(PUT);
         shouldCalculateRequestContentLengthFromEmptyPublisher(PATCH);
@@ -96,28 +97,28 @@ public class ContentLengthTest extends AbstractNettyHttpServerTest {
             throws Exception {
         StreamingHttpRequest request = newAggregatedRequest(method).toStreamingRequest()
                 .payloadBody(Publisher.empty());
-        setRequestContentLengthAndVerify(request, is("0"));
+        setRequestContentLengthAndVerify(request, contentEqualTo("0"));
     }
 
     @Test
     public void shouldCalculateRequestContentLengthFromSingleItemPublisher() throws Exception {
         StreamingHttpRequest request = newAggregatedRequest().toStreamingRequest()
                 .payloadBody(Publisher.from("Hello"), textSerializer());
-        setRequestContentLengthAndVerify(request, is("5"));
+        setRequestContentLengthAndVerify(request, contentEqualTo("5"));
     }
 
     @Test
     public void shouldCalculateRequestContentLengthFromTwoItemPublisher() throws Exception {
         StreamingHttpRequest request = newAggregatedRequest().toStreamingRequest()
                 .payloadBody(Publisher.from("Hello", "World"), textSerializer());
-        setRequestContentLengthAndVerify(request, is("10"));
+        setRequestContentLengthAndVerify(request, contentEqualTo("10"));
     }
 
     @Test
     public void shouldCalculateRequestContentLengthFromMultipleItemPublisher() throws Exception {
         StreamingHttpRequest request = newAggregatedRequest().toStreamingRequest()
                 .payloadBody(Publisher.from("Hello", " ", "World", "!"), textSerializer());
-        setRequestContentLengthAndVerify(request, is("12"));
+        setRequestContentLengthAndVerify(request, contentEqualTo("12"));
     }
 
     @Test
@@ -125,7 +126,7 @@ public class ContentLengthTest extends AbstractNettyHttpServerTest {
         StreamingHttpRequest request = newAggregatedRequest().payloadBody("Hello", textSerializer())
                 .toStreamingRequest().transformPayloadBody(payload -> payload.concat(Publisher.from(" ", "World", "!")),
                         textDeserializer(), textSerializer());
-        setRequestContentLengthAndVerify(request, is("12"));
+        setRequestContentLengthAndVerify(request, contentEqualTo("12"));
     }
 
     @Test
@@ -133,35 +134,35 @@ public class ContentLengthTest extends AbstractNettyHttpServerTest {
         StreamingHttpRequest request = newAggregatedRequest().payloadBody("Hello", textSerializer())
                 .toStreamingRequest().transformMessageBody(payload -> payload.map(obj -> (Buffer) obj)
                         .concat(Publisher.from(" ", "World", "!").map(DEFAULT_RO_ALLOCATOR::fromAscii)));
-        setRequestContentLengthAndVerify(request, is("12"));
+        setRequestContentLengthAndVerify(request, contentEqualTo("12"));
     }
 
     @Test
     public void shouldCalculateResponseContentLengthFromEmptyPublisher() throws Exception {
         StreamingHttpResponse response = newAggregatedResponse().toStreamingResponse()
                 .payloadBody(Publisher.empty());
-        setResponseContentLengthAndVerify(response, is("0"));
+        setResponseContentLengthAndVerify(response, contentEqualTo("0"));
     }
 
     @Test
     public void shouldCalculateResponseContentLengthFromSingleItemPublisher() throws Exception {
         StreamingHttpResponse response = newAggregatedResponse().toStreamingResponse()
                 .payloadBody(Publisher.from("Hello"), textSerializer());
-        setResponseContentLengthAndVerify(response, is("5"));
+        setResponseContentLengthAndVerify(response, contentEqualTo("5"));
     }
 
     @Test
     public void shouldCalculateResponseContentLengthFromTwoItemPublisher() throws Exception {
         StreamingHttpResponse response = newAggregatedResponse().toStreamingResponse()
                 .payloadBody(Publisher.from("Hello", "World"), textSerializer());
-        setResponseContentLengthAndVerify(response, is("10"));
+        setResponseContentLengthAndVerify(response, contentEqualTo("10"));
     }
 
     @Test
     public void shouldCalculateResponseContentLengthFromMultipleItemPublisher() throws Exception {
         StreamingHttpResponse response = newAggregatedResponse().toStreamingResponse()
                 .payloadBody(Publisher.from("Hello", " ", "World", "!"), textSerializer());
-        setResponseContentLengthAndVerify(response, is("12"));
+        setResponseContentLengthAndVerify(response, contentEqualTo("12"));
     }
 
     @Test
@@ -170,7 +171,7 @@ public class ContentLengthTest extends AbstractNettyHttpServerTest {
                 .toStreamingResponse()
                 .transformPayloadBody(payload -> payload.concat(Publisher.from(" ", "World", "!")),
                         textDeserializer(), textSerializer());
-        setResponseContentLengthAndVerify(response, is("12"));
+        setResponseContentLengthAndVerify(response, contentEqualTo("12"));
     }
 
     private static HttpRequest newAggregatedRequest() {
@@ -193,9 +194,9 @@ public class ContentLengthTest extends AbstractNettyHttpServerTest {
         assertThat("Unexpected items in the flattened request.", flattened, hasSize(greaterThanOrEqualTo(2)));
         Iterator<Object> iterator = flattened.iterator();
         Object firstItem = iterator.next();
-        assertThat("Unexpected items in the flattened request.", firstItem, is(instanceOf(HttpMetaData.class)));
+        assertThat("Unexpected items in the flattened request.", firstItem, instanceOf(HttpMetaData.class));
         assertThat(((HttpMetaData) firstItem).headers().get(CONTENT_LENGTH), matcher);
-        assertLastItem(iterator);
+        assertLastItems(iterator);
     }
 
     private static void setResponseContentLengthAndVerify(final StreamingHttpResponse response,
@@ -204,16 +205,20 @@ public class ContentLengthTest extends AbstractNettyHttpServerTest {
         assertThat("Unexpected items in the flattened response.", flattened, hasSize(greaterThanOrEqualTo(2)));
         Iterator<Object> iterator = flattened.iterator();
         Object firstItem = iterator.next();
-        assertThat("Unexpected items in the flattened response.", firstItem, is(instanceOf(HttpMetaData.class)));
+        assertThat("Unexpected items in the flattened response.", firstItem, instanceOf(HttpMetaData.class));
         assertThat(((HttpMetaData) firstItem).headers().get(CONTENT_LENGTH), matcher);
-        assertLastItem(iterator);
+        assertLastItems(iterator);
     }
 
-    private static void assertLastItem(Iterator<Object> iterator) {
-        Object item = null;
+    private static void assertLastItems(Iterator<Object> iterator) {
+        Object prev = null;
+        Object last = null;
         while (iterator.hasNext()) {
-            item = iterator.next();
+            prev = last;
+            last = iterator.next();
         }
-        assertThat("Unexpected last item in the flattened stream.", item, is(instanceOf(HttpHeaders.class)));
+        assertThat("Unexpected last item in the flattened stream.", last, instanceOf(HttpHeaders.class));
+        assertThat("Unexpected previous item in the flattened stream.", prev,
+                anyOf(nullValue(), instanceOf(Buffer.class)));
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PayloadBodyModificationsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PayloadBodyModificationsTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.api.StreamingHttpRequest;
+
+import org.junit.Test;
+
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
+import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED;
+import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED_SERVER;
+import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ECHO;
+
+public class PayloadBodyModificationsTest extends AbstractNettyHttpServerTest {
+
+    private static final String CONTENT = "content";
+
+    public PayloadBodyModificationsTest() {
+        super(CACHED, CACHED_SERVER);
+    }
+
+    @Test
+    public void aggregatedSetPayloadBody() throws Exception {
+        HttpClient client = streamingHttpClient().asClient();
+        HttpRequest request = client.post(SVC_ECHO)
+                .payloadBody(client.executionContext().bufferAllocator().fromAscii(CONTENT));
+        assertResponse(makeRequest(request.toStreamingRequest()), request.version(), OK, CONTENT);
+    }
+
+    @Test
+    public void aggregatedSetPayloadBodyWithSerializer() throws Exception {
+        HttpRequest request = streamingHttpClient().asClient().post(SVC_ECHO)
+                .payloadBody(CONTENT, textSerializer());
+        assertResponse(makeRequest(request.toStreamingRequest()), request.version(), OK, CONTENT);
+    }
+
+    @Test
+    public void aggregatedExpandOriginalBuffer() throws Exception {
+        HttpRequest request = streamingHttpClient().asClient().post(SVC_ECHO);
+        Buffer payload = request.payloadBody();
+        payload.writeAscii(CONTENT);
+        assertResponse(makeRequest(request.toStreamingRequest()), request.version(), OK, CONTENT);
+    }
+
+    @Test
+    public void aggregatedExpandOriginalBufferAfterTypeConversion() throws Exception {
+        HttpRequest request = streamingHttpClient().asClient().post(SVC_ECHO);
+        Buffer payload = request.payloadBody();
+        StreamingHttpRequest streamingRequest = request.toStreamingRequest();
+        payload.writeAscii(CONTENT);
+        assertResponse(makeRequest(streamingRequest), request.version(), OK, CONTENT);
+    }
+
+    @Test
+    public void aggregatedTakeAndExpandOriginalBufferAfterTypeConversion() throws Exception {
+        HttpRequest request = streamingHttpClient().asClient().post(SVC_ECHO);
+        StreamingHttpRequest streamingRequest = request.toStreamingRequest();
+        // Too late to take the buffer from the original aggregated request object, modifications won't be visible:
+        Buffer payload = request.payloadBody();
+        payload.writeAscii(CONTENT);
+        assertResponse(makeRequest(streamingRequest), request.version(), OK, 0);
+    }
+
+    @Test
+    public void streamingSetPayloadBody() throws Exception {
+        StreamingHttpClient client = streamingHttpClient();
+        StreamingHttpRequest request = client.post(SVC_ECHO)
+                .payloadBody(from(client.executionContext().bufferAllocator().fromAscii(CONTENT)));
+        assertResponse(makeRequest(request), request.version(), OK, CONTENT);
+    }
+
+    @Test
+    public void streamingSetPayloadBodyWithSerializer() throws Exception {
+        StreamingHttpRequest request = streamingHttpClient().post(SVC_ECHO)
+                .payloadBody(from(CONTENT), textSerializer());
+        assertResponse(makeRequest(request), request.version(), OK, CONTENT);
+    }
+
+    @Test
+    public void streamingExpandOriginalBuffer() throws Exception {
+        StreamingHttpClient client = streamingHttpClient();
+        Buffer buffer = client.executionContext().bufferAllocator().newBuffer(0, false);
+        StreamingHttpRequest request = client.post(SVC_ECHO).payloadBody(from(buffer));
+        buffer.writeAscii(CONTENT);
+        assertResponse(makeRequest(request), request.version(), OK, CONTENT);
+    }
+
+    @Test
+    public void streamingExpandOriginalBufferAfterTypeConversions() throws Exception {
+        StreamingHttpClient client = streamingHttpClient();
+        Buffer buffer = client.executionContext().bufferAllocator().newBuffer(0, false);
+        StreamingHttpRequest request = client.post(SVC_ECHO).payloadBody(from(buffer))
+                .toRequest().toFuture().get().toStreamingRequest();
+        buffer.writeAscii(CONTENT);
+        assertResponse(makeRequest(request), request.version(), OK, CONTENT);
+    }
+}


### PR DESCRIPTION
Motivation:

In many cases users do not set payload body when they create an HTTP
request (like `GET`) or response (like, 204). We can optimize flush
strategy and HTTP/1.1 encoding in these cases.

Modifications:

- Introduce `PayloadInfo#isEmpty()` flag that tells internal layers when
an HTTP message contains payload body;
- Use this flag to choose a flush strategy and set `content-length` header;
- Adjust existing `content-length` tests to verify new use-cases with
empty payload body;
- Enhance existing `FlushStrategyOnServerTest` to verify empty responses
flush on end;
- Filter out empty payload body buffer when converting between types;
- Add more tests to verify users can keep using different ways to set payload;

Behavior changes:
- Users cannot write more data into a payload body `Buffer` of new
request/response objects after types conversion:
```
HttpRequest request = streamingHttpClient().asClient().post(SVC_ECHO);
StreamingHttpRequest streamingRequest = request.toStreamingRequest();
// Too late to take the buffer from the original aggregated request object, modifications won't be visible:
Buffer payload = request.payloadBody();
payload.writeAscii(CONTENT);
assertResponse(makeRequest(streamingRequest), request.version(), OK, 0);
```
- Streaming HTTP/1.1 requests and responses with empty payload body are
encoded with `content-length: 0` instead of `transfer-encoding: chunked`;

Result:

Less flushes + non-chunked HTTP/1.1 encoding when there is no payload body
results in better throughput (+30% RPS) for these use-cases, latency improves
by ~15%.