### PR TITLE
Deprecate HTTP/gRPC offloadWithThreadAffinity

### DIFF
--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/ExecutorThrowsTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/ExecutorThrowsTest.java
@@ -38,7 +38,7 @@ import static io.servicetalk.concurrent.api.Executors.from;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.concurrent.internal.EmptySubscriptions.EMPTY_SUBSCRIPTION;
-import static io.servicetalk.concurrent.internal.SignalOffloaders.threadBasedOffloaderFactory;
+import static io.servicetalk.concurrent.internal.SignalOffloaders.defaultOffloaderFactory;
 
 @RunWith(Parameterized.class)
 public class ExecutorThrowsTest {
@@ -165,7 +165,7 @@ public class ExecutorThrowsTest {
         Executor original = from(task -> {
             throw DELIBERATE_EXCEPTION;
         });
-        return new OffloaderAwareExecutor(original, threadBasedOffloaderFactory());
+        return new OffloaderAwareExecutor(original, defaultOffloaderFactory());
     }
 
     private void verifyError() throws Throwable {

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractPublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractPublishAndSubscribeOnTest.java
@@ -35,7 +35,7 @@ import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.api.completable.AbstractPublishAndSubscribeOnTest.verifyCapturedThreads;
-import static io.servicetalk.concurrent.internal.SignalOffloaders.threadBasedOffloaderFactory;
+import static io.servicetalk.concurrent.internal.SignalOffloaders.defaultOffloaderFactory;
 import static java.lang.Long.MAX_VALUE;
 import static java.lang.Thread.currentThread;
 
@@ -49,7 +49,7 @@ public abstract class AbstractPublishAndSubscribeOnTest {
     public final Timeout timeout = new ServiceTalkTestTimeout();
     @Rule
     public final ExecutorRule originalSourceExecutorRule = ExecutorRule.withExecutor(
-            () -> new OffloaderAwareExecutor(newCachedThreadExecutor(), threadBasedOffloaderFactory()));
+            () -> new OffloaderAwareExecutor(newCachedThreadExecutor(), defaultOffloaderFactory()));
 
     protected AtomicReferenceArray<Thread> setupAndSubscribe(
             BiFunction<Publisher<String>, Executor, Publisher<String>> offloadingFunction, Executor executor)

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/PublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/PublishAndSubscribeOnTest.java
@@ -15,26 +15,28 @@
  */
 package io.servicetalk.concurrent.api.publisher;
 
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ExecutorRule;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.internal.OffloaderAwareExecutor;
 
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
-import static io.servicetalk.concurrent.internal.SignalOffloaders.threadBasedOffloaderFactory;
+import static io.servicetalk.concurrent.internal.SignalOffloaders.defaultOffloaderFactory;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 public class PublishAndSubscribeOnTest extends AbstractPublishAndSubscribeOnTest {
 
     @Rule
-    public final ExecutorRule executorRule = ExecutorRule.withExecutor(() ->
-            new OffloaderAwareExecutor(newCachedThreadExecutor(), threadBasedOffloaderFactory()));
+    public final ExecutorRule<Executor> executorRule = ExecutorRule.withExecutor(() ->
+            new OffloaderAwareExecutor(newCachedThreadExecutor(), defaultOffloaderFactory()));
 
     @Test
     public void testPublishOnNoOverride() throws InterruptedException {
@@ -42,12 +44,14 @@ public class PublishAndSubscribeOnTest extends AbstractPublishAndSubscribeOnTest
                 setupAndSubscribe(Publisher::publishOn, executorRule.executor());
 
         assertThat("Unexpected threads for subscription and subscriber for original source.",
-                capturedThreads.get(ORIGINAL_SUBSCRIBER_THREAD), is(capturedThreads.get(ORIGINAL_SUBSCRIPTION_THREAD)));
+                capturedThreads.get(ORIGINAL_SUBSCRIBER_THREAD),
+                sameThreadFactory(capturedThreads.get(ORIGINAL_SUBSCRIPTION_THREAD)));
         assertThat("Unexpected threads for subscription and subscriber for offloaded source.",
                 capturedThreads.get(OFFLOADED_SUBSCRIBER_THREAD),
-                not(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD)));
+                not(sameThreadFactory(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD))));
         assertThat("Unexpected threads for original and offloaded source.",
-                capturedThreads.get(ORIGINAL_SUBSCRIBER_THREAD), not(capturedThreads.get(OFFLOADED_SUBSCRIBER_THREAD)));
+                capturedThreads.get(ORIGINAL_SUBSCRIBER_THREAD),
+                not(sameThreadFactory(capturedThreads.get(OFFLOADED_SUBSCRIBER_THREAD))));
     }
 
     @Test
@@ -57,12 +61,13 @@ public class PublishAndSubscribeOnTest extends AbstractPublishAndSubscribeOnTest
 
         assertThat("Unexpected threads for subscription and subscriber for original source.",
                 capturedThreads.get(ORIGINAL_SUBSCRIBER_THREAD),
-                not(capturedThreads.get(ORIGINAL_SUBSCRIPTION_THREAD)));
+                not(sameThreadFactory(capturedThreads.get(ORIGINAL_SUBSCRIPTION_THREAD))));
         assertThat("Unexpected threads for subscription and subscriber for offloaded source.",
                 capturedThreads.get(OFFLOADED_SUBSCRIBER_THREAD),
-                not(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD)));
+                not(sameThreadFactory(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD))));
         assertThat("Unexpected threads for original and offloaded source.",
-                capturedThreads.get(ORIGINAL_SUBSCRIBER_THREAD), is(capturedThreads.get(OFFLOADED_SUBSCRIBER_THREAD)));
+                capturedThreads.get(ORIGINAL_SUBSCRIBER_THREAD),
+                sameThreadFactory(capturedThreads.get(OFFLOADED_SUBSCRIBER_THREAD)));
     }
 
     @Test
@@ -71,13 +76,14 @@ public class PublishAndSubscribeOnTest extends AbstractPublishAndSubscribeOnTest
                 setupAndSubscribe(Publisher::subscribeOn, executorRule.executor());
 
         assertThat("Unexpected threads for subscription and subscriber for original source.",
-                capturedThreads.get(ORIGINAL_SUBSCRIBER_THREAD), is(capturedThreads.get(ORIGINAL_SUBSCRIPTION_THREAD)));
+                capturedThreads.get(ORIGINAL_SUBSCRIBER_THREAD),
+                sameThreadFactory(capturedThreads.get(ORIGINAL_SUBSCRIPTION_THREAD)));
         assertThat("Unexpected threads for subscription and subscriber for offloaded source.",
                 capturedThreads.get(OFFLOADED_SUBSCRIBER_THREAD),
-                not(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD)));
+                not(sameThreadFactory(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD))));
         assertThat("Unexpected threads for original and offloaded source.",
                 capturedThreads.get(ORIGINAL_SUBSCRIPTION_THREAD),
-                not(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD)));
+                not(sameThreadFactory(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD))));
     }
 
     @Test
@@ -87,13 +93,13 @@ public class PublishAndSubscribeOnTest extends AbstractPublishAndSubscribeOnTest
 
         assertThat("Unexpected threads for subscription and subscriber for original source.",
                 capturedThreads.get(ORIGINAL_SUBSCRIBER_THREAD),
-                not(capturedThreads.get(ORIGINAL_SUBSCRIPTION_THREAD)));
+                not(sameThreadFactory(capturedThreads.get(ORIGINAL_SUBSCRIPTION_THREAD))));
         assertThat("Unexpected threads for subscription and subscriber for offloaded source.",
                 capturedThreads.get(OFFLOADED_SUBSCRIBER_THREAD),
-                not(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD)));
+                not(sameThreadFactory(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD))));
         assertThat("Unexpected threads for original and offloaded source.",
                 capturedThreads.get(ORIGINAL_SUBSCRIPTION_THREAD),
-                is(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD)));
+                sameThreadFactory(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD)));
     }
 
     @Test
@@ -103,13 +109,13 @@ public class PublishAndSubscribeOnTest extends AbstractPublishAndSubscribeOnTest
 
         assertThat("Unexpected threads for subscription and subscriber for original source.",
                 capturedThreads.get(ORIGINAL_SUBSCRIBER_THREAD),
-                is(capturedThreads.get(ORIGINAL_SUBSCRIPTION_THREAD)));
+                sameThreadFactory(capturedThreads.get(ORIGINAL_SUBSCRIPTION_THREAD)));
         assertThat("Unexpected threads for subscription and subscriber for offloaded source.",
                 capturedThreads.get(OFFLOADED_SUBSCRIBER_THREAD),
-                is(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD)));
+                sameThreadFactory(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD)));
         assertThat("Unexpected threads for original and offloaded source.",
                 capturedThreads.get(ORIGINAL_SUBSCRIPTION_THREAD),
-                not(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD)));
+                not(sameThreadFactory(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD))));
     }
 
     @Test
@@ -119,12 +125,40 @@ public class PublishAndSubscribeOnTest extends AbstractPublishAndSubscribeOnTest
 
         assertThat("Unexpected threads for subscription and subscriber for original source.",
                 capturedThreads.get(ORIGINAL_SUBSCRIBER_THREAD),
-                is(capturedThreads.get(ORIGINAL_SUBSCRIPTION_THREAD)));
+                sameThreadFactory(capturedThreads.get(ORIGINAL_SUBSCRIPTION_THREAD)));
         assertThat("Unexpected threads for subscription and subscriber for offloaded source.",
                 capturedThreads.get(OFFLOADED_SUBSCRIBER_THREAD),
-                is(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD)));
+                sameThreadFactory(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD)));
         assertThat("Unexpected threads for original and offloaded source.",
                 capturedThreads.get(ORIGINAL_SUBSCRIPTION_THREAD),
-                is(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD)));
+                sameThreadFactory(capturedThreads.get(OFFLOADED_SUBSCRIPTION_THREAD)));
+    }
+
+    TypeSafeMatcher<Thread> sameThreadFactory(Thread matchThread) {
+        return new TypeSafeMatcher<Thread>() {
+            final String matchPrefix;
+            {
+                matchPrefix = getNamePrefix(matchThread.getName());
+            }
+
+            @Override
+            public void describeTo(final Description description) {
+                description.appendText("non-matching name prefix");
+            }
+
+            @Override
+            protected boolean matchesSafely(final Thread item) {
+                String prefix = getNamePrefix(item.getName());
+
+                return matchPrefix.equals(prefix);
+            }
+        };
+    }
+
+    private static String getNamePrefix(String name) {
+        int lastDash = name.lastIndexOf('-');
+        return -1 == lastDash ?
+                name :
+                name.substring(0, lastDash);
     }
 }

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/PublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/PublishAndSubscribeOnTest.java
@@ -136,10 +136,7 @@ public class PublishAndSubscribeOnTest extends AbstractPublishAndSubscribeOnTest
 
     TypeSafeMatcher<Thread> sameThreadFactory(Thread matchThread) {
         return new TypeSafeMatcher<Thread>() {
-            final String matchPrefix;
-            {
-                matchPrefix = getNamePrefix(matchThread.getName());
-            }
+            final String matchPrefix = getNamePrefix(matchThread.getName());
 
             @Override
             public void describeTo(final Description description) {

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
@@ -143,8 +143,11 @@ public final class GrpcExecutionStrategies {
          * Enable thread affinity while offloading. When enabled, offloading implementation will favor using a
          * single thread per subscribe of a source.
          *
+         * @deprecated Use a single threaded executor with {@link #executor(Executor)} to ensure affinity.
+         *
          * @return {@code this}.
          */
+        @Deprecated
         public Builder offloadWithThreadAffinity() {
             httpBuilder.offloadWithThreadAffinity();
             return this;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
@@ -236,8 +236,11 @@ public final class HttpExecutionStrategies {
          * Enable thread affinity while offloading. When enabled, offloading implementation will favor using a
          * single thread per subscribe of a source.
          *
+         * @deprecated Use a single threaded executor with {@link #executor(Executor)} to ensure affinity.
+         *
          * @return {@code this}.
          */
+        @Deprecated
         public Builder offloadWithThreadAffinity() {
             threadAffinity = true;
             return this;


### PR DESCRIPTION
**Motivation**:
The method used for ensuring thread affinity used by the HTTP/gRPC builders, `offloadWithThreadAffinity()` will be removed in a near future version of ServiceTalk. The offered alternative is to use a single threaded executor which provides the same affinity guarantee.

**Modifications**:
The  `offloadWithThreadAffinity()` builder methods are marked deprecated. Some existing tests which reference the thread based signal offloader are converted to the default signal offloader.

**Result**:
Deprecation warning provided for methods which will eventually be removed.