### PR TITLE
Reduce test logging output from build

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -170,8 +170,14 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
         systemProperty "junit.jupiter.extensions.autodetection.enabled", "true"
 
         testLogging {
-          events "passed", "skipped", "failed"
-          showStandardStreams = true
+          events "failed"
+          showStandardStreams = false
+
+          warn {
+            // Show more complete info when gradle run in --warn mode
+            events "started", "passed", "skipped", "failed"
+            showStandardStreams = true
+          }
         }
 
         jvmArgs "-server", "-Xms2g", "-Xmx4g", "-dsa", "-da", "-ea:io.servicetalk...",

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -29,6 +29,12 @@ import static io.servicetalk.gradle.plugin.internal.ProjectUtils.locateBuildLeve
 import static io.servicetalk.gradle.plugin.internal.Versions.PMD_VERSION
 import static io.servicetalk.gradle.plugin.internal.Versions.SPOTBUGS_VERSION
 import static io.servicetalk.gradle.plugin.internal.Versions.TARGET_VERSION
+import static org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+import static org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
+import static org.gradle.api.tasks.testing.logging.TestLogEvent.PASSED
+import static org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED
+import static org.gradle.api.tasks.testing.logging.TestLogEvent.STARTED
+
 
 final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
   void apply(Project project) {
@@ -170,12 +176,13 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
         systemProperty "junit.jupiter.extensions.autodetection.enabled", "true"
 
         testLogging {
-          events "failed"
+          events = [FAILED]
           showStandardStreams = false
+          exceptionFormat = FULL
 
           warn {
             // Show more complete info when gradle run in --warn mode
-            events "started", "passed", "skipped", "failed"
+            events = [STARTED, PASSED, SKIPPED, FAILED]
             showStandardStreams = true
           }
         }


### PR DESCRIPTION
Motivation:
The gradle currently produces voluminous test output in the default
configuration. This change reduces the default verbosity to only show
test failures. The test report still contains full output from failed
tests.
Modifications:
default test logging output verbosity is reduce to show only failed
cases and hide standard out/err from console. Additional configuration
is provided for gradle `--warn` mode which provides slightly more
output than the current default.
Result:
Terse build output making warnings and failures more obvious