### PR TITLE
`shutdownOutput()` for SSL connections prematurely closes the Channel

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.socket.DuplexChannel;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.ssl.SslCloseCompletionEvent;
 
 import java.nio.channels.ClosedChannelException;
 import java.util.function.Consumer;
@@ -128,6 +129,16 @@ public abstract class CloseHandler {
      * @param ctx {@link ChannelHandlerContext}
      */
     abstract void channelClosedOutbound(ChannelHandlerContext ctx);
+
+    /**
+     * Signal {@link Channel} observed {@link SslCloseCompletionEvent#SUCCESS}.
+     * <p>
+     * Received <a href="https://tools.ietf.org/html/rfc5246#section-7.2.1">close_notify</a> alert from the peer.
+     * This message notifies that the sender will not send any more messages on this connection.
+     *
+     * @param ctx {@link ChannelHandlerContext}
+     */
+    abstract void channelCloseNotify(ChannelHandlerContext ctx);
 
     /**
      * Request {@link Channel} inbound close, to be emitted from the {@link EventLoop} for the channel.
@@ -248,6 +259,10 @@ public abstract class CloseHandler {
 
         @Override
         void channelClosedOutbound(final ChannelHandlerContext ctx) {
+        }
+
+        @Override
+        void channelCloseNotify(final ChannelHandlerContext ctx) {
         }
 
         @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -643,14 +643,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
                 connection.channelOutboundListener.channelClosed(StacklessClosedChannelException.newInstance(
                         DefaultNettyConnection.class, "userEventTriggered(ChannelOutputShutdownEvent)"));
             } else if (evt == SslCloseCompletionEvent.SUCCESS) {
-                // Received "close_notify" alert from the peer: https://tools.ietf.org/html/rfc5246#section-7.2.1.
-                // This message notifies that the sender will not send any more messages on this connection.
-
-                // Notify close handler first to enhance error reporting and prevent LB from selecting this connection
-                connection.closeHandler.channelClosedInbound(ctx);
-                // We MUST respond with a "close_notify" alert and close down the connection immediately,
-                // discarding any pending writes.
-                connection.closeHandler.closeChannelOutbound(ctx.channel());
+                connection.closeHandler.channelCloseNotify(ctx);
             } else if (evt == ChannelInputShutdownReadComplete.INSTANCE) {
                 // Notify close handler first to enhance error reporting and prevent LB from selecting this connection
                 connection.closeHandler.channelClosedInbound(ctx);


### PR DESCRIPTION
Motivation:

Before `RequestResponseCloseHandler` invokes `shutdownOutput()`, it forces
`SslHandler` to close `SSLEngine` and send `close_notify` to the remote peer.
Because `SSLEngine` is closed, `SslHandler` will generate
`SslCloseCompletionEvent` on the next read regardless of receiving the
`close_notify` alert from the remote peer or not. This premature event is
handled incorrectly by the `DefaultNettyConnection` and forces the channel
closure, breaking graceful closure and `connection: close` handling on the
server-side.

Modifications:

- Move handling of `SslCloseCompletionEvent` to the `CloseHandler` that is
aware of the current state;
- `RequestResponseCloseHandler` now ignores `SslCloseCompletionEvent` if it
knows that the outbound was shutdown. It will wait for the `FIN` from
remote peer to finish graceful closure;
- Enhance `RequestResponseCloseHandlerTest` to validate new behavior;
- Add logging for `NonPipelinedCloseHandler`;

Result:

1. `shutdownOutput()` does not break graceful closure.
2. Fixes #1192. Use-case
`[4: protocol=HTTP_1 initiateClosureFromClient=false useUds=false viaProxy=true]`
is not flaky anymore.
3. Fixes #1277.
4. Fixes #1323.