### PR TITLE
Publisher#flatMapMergeSingle mapped source duplicate terminal improved visibility

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
@@ -405,9 +405,22 @@ final class PublisherFlatMapSingle<T, R> extends AbstractAsynchronousPublisherOp
             }
 
             private boolean onSingleTerminated() {
-                assert singleCancellable != null;
+                if (singleCancellable == null) {
+                    logDuplicateTerminal();
+                    return false;
+                }
                 cancellableSet.remove(singleCancellable);
+                singleCancellable = null;
                 return decrementActiveMappedSources();
+            }
+
+            private void logDuplicateTerminal() {
+                LOGGER.warn("onSubscribe not called before terminal or duplicate terminal on Subscriber {}", this,
+                        new IllegalStateException(
+                                "onSubscribe not called before terminal or duplicate terminal on Subscriber " + this +
+                                " forbidden see: " +
+                                "https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#1.9" +
+                                "https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#1.7"));
             }
         }
     }


### PR DESCRIPTION
Motivation:
A mapped source sending multiple terminal signals is in violation of the
Reactive Streams specification [1]. However if there is a faulty source
this may happen, and Publisher#flatMapMergeSingle will fail on an
assertion due to the activeMappedSources being 0 in
decrementActiveMappedSources. The assertion doesn't provide any
additional context as to what went wrong, and the downstream source may
not be completed as a result. This can be difficult to debug the root
cause and understand where the duplicate terminal signal originates
from.

[1] https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#1.7

Modifications:
- Enhance Publisher#flatMapMergeSingle and Publisher#flatMapMerge to log
  a warning when a duplicate terminal signal is detected, and still
  allow for control flow to continue.

Result:
Publisher#flatMapMergeSingle and flatMapMerge still complete control
flow in the presense of RS violations and provide log statement to help
folks track down the cause of the duplicate terminal signal.