### PR TITLE
Add SingleThreadedExecutor

### DIFF
--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/ReduceOffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/ReduceOffloadingTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.servicetalk.concurrent.api.Executors.from;
-import static io.servicetalk.concurrent.api.Executors.newFixedSizeExecutor;
+import static io.servicetalk.concurrent.api.Executors.newSingleThreadedExecutor;
 import static io.servicetalk.concurrent.internal.SignalOffloaders.threadBasedOffloaderFactory;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -31,7 +31,7 @@ class ReduceOffloadingTest {
 
     @Test
     void reduceShouldOffloadOnce() throws Exception {
-        Executor executor = newFixedSizeExecutor(1);
+        Executor executor = newSingleThreadedExecutor();
         AtomicInteger taskCount = new AtomicInteger();
         Executor wrapped = new OffloaderAwareExecutor(from(task -> {
             taskCount.incrementAndGet();

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextHolderThread.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextHolderThread.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import javax.annotation.Nullable;
+
+class AsyncContextHolderThread extends Thread implements AsyncContextMapHolder {
+    @Nullable
+    private AsyncContextMap asyncContextMap;
+
+    AsyncContextHolderThread(String name) {
+        super(name);
+    }
+
+    AsyncContextHolderThread(Runnable target, String name) {
+        super(target, name);
+    }
+
+    @Override
+    public void asyncContextMap(@Nullable final AsyncContextMap asyncContextMap) {
+        this.asyncContextMap = asyncContextMap;
+    }
+
+    @Nullable
+    @Override
+    public AsyncContextMap asyncContextMap() {
+        return asyncContextMap;
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultThreadFactory.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package io.servicetalk.concurrent.api;
 
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.Nullable;
 
 import static java.lang.Thread.NORM_PRIORITY;
 import static java.util.Objects.requireNonNull;
@@ -103,25 +102,5 @@ public final class DefaultThreadFactory implements ThreadFactory {
             t.setPriority(priority);
         }
         return t;
-    }
-
-    private static final class AsyncContextHolderThread extends Thread implements AsyncContextMapHolder {
-        @Nullable
-        private AsyncContextMap asyncContextMap;
-
-        AsyncContextHolderThread(Runnable target, String name) {
-            super(target, name);
-        }
-
-        @Override
-        public void asyncContextMap(@Nullable final AsyncContextMap asyncContextMap) {
-            this.asyncContextMap = asyncContextMap;
-        }
-
-        @Nullable
-        @Override
-        public AsyncContextMap asyncContextMap() {
-            return asyncContextMap;
-        }
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Executors.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Executors.java
@@ -49,6 +49,29 @@ public final class Executors {
     }
 
     /**
+     * Creates a new {@link Executor} that has a single dedicated worker thread. If {@link Executor#execute(Runnable)}
+     * method is invoked on the worker thread the {@link Runnable#run()} method will be executed immediately, but
+     * concurrent use is otherwise rejected.
+     *
+     * @return A new {@link Executor} that will use a single thread.
+     */
+    public static Executor newSingleThreadedExecutor() {
+        return from(new SingleThreadedExecutor());
+    }
+
+    /**
+     * Creates a new {@link Executor} that has a single dedicated worker thread. If {@link Executor#execute(Runnable)}
+     * method is invoked on the worker thread the {@link Runnable#run()} method will be executed immediately, but
+     * concurrent use is otherwise rejected.
+     *
+     * @param namePrefix A prefix for the worker thread name. A sequence number will always be appended.
+     * @return A new {@link Executor} that will use a single worker thread.
+     */
+    public static Executor newSingleThreadedExecutor(String namePrefix) {
+        return from(new SingleThreadedExecutor(namePrefix));
+    }
+
+    /**
      * Creates a new {@link Executor} that has a fixed number of threads as specified by the {@code size}.
      *
      * @param size Number of threads used by the newly created {@link Executor}.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleThreadedExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleThreadedExecutor.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
+
+/**
+ * Executor that can execute one task at a time on a dedicated worker thread. While concurrent tasks are generally
+ * rejected, the `execute(Runnable)` method provides special behavior if the invoking thread is the executor worker
+ * thread: the `Runnable` will be executed immediately on the calling thread.
+ */
+class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoCloseable {
+    static final Logger LOGGER = LoggerFactory.getLogger(SingleThreadedExecutor.class);
+    private static final String DEFAULT_NAME_PREFIX = "servicetalk-solo";
+    private static final AtomicInteger INSTANCE_COUNT = new AtomicInteger();
+    final boolean nonblocking;
+    final boolean interruptOnClose;
+    private final WorkerThread thread;
+
+    SingleThreadedExecutor() {
+        this(DEFAULT_NAME_PREFIX);
+    }
+
+    SingleThreadedExecutor(String namePrefix) {
+        this(namePrefix, true, true);
+    }
+
+    SingleThreadedExecutor(String namePrefix, boolean nonblocking, boolean interruptOnClose) {
+        String name = namePrefix + "-" + INSTANCE_COUNT.incrementAndGet();
+        this.nonblocking = nonblocking;
+        this.interruptOnClose = interruptOnClose;
+        thread = new WorkerThread(this, name);
+        thread.start();
+    }
+
+    @Override
+    public void execute(final Runnable command) {
+        if (Thread.currentThread() == thread) {
+            try {
+                command.run();
+            } catch (Throwable all) {
+                LOGGER.warn("Uncaught throwable from command " + command, all);
+            }
+        } else {
+            try {
+                if (nonblocking) {
+                    if (!thread.queue.offer(command, 100, TimeUnit.MICROSECONDS)) {
+                        throw new RejectedExecutionException("Executor is busy");
+                    }
+                 } else {
+                    thread.queue.put(command);
+                }
+            } catch (InterruptedException woken) {
+                // Interrupt status is not cleared
+                throw new RejectedExecutionException("Enqueue was interrupted", woken);
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        if (thread.isAlive() &&
+                WorkerThread.stateUpdater.compareAndSet(thread, WorkerThread.OPEN, WorkerThread.CLOSED) &&
+                interruptOnClose &&
+                Thread.currentThread() != thread) {
+            thread.interrupt();
+        }
+    }
+
+    private static class WorkerThread extends AsyncContextHolderThread {
+        static final AtomicIntegerFieldUpdater<WorkerThread> stateUpdater =
+                newUpdater(WorkerThread.class, "state");
+        static final int OPEN = 0;
+        static final int CLOSED = 1;
+        static final int EXITED = 2;
+
+        final SynchronousQueue<Runnable> queue = new SynchronousQueue<>();
+        /**
+         * If the executor is discarded and GCed this reference will be cleared and the worker thread can exit.
+         */
+        private final WeakReference<SingleThreadedExecutor> owner;
+        volatile int state;
+
+        WorkerThread(SingleThreadedExecutor owner, String name) {
+            super(name);
+            this.owner = new WeakReference<>(owner);
+
+            if (!isDaemon()) {
+                setDaemon(true);
+            }
+
+            if (Thread.NORM_PRIORITY != getPriority()) {
+                setPriority(Thread.NORM_PRIORITY);
+            }
+        }
+
+        public void run() {
+            while (OPEN == state && null != owner.get()) {
+                try {
+                    Runnable command = queue.poll(1L, TimeUnit.MINUTES);
+                    if (null == command) {
+                        continue;
+                    }
+                    try {
+                        command.run();
+                    } catch (Throwable all) {
+                        LOGGER.warn("Uncaught throwable from command " + command, all);
+                    }
+                } catch (InterruptedException woken) {
+                    Thread.interrupted();
+                    // closing?
+                } catch (Throwable all) {
+                    LOGGER.warn("Uncaught throwable", all);
+                }
+            }
+            int was = stateUpdater.getAndSet(this, EXITED);
+            SingleThreadedExecutor.LOGGER.debug("WorkerThread exiting " + (CLOSED == was ? "cleanly" : "messily"));
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleThreadedExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleThreadedExecutor.java
@@ -19,10 +19,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.ref.WeakReference;
-import java.util.concurrent.BlockingQueue;
+import java.util.Objects;
+import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TransferQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Supplier;
@@ -39,8 +41,9 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
 
     private static final String DEFAULT_NAME_PREFIX = "servicetalk-solo";
     private static final AtomicInteger INSTANCE_COUNT = new AtomicInteger();
+
     /**
-     * Using plain {@link SynchronousQueue#offer(Object)} with only a single worker thread will result in occasional
+     * Using plain {@link TransferQueue#offer(Object)} with only a single worker thread will result in occasional
      * spurious rejections as thread scheduling jitter can cause delay it entering {@link SynchronousQueue#poll()}
      * following a task. The "right" default is unfortunately difficult because the reasonable amount of time to wait is
      * dependent upon system environment and load and is, in any event, just a guess. The default is instead chosen to
@@ -74,7 +77,7 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
      * appended.
      */
     SingleThreadedExecutor(String namePrefix) {
-        this(namePrefix, SynchronousQueue::new, DEFAULT_OFFER_WAIT, TimeUnit.NANOSECONDS, true);
+        this(namePrefix, LinkedTransferQueue::new, DEFAULT_OFFER_WAIT, TimeUnit.NANOSECONDS, true);
     }
 
     /**
@@ -89,7 +92,7 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
      * @param interruptOnClose If true then {@link #close()} will {@linkplain Thread#interrupt() interrupt} the worker
      * thread to close it more quickly.
      */
-    SingleThreadedExecutor(String namePrefix, Supplier<? extends BlockingQueue> queueSupplier,
+    SingleThreadedExecutor(String namePrefix, Supplier<? extends TransferQueue> queueSupplier,
                            long offerWait, TimeUnit offerWaitUnits,
                            boolean interruptOnClose) {
         String name = namePrefix + "-" + INSTANCE_COUNT.incrementAndGet();
@@ -107,9 +110,12 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
      * @param command {@inheritDoc}
      * @throws RejectedExecutionException if executor is closed, thread enqueuing task was interrupted, or the task
      * could not be enqueued
+     * @throws NullPointerException if command is null
      */
     @Override
     public void execute(final Runnable command) throws RejectedExecutionException {
+        Objects.requireNonNull(command, "command");
+
         if (WorkerThread.OPEN != thread.state) {
             throw new RejectedExecutionException(thread.getName() + ": Executor closed");
         }
@@ -123,16 +129,17 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
         } else {
             try {
                 if (offerWaitNanos < Long.MAX_VALUE) {
-                    // Using non-waiting offer() sometimes results in spurious rejections for sequential tasks.
-                    if (!thread.queue.offer(command)) {
-                        // So if offer() fails, try again giving the worker thread a better chance to be ready and
+                    // Using non-waiting tryTransfer() sometimes results in spurious rejections for sequential tasks.
+                    if (!thread.queue.hasWaitingConsumer() || !thread.queue.tryTransfer(command)) {
+                        // So if tryTransfer() fails, try again giving the worker thread a better chance to be ready and
                         // waiting in poll() before rejecting execution.
                         Thread.yield();
-                        // offer() again with a (typically) very small wait to give worker thread a chance to poll().
-                        if (!thread.queue.offer(command, offerWaitNanos, TimeUnit.NANOSECONDS)) {
+                        // tryTransfer() again with a (typically) very small wait to give worker thread a chance to
+                        // poll().
+                        if (!thread.queue.tryTransfer(command, offerWaitNanos, TimeUnit.NANOSECONDS)) {
                             // worker thread is probably busy with another task.
                             throw new RejectedExecutionException(
-                                    thread.getName() + ": Enqueue rejected, refusing to wait");
+                                    thread.getName() + ": Refusing to wait; enqueue rejected for " + command);
                         }
                     }
                  } else {
@@ -164,13 +171,13 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
         static final int ORPHANED = 2; // executor GCed without close()
         static final int EXITED = 3; // Worker thread exit
 
-        private final BlockingQueue<Runnable> queue;
+        private final TransferQueue<Runnable> queue;
         /**
          * If the executor is discarded and GCed this reference will be cleared and the worker thread can exit.
          */
         private final WeakReference<SingleThreadedExecutor> owner;
 
-        WorkerThread(SingleThreadedExecutor owner, Supplier<? extends BlockingQueue> queueSupplier, String name) {
+        WorkerThread(SingleThreadedExecutor owner, Supplier<? extends TransferQueue> queueSupplier, String name) {
             super(name);
             this.queue = queueSupplier.get();
             this.owner = new WeakReference<>(owner);
@@ -207,6 +214,9 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
                 } catch (Throwable all) {
                     LOGGER.warn("Uncaught throwable in worker thread", all);
                 }
+            }
+            if (queue.size() > 0) {
+                LOGGER.warn("WorkerThread exiting with {} enqueued", queue.size());
             }
             int terminal = null != owner.get() ? ORPHANED : EXITED;
             int was = stateUpdater.getAndSet(this, terminal);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleThreadedExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleThreadedExecutor.java
@@ -22,7 +22,6 @@ import java.lang.ref.WeakReference;
 import java.util.Objects;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TransferQueue;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -32,9 +31,9 @@ import java.util.function.Supplier;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 
 /**
- * Executor that can execute one task at a time on a dedicated worker thread. While concurrent tasks are generally
+ * Executor that can execute one task at a time on a dedicated worker thread. While concurrent tasks may be generally
  * rejected, the {@link Executor#execute(Runnable)} method provides special behavior if the invoking thread is the
- * executor worker thread: the {@code Runnable} will be executed immediately on the calling thread.
+ * executor worker thread: the {@code Runnable} will be executed synchronously on the worker thread.
  */
 class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoCloseable {
     static final Logger LOGGER = LoggerFactory.getLogger(SingleThreadedExecutor.class);
@@ -43,11 +42,11 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
     private static final AtomicInteger INSTANCE_COUNT = new AtomicInteger();
 
     /**
-     * Using plain {@link TransferQueue#offer(Object)} with only a single worker thread will result in occasional
-     * spurious rejections as thread scheduling jitter can cause delay it entering {@link SynchronousQueue#poll()}
-     * following a task. The "right" default is unfortunately difficult because the reasonable amount of time to wait is
-     * dependent upon system environment and load and is, in any event, just a guess. The default is instead chosen to
-     * reflect the cost of a rejected task.
+     * Using plain {@link TransferQueue#tryTransfer(Object)} with only a single consumer thread will result in
+     * occasional spurious rejections as thread scheduling jitter can cause delay it entering
+     * {@link TransferQueue#poll()} following a task. The "right" default is unfortunately difficult because the
+     * reasonable amount of time to wait is dependent upon system environment and load and is, in any event, just a
+     * guess. The default is instead chosen to reflect the cost of a rejected task.
      */
     private static final long DEFAULT_OFFER_WAIT = TimeUnit.MILLISECONDS.toNanos(1);
 
@@ -55,7 +54,7 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
      * If less than {@link Long#MAX_VALUE} then the {@link #execute(Runnable)} queue operation will be non-blocking and
      * fast-fail if the command cannot be immediately executed.
      */
-    private final long offerWaitNanos;
+    private final long enqueueWaitNanos;
     /**
      * If true then {@link #close()} will {@linkplain Thread#interrupt() interrupt} the worker
      * thread.
@@ -85,27 +84,30 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
      *
      * @param namePrefix Prefix to use for name of worker thread. The prefix will always have a sequence number
      * appended.
-     * @param queueSupplier Supplier for the queue used for tasks.
-     * @param offerWait If less than {@link Long#MAX_VALUE} nanos then the {@link #execute(Runnable)} queue operation
-     * will be non-blocking and fast-fail if the command cannot be immediately executed.
-     * @param offerWaitUnits units for offer wait time.
+     * @param queueSupplier Supplier for the {@link TransferQueue} used for tasks. If {@link #enqueueWaitNanos} is less
+     * than {@link Long#MAX_VALUE} then the queue will be only used for synchronous consumer-waiting task transfers
+     * otherwise tasks will be enqueued for asynchronous execution.
+     * @param enqueueWait If less than {@link Long#MAX_VALUE} nanos then the {@link #execute(Runnable)} enqueue
+     * operation will fail if the command cannot be enqueued in the specified time interval. If {@link Long#MAX_VALUE}
+     * then the enqueue operation may block indefinitely as necessary until the {@link #execute(Runnable)} is enqueued
+     * (and subject to potentially deadlocking).
+     * @param enqueueWaitUnits units for enqueue wait time.
      * @param interruptOnClose If true then {@link #close()} will {@linkplain Thread#interrupt() interrupt} the worker
      * thread to close it more quickly.
      */
-    SingleThreadedExecutor(String namePrefix, Supplier<? extends TransferQueue> queueSupplier,
-                           long offerWait, TimeUnit offerWaitUnits,
+    SingleThreadedExecutor(String namePrefix, Supplier<? extends TransferQueue<Runnable>> queueSupplier,
+                           long enqueueWait, TimeUnit enqueueWaitUnits,
                            boolean interruptOnClose) {
         String name = namePrefix + "-" + INSTANCE_COUNT.incrementAndGet();
-        this.offerWaitNanos = offerWaitUnits.toNanos(offerWait);
+        this.enqueueWaitNanos = enqueueWaitUnits.toNanos(enqueueWait);
         this.interruptOnClose = interruptOnClose;
         thread = new WorkerThread(this, queueSupplier, name);
-        thread.start();
     }
 
     /**
      * {@inheritDoc}
      *
-     * <p>If invoked on the worker thread the provided command will be executed syncrhonously immediately.
+     * <p>If invoked on the worker thread the provided command will be executed synchronously immediately.
      *
      * @param command {@inheritDoc}
      * @throws RejectedExecutionException if executor is closed, thread enqueuing task was interrupted, or the task
@@ -117,7 +119,14 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
         Objects.requireNonNull(command, "command");
 
         if (WorkerThread.OPEN != thread.state) {
-            throw new RejectedExecutionException(thread.getName() + ": Executor closed");
+            if (WorkerThread.CREATED == thread.state) {
+                if (WorkerThread.stateUpdater.compareAndSet(thread, WorkerThread.CREATED, WorkerThread.OPEN)) {
+                    // We get to start the worker thread!
+                    thread.start();
+                }
+            } else {
+                throw new RejectedExecutionException(thread.getName() + ": Executor closed");
+            }
         }
 
         if (Thread.currentThread() == thread) {
@@ -128,7 +137,7 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
             }
         } else {
             try {
-                if (offerWaitNanos < Long.MAX_VALUE) {
+                if (enqueueWaitNanos < Long.MAX_VALUE) {
                     // Using non-waiting tryTransfer() sometimes results in spurious rejections for sequential tasks.
                     if (!thread.queue.hasWaitingConsumer() || !thread.queue.tryTransfer(command)) {
                         // So if tryTransfer() fails, try again giving the worker thread a better chance to be ready and
@@ -136,13 +145,14 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
                         Thread.yield();
                         // tryTransfer() again with a (typically) very small wait to give worker thread a chance to
                         // poll().
-                        if (!thread.queue.tryTransfer(command, offerWaitNanos, TimeUnit.NANOSECONDS)) {
+                        if (!thread.queue.tryTransfer(command, enqueueWaitNanos, TimeUnit.NANOSECONDS)) {
                             // worker thread is probably busy with another task.
                             throw new RejectedExecutionException(
-                                    thread.getName() + ": Refusing to wait; enqueue rejected for " + command);
+                                    thread.getName() + ": Refusing to wait longer; enqueue rejected for " + command);
                         }
                     }
-                 } else {
+                } else {
+                    // blocking enqueue
                     thread.queue.put(command);
                 }
             } catch (InterruptedException woken) {
@@ -152,13 +162,23 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p><b>Note:</b> It is unspecified whether tasks already (or concurrently being) enqueued will be executed after
+     * this method is invoked.
+     */
     @Override
     public void close() {
-        if (thread.isAlive() &&
-                WorkerThread.stateUpdater.compareAndSet(thread, WorkerThread.OPEN, WorkerThread.CLOSED) &&
-                interruptOnClose &&
-                Thread.currentThread() != thread) {
-            thread.interrupt();
+        if (thread.isAlive()) {
+            if (WorkerThread.stateUpdater.compareAndSet(thread, WorkerThread.OPEN, WorkerThread.CLOSED) &&
+                    interruptOnClose &&
+                    Thread.currentThread() != thread) {
+                thread.interrupt();
+            }
+        } else {
+            // closing without ever having started
+            WorkerThread.stateUpdater.compareAndSet(thread, WorkerThread.CREATED, WorkerThread.EXITED);
         }
     }
 
@@ -166,10 +186,11 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
         static final AtomicIntegerFieldUpdater<WorkerThread> stateUpdater =
                 newUpdater(WorkerThread.class, "state");
         private volatile int state;
-        static final int OPEN = 0; // running tasks
-        static final int CLOSED = 1; // executor has closed
-        static final int ORPHANED = 2; // executor GCed without close()
-        static final int EXITED = 3; // Worker thread exit
+        static final int CREATED = 0; // not started
+        static final int OPEN = 1; // running tasks
+        static final int CLOSED = 2; // executor has closed
+        static final int ORPHANED = 3; // executor GCed without close()
+        static final int EXITED = 4; // Worker thread exit
 
         private final TransferQueue<Runnable> queue;
         /**
@@ -177,7 +198,9 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
          */
         private final WeakReference<SingleThreadedExecutor> owner;
 
-        WorkerThread(SingleThreadedExecutor owner, Supplier<? extends TransferQueue> queueSupplier, String name) {
+        WorkerThread(SingleThreadedExecutor owner,
+                     Supplier<? extends TransferQueue<Runnable>> queueSupplier,
+                     String name) {
             super(name);
             this.queue = queueSupplier.get();
             this.owner = new WeakReference<>(owner);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleThreadedExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleThreadedExecutor.java
@@ -40,11 +40,13 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
     private static final String DEFAULT_NAME_PREFIX = "servicetalk-solo";
     private static final AtomicInteger INSTANCE_COUNT = new AtomicInteger();
     /**
-     * Using plain {@link BlockingQueue#offer(Object)} with only a single worker thread will result in occasional
-     * spurious rejections as scheduling jitter can cause delay it entering {@link BlockingQueue#poll()} following a
-     * task. Almost any amount of delay is sufficient.
+     * Using plain {@link SynchronousQueue#offer(Object)} with only a single worker thread will result in occasional
+     * spurious rejections as thread scheduling jitter can cause delay it entering {@link SynchronousQueue#poll()}
+     * following a task. The "right" default is unfortunately difficult because the reasonable amount of time to wait is
+     * dependent upon system environment and load and is, in any event, just a guess. The default is instead chosen to
+     * reflect the cost of a rejected task.
      */
-    private static final long DEFAULT_OFFER_WAIT = TimeUnit.MICROSECONDS.toNanos(100);
+    private static final long DEFAULT_OFFER_WAIT = TimeUnit.MILLISECONDS.toNanos(1);
 
     /**
      * If less than {@link Long#MAX_VALUE} then the {@link #execute(Runnable)} queue operation will be non-blocking and

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleThreadedExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleThreadedExecutor.java
@@ -107,7 +107,7 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
     @Override
     public void execute(final Runnable command) throws RejectedExecutionException {
         if (WorkerThread.OPEN != thread.state) {
-            throw new RejectedExecutionException("Executor closed");
+            throw new RejectedExecutionException(thread.getName() + ": Executor closed");
         }
 
         if (Thread.currentThread() == thread) {
@@ -123,14 +123,14 @@ class SingleThreadedExecutor implements java.util.concurrent.Executor, AutoClose
                     // Using non-waiting offer() resulted in spurious rejections for sequential tasks.
                     if (!thread.queue.offer(command, offerWaitNanos, TimeUnit.NANOSECONDS)) {
                         // worker thread is probably busy with another task.
-                        throw new RejectedExecutionException("Enqueue rejected, refusing to wait");
+                        throw new RejectedExecutionException(thread.getName() + ": Enqueue rejected, refusing to wait");
                     }
                  } else {
                     thread.queue.put(command);
                 }
             } catch (InterruptedException woken) {
                 // Interrupt status is not cleared
-                throw new RejectedExecutionException("Task enqueue was interrupted", woken);
+                throw new RejectedExecutionException(thread.getName() + ": Task enqueue was interrupted", woken);
             }
         }
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultExecutorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultExecutorTest.java
@@ -159,7 +159,7 @@ final class DefaultExecutorTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void executeRecursive(ExecutorParam executorParam) throws Throwable {
+    void executeRecursive(ExecutorParam executorParam) throws Throwable {
         executor = executorParam.get();
         assumeTrue(executorParam.supportsImmediateExecutionDuringExecute() || executorParam.size() >= 2,
                 () -> "Ignoring incompatible executor: " + executorParam);


### PR DESCRIPTION
Motivation:
For some applications it is important that all signals be handled on
the same thread, sometimes called "Thread Affinity". This is typically
needed because of the use of `ThreadLocal` to pass state between
invocations.

Modifications:
Add a SingleThreadedExecutor implementation that can execute one task
at a time. While concurrent tasks are generally rejected, the
`execute(Runnable)` method provides special behavior if the invoking
thread is the executor worker thread: the `Runnable` will be executed
immediately on the calling thread.

Result:
Another option for handling of signals where thread affinity is
desired.