### PR TITLE
Respect missing B3 sampled headers

### DIFF
--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpHeadersFormatter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpHeadersFormatter.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.buffer.api.CharSequences.contentEqualsIgnoreCase;
 import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.opentracing.internal.HexUtils.validateHexBytes;
+import static java.lang.Boolean.TRUE;
 import static java.lang.String.valueOf;
 
 final class TracingHttpHeadersFormatter implements InMemoryTraceStateFormat<HttpHeaders> {
@@ -65,7 +66,9 @@ final class TracingHttpHeadersFormatter implements InMemoryTraceStateFormat<Http
         if (parentSpanIdHex != null) {
             carrier.set(PARENT_SPAN_ID, parentSpanIdHex);
         }
-        carrier.set(SAMPLED, state.isSampled() ? "1" : "0");
+        if (state.isSampled() != null) {
+            carrier.set(SAMPLED, TRUE.equals(state.isSampled()) ? "1" : "0");
+        }
     }
 
     @Nullable
@@ -96,6 +99,6 @@ final class TracingHttpHeadersFormatter implements InMemoryTraceStateFormat<Http
 
         CharSequence sampleId = carrier.get(SAMPLED);
         return new DefaultInMemoryTraceState(traceId.toString(), spanId.toString(),
-                valueOf(parentSpanId), sampleId != null && sampleId.length() == 1 && sampleId.charAt(0) != '0');
+                valueOf(parentSpanId), sampleId != null ? (sampleId.length() == 1 && sampleId.charAt(0) != '0') : null);
     }
 }

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpHeadersFormatter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpHeadersFormatter.java
@@ -17,6 +17,7 @@ package io.servicetalk.opentracing.http;
 
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.opentracing.inmemory.DefaultInMemoryTraceState;
+import io.servicetalk.opentracing.inmemory.api.InMemorySpanContext;
 import io.servicetalk.opentracing.inmemory.api.InMemoryTraceState;
 import io.servicetalk.opentracing.inmemory.api.InMemoryTraceStateFormat;
 import io.servicetalk.opentracing.internal.ZipkinHeaderNames;
@@ -59,16 +60,15 @@ final class TracingHttpHeadersFormatter implements InMemoryTraceStateFormat<Http
     }
 
     @Override
-    public void inject(final InMemoryTraceState state, final HttpHeaders carrier) {
+    public void inject(final InMemorySpanContext context, final HttpHeaders carrier) {
+        final InMemoryTraceState state = context.traceState();
         carrier.set(TRACE_ID, state.traceIdHex());
         carrier.set(SPAN_ID, state.spanIdHex());
         String parentSpanIdHex = state.parentSpanIdHex();
         if (parentSpanIdHex != null) {
             carrier.set(PARENT_SPAN_ID, parentSpanIdHex);
         }
-        if (state.isSampled() != null) {
-            carrier.set(SAMPLED, TRUE.equals(state.isSampled()) ? "1" : "0");
-        }
+        carrier.set(SAMPLED, context.isSampled() ? "1" : "0");
     }
 
     @Nullable

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpHeadersFormatter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpHeadersFormatter.java
@@ -30,7 +30,6 @@ import javax.annotation.Nullable;
 import static io.servicetalk.buffer.api.CharSequences.contentEqualsIgnoreCase;
 import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.opentracing.internal.HexUtils.validateHexBytes;
-import static java.lang.Boolean.TRUE;
 import static java.lang.String.valueOf;
 
 final class TracingHttpHeadersFormatter implements InMemoryTraceStateFormat<HttpHeaders> {

--- a/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilterTest.java
+++ b/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilterTest.java
@@ -143,7 +143,7 @@ public class TracingHttpRequesterFilterTest {
                 assertFalse(lastFinishedSpan.tags().containsKey(ERROR.getKey()));
 
                 verifyTraceIdPresentInLogs(stableAccumulated(1000), requestUrl, serverSpanState.traceId,
-                        serverSpanState.spanId, serverSpanState.parentSpanId, TRACING_TEST_LOG_LINE_PREFIX);
+                        serverSpanState.spanId, null, TRACING_TEST_LOG_LINE_PREFIX);
             }
         }
     }
@@ -168,8 +168,10 @@ public class TracingHttpRequesterFilterTest {
                         assertThat(serverSpanState.spanId, isHexId());
                         assertThat(serverSpanState.parentSpanId, isHexId());
 
-                        assertThat(serverSpanState.traceId, equalToIgnoringCase(clientSpan.traceIdHex()));
-                        assertThat(serverSpanState.parentSpanId, equalToIgnoringCase(clientSpan.spanIdHex()));
+                        assertThat(serverSpanState.traceId, equalToIgnoringCase(
+                                clientSpan.context().traceState().traceIdHex()));
+                        assertThat(serverSpanState.parentSpanId, equalToIgnoringCase(
+                                clientSpan.context().traceState().spanIdHex()));
 
                         // don't mess with caller span state
                         assertEquals(clientSpan, tracer.activeSpan());

--- a/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpServiceFilterTest.java
+++ b/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpServiceFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import io.servicetalk.http.netty.HttpServers;
 import io.servicetalk.log4j2.mdc.utils.LoggerStringWriter;
 import io.servicetalk.opentracing.http.TestUtils.CountingInMemorySpanEventListener;
 import io.servicetalk.opentracing.inmemory.DefaultInMemoryTracer;
+import io.servicetalk.opentracing.inmemory.SamplingStrategies;
 import io.servicetalk.opentracing.inmemory.api.InMemorySpan;
 import io.servicetalk.transport.api.ServerContext;
 
@@ -47,27 +48,21 @@ import org.mockito.Mock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiFunction;
 import javax.annotation.Nullable;
 
 import static io.opentracing.tag.Tags.ERROR;
-import static io.opentracing.tag.Tags.HTTP_METHOD;
-import static io.opentracing.tag.Tags.HTTP_STATUS;
-import static io.opentracing.tag.Tags.HTTP_URL;
-import static io.opentracing.tag.Tags.SPAN_KIND;
-import static io.opentracing.tag.Tags.SPAN_KIND_SERVER;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
-import static io.servicetalk.http.api.HttpRequestMethod.GET;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
-import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializationProviders.jsonSerializer;
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
 import static io.servicetalk.log4j2.mdc.utils.LoggerStringWriter.stableAccumulated;
 import static io.servicetalk.opentracing.asynccontext.AsyncContextInMemoryScopeManager.SCOPE_MANAGER;
 import static io.servicetalk.opentracing.http.TestUtils.TRACING_TEST_LOG_LINE_PREFIX;
-import static io.servicetalk.opentracing.http.TestUtils.isHexId;
 import static io.servicetalk.opentracing.http.TestUtils.randomHexId;
 import static io.servicetalk.opentracing.http.TestUtils.verifyTraceIdPresentInLogs;
 import static io.servicetalk.opentracing.internal.ZipkinHeaderNames.PARENT_SPAN_ID;
@@ -84,7 +79,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -111,7 +105,13 @@ public class TracingHttpServiceFilterTest {
     }
 
     private static ServerContext buildServer(CountingInMemorySpanEventListener spanListener) throws Exception {
+        return buildServer(spanListener, SamplingStrategies.sampleUnlessFalse());
+    }
+
+    private static ServerContext buildServer(CountingInMemorySpanEventListener spanListener,
+                                             BiFunction<String, Boolean, Boolean> sampler) throws Exception {
         DefaultInMemoryTracer tracer = new DefaultInMemoryTracer.Builder(SCOPE_MANAGER)
+                .withSampler(sampler)
                 .addListener(spanListener).build();
         return HttpServers.forAddress(localAddress(0))
                 .appendServiceFilter(new TracingHttpServiceFilter(tracer, "testServer"))
@@ -149,51 +149,70 @@ public class TracingHttpServiceFilterTest {
                 HttpResponse response = client.request(request).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(httpSerializer.deserializerFor(
                         TestSpanState.class));
-                assertThat(serverSpanState.traceId, equalToIgnoringCase(traceId));
-                assertThat(serverSpanState.spanId, not(equalToIgnoringCase(spanId)));
-                assertThat(serverSpanState.parentSpanId, equalToIgnoringCase(spanId));
-                assertFalse(serverSpanState.sampled);
-                assertFalse(serverSpanState.error);
-                assertEquals(0, spanListener.spanFinishedCount()); // not sampled, so no finish
-
-                InMemorySpan lastFinishedSpan = spanListener.lastFinishedSpan();
-                assertNull(lastFinishedSpan);
-
-                verifyTraceIdPresentInLogs(stableAccumulated(1000), requestUrl, serverSpanState.traceId,
-                        serverSpanState.spanId, serverSpanState.parentSpanId, TRACING_TEST_LOG_LINE_PREFIX);
+                assertSpan(spanListener, traceId, spanId, requestUrl, serverSpanState, false);
             }
         }
     }
 
     @Test
-    public void testRequestWithoutTraceKey() throws Exception {
-        final String requestUrl = "/foo";
+    public void testRequestWithTraceKeyWithoutSampled() throws Exception {
         CountingInMemorySpanEventListener spanListener = new CountingInMemorySpanEventListener();
         try (ServerContext context = buildServer(spanListener)) {
             try (HttpClient client = forSingleAddress(serverHostAndPort(context)).build()) {
+                String traceId = randomHexId();
+                String spanId = randomHexId();
+                String requestUrl = "/";
                 HttpRequest request = client.get(requestUrl);
+                request.headers().set(TRACE_ID, traceId)
+                                 .set(SPAN_ID, spanId);
                 HttpResponse response = client.request(request).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(httpSerializer.deserializerFor(
                         TestSpanState.class));
-                assertThat(serverSpanState.traceId, isHexId());
-                assertThat(serverSpanState.spanId, isHexId());
-                assertNull(serverSpanState.parentSpanId);
-                assertTrue(serverSpanState.sampled);
-                assertFalse(serverSpanState.error);
-                assertEquals(1, spanListener.spanFinishedCount()); // sampled, so only finish once!
-
-                InMemorySpan lastFinishedSpan = spanListener.lastFinishedSpan();
-                assertNotNull(lastFinishedSpan);
-                assertEquals(SPAN_KIND_SERVER, lastFinishedSpan.tags().get(SPAN_KIND.getKey()));
-                assertEquals(GET.name(), lastFinishedSpan.tags().get(HTTP_METHOD.getKey()));
-                assertEquals(requestUrl, lastFinishedSpan.tags().get(HTTP_URL.getKey()));
-                assertEquals(OK.code(), lastFinishedSpan.tags().get(HTTP_STATUS.getKey()));
-                assertFalse(lastFinishedSpan.tags().containsKey(ERROR.getKey()));
-
-                verifyTraceIdPresentInLogs(stableAccumulated(1000), requestUrl, serverSpanState.traceId,
-                        serverSpanState.spanId, serverSpanState.parentSpanId, TRACING_TEST_LOG_LINE_PREFIX);
+                assertSpan(spanListener, traceId, spanId, requestUrl, serverSpanState, true);
             }
         }
+    }
+
+    @Test
+    public void testRequestWithTraceKeyWithNegativeSampledAndAlwaysTrueSampler() throws Exception {
+        final CountingInMemorySpanEventListener spanListener = new CountingInMemorySpanEventListener();
+        try (ServerContext context = buildServer(spanListener, (__, ___) -> true)) {
+            try (HttpClient client = forSingleAddress(serverHostAndPort(context)).build()) {
+                String traceId = randomHexId();
+                String spanId = randomHexId();
+                String requestUrl = "/";
+                HttpRequest request = client.get(requestUrl);
+                request.headers().set(TRACE_ID, traceId)
+                                 .set(SPAN_ID, spanId)
+                                 .set(SAMPLED, "0");
+                HttpResponse response = client.request(request).toFuture().get();
+                TestSpanState serverSpanState = response.payloadBody(httpSerializer.deserializerFor(
+                        TestSpanState.class));
+                assertSpan(spanListener, traceId, spanId, requestUrl, serverSpanState, true);
+            }
+        }
+    }
+
+    private void assertSpan(final CountingInMemorySpanEventListener spanListener, final String traceId,
+                            final String spanId, final String requestUrl, final TestSpanState serverSpanState,
+                            final boolean expectedSampled)
+            throws InterruptedException, TimeoutException {
+        assertThat(serverSpanState.traceId, equalToIgnoringCase(traceId));
+        assertThat(serverSpanState.spanId, not(equalToIgnoringCase(spanId)));
+        assertThat(serverSpanState.parentSpanId, equalToIgnoringCase(spanId));
+        assertEquals(expectedSampled, serverSpanState.sampled);
+        assertFalse(serverSpanState.error);
+        assertEquals(expectedSampled ? 1 : 0, spanListener.spanFinishedCount());
+
+        InMemorySpan lastFinishedSpan = spanListener.lastFinishedSpan();
+        if (expectedSampled) {
+            assertNotNull(lastFinishedSpan);
+        } else {
+            assertNull(lastFinishedSpan);
+        }
+
+        verifyTraceIdPresentInLogs(stableAccumulated(1000), requestUrl, serverSpanState.traceId,
+                serverSpanState.spanId, serverSpanState.parentSpanId, TRACING_TEST_LOG_LINE_PREFIX);
     }
 
     @Test

--- a/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpServiceFilterTest.java
+++ b/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpServiceFilterTest.java
@@ -123,10 +123,10 @@ public class TracingHttpServiceFilterTest {
                                 textSerializer()));
                     }
                     return succeeded(responseFactory.ok().payloadBody(from(new TestSpanState(
-                                    span.traceIdHex(),
-                                    span.spanIdHex(),
-                                    span.parentSpanIdHex(),
-                                    span.isSampled(),
+                                    span.context().traceState().traceIdHex(),
+                                    span.context().traceState().spanIdHex(),
+                                    span.context().traceState().parentSpanIdHex(),
+                                    span.context().isSampled(),
                                     span.tags().containsKey(ERROR.getKey()))),
                             httpSerializer.serializerFor(TestSpanState.class)));
                 });
@@ -142,7 +142,8 @@ public class TracingHttpServiceFilterTest {
                 String parentSpanId = randomHexId();
                 String requestUrl = "/";
                 HttpRequest request = client.get(requestUrl);
-                request.headers().set(TRACE_ID, traceId)
+                request.headers()
+                        .set(TRACE_ID, traceId)
                         .set(SPAN_ID, spanId)
                         .set(PARENT_SPAN_ID, parentSpanId)
                         .set(SAMPLED, "0");

--- a/servicetalk-opentracing-inmemory-api/src/main/java/io/servicetalk/opentracing/inmemory/api/InMemorySpan.java
+++ b/servicetalk-opentracing-inmemory-api/src/main/java/io/servicetalk/opentracing/inmemory/api/InMemorySpan.java
@@ -31,31 +31,6 @@ public interface InMemorySpan extends Span {
     InMemorySpanContext context();
 
     /**
-     * The hex representation of the traceId.
-     * @return hex representation of the traceId.
-     */
-    String traceIdHex();
-
-    /**
-     * The hex representation of the traceId.
-     * @return hex representation of the traceId.
-     */
-    String spanIdHex();
-
-    /**
-     * The hex representation of the parent's spanId.
-     * @return hex representation of the parent's spanId, or {@code null} if there is no parent.
-     */
-    @Nullable
-    String parentSpanIdHex();
-
-    /**
-     * Determine if this span is sampled.
-     * @return {@code true} if this span is sampled.
-     */
-    boolean isSampled();
-
-    /**
      * Returns the operation name.
      *
      * @return operation name
@@ -75,7 +50,7 @@ public interface InMemorySpan extends Span {
      * @return low 64 bits of the trace ID
      */
     default long traceId() {
-        String traceIdHex = traceIdHex();
+        String traceIdHex = context().traceState().traceIdHex();
         return longOfHexBytes(traceIdHex, traceIdHex.length() >= 32 ? 16 : 0);
     }
 
@@ -85,7 +60,7 @@ public interface InMemorySpan extends Span {
      * @return high 64 bits of the trace ID
      */
     default long traceIdHigh() {
-        String traceIdHex = traceIdHex();
+        String traceIdHex = context().traceState().traceIdHex();
         return traceIdHex.length() >= 32 ? longOfHexBytes(traceIdHex, 0) : 0;
     }
 
@@ -95,7 +70,7 @@ public interface InMemorySpan extends Span {
      * @return span ID
      */
     default long spanId() {
-        return longOfHexBytes(spanIdHex(), 0);
+        return longOfHexBytes(context().traceState().spanIdHex(), 0);
     }
 
     /**
@@ -105,7 +80,7 @@ public interface InMemorySpan extends Span {
      */
     @Nullable
     default Long parentSpanId() {
-        String parentSpanIdHex = parentSpanIdHex();
+        String parentSpanIdHex = context().traceState().parentSpanIdHex();
         return parentSpanIdHex == null ? null : longOfHexBytes(parentSpanIdHex, 0);
     }
 
@@ -115,7 +90,7 @@ public interface InMemorySpan extends Span {
      * @return parent span ID in hex
      */
     default String nonnullParentSpanIdHex() {
-        String parentSpanIdHex = parentSpanIdHex();
+        String parentSpanIdHex = context().traceState().parentSpanIdHex();
         return parentSpanIdHex == null ? NO_PARENT_ID : parentSpanIdHex;
     }
 

--- a/servicetalk-opentracing-inmemory-api/src/main/java/io/servicetalk/opentracing/inmemory/api/InMemorySpan.java
+++ b/servicetalk-opentracing-inmemory-api/src/main/java/io/servicetalk/opentracing/inmemory/api/InMemorySpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,34 @@ import static io.servicetalk.opentracing.internal.TracingConstants.NO_PARENT_ID;
 /**
  * A span that allows reading values at runtime.
  */
-public interface InMemorySpan extends Span, InMemoryTraceState {
+public interface InMemorySpan extends Span {
     @Override
     InMemorySpanContext context();
+
+    /**
+     * The hex representation of the traceId.
+     * @return hex representation of the traceId.
+     */
+    String traceIdHex();
+
+    /**
+     * The hex representation of the traceId.
+     * @return hex representation of the traceId.
+     */
+    String spanIdHex();
+
+    /**
+     * The hex representation of the parent's spanId.
+     * @return hex representation of the parent's spanId, or {@code null} if there is no parent.
+     */
+    @Nullable
+    String parentSpanIdHex();
+
+    /**
+     * Determine if this span is sampled.
+     * @return {@code true} if this span is sampled.
+     */
+    boolean isSampled();
 
     /**
      * Returns the operation name.

--- a/servicetalk-opentracing-inmemory-api/src/main/java/io/servicetalk/opentracing/inmemory/api/InMemorySpanContext.java
+++ b/servicetalk-opentracing-inmemory-api/src/main/java/io/servicetalk/opentracing/inmemory/api/InMemorySpanContext.java
@@ -30,8 +30,8 @@ public interface InMemorySpanContext extends SpanContext {
     /**
      * Returns whether the span should be sampled.
      * <p>
-     * Note this may differ from {@link InMemorySpan#isSampled()} from {@link #traceState()} if the value is overridden
-     * based upon some sampling policy.
+     * Note this may differ from {@link InMemoryTraceState#isSampled()} if the value is overridden based upon
+     * some sampling policy.
      *
      * @return whether the span should be sampled
      */

--- a/servicetalk-opentracing-inmemory-api/src/main/java/io/servicetalk/opentracing/inmemory/api/InMemorySpanContext.java
+++ b/servicetalk-opentracing-inmemory-api/src/main/java/io/servicetalk/opentracing/inmemory/api/InMemorySpanContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,9 +35,7 @@ public interface InMemorySpanContext extends SpanContext {
      *
      * @return whether the span should be sampled
      */
-    default boolean isSampled() {
-        return traceState().isSampled();
-    }
+    boolean isSampled();
 
     default String toTraceId() {
         return traceState().traceIdHex();

--- a/servicetalk-opentracing-inmemory-api/src/main/java/io/servicetalk/opentracing/inmemory/api/InMemoryTraceState.java
+++ b/servicetalk-opentracing-inmemory-api/src/main/java/io/servicetalk/opentracing/inmemory/api/InMemoryTraceState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.servicetalk.opentracing.inmemory.api;
 import javax.annotation.Nullable;
 
 /**
- * Utility for representing a Ziplin-like trace state.
+ * Utility for representing a Zipkin-like trace state.
  */
 public interface InMemoryTraceState {
     /**
@@ -42,7 +42,9 @@ public interface InMemoryTraceState {
 
     /**
      * Determine if this state is sampled.
-     * @return {@code true} if this state is sampled.
+     * @return {@code true} if this state is sampled, {@code false} if this state isn't sampled and
+     * {@code null} if sampling is not specified.
      */
-    boolean isSampled();
+    @Nullable
+    Boolean isSampled();
 }

--- a/servicetalk-opentracing-inmemory-api/src/main/java/io/servicetalk/opentracing/inmemory/api/InMemoryTraceStateFormat.java
+++ b/servicetalk-opentracing-inmemory-api/src/main/java/io/servicetalk/opentracing/inmemory/api/InMemoryTraceStateFormat.java
@@ -27,10 +27,10 @@ public interface InMemoryTraceStateFormat<C> extends Format<C> {
     /**
      * Inject a trace state into a carrier.
      *
-     * @param state   trace state
+     * @param context span context
      * @param carrier carrier to inject into
      */
-    void inject(InMemoryTraceState state, C carrier);
+    void inject(InMemorySpanContext context, C carrier);
 
     /**
      * Extract the trace state from a carrier.

--- a/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/AbstractInMemorySpan.java
+++ b/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/AbstractInMemorySpan.java
@@ -86,28 +86,12 @@ abstract class AbstractInMemorySpan extends DefaultInMemorySpanContext implement
     }
 
     @Override
-    public final String traceIdHex() {
+    public String toTraceId() {
         return traceState.traceIdHex();
     }
 
     @Override
-    public final String spanIdHex() {
-        return traceState.spanIdHex();
-    }
-
-    @Nullable
-    @Override
-    public final String parentSpanIdHex() {
-        return traceState.parentSpanIdHex();
-    }
-
-    @Override
-    public String toTraceId() {
-        return traceIdHex();
-    }
-
-    @Override
     public String toSpanId() {
-        return spanIdHex();
+        return traceState.spanIdHex();
     }
 }

--- a/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/AbstractInMemoryTracer.java
+++ b/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/AbstractInMemoryTracer.java
@@ -44,9 +44,9 @@ abstract class AbstractInMemoryTracer implements InMemoryTracer {
 
         try {
             if (format instanceof InMemoryTraceStateFormat) {
-                ((InMemoryTraceStateFormat<C>) format).inject(spanContext.traceState(), carrier);
+                ((InMemoryTraceStateFormat<C>) format).inject(spanContext, carrier);
             } else if (format == Format.Builtin.TEXT_MAP) {
-                TextMapFormatter.INSTANCE.inject(spanContext.traceState(), (TextMap) carrier);
+                TextMapFormatter.INSTANCE.inject(spanContext, (TextMap) carrier);
             } else {
                 throw new UnsupportedOperationException("Format " + format + " is not supported");
             }

--- a/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/AbstractInMemoryTracer.java
+++ b/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/AbstractInMemoryTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/DefaultInMemorySpanContext.java
+++ b/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/DefaultInMemorySpanContext.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Map.Entry;
 
 import static io.servicetalk.opentracing.inmemory.SingleLineValue.format;
+import static java.lang.Boolean.TRUE;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -37,7 +38,7 @@ class DefaultInMemorySpanContext implements InMemorySpanContext {
     final boolean isSampledOverride;
 
     DefaultInMemorySpanContext(InMemoryTraceState state) {
-        this(state, state.isSampled() != null && requireNonNull(state.isSampled()));
+        this(state, TRUE.equals(state.isSampled()));
     }
 
     DefaultInMemorySpanContext(InMemoryTraceState state,

--- a/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/DefaultInMemorySpanContext.java
+++ b/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/DefaultInMemorySpanContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ class DefaultInMemorySpanContext implements InMemorySpanContext {
     final boolean isSampledOverride;
 
     DefaultInMemorySpanContext(InMemoryTraceState state) {
-        this(state, state.isSampled());
+        this(state, state.isSampled() != null && requireNonNull(state.isSampled()));
     }
 
     DefaultInMemorySpanContext(InMemoryTraceState state,

--- a/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/DefaultInMemoryTraceState.java
+++ b/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/DefaultInMemoryTraceState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,8 @@ public final class DefaultInMemoryTraceState implements InMemoryTraceState {
     private final String spanIdHex;
     @Nullable
     private final String parentSpanIdHex;
-    private final boolean sampled;
+    @Nullable
+    private final Boolean sampled;
 
     /**
      * Constructs an instance.
@@ -35,10 +36,10 @@ public final class DefaultInMemoryTraceState implements InMemoryTraceState {
      * @param traceIdHex      trace ID
      * @param spanIdHex       span ID
      * @param parentSpanIdHex parent span ID, optional
-     * @param sampled      whether the trace is sampled
+     * @param sampled         whether the trace is sampled
      */
     public DefaultInMemoryTraceState(String traceIdHex, String spanIdHex, @Nullable String parentSpanIdHex,
-                                     boolean sampled) {
+                                     @Nullable Boolean sampled) {
         this.traceIdHex = traceIdHex;
         this.spanIdHex = spanIdHex;
         this.parentSpanIdHex = parentSpanIdHex;
@@ -62,7 +63,7 @@ public final class DefaultInMemoryTraceState implements InMemoryTraceState {
     }
 
     @Override
-    public boolean isSampled() {
+    public Boolean isSampled() {
         return sampled;
     }
 }

--- a/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/SingleLineFormatter.java
+++ b/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/SingleLineFormatter.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.opentracing.inmemory;
 
+import io.servicetalk.opentracing.inmemory.api.InMemorySpanContext;
 import io.servicetalk.opentracing.inmemory.api.InMemoryTraceState;
 import io.servicetalk.opentracing.inmemory.api.InMemoryTraceStateFormat;
 
@@ -39,8 +40,9 @@ public final class SingleLineFormatter implements InMemoryTraceStateFormat<Singl
     }
 
     @Override
-    public void inject(InMemoryTraceState state, SingleLineValue carrier) {
-        carrier.set(format(state.traceIdHex(), state.spanIdHex(), state.parentSpanIdHex(), state.isSampled()));
+    public void inject(final InMemorySpanContext context, final SingleLineValue carrier) {
+        final InMemoryTraceState state = context.traceState();
+        carrier.set(format(state.traceIdHex(), state.spanIdHex(), state.parentSpanIdHex(), context.isSampled()));
     }
 
     @Nullable

--- a/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/TextMapFormatter.java
+++ b/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/TextMapFormatter.java
@@ -31,7 +31,6 @@ import static io.servicetalk.opentracing.internal.ZipkinHeaderNames.PARENT_SPAN_
 import static io.servicetalk.opentracing.internal.ZipkinHeaderNames.SAMPLED;
 import static io.servicetalk.opentracing.internal.ZipkinHeaderNames.SPAN_ID;
 import static io.servicetalk.opentracing.internal.ZipkinHeaderNames.TRACE_ID;
-import static java.lang.Boolean.TRUE;
 
 /**
  * Zipkin-styled header serialization format.

--- a/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/TextMapFormatter.java
+++ b/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/TextMapFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,9 +30,10 @@ import static io.servicetalk.opentracing.internal.ZipkinHeaderNames.PARENT_SPAN_
 import static io.servicetalk.opentracing.internal.ZipkinHeaderNames.SAMPLED;
 import static io.servicetalk.opentracing.internal.ZipkinHeaderNames.SPAN_ID;
 import static io.servicetalk.opentracing.internal.ZipkinHeaderNames.TRACE_ID;
+import static java.lang.Boolean.TRUE;
 
 /**
- * Ziplin-styled header serialization format.
+ * Zipkin-styled header serialization format.
  */
 final class TextMapFormatter implements InMemoryTraceStateFormat<TextMap> {
     public static final TextMapFormatter INSTANCE = new TextMapFormatter();
@@ -49,7 +50,9 @@ final class TextMapFormatter implements InMemoryTraceStateFormat<TextMap> {
         if (state.parentSpanIdHex() != null) {
             carrier.put(PARENT_SPAN_ID, state.parentSpanIdHex());
         }
-        carrier.put(SAMPLED, state.isSampled() ? "1" : "0");
+        if (state.isSampled() != null) {
+            carrier.put(SAMPLED, TRUE.equals(state.isSampled()) ? "1" : "0");
+        }
     }
 
     @Nullable

--- a/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/TextMapFormatter.java
+++ b/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/TextMapFormatter.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.opentracing.inmemory;
 
+import io.servicetalk.opentracing.inmemory.api.InMemorySpanContext;
 import io.servicetalk.opentracing.inmemory.api.InMemoryTraceState;
 import io.servicetalk.opentracing.inmemory.api.InMemoryTraceStateFormat;
 
@@ -44,15 +45,14 @@ final class TextMapFormatter implements InMemoryTraceStateFormat<TextMap> {
     }
 
     @Override
-    public void inject(InMemoryTraceState state, TextMap carrier) {
+    public void inject(final InMemorySpanContext context, final TextMap carrier) {
+        final InMemoryTraceState state = context.traceState();
         carrier.put(TRACE_ID, state.traceIdHex());
         carrier.put(SPAN_ID, state.spanIdHex());
         if (state.parentSpanIdHex() != null) {
             carrier.put(PARENT_SPAN_ID, state.parentSpanIdHex());
         }
-        if (state.isSampled() != null) {
-            carrier.put(SAMPLED, TRUE.equals(state.isSampled()) ? "1" : "0");
-        }
+        carrier.put(SAMPLED, context.isSampled() ? "1" : "0");
     }
 
     @Nullable

--- a/servicetalk-opentracing-log4j2/src/main/java/io/servicetalk/opentracing/log4j2/ServiceTalkTracingThreadContextMap.java
+++ b/servicetalk-opentracing-log4j2/src/main/java/io/servicetalk/opentracing/log4j2/ServiceTalkTracingThreadContextMap.java
@@ -58,14 +58,14 @@ public final class ServiceTalkTracingThreadContextMap extends ServiceTalkThreadC
             case TRACE_ID_KEY: {
                 InMemorySpan span = SCOPE_MANAGER.activeSpan();
                 if (span != null) {
-                    return span.traceIdHex();
+                    return span.context().traceState().traceIdHex();
                 }
                 break;
             }
             case SPAN_ID_KEY: {
                 InMemorySpan span = SCOPE_MANAGER.activeSpan();
                 if (span != null) {
-                    return span.spanIdHex();
+                    return span.context().traceState().spanIdHex();
                 }
                 break;
             }
@@ -92,8 +92,8 @@ public final class ServiceTalkTracingThreadContextMap extends ServiceTalkThreadC
         Map<String, String> copy = super.getCopy();
         InMemorySpan span = SCOPE_MANAGER.activeSpan();
         if (span != null) {
-            copy.put(TRACE_ID_KEY, span.traceIdHex());
-            copy.put(SPAN_ID_KEY, span.spanIdHex());
+            copy.put(TRACE_ID_KEY, span.context().traceState().traceIdHex());
+            copy.put(SPAN_ID_KEY, span.context().traceState().spanIdHex());
             copy.put(PARENT_SPAN_ID_KEY, span.nonnullParentSpanIdHex());
         }
         return copy;
@@ -130,8 +130,8 @@ public final class ServiceTalkTracingThreadContextMap extends ServiceTalkThreadC
             copy = new HashMap<>(4);
         }
         if (span != null) {
-            copy.put(TRACE_ID_KEY, span.traceIdHex());
-            copy.put(SPAN_ID_KEY, span.spanIdHex());
+            copy.put(TRACE_ID_KEY, span.context().traceState().traceIdHex());
+            copy.put(SPAN_ID_KEY, span.context().traceState().spanIdHex());
             copy.put(PARENT_SPAN_ID_KEY, span.nonnullParentSpanIdHex());
         }
         return copy;

--- a/servicetalk-opentracing-log4j2/src/test/java/io/servicetalk/opentracing/log4j2/ServiceTalkTracingThreadContextMapTest.java
+++ b/servicetalk-opentracing-log4j2/src/test/java/io/servicetalk/opentracing/log4j2/ServiceTalkTracingThreadContextMapTest.java
@@ -60,8 +60,8 @@ public class ServiceTalkTracingThreadContextMapTest {
 
         LOGGER.debug("testing logging and MDC");
         String v = stableAccumulated(1000);
-        assertContainsMdcPair(v, "traceId=", span.traceIdHex());
-        assertContainsMdcPair(v, "spanId=", span.spanIdHex());
+        assertContainsMdcPair(v, "traceId=", span.context().traceState().traceIdHex());
+        assertContainsMdcPair(v, "spanId=", span.context().traceState().spanIdHex());
         assertContainsMdcPair(v, "parentSpanId=", span.nonnullParentSpanIdHex());
     }
 }

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/ZipkinPublisher.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/ZipkinPublisher.java
@@ -161,9 +161,9 @@ public final class ZipkinPublisher implements InMemorySpanEventListener, AsyncCl
 
         Span.Builder builder = Span.newBuilder()
                 .name(span.operationName())
-                .traceId(span.traceIdHex())
+                .traceId(span.context().traceState().traceIdHex())
                 .id(span.spanId())
-                .parentId(span.parentSpanIdHex())
+                .parentId(span.context().traceState().parentSpanIdHex())
                 .timestamp(begin)
                 .addAnnotation(end, "end")
                 .localEndpoint(endpoint)


### PR DESCRIPTION
Motivation:
Missing B3 sampled header (OpenTracing) from upstream translates to no sampling but according to the [spec](https://github.com/openzipkin/b3-propagation#sampling-state-1) absent should translate to receiver's choice.

Modifications:
Split class relation between span and trace-state and allow for trace state to have a Nullable sampled field, which in turn allows the sampler to take the right decision. The decision will propagate downstream.

Result:
Sampled field is now not required and sampler is allowed the make the right choice. That choice propagates downstream.