### PR TITLE
Do not concatenate `Publisher.empty()` message body

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
@@ -177,7 +177,11 @@ final class HeaderUtils {
                                                       final BiIntConsumer<HttpHeaders> contentLengthUpdater) {
         if (messageBody == empty() || (isPayloadEmpty(metadata) && !mayHaveTrailers(metadata))) {
             contentLengthUpdater.apply(0, metadata.headers());
-            return from(metadata, EmptyHttpHeaders.INSTANCE).concat(messageBody.ignoreElements());
+            return messageBody == empty() ?
+                    from(metadata, EmptyHttpHeaders.INSTANCE) :
+                    // Subscribe to the messageBody publisher to trigger any applied transformations, but ignore its
+                    // content because the PayloadInfo indicated it's effectively empty and does not contain trailers
+                    from(metadata, EmptyHttpHeaders.INSTANCE).concat(messageBody.ignoreElements());
         }
         return messageBody.collect(() -> null, (reduction, item) -> {
             if (reduction == null) {


### PR DESCRIPTION
Motivation:

For `HeaderUtils#setContentLength(...)`, when the `messageBody` is exactly
`Publisher.empty()` there are no operators applied for the `messageBody`.
In this case we do not need concatenation.

Modifications:

- Skip concatenation when `messageBody == empty()`;
- Add tests when payloadBody is not set at all;

Result:

Less operators applied during request/response processing when not
necessary.