### PR TITLE
Fix ProxyTunnel to always use the address instead of the hostname.

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -85,7 +85,8 @@ final class ProxyTunnel implements AutoCloseable {
             }
             return null;
         });
-        return HostAndPort.of(getLoopbackAddress().getHostAddress(), serverSocket.getLocalPort());
+        InetSocketAddress serverSocketAddress = (InetSocketAddress) serverSocket.getLocalSocketAddress();
+        return HostAndPort.of(serverSocketAddress.getAddress().getHostAddress(), serverSocketAddress.getPort());
     }
 
     void badResponseProxy() {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.ExecutorService;
@@ -86,7 +85,7 @@ final class ProxyTunnel implements AutoCloseable {
             }
             return null;
         });
-        return HostAndPort.of((InetSocketAddress) serverSocket.getLocalSocketAddress());
+        return HostAndPort.of(getLoopbackAddress().getHostAddress(), serverSocket.getLocalPort());
     }
 
     void badResponseProxy() {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.ExecutorService;
@@ -60,6 +61,7 @@ final class ProxyTunnel implements AutoCloseable {
 
     HostAndPort startProxy() throws IOException {
         serverSocket = new ServerSocket(0, 50, getLoopbackAddress());
+        final InetSocketAddress serverSocketAddress = (InetSocketAddress) serverSocket.getLocalSocketAddress();
         executor.submit(() -> {
             while (!executor.isShutdown()) {
                 final Socket socket = serverSocket.accept();
@@ -85,7 +87,7 @@ final class ProxyTunnel implements AutoCloseable {
             }
             return null;
         });
-        InetSocketAddress serverSocketAddress = (InetSocketAddress) serverSocket.getLocalSocketAddress();
+
         return HostAndPort.of(serverSocketAddress.getAddress().getHostAddress(), serverSocketAddress.getPort());
     }
 


### PR DESCRIPTION
Motivation:

ProxyTunnel was returning the `localhost` hostname instead of the IP-address, which in some configurations
where the IPv4 is preferred but the DNS resolves in both IPv4 and IPv6 for the loopback hostname,
cause connectivity issues.

Modifications:

Modified the ProxyTunnel to always return the IP-address for the clients to connect to.

Result:

More stable test.