### PR TITLE
Don't load netty-transport-native classes when native lib isn't available

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BuilderUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BuilderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,18 +19,15 @@ import io.servicetalk.transport.api.FileDescriptorSocketAddress;
 import io.servicetalk.transport.api.HostAndPort;
 
 import io.netty.channel.Channel;
-import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.epoll.EpollDatagramChannel;
 import io.netty.channel.epoll.EpollDomainSocketChannel;
-import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollServerDomainSocketChannel;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.epoll.EpollSocketChannel;
 import io.netty.channel.kqueue.KQueueDatagramChannel;
 import io.netty.channel.kqueue.KQueueDomainSocketChannel;
-import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.channel.kqueue.KQueueServerDomainSocketChannel;
 import io.netty.channel.kqueue.KQueueServerSocketChannel;
 import io.netty.channel.kqueue.KQueueSocketChannel;
@@ -51,6 +48,8 @@ import java.net.UnknownHostException;
 import javax.annotation.Nullable;
 
 import static io.netty.util.NetUtil.createByteArrayFromIpAddressString;
+import static io.servicetalk.transport.netty.internal.NativeTransportUtils.useEpoll;
+import static io.servicetalk.transport.netty.internal.NativeTransportUtils.useKQueue;
 import static java.net.InetAddress.getByAddress;
 
 /**
@@ -59,32 +58,6 @@ import static java.net.InetAddress.getByAddress;
 public final class BuilderUtils {
     private BuilderUtils() {
         // Utility methods only
-    }
-
-    /**
-     * Returns {@code true} if native epoll transport should be used.
-     *
-     * @param group the used {@link EventLoopGroup}
-     * @return {@code true} if native transport should be used
-     */
-    public static boolean useEpoll(EventLoopGroup group) {
-        // Check if we should use the epoll transport. This is true if either the EpollEventLoopGroup is used directly
-        // or if the passed group is a EventLoop and it's parent is an EpollEventLoopGroup.
-        return group instanceof EpollEventLoopGroup || (group instanceof EventLoop &&
-                ((EventLoop) group).parent() instanceof EpollEventLoopGroup);
-    }
-
-    /**
-     * Returns {@code true} if native kqueue transport should be used.
-     *
-     * @param group the used {@link EventLoopGroup}
-     * @return {@code true} if native transport should be used
-     */
-    public static boolean useKQueue(EventLoopGroup group) {
-        // Check if we should use the kqueue transport. This is true if either the KQueueEventLoopGroup is used directly
-        // or if the passed group is a EventLoop and it's parent is an KQueueEventLoopGroup.
-        return group instanceof KQueueEventLoopGroup || (group instanceof EventLoop &&
-                ((EventLoop) group).parent() instanceof KQueueEventLoopGroup);
     }
 
     /**

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NativeTransportUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NativeTransportUtils.java
@@ -84,10 +84,10 @@ final class NativeTransportUtils {
     }
 
     /**
-     * Returns {@code true} if native {@link Epoll} transport should be used.
+     * Returns {@code true} if native {@link Epoll} transport could be used.
      *
      * @param group the used {@link EventLoopGroup}
-     * @return {@code true} if native {@link Epoll} transport should be used
+     * @return {@code true} if native {@link Epoll} transport could be used
      */
     static boolean useEpoll(final EventLoopGroup group) {
         if (!isEpollAvailable()) {
@@ -100,10 +100,10 @@ final class NativeTransportUtils {
     }
 
     /**
-     * Returns {@code true} if native {@link KQueue} transport should be used.
+     * Returns {@code true} if native {@link KQueue} transport could be used.
      *
      * @param group the used {@link EventLoopGroup}
-     * @return {@code true} if native {@link KQueue} transport should be used
+     * @return {@code true} if native {@link KQueue} transport could be used
      */
     static boolean useKQueue(final EventLoopGroup group) {
         if (!isKQueueAvailable()) {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutors.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,14 @@ import io.servicetalk.transport.api.IoExecutor;
 
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.channel.kqueue.KQueue;
 import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 
 import java.util.concurrent.ThreadFactory;
 
+import static io.servicetalk.transport.netty.internal.NativeTransportUtils.isEpollAvailable;
+import static io.servicetalk.transport.netty.internal.NativeTransportUtils.isKQueueAvailable;
 import static java.lang.Runtime.getRuntime;
 import static java.util.Objects.requireNonNull;
 
@@ -70,8 +70,8 @@ public final class NettyIoExecutors {
      */
     public static EventLoopGroup createEventLoopGroup(int ioThreads, ThreadFactory threadFactory) {
         validateIoThreads(ioThreads);
-        return Epoll.isAvailable() ? new EpollEventLoopGroup(ioThreads, threadFactory) :
-                KQueue.isAvailable() ? new KQueueEventLoopGroup(ioThreads, threadFactory) :
+        return isEpollAvailable() ? new EpollEventLoopGroup(ioThreads, threadFactory) :
+                isKQueueAvailable() ? new KQueueEventLoopGroup(ioThreads, threadFactory) :
                         new NioEventLoopGroup(ioThreads, threadFactory);
     }
 


### PR DESCRIPTION
Motivation:

1. Do not try to load native libraries when it's known that OS does not
support it.
2. Log when OS supports native transport, but native lib cannot be
loaded.
3. Prevent class loading of any classes related to native transport when
it's not available.

Modifications:

- Enhance `NativeTransportUtils` to protect class loading when it's
known that OS does not support a specific type of transport;
- Log when native transport can not be loaded;

Result:

1. Less unused classes are loaded in memory.
2. Users are notified when native transport can be used but is not
loaded properly.