### PR TITLE
Move `Publisher#toNanos` to `DurationUtils`

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -61,6 +61,7 @@ import static io.servicetalk.concurrent.api.PublisherDoOnUtils.doOnRequestSuppli
 import static io.servicetalk.concurrent.api.PublisherDoOnUtils.doOnSubscribeSupplier;
 import static io.servicetalk.concurrent.internal.SignalOffloaders.newOffloaderFor;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
+import static io.servicetalk.utils.internal.DurationUtils.toNanos;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -78,15 +79,6 @@ import static java.util.Objects.requireNonNull;
  */
 public abstract class Publisher<T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(Publisher.class);
-
-    /**
-     * Maximum positive duration which can be expressed as a signed 64-bit number of nanoseconds.
-     */
-    private static final Duration LONG_MAX_NANOS = Duration.ofNanos(Long.MAX_VALUE);
-    /**
-     * Maximum negative duration which can be expressed as a signed 64-bit number of nanoseconds.
-     */
-    private static final Duration LONG_MIN_NANOS = Duration.ofNanos(Long.MIN_VALUE);
 
     private final Executor executor;
     private final boolean shareContextOnSubscribe;
@@ -1685,19 +1677,6 @@ public abstract class Publisher<T> {
     public final Publisher<T> timeout(long duration, TimeUnit unit,
                                       io.servicetalk.concurrent.Executor timeoutExecutor) {
         return new TimeoutPublisher<>(this, executor, duration, unit, true, timeoutExecutor);
-    }
-
-    /**
-     * Converts a {@code Duration} to nanoseconds or if the resulting value would overflow a 64-bit signed integer then
-     * either {@code Long.MIN_VALUE} or {@code Long.MAX_VALUE} as appropriate.
-     *
-     * @param duration The duration to convert
-     * @return The converted nanoseconds value.
-     */
-    private static long toNanos(Duration duration) {
-        return duration.compareTo(LONG_MAX_NANOS) < 0 ?
-                duration.compareTo(LONG_MIN_NANOS) > 0 ? duration.toNanos() : Long.MIN_VALUE
-                : Long.MAX_VALUE;
     }
 
     /**

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/DurationUtils.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/DurationUtils.java
@@ -18,12 +18,23 @@ package io.servicetalk.utils.internal;
 import java.time.Duration;
 
 import static java.time.Duration.ZERO;
+import static java.time.Duration.ofNanos;
 import static java.util.Objects.requireNonNull;
 
 /**
  * Helper utilities for {@link Duration}.
  */
 public final class DurationUtils {
+
+    /**
+     * Maximum positive duration which can be expressed as a signed 64-bit number of nanoseconds.
+     */
+    private static final Duration LONG_MAX_NANOS = ofNanos(Long.MAX_VALUE);
+
+    /**
+     * Maximum negative duration which can be expressed as a signed 64-bit number of nanoseconds.
+     */
+    private static final Duration LONG_MIN_NANOS = ofNanos(Long.MIN_VALUE);
 
     private DurationUtils() {
         // No instances
@@ -53,5 +64,18 @@ public final class DurationUtils {
             throw new IllegalArgumentException(name + ": " + duration + " (expected > 0)");
         }
         return duration;
+    }
+
+    /**
+     * Converts a {@code Duration} to nanoseconds or if the resulting value would overflow a 64-bit signed integer then
+     * either {@code Long.MIN_VALUE} or {@code Long.MAX_VALUE} as appropriate.
+     *
+     * @param duration the duration to convert
+     * @return the converted nanoseconds value
+     */
+    public static long toNanos(final Duration duration) {
+        return duration.compareTo(LONG_MAX_NANOS) < 0 ?
+                (duration.compareTo(LONG_MIN_NANOS) > 0 ? duration.toNanos() : Long.MIN_VALUE)
+                : Long.MAX_VALUE;
     }
 }


### PR DESCRIPTION
Motivation:

`Publisher` is already a complicated class. We should not expand its
scope by additional utilities, even if they are internal. We have a
better place for `Publisher#toNanos` now - `DurationUtils`.

Modifications:

- Move `Publisher#toNanos` to `DurationUtils`;

Result:

Less utilities in `Publisher`, all `compareTo` operations for
`Duration` are in a single place.