### PR TITLE
Optimize encoding of HTTP/2 frames to write less on the wire

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpApiConversions.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpApiConversions.java
@@ -190,7 +190,7 @@ public final class HttpApiConversions {
      * @return {@code true} is the request/response payload body is empty, {@code false} otherwise.
      */
     public static boolean isPayloadEmpty(HttpMetaData metadata) {
-        return (metadata instanceof PayloadInfo && ((PayloadInfo) metadata).isEmpty());
+        return metadata instanceof PayloadInfo && ((PayloadInfo) metadata).isEmpty();
     }
 
     /**
@@ -201,7 +201,7 @@ public final class HttpApiConversions {
      * @return {@code true} is the request/response payload is safe to aggregate, {@code false} otherwise.
      */
     public static boolean isSafeToAggregate(HttpMetaData metadata) {
-        return (metadata instanceof PayloadInfo && ((PayloadInfo) metadata).isSafeToAggregate());
+        return metadata instanceof PayloadInfo && ((PayloadInfo) metadata).isSafeToAggregate();
     }
 
     /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractH2DuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractH2DuplexHandler.java
@@ -76,6 +76,9 @@ abstract class AbstractH2DuplexHandler extends ChannelDuplexHandler {
     final void writeMetaData(ChannelHandlerContext ctx, HttpMetaData metaData, Http2Headers h2Headers,
                              ChannelPromise promise) {
         endStream = !mayHaveTrailers(metaData) && isPayloadEmpty(metaData);
+        if (endStream) {
+            closeHandler.protocolPayloadEndOutbound(ctx, promise);
+        }
         ctx.write(new DefaultHttp2HeadersFrame(h2Headers, endStream), promise);
     }
 
@@ -89,7 +92,6 @@ abstract class AbstractH2DuplexHandler extends ChannelDuplexHandler {
     }
 
     final void writeTrailers(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-        closeHandler.protocolPayloadEndOutbound(ctx, promise);
         HttpHeaders trailers = (HttpHeaders) msg;
         if (endStream) {
             promise.setSuccess();
@@ -100,6 +102,7 @@ abstract class AbstractH2DuplexHandler extends ChannelDuplexHandler {
             return;
         }
 
+        closeHandler.protocolPayloadEndOutbound(ctx, promise);
         if (trailers.isEmpty()) {
             writeEmptyEndStream(ctx, promise);
         } else {
@@ -154,7 +157,7 @@ abstract class AbstractH2DuplexHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void channelInactive(final ChannelHandlerContext ctx) {
+    public final void channelInactive(final ChannelHandlerContext ctx) {
         final Throwable t = channelError(ctx.channel());
         if (t == null) {
             observer.streamClosed();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractH2DuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractH2DuplexHandler.java
@@ -19,6 +19,7 @@ import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpHeadersFactory;
+import io.servicetalk.http.api.HttpMetaData;
 import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
 import io.servicetalk.transport.netty.internal.CloseHandler;
 
@@ -35,8 +36,9 @@ import io.netty.util.ReferenceCountUtil;
 
 import javax.annotation.Nullable;
 
-import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
 import static io.servicetalk.buffer.netty.BufferUtils.toByteBuf;
+import static io.servicetalk.http.api.HttpApiConversions.isPayloadEmpty;
+import static io.servicetalk.http.api.HttpApiConversions.mayHaveTrailers;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h1HeadersToH2Headers;
 import static io.servicetalk.http.netty.Http2Exception.newStreamResetException;
 import static io.servicetalk.http.netty.HttpObjectEncoder.encodeAndRetain;
@@ -47,6 +49,7 @@ abstract class AbstractH2DuplexHandler extends ChannelDuplexHandler {
     final HttpHeadersFactory headersFactory;
     final CloseHandler closeHandler;
     private final StreamObserver observer;
+    private boolean endStream;
 
     AbstractH2DuplexHandler(BufferAllocator allocator, HttpHeadersFactory headersFactory, CloseHandler closeHandler,
                             StreamObserver observer) {
@@ -65,17 +68,42 @@ abstract class AbstractH2DuplexHandler extends ChannelDuplexHandler {
         }
     }
 
+    final void writeMetaData(ChannelHandlerContext ctx, HttpMetaData metaData, Http2Headers h2Headers,
+                             ChannelPromise promise) {
+        endStream = !mayHaveTrailers(metaData) && isPayloadEmpty(metaData);
+        ctx.write(new DefaultHttp2HeadersFrame(h2Headers, endStream), promise);
+    }
+
     static void writeBuffer(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-        ctx.write(new DefaultHttp2DataFrame(encodeAndRetain((Buffer) msg), false), promise);
+        Buffer buffer = (Buffer) msg;
+        if (buffer.readableBytes() > 0) {
+            ctx.write(new DefaultHttp2DataFrame(encodeAndRetain(buffer), false), promise);
+        } else {
+            promise.setSuccess();
+        }
     }
 
     final void writeTrailers(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         closeHandler.protocolPayloadEndOutbound(ctx, promise);
-        Http2Headers h2Headers = h1HeadersToH2Headers((HttpHeaders) msg);
-        if (h2Headers.isEmpty()) {
-            ctx.write(new DefaultHttp2DataFrame(EMPTY_BUFFER, true), promise);
+        HttpHeaders trailers = (HttpHeaders) msg;
+        if (trailers.isEmpty()) {
+            writeEmptyEndStream(ctx, promise);
         } else {
-            ctx.write(new DefaultHttp2HeadersFrame(h2Headers, true), promise);
+            Http2Headers h2Headers = h1HeadersToH2Headers(trailers);
+            if (h2Headers.isEmpty()) {
+                writeEmptyEndStream(ctx, promise);
+            } else {
+                ctx.write(new DefaultHttp2HeadersFrame(h2Headers, true), promise);
+            }
+        }
+        endStream = true;
+    }
+
+    private void writeEmptyEndStream(ChannelHandlerContext ctx, ChannelPromise promise) {
+        if (endStream) {
+            promise.setSuccess();
+        } else {
+            ctx.write(new DefaultHttp2DataFrame(true), promise);
         }
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -28,7 +28,6 @@ import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpScheme;
-import io.netty.handler.codec.http2.DefaultHttp2HeadersFrame;
 import io.netty.handler.codec.http2.Http2DataFrame;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2HeadersFrame;
@@ -86,7 +85,7 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
                 h2Headers.scheme(scheme.name());
                 h2Headers.path(metaData.requestTarget());
             }
-            ctx.write(new DefaultHttp2HeadersFrame(h2Headers, false), promise);
+            writeMetaData(ctx, metaData, h2Headers, promise);
         } else if (msg instanceof Buffer) {
             writeBuffer(ctx, msg, promise);
         } else if (msg instanceof HttpHeaders) {
@@ -109,7 +108,7 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
                     throw new IllegalArgumentException("a response must have " + STATUS + " header");
                 }
                 httpStatus = HttpResponseStatus.of(status);
-                if (httpStatus.statusClass().equals(INFORMATIONAL_1XX)) {
+                if (httpStatus.statusClass() == INFORMATIONAL_1XX) {
                     // We don't expose 1xx "interim responses" [2] to the user, and discard them to make way for the
                     // "real" response.
                     //

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
@@ -26,7 +26,6 @@ import io.servicetalk.transport.netty.internal.CloseHandler;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.handler.codec.http2.DefaultHttp2HeadersFrame;
 import io.netty.handler.codec.http2.Http2DataFrame;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2HeadersFrame;
@@ -64,7 +63,7 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
             HttpResponseMetaData metaData = (HttpResponseMetaData) msg;
             Http2Headers h2Headers = h1HeadersToH2Headers(metaData.headers());
             h2Headers.status(metaData.status().codeAsCharSequence());
-            ctx.write(new DefaultHttp2HeadersFrame(h2Headers, false), promise);
+            writeMetaData(ctx, metaData, h2Headers, promise);
         } else if (msg instanceof Buffer) {
             writeBuffer(ctx, msg, promise);
         } else if (msg instanceof HttpHeaders) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
@@ -107,6 +107,13 @@ final class H2ToStH1Utils {
     }
 
     static Http2Headers h1HeadersToH2Headers(HttpHeaders h1Headers) {
+        if (h1Headers.isEmpty()) {
+            if (h1Headers instanceof NettyH2HeadersToHttpHeaders) {
+                return ((NettyH2HeadersToHttpHeaders) h1Headers).nettyHeaders();
+            }
+            return new DefaultHttp2Headers(false, 0);
+        }
+
         // H2 doesn't support connection headers, so remove each one, and the headers corresponding to the
         // connection value.
         // https://tools.ietf.org/html/rfc7540#section-8.1.2.2
@@ -164,6 +171,10 @@ final class H2ToStH1Utils {
             // Assume header field names are already lowercase if they reside in the Http2Headers. We may want to be
             // more strict in the future, but that would require iteration.
             return ((NettyH2HeadersToHttpHeaders) h1Headers).nettyHeaders();
+        }
+
+        if (h1Headers.isEmpty()) {
+            return new DefaultHttp2Headers(false, 0);
         }
 
         DefaultHttp2Headers http2Headers = new DefaultHttp2Headers(false);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ConcurrencyControllerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ConcurrencyControllerTest.java
@@ -98,7 +98,7 @@ public class H2ConcurrencyControllerTest {
             protected void initChannel(Http2StreamChannel ch) {
                 // Respond only for the first request which is used to propagate MAX_CONCURRENT_STREAMS_VALUE
                 if (secondAndMore.compareAndSet(false, true)) {
-                    ch.pipeline().addLast(EchoHttp2Handler.INSTANCE);
+                    ch.pipeline().addLast(new EchoHttp2Handler());
                 } else {
                     // Do not respond to any subsequent requests, only release the associated latch to notify the client
                     // that server received the request.

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TestServiceStreaming.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TestServiceStreaming.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.StatelessTrailersTransformer;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
@@ -121,7 +122,10 @@ final class TestServiceStreaming implements StreamingHttpService {
     private static StreamingHttpResponse newEchoResponse(final StreamingHttpRequest req,
                                                          final StreamingHttpResponseFactory factory) {
         final StreamingHttpResponse response = factory.ok().version(req.version())
-                .transformMessageBody(pub -> pub.ignoreElements().merge(req.messageBody()));
+                .transformMessageBody(pub -> pub.ignoreElements().merge(req.messageBody()))
+                // Apply empty transform operation only to inform internal PayloadHolder that the payload
+                // body may contain content and trailers
+                .transform(new StatelessTrailersTransformer<>());
         final CharSequence contentLength = req.headers().get(CONTENT_LENGTH);
         if (contentLength != null) {
             response.addHeader(CONTENT_LENGTH, contentLength);


### PR DESCRIPTION
Motivation:

We can infer from the `PayloadInfo` when HTTP message does not contain
payload body or trailers. In this case, we can write it in a single frame.
Also, we do not need to write `Http2DataFrame`(s) for empty `Buffer`(s)
or process `HttpHeaders` when it's empty.

Modifications:

- Detect if the `HttpMetaData` can be written in a single frame;
- Emit `CloseHandler#protocolPayloadEndOutbound` on `endStream`;
- Ignore empty `Buffer`(s) when writing `Http2DataFrame`(s);
- Do not process `HttpHeaders` when they are empty;
- Add tests for new behavior;

Result:

Less `Http2StreamFrame`(s) allocated and written on the wire, results in
+10% RPS, -12% latency for some HTTP/2 use-cases.