### PR TITLE
Jersey example with multipart file upload support

### DIFF
--- a/servicetalk-examples/http/jaxrs/build.gradle
+++ b/servicetalk-examples/http/jaxrs/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ dependencies {
   implementation project(":servicetalk-data-jackson-jersey")
   implementation project(":servicetalk-http-netty")
   implementation project(":servicetalk-http-router-jersey")
+  implementation "org.glassfish.jersey.media:jersey-media-multipart:$jerseyVersion"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/servicetalk-examples/http/jaxrs/src/main/java/io/servicetalk/examples/http/jaxrs/HelloWorldJaxRsApplication.java
+++ b/servicetalk-examples/http/jaxrs/src/main/java/io/servicetalk/examples/http/jaxrs/HelloWorldJaxRsApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,14 @@
  */
 package io.servicetalk.examples.http.jaxrs;
 
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import javax.ws.rs.core.Application;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 
 /**
@@ -26,6 +31,10 @@ import static java.util.Collections.singleton;
 public class HelloWorldJaxRsApplication extends Application {
     @Override
     public Set<Class<?>> getClasses() {
-        return singleton(HelloWorldJaxRsResource.class);
+        return new HashSet<>(asList(
+                MultiPartFeature.class,
+                HelloWorldJaxRsResource.class
+            )
+        );
     }
 }


### PR DESCRIPTION
Motivation:

Include an example of a Jersey resource that supports `mulitpart/form-data` requests.

Modifications:

A new handler in the existing greetings resource.

Result:

More examples for users who want to support multipart file uploads.