### PR TITLE
Use consistent defaults for HTTP Timeout filters

### DIFF
--- a/servicetalk-examples/http/service-composition/src/main/java/io/servicetalk/examples/http/service/composition/GatewayServer.java
+++ b/servicetalk-examples/http/service-composition/src/main/java/io/servicetalk/examples/http/service/composition/GatewayServer.java
@@ -122,7 +122,7 @@ public final class GatewayServer {
                                 .maxRetries(3)
                                 .buildWithExponentialBackoffDeltaJitter(ofMillis(100), ofMillis(50), ofSeconds(30)))
                         // Apply a timeout filter for the client to guard against latent clients.
-                        .appendClientFilter(new TimeoutHttpRequesterFilter(ofMillis(500)))
+                        .appendClientFilter(new TimeoutHttpRequesterFilter(ofMillis(500), false))
                         // Apply a filter that returns an error if any response status code is not 200 OK
                         .appendClientFilter(new ResponseCheckingClientFilter(backendName))
                         .ioExecutor(ioExecutor)

--- a/servicetalk-examples/http/timeout/src/main/java/io/servicetalk/examples/http/timeout/TimeoutServer.java
+++ b/servicetalk-examples/http/timeout/src/main/java/io/servicetalk/examples/http/timeout/TimeoutServer.java
@@ -32,7 +32,7 @@ public final class TimeoutServer {
     public static void main(String[] args) throws Exception {
         HttpServers.forPort(8080)
                 // Filter enforces that responses must complete within 30 seconds or will be cancelled.
-                .appendServiceFilter(new TimeoutHttpServiceFilter(Duration.ofSeconds(30)))
+                .appendServiceFilter(new TimeoutHttpServiceFilter(Duration.ofSeconds(30), true))
                 .listenAndAwait((ctx, request, responseFactory) ->
                         Single.defer(() -> {
                             // Force a 5 second delay in the response.

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseTimeoutTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseTimeoutTest.java
@@ -96,7 +96,7 @@ public class ResponseTimeoutTest {
                                Duration serverTimeout,
                                Class<? extends Throwable> expectThrowableClazz) throws Exception {
         ctx = forAddress(localAddress(0))
-                .appendServiceFilter(new TimeoutHttpServiceFilter(serverTimeout))
+                .appendServiceFilter(new TimeoutHttpServiceFilter(serverTimeout, true))
                 .listenAndAwait((__, ___, factory) -> {
                     Processor<HttpResponse, HttpResponse> resp = newSingleProcessor();
                     serverResponses.add(resp);

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpServiceFilter.java
@@ -58,45 +58,45 @@ public final class TimeoutHttpServiceFilter
     private final Executor timeoutExecutor;
 
     /**
-     * Construct a new instance.
+     * Creates a new instance which requires only that the response metadata be received before the timeout.
      *
      * @param duration the timeout {@link Duration}
      */
     public TimeoutHttpServiceFilter(Duration duration) {
-        this(simpleDurationTimeout(duration));
+        this(simpleDurationTimeout(duration), false);
     }
 
     /**
-     * Construct a new instance.
+     * Creates a new instance which requires only that the response metadata be received before the timeout.
      *
      * @param duration the timeout {@link Duration}
      * @param timeoutExecutor the {@link Executor} to use for managing the timer notifications
      */
-    public TimeoutHttpServiceFilter(Duration duration,
-                                    Executor timeoutExecutor) {
-        this(simpleDurationTimeout(duration), timeoutExecutor);
+    public TimeoutHttpServiceFilter(Duration duration, Executor timeoutExecutor) {
+        this(simpleDurationTimeout(duration), false, timeoutExecutor);
     }
 
     /**
-     * Construct a new instance.
+     * Creates a new instance.
      *
-     * @param timeoutForRequest function for extracting timeout from request which may also determine the timeout using
-     * other sources. If no timeout is to be applied then the function should return null.
+     * @param duration the timeout {@link Duration}
+     * @param fullRequestResponse if {@code true} then timeout is for full request/response transaction otherwise only
+     * the response metadata must complete before the timeout.
      */
-    public TimeoutHttpServiceFilter(TimeoutFromRequest timeoutForRequest) {
-        this(timeoutForRequest, true);
+    public TimeoutHttpServiceFilter(Duration duration, boolean fullRequestResponse) {
+        this(simpleDurationTimeout(duration), fullRequestResponse);
     }
 
     /**
-     * Construct a new instance.
+     * Creates a new instance.
      *
-     * @param timeoutForRequest function for extracting timeout from request which may also determine the timeout using
-     * other sources. If no timeout is to be applied then the function should return null.
+     * @param duration the timeout {@link Duration}
+     * @param fullRequestResponse if {@code true} then timeout is for full request/response transaction otherwise only
+     * the response metadata must complete before the timeout.
      * @param timeoutExecutor the {@link Executor} to use for managing the timer notifications
      */
-    public TimeoutHttpServiceFilter(TimeoutFromRequest timeoutForRequest,
-                                    Executor timeoutExecutor) {
-        this(timeoutForRequest, true, timeoutExecutor);
+    public TimeoutHttpServiceFilter(Duration duration, boolean fullRequestResponse, Executor timeoutExecutor) {
+        this(simpleDurationTimeout(duration), fullRequestResponse, timeoutExecutor);
     }
 
     /**
@@ -107,8 +107,7 @@ public final class TimeoutHttpServiceFilter
      * @param fullRequestResponse if {@code true} then timeout is for full request/response transaction otherwise only
      * the response metadata must complete before the timeout.
      */
-    public TimeoutHttpServiceFilter(TimeoutFromRequest timeoutForRequest,
-                                    boolean fullRequestResponse) {
+    public TimeoutHttpServiceFilter(TimeoutFromRequest timeoutForRequest, boolean fullRequestResponse) {
         this.timeoutForRequest = Objects.requireNonNull(timeoutForRequest, "timeoutForRequest");
         this.fullRequestResponse = fullRequestResponse;
         this.timeoutExecutor = null;


### PR DESCRIPTION
Motivation:
There are two timeout filters for HTTP, `TimeoutHttpRequesterFilter`
and `TimeoutHttpServiceFilter` but they have differing defaults for the
behaviour of whether the timeout applies to the entire response or only
the response metadata.
Modifications:
Both filters now have the same set of constructors and defaults.
Result:
Reduced opportunity for API misuse due to inconsistent behaviour.