### PR TITLE
Fix broken link in HTTP timeout example

### DIFF
--- a/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
@@ -97,10 +97,10 @@ Extends the async "Hello World" example to demonstrate some useful features avai
 
 Extends the async "Hello World" example to demonstrate the use of timeout filters and operators. You should read and
  understand the async "Hello World" example first to understand the additions this example adds. No separate example is
- needed for the other API variants as the usage of the debugging features are the same for all API styles.
+ needed for the other API variants as the usage of the timeout features are the same for all API styles.
 
 * link:{source-root}/servicetalk-examples/http/timeout/src/main/java/io/servicetalk/examples/http/timeout/TimeoutServer.java[TimeoutServer] - the async `Hello World!` server client enhanced to use timeout capabilities.
-* link:{source-root}/servicetalk-examples/http/timeout/src/main/java/io/servicetalk/examples/http/timeout/DebuggingExampleClient.java[TimeoutClient.java] - the async `Hello World!` client enhanced to use timeout capabilities.
+* link:{source-root}/servicetalk-examples/http/timeout/src/main/java/io/servicetalk/examples/http/timeout/TimeoutClient.java[TimeoutClient.java] - the async `Hello World!` client enhanced to use timeout capabilities.
 
 [#Serialization]
 == Serialization


### PR DESCRIPTION
Motivation:
The link to the HTTP Timeout example client code is broken.
Modifications:
Correct the link target URL
Result:
Link can be followed to example