### PR TITLE
release.sh: identify the remote before switching to `DRYRUN` mode

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -49,17 +49,17 @@ fi
 echo "Releasing version $version"
 version_majorminor="${version%.*}"
 
+remote=$(git remote -v | grep "apple/servicetalk.git" | head -n1)
+remote_name=$(echo $remote | cut -d' ' -f1)
+remote_url=$(echo $remote | cut -d' ' -f2)
+echo "Working with remote $remote_name -> $remote_url"
+
 if [ -z "${DRYRUN:-}" ]; then
     git="git"
 else
     git="echo git"
+    echo "DRYRUN mode is enabled, any further changes won't be committed."
 fi
-
-remote=$(git remote -v | grep "apple/servicetalk.git" | head -n1)
-remote_name=$(echo $remote | cut -d' ' -f1)
-remote_url=$(echo $remote | cut -d' ' -f2)
-
-echo "Working with remote $remote_name -> $remote_url"
 
 $git fetch -p
 if $git rev-parse --quiet --verify main > /dev/null; then


### PR DESCRIPTION
Motivation:

Current version of the release script identifies the remote after the
`DRYRUN` mode overrides `git` command. As the result, logs do not show
which remote will be used when the `DRYRUN` mode will be off.

Modifications:

- Move lines that identify `remote` before the `DRYRUN` mode check;
- Print a message when `DRYRUN` mode is enabled;

Result:

`DRYRUN` mode correctly shows the git remote.