### PR TITLE
Fix flaky `closePipelinedAfterTwoRequestsSentBeforeAnyResponseReceived`

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
@@ -500,7 +500,7 @@ public class GracefulConnectionClosureHandlingTest {
     private void assertClosedChannelException(ThrowingRunnable runnable, CloseEvent expectedCloseEvent) {
         Exception e = assertThrows(ExecutionException.class, runnable);
         Throwable cause = e.getCause();
-        assertThat(cause, instanceOf(ClosedChannelException.class));
+        assertThat(cause, anyOf(instanceOf(ClosedChannelException.class), instanceOf(IOException.class)));
         if (protocol == HTTP_2) {
             // HTTP/2 does not enhance ClosedChannelException with CloseEvent
             return;


### PR DESCRIPTION
Motivation:

`closePipelinedAfterTwoRequestsSentBeforeAnyResponseReceived` may be in
a situation when the 2nd request actually gets written after client
receives `GO_AWAY` frame from the server. Therefore, `Http2Exception` is
also excepted. We will use `IOException` for simplicity and consistency.

Modifications:

- `assertClosedChannelException` should expect either
`ClosedChannelException` or `IOException`;

Result:

`closePipelinedAfterTwoRequestsSentBeforeAnyResponseReceived` is not
flaky.