### PR TITLE
Fix flaky `GracefulConnectionClosureHandlingTest#closeIdleBeforeExchange` test

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
@@ -118,6 +118,7 @@ public class GracefulConnectionClosureHandlingTest {
     private final boolean initiateClosureFromClient;
     private final AsyncCloseable toClose;
     private final CountDownLatch onClosing = new CountDownLatch(1);
+    private final CountDownLatch connectionAccepted = new CountDownLatch(1);
 
     @Nullable
     private final ProxyTunnel proxyTunnel;
@@ -163,6 +164,7 @@ public class GracefulConnectionClosureHandlingTest {
                                     .whenFinally(onClosing::countDown).subscribe();
                         }
                         context.onClose().whenFinally(serverConnectionClosed::countDown).subscribe();
+                        connectionAccepted.countDown();
                         return completed();
                     }
                 });
@@ -215,6 +217,7 @@ public class GracefulConnectionClosureHandlingTest {
                 .buildStreaming();
         connection = client.reserveConnection(client.get("/")).toFuture().get();
         connection.onClose().whenFinally(clientConnectionClosed::countDown).subscribe();
+        connectionAccepted.await(); // wait until server accepts connection
 
         toClose = initiateClosureFromClient ? connection : serverContext;
     }


### PR DESCRIPTION
Motivation:

Client fires `SslHandshakeCompletionEvent` before the server. Therefore,
client my already return the reserved connection before server's
`ConnectionAcceptor` is invoked. As the result, test may initiate graceful
closure before `onClosing` event is registered, leading to the test timeout
exception.

Modifications:

- Use another `CountDownLatch` to wait until server invokes
`ConnectionAcceptor` before proceeding to the test scenario;

Result:

Fixes #1200.