### PR TITLE
Mark `AbstractTcpConfig#enableWireLogging(String)` as deprecated

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
@@ -51,6 +51,7 @@ import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
 import static io.servicetalk.http.netty.NettyHttpServer.initChannel;
+import static io.servicetalk.logging.api.LogLevel.TRACE;
 import static io.servicetalk.transport.netty.internal.NettyIoExecutors.fromNettyEventLoop;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -78,7 +79,7 @@ public class ServerRespondsOnClosingTest {
         DefaultHttpExecutionContext httpExecutionContext = new DefaultHttpExecutionContext(DEFAULT_ALLOCATOR,
                 fromNettyEventLoop(channel.eventLoop()), immediate(), noOffloadsStrategy());
         final HttpServerConfig httpServerConfig = new HttpServerConfig();
-        httpServerConfig.tcpConfig().enableWireLogging("servicetalk-tests-wire-logger");
+        httpServerConfig.tcpConfig().enableWireLogging("servicetalk-tests-wire-logger", TRACE, () -> true);
         ReadOnlyHttpServerConfig config = httpServerConfig.asReadOnly();
         ConnectionObserver connectionObserver = NoopConnectionObserver.INSTANCE;
         HttpService service = (ctx, request, responseFactory) -> {

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
@@ -126,8 +126,10 @@ abstract class AbstractTcpConfig<SslConfigType> {
     /**
      * Enable wire-logging for all connections. All wire events will be logged at trace level.
      *
+     * @deprecated Use {@link #enableWireLogging(String, LogLevel, BooleanSupplier)} instead
      * @param loggerName The name of the logger to log wire events
      */
+    @Deprecated
     public final void enableWireLogging(final String loggerName) {
         enableWireLogging(loggerName, TRACE, () -> false);
     }

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
@@ -39,6 +39,7 @@ import org.junit.rules.Timeout;
 import java.net.InetSocketAddress;
 import java.util.function.Function;
 
+import static io.servicetalk.logging.api.LogLevel.TRACE;
 import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;
 import static io.servicetalk.transport.api.ConnectionAcceptor.ACCEPT_ALL;
 import static io.servicetalk.transport.netty.internal.ExecutionContextRule.cached;
@@ -102,7 +103,7 @@ public abstract class AbstractTcpServerTest {
                     .peerPort(serverHostAndPort.port())
                     .build());
         }
-        tcpClientConfig.enableWireLogging("servicetalk-tests-wire-logger");
+        tcpClientConfig.enableWireLogging("servicetalk-tests-wire-logger", TRACE, () -> true);
         return tcpClientConfig;
     }
 
@@ -123,7 +124,7 @@ public abstract class AbstractTcpServerTest {
             tcpServerConfig.sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem,
                     DefaultTestCerts::loadServerKey).build());
         }
-        tcpServerConfig.enableWireLogging("servicetalk-tests-wire-logger");
+        tcpServerConfig.enableWireLogging("servicetalk-tests-wire-logger", TRACE, () -> true);
         return tcpServerConfig;
     }
 


### PR DESCRIPTION
Motivation:

We marked all public `enableWireLogging(String)` methods as deprecated
a few releases back. But did not mark internal method
`AbstractTcpConfig#enableWireLogging(String)`. As the result, we still
use the deprecated method in a few tests.

Modifications:

- Mark `AbstractTcpConfig#enableWireLogging(String)` as deprecated;
- Replace its usage with a non-deprecated variant;

Results:

No usage of deprecated `enableWireLogging(String)` overload in tests.