### PR TITLE
Restore public API changes for `grpc-api`

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -20,7 +20,9 @@ import io.servicetalk.client.api.AutoRetryStrategyProvider;
 import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.AsyncContextMap;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.grpc.internal.DeadlineUtils;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpLoadBalancerFactory;
@@ -52,6 +54,15 @@ import static io.servicetalk.grpc.api.GrpcStatus.fromThrowable;
  */
 public abstract class GrpcClientBuilder<U, R>
         implements SingleAddressGrpcClientBuilder<U, R, ServiceDiscovererEvent<R>> {
+
+    /**
+     * gRPC timeout is stored in context as a deadline so that when propagated to a new request the remaining time to be
+     * included in the request can be calculated.
+     *
+     * @deprecated Do not use. This is internal implementation details that users should not depend on.
+     */
+    @Deprecated
+    protected static final AsyncContextMap.Key<Long> GRPC_DEADLINE_KEY = DeadlineUtils.GRPC_DEADLINE_KEY;
 
     private boolean appendedCatchAllFilter;
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientMetadata.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientMetadata.java
@@ -20,10 +20,23 @@ import io.servicetalk.encoding.api.ContentCodec;
 import java.time.Duration;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.grpc.internal.DeadlineUtils.EIGHT_NINES;
+
 /**
  * Metadata for a <a href="https://www.grpc.io">gRPC</a> client call.
  */
 public interface GrpcClientMetadata extends GrpcMetadata {
+
+    /**
+     * Maximum timeout which can be specified for a <a href="https://www.grpc.io">gRPC</a>
+     * <a href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests">request</a>. Note that this
+     * maximum is effectively infinite as the duration is more than 11,000 years.
+     *
+     * @deprecated Do not use. This constant will be removed in future releases. If necessary, define an alternative
+     * constant in your application or use {@code null} for infinite {@link #timeout() timeout}.
+     */
+    @Deprecated
+    Duration GRPC_MAX_TIMEOUT = Duration.ofHours(EIGHT_NINES);
 
     /**
      * {@link GrpcExecutionStrategy} to use for the associated

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -16,7 +16,9 @@
 package io.servicetalk.grpc.api;
 
 import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.concurrent.api.AsyncContextMap;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.grpc.internal.DeadlineUtils;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpRequest;
@@ -52,6 +54,15 @@ import static io.servicetalk.grpc.api.GrpcUtils.newErrorResponse;
  * A builder for building a <a href="https://www.grpc.io">gRPC</a> server.
  */
 public abstract class GrpcServerBuilder {
+
+    /**
+     * gRPC timeout is stored in context as a deadline so that when propagated to a new client request the remaining
+     * time to be included in the request can be calculated.
+     *
+     * @deprecated Do not use. This is internal implementation details that users should not depend on.
+     */
+    @Deprecated
+    protected static final AsyncContextMap.Key<Long> GRPC_DEADLINE_KEY = DeadlineUtils.GRPC_DEADLINE_KEY;
 
     private boolean appendedCatchAllFilter;
 


### PR DESCRIPTION
Motivation:

All public API breaking changes should be deferred until 0.41.0.

Modifications:

- Restore `grpc-api` that was removed in #1501.

Result:

No public API changes for 0.40.0.