### PR TITLE
Add README.adoc to servicetalk-test-resources

### DIFF
--- a/servicetalk-test-resources/README.adoc
+++ b/servicetalk-test-resources/README.adoc
@@ -1,0 +1,37 @@
+////
+* Copyright © 2018-2021 Apple Inc. and the ServiceTalk project authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+////
+= ServiceTalk Test Resources
+
+This module provides internal common resources to be used for ServiceTalk tests.
+
+The useful resources provided are:
+
+* Certificates and Keys
+* Log4J configuration file
+
+This module should be included as a dependency in other ServiceTalk modules as:
+
+.gradle.build file
+[source,groovy]
+----
+  dependencies {
+
+      testImplementation project(":servicetalk-test-resources")
+
+  }
+----
+
+See the link:https://docs.servicetalk.io/[ServiceTalk docs] for more information.


### PR DESCRIPTION
Motivation:
Describe the resources in the module.
Modifications:
Adds a readme file which documents the resources provided by the
module: a log4j.xml configuration file and a set of test certificates
and keys for use by other tests.
Result:
Basic description of test resources now included.