### PR TITLE
Disable auto ack for HTTP/2 PING frames by netty

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
@@ -48,6 +48,8 @@ final class H2ClientParentChannelInitializer implements ChannelInitializer {
                 // The max concurrent streams is made available via a publisher and may be consumed asynchronously
                 // (e.g. when offloading is enabled), so we manually control the SETTINGS ACK frames.
                 .autoAckSettingsFrame(false)
+                // We ack PING frames in KeepAliveManager#pingReceived.
+                .autoAckPingFrame(false)
                 // We don't want to rely upon Netty to manage the graceful close timeout, because we expect
                 // the user to apply their own timeout at the call site.
                 .gracefulShutdownTimeoutMillis(-1);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
@@ -46,6 +46,8 @@ final class H2ServerParentChannelInitializer implements ChannelInitializer {
                 // We do not want close to trigger graceful closure (go away), instead when user triggers a graceful
                 // close, we do the appropriate go away handling.
                 .decoupleCloseAndGoAway(true)
+                // We ack PING frames in KeepAliveManager#pingReceived.
+                .autoAckPingFrame(false)
                 // We don't want to rely upon Netty to manage the graceful close timeout, because we expect
                 // the user to apply their own timeout at the call site.
                 .gracefulShutdownTimeoutMillis(-1);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -231,8 +231,10 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
 
         @Override
         boolean ackSettings(final ChannelHandlerContext ctx, final Http2SettingsFrame settingsFrame) {
-            // server side doesn't asynchronously need to ACK the settings because there is no need to coordinate
+            // Server side doesn't asynchronously need to ACK the settings because there is no need to coordinate
             // the maximum concurrent streams value with the application.
+            // All SETTINGS frames are automatically ack'ed by netty, see
+            // Http2FrameCodecBuilder#autoAckSettingsFrame(boolean) in H2ServerParentChannelInitializer.
             return false;
         }
     }


### PR DESCRIPTION
Motivation:

`KeepAliveManager#pingReceived` always acks PING frames. Netty's auto
ack produces additional PING-ack frames that are not necessary and
confusing.

Modifications:

- Use `Http2FrameCodecBuilder#autoAckPingFrame(false)` on client and
server sides;

Result:

No duplicated PING frames written with ack=true.