### PR TITLE
Reduce default test timeout on CI to 30s for jUnit4

### DIFF
--- a/servicetalk-concurrent-internal/src/testFixtures/java/io/servicetalk/concurrent/internal/ServiceTalkTestTimeout.java
+++ b/servicetalk-concurrent-internal/src/testFixtures/java/io/servicetalk/concurrent/internal/ServiceTalkTestTimeout.java
@@ -42,7 +42,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  */
 public final class ServiceTalkTestTimeout extends Timeout {
     public static final boolean CI = parseBoolean(System.getenv("CI"));
-    public static final int DEFAULT_TIMEOUT_SECONDS = CI ? 90 : 10;
+    public static final int DEFAULT_TIMEOUT_SECONDS = CI ? 30 : 10;
     public static final String THREAD_PREFIX = "Time-limited test";
     private final Runnable onTimeout;
 


### PR DESCRIPTION
Motivation:

We set 90s timeout for CI a while ago, when we used a custom CI server.
With GitHub Actions there is no need for that high timeout value. It
only slows down the overall build duration if any timeout happens, but
does not provide much value. The default timeout for jUnit5 tests is
already 30s.

Modifications:

- Change `ServiceTalkTestTimeout.DEFAULT_TIMEOUT_SECONDS` to 30 when
`CI == true`;

Result:

Shorter timeout for jUnit4 tests when build runs on CI.