### PR TITLE
Do not use TLSv1.1 in tests

### DIFF
--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverErrorsTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverErrorsTest.java
@@ -124,7 +124,7 @@ public final class SecureTcpTransportObserverErrorsTest extends AbstractTranspor
             case NOT_MATCHING_PROTOCOLS:
                 clientSslBuilder.sslProtocols("TLSv1.2");
                 clientConfig.sslConfig(clientSslBuilder.build());
-                serverSslBuilder.sslProtocols("TLSv1.1");
+                serverSslBuilder.sslProtocols("TLSv1.3");
                 serverConfig.sslConfig(serverSslBuilder.build());
                 break;
             case NOT_MATCHING_CIPHERS:


### PR DESCRIPTION
Motivation:

TLS 1.0 and 1.1 were disabled in the latest JDK releases because they are
no longer considered secure [1, 2]. As the result of this JDK upgrade,
`SecureTcpTransportObserverErrorsTest.testSslErrors` started to fail when
it uses JDK provider with TLSv1.1.

1. https://www.oracle.com/java/technologies/javase/8u291-relnotes.html
2. https://www.oracle.com/java/technologies/javase/11-0-11-relnotes.html

Modifications:

- Use TLSv1.3 instead of TLSv1.1 for `SecureTcpTransportObserverErrorsTest`;

Result:

Fixes #1530.