### PR TITLE
Enable back SHA256 and SHA512 checksums for published artifacts

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -64,9 +64,3 @@ commonsLangVersion=2.6
 grpcVersion=1.37.0
 javaxAnnotationsApiVersion=1.3.5
 jsonUnitVersion=2.8.1
-
-# Disable SHA256 and SHA512 checksums until Sonatype and Maven Central supports them:
-# https://issues.sonatype.org/browse/NEXUS-21802
-# https://issues.sonatype.org/browse/MVNCENTRAL-5276
-# https://issues.apache.org/jira/browse/INFRA-14923
-systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
Motivation:

We had to disable SHA256 and SHA512 checksums until Sonatype and Maven Central
support them. The referenced issues were closed. We can start publishing artifacts
with SHA256 and SHA512 checksum files.

Modification:

- Remove a parameter from `gradle.properties` that did disable this feature;

Result:

Gradle will generate  SHA256 and SHA512 checksum files for published artifacts.