### PR TITLE
Do not write GOAWAY frame if HTTP/2 connection is already closed

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/KeepAliveManager.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/KeepAliveManager.java
@@ -274,7 +274,7 @@ final class KeepAliveManager {
     private void gracefulCloseWriteSecondGoAway() {
         assert channel.eventLoop().inEventLoop();
 
-        if (gracefulCloseState == GRACEFUL_CLOSE_SECOND_GO_AWAY_SENT) {
+        if (gracefulCloseState == GRACEFUL_CLOSE_SECOND_GO_AWAY_SENT || gracefulCloseState == CLOSED) {
             return;
         }
 


### PR DESCRIPTION
Motivation:

`KeepAliveManager#gracefulCloseWriteSecondGoAway()` can be triggered on
PING-ack frame at the time when the connection is already closed,
because there were no active streams.

Modifications:

- Do not write GOAWAY frame if `gracefulCloseState == CLOSED`;

Result:

No failure on trying to write a GOAWAY frame after connection is already
closed.