### PR TITLE
Config test ignoreFailures via system property

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -186,13 +186,13 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
             showStandardStreams = true
           }
         }
-
+      
+        // if property is defined and true allow tests to continue running after first fail
+        ignoreFailures = Boolean.getBoolean("servicetalk.test.ignoreFailures")
+        
         jvmArgs "-server", "-Xms2g", "-Xmx4g", "-dsa", "-da", "-ea:io.servicetalk...",
                 "-XX:+HeapDumpOnOutOfMemoryError"
       }
-      
-      // if property is defined and true allow tests to continue running after first fail
-      ignoreFailures = Boolean.getBoolean("servicetalk.test.ignoreFailures")
 
       dependencies {
         testRuntimeOnly("org.junit.vintage:junit-vintage-engine:$junit5Version") {

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -190,6 +190,9 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
         jvmArgs "-server", "-Xms2g", "-Xmx4g", "-dsa", "-da", "-ea:io.servicetalk...",
                 "-XX:+HeapDumpOnOutOfMemoryError"
       }
+      
+      // if property is defined and true allow tests to continue running after first fail
+      ignoreFailures Boolean.getBoolean("servicetalk.test.ignoreFailures")
 
       dependencies {
         testRuntimeOnly("org.junit.vintage:junit-vintage-engine:$junit5Version") {

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -192,7 +192,7 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
       }
       
       // if property is defined and true allow tests to continue running after first fail
-      ignoreFailures Boolean.getBoolean("servicetalk.test.ignoreFailures")
+      ignoreFailures = Boolean.getBoolean("servicetalk.test.ignoreFailures")
 
       dependencies {
         testRuntimeOnly("org.junit.vintage:junit-vintage-engine:$junit5Version") {


### PR DESCRIPTION
Motivation:
The default behaviour of Gradle is to stop the build with an error in
the first module with a test failure. In some cases it is useful to
run all tests to get a survey of which tests are failing. It can also
be annoying if flaky tests are stopping the build from completing.

Modifications:
This change allows configuration of the Gradle test `ignoreFailures`
option to continue the build after test failures. The `ignoreFailures`
test configuration is initialized from the system property 
`servicetalk.test.ignoreFailures` allowing for command line
configuration. `./gradlew -Dservicetalk.test.ignoreFailures=true build`

Result:
Dynamically configurable ignoreFailures. This feature should not be
used for CI builds as it will mask build failures. Build results
should always be manually examined for test failures if this option
is used.