### PR TITLE
Add `DurationUtils#isInfinite` utility

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientMetadata.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientMetadata.java
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.encoding.api.Identity.identity;
 import static io.servicetalk.utils.internal.DurationUtils.ensurePositive;
+import static io.servicetalk.utils.internal.DurationUtils.isInfinite;
 
 /**
  * Default implementation for {@link DefaultGrpcClientMetadata}.
@@ -153,7 +154,7 @@ public class DefaultGrpcClientMetadata extends DefaultGrpcMetadata implements Gr
         if (null != timeout) {
             ensurePositive(timeout, "timeout");
         }
-        this.timeout = null != timeout && timeout.compareTo(GRPC_MAX_TIMEOUT) <= 0 ? timeout : null;
+        this.timeout = isInfinite(timeout, GRPC_MAX_TIMEOUT) ? null : timeout;
     }
 
     @Override

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
@@ -57,6 +57,7 @@ import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.encoding.api.Identity.identity;
 import static io.servicetalk.encoding.api.internal.HeaderUtils.encodingFor;
+import static io.servicetalk.grpc.api.GrpcClientMetadata.GRPC_MAX_TIMEOUT;
 import static io.servicetalk.grpc.api.GrpcStatusCode.CANCELLED;
 import static io.servicetalk.grpc.api.GrpcStatusCode.DEADLINE_EXCEEDED;
 import static io.servicetalk.grpc.api.GrpcStatusCode.INTERNAL;
@@ -69,6 +70,7 @@ import static io.servicetalk.http.api.HttpHeaderNames.TE;
 import static io.servicetalk.http.api.HttpHeaderNames.USER_AGENT;
 import static io.servicetalk.http.api.HttpHeaderValues.TRAILERS;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
+import static io.servicetalk.utils.internal.DurationUtils.isInfinite;
 import static java.lang.String.valueOf;
 
 final class GrpcUtils {
@@ -173,8 +175,7 @@ final class GrpcUtils {
      * @return The timeout header text value or null for infinite timeouts
      */
     static @Nullable CharSequence makeTimeoutHeader(@Nullable Duration timeout) {
-        if (null == timeout || timeout.compareTo(GrpcClientMetadata.GRPC_MAX_TIMEOUT) > 0) {
-            // no timeout specified or "infinite" timeout
+        if (isInfinite(timeout, GRPC_MAX_TIMEOUT)) {
             return null;
         }
 

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
@@ -53,6 +53,7 @@ import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.grpc.api.GrpcClientMetadata.GRPC_MAX_TIMEOUT;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h2Default;
 import static io.servicetalk.utils.internal.DurationUtils.ensurePositive;
+import static io.servicetalk.utils.internal.DurationUtils.isInfinite;
 
 final class DefaultGrpcClientBuilder<U, R> extends GrpcClientBuilder<U, R> {
     /**
@@ -216,8 +217,7 @@ final class DefaultGrpcClientBuilder<U, R> extends GrpcClientBuilder<U, R> {
 
     @Override
     protected GrpcClientCallFactory newGrpcClientCallFactory() {
-        Duration timeout = null == defaultTimeout || GRPC_MAX_TIMEOUT.compareTo(defaultTimeout) < 0 ?
-                null : defaultTimeout;
+        Duration timeout = isInfinite(defaultTimeout, GRPC_MAX_TIMEOUT) ? null : defaultTimeout;
         if (!invokedBuild && null != timeout) {
             httpClientBuilder.appendClientFilter(new TimeoutHttpRequesterFilter(GRPC_TIMEOUT_REQHDR, true));
         }

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -58,6 +58,7 @@ import static io.servicetalk.grpc.api.GrpcClientMetadata.GRPC_MAX_TIMEOUT;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h2Default;
 import static io.servicetalk.utils.internal.DurationUtils.ensurePositive;
+import static io.servicetalk.utils.internal.DurationUtils.isInfinite;
 
 final class DefaultGrpcServerBuilder extends GrpcServerBuilder implements ServerBinder {
 
@@ -196,7 +197,7 @@ final class DefaultGrpcServerBuilder extends GrpcServerBuilder implements Server
     }
 
     private HttpServerBuilder preBuild() {
-        if (!invokedBuild && null != defaultTimeout && GRPC_MAX_TIMEOUT.compareTo(defaultTimeout) >= 0) {
+        if (!invokedBuild && !isInfinite(defaultTimeout, GRPC_MAX_TIMEOUT)) {
             doAppendHttpServiceFilter(new TimeoutHttpServiceFilter(grpcDetermineTimeout(defaultTimeout), true));
         }
         invokedBuild = true;

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/DurationUtils.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/DurationUtils.java
@@ -16,6 +16,7 @@
 package io.servicetalk.utils.internal;
 
 import java.time.Duration;
+import javax.annotation.Nullable;
 
 import static java.time.Duration.ZERO;
 import static java.time.Duration.ofNanos;
@@ -64,6 +65,18 @@ public final class DurationUtils {
             throw new IllegalArgumentException(name + ": " + duration + " (expected > 0)");
         }
         return duration;
+    }
+
+    /**
+     * Checks if the duration is considered "infinite".
+     *
+     * @param duration the {@link Duration} to validate
+     * @param maxDuration the max {@link Duration} limit
+     * @return {@code true} if the passed duration is {@code null} or exceeds the {@code maxDuration}, {@code false}
+     * otherwise
+     */
+    public static boolean isInfinite(@Nullable final Duration duration, final Duration maxDuration) {
+        return duration == null || maxDuration.compareTo(duration) < 0;
     }
 
     /**

--- a/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/DurationUtilsTest.java
+++ b/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/DurationUtilsTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import java.time.Duration;
 
 import static io.servicetalk.utils.internal.DurationUtils.ensurePositive;
+import static io.servicetalk.utils.internal.DurationUtils.isInfinite;
 import static io.servicetalk.utils.internal.DurationUtils.isPositive;
 import static java.time.Duration.ofNanos;
 import static java.time.Duration.ofSeconds;
@@ -28,6 +29,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 
 public class DurationUtilsTest {
+
+    private static final Duration MAX_DURATION = ofSeconds(2);
 
     @Test
     public void testIsPositiveSeconds() {
@@ -49,5 +52,13 @@ public class DurationUtilsTest {
         assertThrows(IllegalArgumentException.class, () -> ensurePositive(Duration.ZERO, "duration"));
         assertThrows(IllegalArgumentException.class, () -> ensurePositive(ofNanos(1L).negated(), "duration"));
         assertThrows(IllegalArgumentException.class, () -> ensurePositive(ofSeconds(1L).negated(), "duration"));
+    }
+
+    @Test
+    public void testIsInfinite() {
+        assertThat(isInfinite(null, MAX_DURATION), is(true));
+        assertThat(isInfinite(ofSeconds(3), MAX_DURATION), is(true));
+        assertThat(isInfinite(ofSeconds(1), MAX_DURATION), is(false));
+        assertThat(isInfinite(MAX_DURATION, MAX_DURATION), is(false));
     }
 }


### PR DESCRIPTION
Motivation:

gRPC module checks if the timeout is considered infinite or not in
multiple places. All use different way of `compareTo` check.

Modifications:
- Introduce `DurationUtils#isInfinite` utility and test it;
- Use the new utility in all places where required;

Result:

Consistent approach to verify when timeout should be handled as infinite.