### PR TITLE
Enhance Buffer byte[] accessor methods javadoc

### DIFF
--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/Buffer.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/Buffer.java
@@ -1909,27 +1909,40 @@ public interface Buffer {
      * {@link #arrayOffset()}.
      *
      * @return {@code true} if backed by an byte array and is not read-only
+     * @see #array()
+     * @see #arrayOffset()
      */
     boolean hasArray();
 
     /**
      * Returns the backing byte array of this buffer.
-     *
+     * <p>
+     * The caller must check {@link #hasArray()} returns {@code true} before calling this method or
+     * {@link UnsupportedOperationException} maybe thrown.
+     * <p>
+     * Use {@link #arrayOffset()} to get the starting point of data for this buffer. The returned array maybe shared and
+     * this {@link Buffer}'s data may reside in a sub-section.
      * @return byte array.
      * @throws UnsupportedOperationException
      *         if there no accessible backing byte array
      * @throws ReadOnlyBufferException if this buffer is read-only
+     * @see #hasArray()
+     * @see #arrayOffset()
      */
     byte[] array();
 
     /**
-     * Returns the offset of the first byte within the backing byte array of
-     * this buffer.
+     * Returns the offset of the first byte within the backing byte array of this buffer.
+     * <p>
+     * The caller must check {@link #hasArray()} returns {@code true} before calling this method or
+     * {@link UnsupportedOperationException} maybe thrown.
      *
      * @return the offset in the array.
      * @throws UnsupportedOperationException
      *         if there no accessible backing byte array
      * @throws ReadOnlyBufferException if this buffer is read-only
+     * @see #hasArray()
+     * @see #array()
      */
     int arrayOffset();
 


### PR DESCRIPTION
Motivation:
Buffer array(), hasArray(), and arrayOffset() methods are coupled.
However the javadocs don't clearly indicate their relationship which may
lead to confusion.

Modifications:
- Clarify the relationship between Buffer array(), hasArray(), and
  arrayOffset() in javadocs.

Result:
Buffer byte[] accessor javadocs clarify the relationship between related
methods.