### PR TITLE
Restore CharSequences.newAsciiString(String)

### DIFF
--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
@@ -62,6 +62,17 @@ public final class CharSequences {
      * @param input a character sequence containing only 8-bit ASCII characters.
      * @return a {@link CharSequence}
      */
+    public static CharSequence newAsciiString(final String input) {
+        return newAsciiString((CharSequence) input);
+    }
+
+    /**
+     * Create a new {@link CharSequence} from the specified {@code input}, supporting only 8-bit ASCII characters, and
+     * with a case-insensitive {@code hashCode}.
+     *
+     * @param input a character sequence containing only 8-bit ASCII characters.
+     * @return a {@link CharSequence}
+     */
     public static CharSequence newAsciiString(final CharSequence input) {
         return newAsciiString(DEFAULT_RO_ALLOCATOR.fromAscii(input));
     }


### PR DESCRIPTION
Motivation:
In ServiceTalk 0.39.0 the method
`CharSequences.newAsciiString(CharSequence)` was introduced which
replaced `CharSequences.newAsciiString(String)`. This was a source
compatible, but binary incompatible change. All existing uses of the
`String` overload could be recompiled to use the `CharSequence`
overload. Existing binary code expected the `String` overload to be present
and fails with `NoSuchMethodError` at runtime.
Modifications:
For cases where the libraries and applications using ServiceTalk cannot
be recompiled conveniently the `CharSequences.newAsciiString(String)`
overload is restored.
Result:
Binary compatibility with libraries and applications which use
`CharSequences.newAsciiString(String)` and are compiled against
versions of ServiceTalk before 0.39.0 is restored.