### PR TITLE
Add Single#zipDelayError operator

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -899,6 +899,31 @@ public abstract class Single<T> {
     }
 
     /**
+     * Create a new {@link Single} that emits the results of a specified zipper {@link BiFunction} to items emitted by
+     * {@code singles}. All operations will terminate (even if there are failures) before the returned {@link Single}
+     * terminates.
+     * <p>
+     * From a sequential programming point of view this method is roughly equivalent to the following:
+     * <pre>{@code
+     *      CompletableFuture<T> f1 = ...; // this
+     *      CompletableFuture<T2> other = ...;
+     *      CompletableFuture.allOf(f1, other).get(); // wait for all futures to complete
+     *      return zipper.apply(f1.get(), other.get());
+     * }</pre>
+     * @param other The other {@link Single} to zip with.
+     * @param zipper Used to combine the completed results for each item from {@code singles}.
+     * @param <T2> The type of {@code other}.
+     * @param <R> The result type of the zipper.
+     * @return a new {@link Single} that emits the results of a specified zipper {@link BiFunction} to items emitted by
+     * {@code singles}.
+     * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX zip operator.</a>
+     */
+    public final <T2, R> Single<R> zipWithDelayError(Single<? extends T2> other,
+                                                     BiFunction<? super T, ? super T2, ? extends R> zipper) {
+        return zipDelayError(this, other, zipper);
+    }
+
+    /**
      * Re-subscribes to this {@link Single} if an error is emitted and the passed {@link BiIntPredicate} returns
      * {@code true}.
      * <p>
@@ -2253,6 +2278,33 @@ public abstract class Single<T> {
     }
 
     /**
+     * Create a new {@link Single} that emits the results of a specified zipper {@link BiFunction} to items emitted
+     * by {@code singles}. All operations will terminate (even if there are failures) before the returned {@link Single}
+     * terminates.
+     * <p>
+     * From a sequential programming point of view this method is roughly equivalent to the following:
+     * <pre>{@code
+     *      CompletableFuture<T1> f1 = ...; // s1
+     *      CompletableFuture<T2> f2 = ...; // s2
+     *      CompletableFuture.allOf(f1, f2).get(); // wait for all futures to complete
+     *      return zipper.apply(f1.get(), f2.get());
+     * }</pre>
+     * @param s1 The first {@link Single} to zip.
+     * @param s2 The second {@link Single} to zip.
+     * @param zipper Used to combine the completed results for each item from {@code singles}.
+     * @param <T1> The type for the first {@link Single}.
+     * @param <T2> The type for the second {@link Single}.
+     * @param <R> The result type of the zipper.
+     * @return a new {@link Single} that emits the results of a specified zipper {@link BiFunction} to items emitted by
+     * {@code singles}.
+     * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX zip operator.</a>
+     */
+    public static <T1, T2, R> Single<R> zipDelayError(Single<? extends T1> s1, Single<? extends T2> s2,
+                                                      BiFunction<? super T1, ? super T2, ? extends R> zipper) {
+        return SingleZipper.zipDelayError(s1, s2, zipper);
+    }
+
+    /**
      * Create a new {@link Single} that emits the results of a specified zipper {@link Function3} to items emitted by
      * {@code singles}.
      * <p>
@@ -2280,6 +2332,37 @@ public abstract class Single<T> {
             Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3,
             Function3<? super T1, ? super T2, ? super T3, ? extends R> zipper) {
         return SingleZipper.zip(s1, s2, s3, zipper);
+    }
+
+    /**
+     * Create a new {@link Single} that emits the results of a specified zipper {@link Function3} to items emitted by
+     * {@code singles}. All operations will terminate (even if there are failures) before the returned {@link Single}
+     * terminates.
+     * <p>
+     * From a sequential programming point of view this method is roughly equivalent to the following:
+     * <pre>{@code
+     *      CompletableFuture<T1> f1 = ...; // s1
+     *      CompletableFuture<T2> f2 = ...; // s2
+     *      CompletableFuture<T3> f3 = ...; // s3
+     *      CompletableFuture.allOf(f1, f2, f3).get(); // wait for all futures to complete
+     *      return zipper.apply(f1.get(), f2.get(), f3.get());
+     * }</pre>
+     * @param s1 The first {@link Single} to zip.
+     * @param s2 The second {@link Single} to zip.
+     * @param s3 The third {@link Single} to zip.
+     * @param zipper Used to combine the completed results for each item from {@code singles}.
+     * @param <T1> The type for the first {@link Single}.
+     * @param <T2> The type for the second {@link Single}.
+     * @param <T3> The type for the third {@link Single}.
+     * @param <R> The result type of the zipper.
+     * @return a new {@link Single} that emits the results of a specified zipper {@link Function3} to items emitted by
+     * {@code singles}.
+     * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX zip operator.</a>
+     */
+    public static <T1, T2, T3, R> Single<R> zipDelayError(
+            Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3,
+            Function3<? super T1, ? super T2, ? super T3, ? extends R> zipper) {
+        return SingleZipper.zipDelayError(s1, s2, s3, zipper);
     }
 
     /**
@@ -2316,6 +2399,40 @@ public abstract class Single<T> {
     }
 
     /**
+     * Create a new {@link Single} that emits the results of a specified zipper {@link Function4} to items emitted by
+     * {@code singles}. All operations will terminate (even if there are failures) before the returned {@link Single}
+     * terminates.
+     * <p>
+     * From a sequential programming point of view this method is roughly equivalent to the following:
+     * <pre>{@code
+     *      CompletableFuture<T1> f1 = ...; // s1
+     *      CompletableFuture<T2> f2 = ...; // s2
+     *      CompletableFuture<T3> f3 = ...; // s3
+     *      CompletableFuture<T4> f4 = ...; // s3
+     *      CompletableFuture.allOf(f1, f2, f3, f4).get(); // wait for all futures to complete
+     *      return zipper.apply(f1.get(), f2.get(), f3.get(), f4.get());
+     * }</pre>
+     * @param s1 The first {@link Single} to zip.
+     * @param s2 The second {@link Single} to zip.
+     * @param s3 The third {@link Single} to zip.
+     * @param s4 The fourth {@link Single} to zip.
+     * @param zipper Used to combine the completed results for each item from {@code singles}.
+     * @param <T1> The type for the first {@link Single}.
+     * @param <T2> The type for the second {@link Single}.
+     * @param <T3> The type for the third {@link Single}.
+     * @param <T4> The type for the fourth {@link Single}.
+     * @param <R> The result type of the zipper.
+     * @return a new {@link Single} that emits the results of a specified zipper {@link Function4} to items emitted by
+     * {@code singles}.
+     * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX zip operator.</a>
+     */
+    public static <T1, T2, T3, T4, R> Single<R> zipDelayError(
+            Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4,
+            Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipper) {
+        return SingleZipper.zipDelayError(s1, s2, s3, s4, zipper);
+    }
+
+    /**
      * Create a new {@link Single} that emits the results of a specified zipper {@link Function} to items emitted by
      * {@code singles}.
      * <p>
@@ -2336,6 +2453,30 @@ public abstract class Single<T> {
      */
     public static <R> Single<R> zip(Function<? super Object[], ? extends R> zipper, Single<?>... singles) {
         return SingleZipper.zip(zipper, singles);
+    }
+
+    /**
+     * Create a new {@link Single} that emits the results of a specified zipper {@link Function} to items emitted by
+     * {@code singles}. All operations will terminate (even if there are failures) before the returned {@link Single}
+     * terminates.
+     * <p>
+     * From a sequential programming point of view this method is roughly equivalent to the following:
+     * <pre>{@code
+     *      Function<? super CompletableFuture<?>[], ? extends R> zipper = ...;
+     *      CompletableFuture<?>[] futures = ...; // Provided Futures (analogous to the Singles here)
+     *      CompletableFuture.allOf(futures).get(); // wait for all futures to complete
+     *      return zipper.apply(futures);
+     * }</pre>
+     * @param zipper Used to combine the completed results for each item from {@code singles}.
+     * @param singles The collection of {@link Single}s that when complete provides the results to "zip" (aka combine)
+     * together.
+     * @param <R> The result type of the zipper.
+     * @return a new {@link Single} that emits the results of a specified zipper {@link Function} to items emitted by
+     * {@code singles}.
+     * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX zip operator.</a>
+     */
+    public static <R> Single<R> zipDelayError(Function<? super Object[], ? extends R> zipper, Single<?>... singles) {
+        return SingleZipper.zipDelayError(zipper, singles);
     }
 
     //

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -890,7 +890,7 @@ public abstract class Single<T> {
      * @param <T2> The type of {@code other}.
      * @param <R> The result type of the zipper.
      * @return a new {@link Single} that emits the results of a specified zipper {@link BiFunction} to items emitted by
-     * {@code singles}.
+     * {@code this} and {@code other}.
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX zip operator.</a>
      */
     public final <T2, R> Single<R> zipWith(Single<? extends T2> other,
@@ -916,7 +916,7 @@ public abstract class Single<T> {
      * @param <T2> The type of {@code other}.
      * @param <R> The result type of the zipper.
      * @return a new {@link Single} that emits the results of a specified zipper {@link BiFunction} to items emitted by
-     * {@code singles}.
+     * {@code this} and {@code other}.
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX zip operator.</a>
      */
     public final <T2, R> Single<R> zipWithDelayError(Single<? extends T2> other,
@@ -2270,7 +2270,7 @@ public abstract class Single<T> {
      * @param <T2> The type for the second {@link Single}.
      * @param <R> The result type of the zipper.
      * @return a new {@link Single} that emits the results of a specified zipper {@link BiFunction} to items emitted by
-     * {@code singles}.
+     * {@code s1} and {@code s2}.
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX zip operator.</a>
      */
     public static <T1, T2, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2,
@@ -2298,7 +2298,7 @@ public abstract class Single<T> {
      * @param <T2> The type for the second {@link Single}.
      * @param <R> The result type of the zipper.
      * @return a new {@link Single} that emits the results of a specified zipper {@link BiFunction} to items emitted by
-     * {@code singles}.
+     * {@code s1} and {@code s2}.
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX zip operator.</a>
      */
     public static <T1, T2, R> Single<R> zipDelayError(Single<? extends T1> s1, Single<? extends T2> s2,
@@ -2327,7 +2327,7 @@ public abstract class Single<T> {
      * @param <T3> The type for the third {@link Single}.
      * @param <R> The result type of the zipper.
      * @return a new {@link Single} that emits the results of a specified zipper {@link Function3} to items emitted by
-     * {@code singles}.
+     * {@code s1}, {@code s2}, and {@code s3}.
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX zip operator.</a>
      */
     public static <T1, T2, T3, R> Single<R> zip(
@@ -2359,7 +2359,7 @@ public abstract class Single<T> {
      * @param <T3> The type for the third {@link Single}.
      * @param <R> The result type of the zipper.
      * @return a new {@link Single} that emits the results of a specified zipper {@link Function3} to items emitted by
-     * {@code singles}.
+     * {@code s1}, {@code s2}, and {@code s3}.
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX zip operator.</a>
      */
     public static <T1, T2, T3, R> Single<R> zipDelayError(
@@ -2392,7 +2392,7 @@ public abstract class Single<T> {
      * @param <T4> The type for the fourth {@link Single}.
      * @param <R> The result type of the zipper.
      * @return a new {@link Single} that emits the results of a specified zipper {@link Function4} to items emitted by
-     * {@code singles}.
+     * {@code s1}, {@code s2}, {@code s3}, and {@code s4}.
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX zip operator.</a>
      */
     public static <T1, T2, T3, T4, R> Single<R> zip(
@@ -2427,7 +2427,7 @@ public abstract class Single<T> {
      * @param <T4> The type for the fourth {@link Single}.
      * @param <R> The result type of the zipper.
      * @return a new {@link Single} that emits the results of a specified zipper {@link Function4} to items emitted by
-     * {@code singles}.
+     * {@code s1}, {@code s2}, {@code s3}, and {@code s4}.
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX zip operator.</a>
      */
     public static <T1, T2, T3, T4, R> Single<R> zipDelayError(

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -876,7 +876,7 @@ public abstract class Single<T> {
 
     /**
      * Create a new {@link Single} that emits the results of a specified zipper {@link BiFunction} to items emitted by
-     * {@code singles}.
+     * {@code this} and {@code other}.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -900,8 +900,9 @@ public abstract class Single<T> {
 
     /**
      * Create a new {@link Single} that emits the results of a specified zipper {@link BiFunction} to items emitted by
-     * {@code singles}. All operations will terminate (even if there are failures) before the returned {@link Single}
-     * terminates.
+     * {@code this} and {@code other}. If any of the {@link Single}s terminate with an error, the returned
+     * {@link Single} will wait for termination till all the other {@link Single}s have been subscribed and terminated,
+     * and then terminate with the first error.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -2253,7 +2254,7 @@ public abstract class Single<T> {
 
     /**
      * Create a new {@link Single} that emits the results of a specified zipper {@link BiFunction} to items emitted
-     * by {@code singles}.
+     * by {@code s1} and {@code s2}.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -2279,8 +2280,9 @@ public abstract class Single<T> {
 
     /**
      * Create a new {@link Single} that emits the results of a specified zipper {@link BiFunction} to items emitted
-     * by {@code singles}. All operations will terminate (even if there are failures) before the returned {@link Single}
-     * terminates.
+     * by {@code s1} and {@code s2}. If any of the {@link Single}s terminate with an error, the returned {@link Single}
+     * will wait for termination till all the other {@link Single}s have been subscribed and terminated, and then
+     * terminate with the first error.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -2306,7 +2308,7 @@ public abstract class Single<T> {
 
     /**
      * Create a new {@link Single} that emits the results of a specified zipper {@link Function3} to items emitted by
-     * {@code singles}.
+     * {@code s1}, {@code s2}, and {@code s3}.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -2336,8 +2338,9 @@ public abstract class Single<T> {
 
     /**
      * Create a new {@link Single} that emits the results of a specified zipper {@link Function3} to items emitted by
-     * {@code singles}. All operations will terminate (even if there are failures) before the returned {@link Single}
-     * terminates.
+     * {@code s1}, {@code s2}, and {@code s3}. If any of the {@link Single}s terminate with an error, the returned
+     * {@link Single} will wait for termination till all the other {@link Single}s have been subscribed and terminated,
+     * and then terminate with the first error.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -2367,7 +2370,7 @@ public abstract class Single<T> {
 
     /**
      * Create a new {@link Single} that emits the results of a specified zipper {@link Function4} to items emitted by
-     * {@code singles}.
+     * {@code s1}, {@code s2}, {@code s3}, and {@code s4}.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -2400,8 +2403,9 @@ public abstract class Single<T> {
 
     /**
      * Create a new {@link Single} that emits the results of a specified zipper {@link Function4} to items emitted by
-     * {@code singles}. All operations will terminate (even if there are failures) before the returned {@link Single}
-     * terminates.
+     * {@code s1}, {@code s2}, {@code s3}, and {@code s4}. If any of the {@link Single}s terminate with an error, the
+     * returned {@link Single}  will wait for termination till all the other {@link Single}s have been subscribed and
+     * terminated, and then terminate with the first error.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -2457,8 +2461,9 @@ public abstract class Single<T> {
 
     /**
      * Create a new {@link Single} that emits the results of a specified zipper {@link Function} to items emitted by
-     * {@code singles}. All operations will terminate (even if there are failures) before the returned {@link Single}
-     * terminates.
+     * {@code singles}. If any of the {@link Single}s terminate with an error, the returned {@link Single} will wait for
+     * termination till all the other {@link Single}s have been subscribed and terminated, and then terminate with the
+     * first error.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleZipper.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleZipper.java
@@ -38,10 +38,33 @@ final class SingleZipper {
     }
 
     @SuppressWarnings("unchecked")
+    static <T1, T2, R> Single<R> zipDelayError(Single<? extends T1> s1, Single<? extends T2> s2,
+                                               BiFunction<? super T1, ? super T2, ? extends R> zipper) {
+        return from(s1.map(v -> new ZipArg(0, v)), s2.map(v -> new ZipArg(1, v)))
+                .flatMapMergeSingleDelayError(identity(), 2, 2)
+                .collect(() -> new Object[2], (array, zipArg) -> {
+                    array[zipArg.index] = zipArg.value;
+                    return array;
+                }).map(array -> zipper.apply((T1) array[0], (T2) array[1]));
+    }
+
+    @SuppressWarnings("unchecked")
     static <T1, T2, T3, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3,
                                          Function3<? super T1, ? super T2, ? super T3, ? extends R> zipper) {
         return from(s1.map(v -> new ZipArg(0, v)), s2.map(v -> new ZipArg(1, v)), s3.map(v -> new ZipArg(2, v)))
                 .flatMapMergeSingle(identity(), 3)
+                .collect(() -> new Object[3], (array, zipArg) -> {
+                    array[zipArg.index] = zipArg.value;
+                    return array;
+                }).map(array -> zipper.apply((T1) array[0], (T2) array[1], (T3) array[2]));
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T1, T2, T3, R> Single<R> zipDelayError(
+            Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3,
+            Function3<? super T1, ? super T2, ? super T3, ? extends R> zipper) {
+        return from(s1.map(v -> new ZipArg(0, v)), s2.map(v -> new ZipArg(1, v)), s3.map(v -> new ZipArg(2, v)))
+                .flatMapMergeSingleDelayError(identity(), 3, 3)
                 .collect(() -> new Object[3], (array, zipArg) -> {
                     array[zipArg.index] = zipArg.value;
                     return array;
@@ -61,6 +84,19 @@ final class SingleZipper {
                 }).map(array -> zipper.apply((T1) array[0], (T2) array[1], (T3) array[2], (T4) array[3]));
     }
 
+    @SuppressWarnings("unchecked")
+    static <T1, T2, T3, T4, R> Single<R> zipDelayError(
+            Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4,
+            Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipper) {
+        return from(s1.map(v -> new ZipArg(0, v)), s2.map(v -> new ZipArg(1, v)),
+                s3.map(v -> new ZipArg(2, v)), s4.map(v -> new ZipArg(3, v)))
+                .flatMapMergeSingleDelayError(identity(), 4, 4)
+                .collect(() -> new Object[4], (array, zipArg) -> {
+                    array[zipArg.index] = zipArg.value;
+                    return array;
+                }).map(array -> zipper.apply((T1) array[0], (T2) array[1], (T3) array[2], (T4) array[3]));
+    }
+
     static <R> Single<R> zip(Function<? super Object[], ? extends R> zipper, Single<?>... singles) {
         @SuppressWarnings("unchecked")
         Single<ZipArg>[] mappedSingles = new Single[singles.length];
@@ -70,6 +106,21 @@ final class SingleZipper {
         }
         return from(mappedSingles)
                 .flatMapMergeSingle(identity(), mappedSingles.length)
+                .collect(() -> new Object[mappedSingles.length], (array, zipArg) -> {
+                    array[zipArg.index] = zipArg.value;
+                    return array;
+                }).map(zipper);
+    }
+
+    static <R> Single<R> zipDelayError(Function<? super Object[], ? extends R> zipper, Single<?>... singles) {
+        @SuppressWarnings("unchecked")
+        Single<ZipArg>[] mappedSingles = new Single[singles.length];
+        for (int i = 0; i < singles.length; ++i) {
+            final int finalI = i;
+            mappedSingles[i] = singles[i].map(v -> new ZipArg(finalI, v));
+        }
+        return from(mappedSingles)
+                .flatMapMergeSingleDelayError(identity(), mappedSingles.length, mappedSingles.length)
                 .collect(() -> new Object[mappedSingles.length], (array, zipArg) -> {
                     array[zipArg.index] = zipArg.value;
                     return array;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleZip3Test.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleZip3Test.java
@@ -16,16 +16,24 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+
 import static io.servicetalk.concurrent.api.Single.zip;
+import static io.servicetalk.concurrent.api.Single.zipDelayError;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class SingleZip3Test {
     private TestSingle<Integer> first;
@@ -164,6 +172,33 @@ public class SingleZip3Test {
         c.cancel();
         cancellable1.awaitCancelled();
         cancellable3.awaitCancelled();
+    }
+
+    @Test
+    public void delayErrorOneFail() {
+        toSource(zipDelayError(first, second, third, SingleZip3Test::combine)).subscribe(subscriber);
+        subscriber.awaitSubscription();
+        DeliberateException e1 = new DeliberateException();
+        second.onError(e1);
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), nullValue());
+        first.onSuccess(1);
+        third.onSuccess((short) 22);
+        assertThat(subscriber.awaitOnError(), is(e1));
+    }
+
+    @Test
+    public void delayErrorAllFail() {
+        toSource(zipDelayError(first, second, third, SingleZip3Test::combine)).subscribe(subscriber);
+        subscriber.awaitSubscription();
+        DeliberateException e1 = new DeliberateException();
+        second.onError(e1);
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), nullValue());
+        DeliberateException e2 = new DeliberateException();
+        first.onError(e2);
+        DeliberateException e3 = new DeliberateException();
+        third.onError(e3);
+        assertThat(subscriber.awaitOnError(), is(e1));
+        assertThat(asList(e1.getSuppressed()), contains(e2, e3));
     }
 
     private static String combine(int i, double d, short s) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleZip3Test.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleZip3Test.java
@@ -22,8 +22,6 @@ import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-
 import static io.servicetalk.concurrent.api.Single.zip;
 import static io.servicetalk.concurrent.api.Single.zipDelayError;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleZip3DelayErrorTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleZip3DelayErrorTckTest.java
@@ -20,7 +20,6 @@ import io.servicetalk.concurrent.api.Publisher;
 import org.testng.annotations.Test;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.concurrent.api.Single.zip;
 import static io.servicetalk.concurrent.api.Single.zipDelayError;
 
 @Test

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleZip3DelayErrorTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleZip3DelayErrorTckTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+import org.testng.annotations.Test;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.concurrent.api.Single.zip;
+import static io.servicetalk.concurrent.api.Single.zipDelayError;
+
+@Test
+public class SingleZip3DelayErrorTckTest extends AbstractSingleTckTest<Integer> {
+    @Override
+    public Publisher<Integer> createServiceTalkPublisher(long elements) {
+        return zipDelayError(succeeded(1), succeeded(null), succeeded(null), (result, ignore1, ignore2) -> result)
+                .toPublisher();
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleZip4DelayErrorTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleZip4DelayErrorTckTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+import org.testng.annotations.Test;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.concurrent.api.Single.zipDelayError;
+
+@Test
+public class SingleZip4DelayErrorTckTest extends AbstractSingleTckTest<Integer> {
+    @Override
+    public Publisher<Integer> createServiceTalkPublisher(long elements) {
+        return zipDelayError(succeeded(1), succeeded(null), succeeded(null), succeeded(null),
+                (result, ignore1, ignore2, ignore3) -> result).toPublisher();
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleZip5DelayErrorTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleZip5DelayErrorTckTest.java
@@ -20,7 +20,6 @@ import io.servicetalk.concurrent.api.Publisher;
 import org.testng.annotations.Test;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.concurrent.api.Single.zip;
 import static io.servicetalk.concurrent.api.Single.zipDelayError;
 
 @Test

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleZip5DelayErrorTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleZip5DelayErrorTckTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+import org.testng.annotations.Test;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.concurrent.api.Single.zip;
+import static io.servicetalk.concurrent.api.Single.zipDelayError;
+
+@Test
+public class SingleZip5DelayErrorTckTest extends AbstractSingleTckTest<Integer> {
+    @Override
+    public Publisher<Integer> createServiceTalkPublisher(long elements) {
+        return zipDelayError(results -> (Integer) results[0], succeeded(1), succeeded(null), succeeded(null),
+                succeeded(null)).toPublisher();
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleZipWithDelayErrorTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleZipWithDelayErrorTckTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Single;
+
+import org.testng.annotations.Test;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+
+@Test
+public class SingleZipWithDelayErrorTckTest extends AbstractSingleOperatorTckTest<Integer> {
+    @Override
+    protected Single<Integer> composeSingle(Single<Integer> single) {
+        return single.zipWithDelayError(succeeded(null), (result, ignore) -> result);
+    }
+}


### PR DESCRIPTION
Motivation:
We have Single#zip but not the zipDelayError variant.

Modifications:
- Add Single#zipDelayError operator to match Single#zip use cases

Result:
Single#zipDelayError operator exists.