### PR TITLE
[HOLD] `GracefulAutoCloseable` renamed to `GracefulCloseable` to eliminate compiler warnings

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Closeables.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Closeables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
 import io.servicetalk.utils.internal.PlatformDependent;
 
 import java.util.concurrent.Future;
@@ -23,27 +23,27 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * A utility class for methods related to {@link AutoCloseable}.
+ * A utility class for methods related to {@link java.io.Closeable}.
  */
-public final class AutoCloseables {
+public final class Closeables {
 
-    private AutoCloseables() {
+    private Closeables() {
         // No instances
     }
 
     /**
-     * Invokes {@link GracefulAutoCloseable#closeGracefully()} on the {@code closable}, applies a timeout, and if the
-     * timeout fires forces a call to {@link GracefulAutoCloseable#close()}.
+     * Invokes {@link GracefulCloseable#closeGracefully()} on the {@code closable}, applies a timeout, and if the
+     * timeout fires forces a call to {@link GracefulCloseable#close()}.
      *
      * @param executor {@link Executor} to use for applying timeout.
-     * @param closable The {@link GracefulAutoCloseable} to initiate {@link GracefulAutoCloseable#closeGracefully()} on.
-     * @param gracefulCloseTimeout The timeout duration to wait for {@link GracefulAutoCloseable#closeGracefully()} to
+     * @param closable The {@link GracefulCloseable} to initiate {@link GracefulCloseable#closeGracefully()} on.
+     * @param gracefulCloseTimeout The timeout duration to wait for {@link GracefulCloseable#closeGracefully()} to
      * complete.
      * @param gracefulCloseTimeoutUnit The time unit applied to {@code gracefulCloseTimeout}.
      *
      * @throws Exception if graceful closure failed.
      */
-    public static void closeGracefully(final Executor executor, final GracefulAutoCloseable closable,
+    public static void closeGracefully(final Executor executor, final GracefulCloseable closable,
                                        final long gracefulCloseTimeout, final TimeUnit gracefulCloseTimeoutUnit)
             throws Exception {
         Future<Void> graceful = executor.submit(() -> {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompositeCloseable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompositeCloseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,16 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
 
 import java.io.Closeable;
+import java.io.IOException;
 
 /**
  * A {@link AsyncCloseable} and {@link Closeable} that allows for adding new {@link AsyncCloseable}s till it is
  * closed.
  */
-public interface CompositeCloseable extends AsyncCloseable, GracefulAutoCloseable {
+public interface CompositeCloseable extends AsyncCloseable, GracefulCloseable {
 
     /**
      * Merges the passed {@link AsyncCloseable} with this {@link CompositeCloseable} such that when this {@link
@@ -147,11 +148,11 @@ public interface CompositeCloseable extends AsyncCloseable, GracefulAutoCloseabl
 
     /**
      * Closes all contained {@link AsyncCloseable}s and awaits termination of all of them. If any of the contained
-     * {@link AsyncCloseable}s terminated with a failure, this method terminates with an {@link Exception} only after
+     * {@link AsyncCloseable}s terminated with a failure, this method terminates with an {@link IOException} only after
      * all the contained {@link AsyncCloseable}s have terminated.
      *
-     * @throws Exception If any of the contained {@link AsyncCloseable}s terminate with a failure.
+     * @throws IOException If any of the contained {@link AsyncCloseable}s terminate with a failure.
      */
     @Override
-    void close() throws Exception;
+    void close() throws IOException;
 }

--- a/servicetalk-concurrent/src/main/java/io/servicetalk/concurrent/GracefulCloseable.java
+++ b/servicetalk-concurrent/src/main/java/io/servicetalk/concurrent/GracefulCloseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,13 @@
  */
 package io.servicetalk.concurrent;
 
+import java.io.Closeable;
+import java.io.IOException;
+
 /**
- * An extension of {@link AutoCloseable} to add graceful closure semantics.
+ * An extension of {@link Closeable} to add graceful closure semantics.
  */
-public interface GracefulAutoCloseable extends AutoCloseable {
+public interface GracefulCloseable extends Closeable {
 
     /**
      * Used to close/shutdown a resource, similar to {@link #close()}, but attempts to cleanup state before
@@ -29,9 +32,9 @@ public interface GracefulAutoCloseable extends AutoCloseable {
      * want to wait indefinitely, and are unsure if the implementation applies a timeout, it is advisable to apply a
      * timeout and force a call to {@link #close()}.
      *
-     * @throws Exception if graceful closure failed.
+     * @throws IOException if graceful closure failed.
      */
-    default void closeGracefully() throws Exception {
+    default void closeGracefully() throws IOException {
         close();
     }
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/BlockingGrpcClient.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/BlockingGrpcClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
  */
 package io.servicetalk.grpc.api;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
 
 /**
  * A blocking client to a <a href="https://www.grpc.io">gRPC</a> service.
  *
  * @param <Client> The corresponding {@link GrpcClient}
  */
-public interface BlockingGrpcClient<Client extends GrpcClient> extends GracefulAutoCloseable {
+public interface BlockingGrpcClient<Client extends GrpcClient> extends GracefulCloseable {
 
     /**
      * Converts this {@link BlockingGrpcClient} to a client.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/BlockingGrpcService.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/BlockingGrpcService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,17 @@
  */
 package io.servicetalk.grpc.api;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
+
+import java.io.IOException;
 
 /**
  * A blocking <a href="https://www.grpc.io">gRPC</a> service.
  */
-public interface BlockingGrpcService extends GracefulAutoCloseable {
+public interface BlockingGrpcService extends GracefulCloseable {
 
     @Override
-    default void close() throws Exception {
+    default void close() throws IOException {
         // noop
     }
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClient.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,10 @@
  */
 package io.servicetalk.grpc.api;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
+
+import java.io.IOException;
 
 import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 
@@ -26,7 +28,7 @@ import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
  * @param <BlockingClient> The corresponding {@link BlockingGrpcClient}
  */
 public interface GrpcClient<BlockingClient extends BlockingGrpcClient>
-        extends ListenableAsyncCloseable, GracefulAutoCloseable {
+        extends ListenableAsyncCloseable, GracefulCloseable {
 
     /**
      * Converts this {@link GrpcClient} to a blocking client.
@@ -46,7 +48,7 @@ public interface GrpcClient<BlockingClient extends BlockingGrpcClient>
     GrpcExecutionContext executionContext();
 
     @Override
-    default void close() throws Exception {
+    default void close() throws IOException {
         awaitTermination(closeAsync().toFuture());
     }
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouteConversions.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouteConversions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package io.servicetalk.grpc.api;
 
 import io.servicetalk.concurrent.CompletableSource;
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.AsyncCloseables;
@@ -298,7 +298,7 @@ final class GrpcRouteConversions {
         return toResponseStreamingRoute(toStreaming(original));
     }
 
-    static AsyncCloseable toAsyncCloseable(final GracefulAutoCloseable original) {
+    static AsyncCloseable toAsyncCloseable(final GracefulCloseable original) {
         return AsyncCloseables.toAsyncCloseable(graceful -> new Completable() {
             @Override
             protected void handleSubscribe(final CompletableSource.Subscriber subscriber) {

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package io.servicetalk.grpc.api;
 
 import io.servicetalk.concurrent.BlockingIterable;
 import io.servicetalk.concurrent.BlockingIterator;
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
 import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.AsyncCloseables;
 import io.servicetalk.concurrent.api.Completable;
@@ -471,12 +471,12 @@ final class GrpcRouter {
                         }
 
                         @Override
-                        public void close() throws Exception {
+                        public void close() throws IOException {
                             route.close();
                         }
 
                         @Override
-                        public void closeGracefully() throws Exception {
+                        public void closeGracefully() throws IOException {
                             route.closeGracefully();
                         }
                     }, strategy -> executionStrategy == null ? strategy : executionStrategy),
@@ -540,12 +540,12 @@ final class GrpcRouter {
                         }
 
                         @Override
-                        public void close() throws Exception {
+                        public void close() throws IOException {
                             route.close();
                         }
 
                         @Override
-                        public void closeGracefully() throws Exception {
+                        public void closeGracefully() throws IOException {
                             route.closeGracefully();
                         }
                     }, strategy -> executionStrategy == null ? strategy : executionStrategy),
@@ -587,12 +587,12 @@ final class GrpcRouter {
                         }
 
                         @Override
-                        public void close() throws Exception {
+                        public void close() throws IOException {
                             route.close();
                         }
 
                         @Override
-                        public void closeGracefully() throws Exception {
+                        public void closeGracefully() throws IOException {
                             route.closeGracefully();
                         }
                     },
@@ -640,12 +640,12 @@ final class GrpcRouter {
                         }
 
                         @Override
-                        public void close() throws Exception {
+                        public void close() throws IOException {
                             route.close();
                         }
 
                         @Override
-                        public void closeGracefully() throws Exception {
+                        public void closeGracefully() throws IOException {
                             route.closeGracefully();
                         }
                     },
@@ -761,7 +761,7 @@ final class GrpcRouter {
                       final Supplier<RequestStreamingRoute<?, ?>> toRequestStreamingRouteConverter,
                       final Supplier<ResponseStreamingRoute<?, ?>> toResponseStreamingRouteConverter,
                       final Supplier<Route<?, ?>> toRouteConverter,
-                      final GracefulAutoCloseable closeable) {
+                      final GracefulCloseable closeable) {
             this(routeProvider, toStreamingConverter, toRequestStreamingRouteConverter,
                     toResponseStreamingRouteConverter, toRouteConverter, toAsyncCloseable(closeable));
         }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package io.servicetalk.grpc.api;
 
 import io.servicetalk.concurrent.BlockingIterable;
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
 import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
@@ -29,6 +29,7 @@ import io.servicetalk.router.api.RouteExecutionStrategyFactory;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.ServerContext;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Set;
 import java.util.TreeSet;
@@ -763,7 +764,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      */
     @FunctionalInterface
     protected interface BlockingRoute<Req, Resp>
-            extends GracefulAutoCloseable {
+            extends GracefulCloseable {
         /**
          * Handles the passed {@link Req}.
          *
@@ -775,23 +776,23 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
         Resp handle(GrpcServiceContext ctx, Req request) throws Exception;
 
         @Override
-        default void close() throws Exception {
+        default void close() throws IOException {
             // No op
         }
 
         /**
          * Convenience method to wrap a raw {@link BlockingRoute} instance with a passed detached close
-         * implementation of {@link GracefulAutoCloseable}.
+         * implementation of {@link GracefulCloseable}.
          *
          * @param rawRoute {@link BlockingRoute} instance that has a detached close implementation.
-         * @param closeable {@link GracefulAutoCloseable} implementation for the passed {@code rawRoute}.
+         * @param closeable {@link GracefulCloseable} implementation for the passed {@code rawRoute}.
          * @param <Req> Type of request.
          * @param <Resp> Type of response.
          * @return A new {@link BlockingRoute} that attaches the passed {@code closeable} to the passed
          * {@code rawRoute}.
          */
         static <Req, Resp> BlockingRoute<Req, Resp> wrap(final BlockingRoute<Req, Resp> rawRoute,
-                                                         final GracefulAutoCloseable closeable) {
+                                                         final GracefulCloseable closeable) {
             return new BlockingRoute<Req, Resp>() {
 
                 @Override
@@ -800,12 +801,12 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
                 }
 
                 @Override
-                public void close() throws Exception {
+                public void close() throws IOException {
                     closeable.close();
                 }
 
                 @Override
-                public void closeGracefully() throws Exception {
+                public void closeGracefully() throws IOException {
                     closeable.closeGracefully();
                 }
             };
@@ -820,7 +821,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      */
     @FunctionalInterface
     protected interface BlockingStreamingRoute<Req, Resp>
-            extends GracefulAutoCloseable {
+            extends GracefulCloseable {
 
         /**
          * Handles the passed {@link Req}.
@@ -834,23 +835,23 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
                     GrpcPayloadWriter<Resp> responseWriter) throws Exception;
 
         @Override
-        default void close() throws Exception {
+        default void close() throws IOException {
             // No op
         }
 
         /**
          * Convenience method to wrap a raw {@link BlockingStreamingRoute} instance with a passed detached close
-         * implementation of {@link GracefulAutoCloseable}.
+         * implementation of {@link GracefulCloseable}.
          *
          * @param rawRoute {@link BlockingStreamingRoute} instance that has a detached close implementation.
-         * @param closeable {@link GracefulAutoCloseable} implementation for the passed {@code rawRoute}.
+         * @param closeable {@link GracefulCloseable} implementation for the passed {@code rawRoute}.
          * @param <Req> Type of request.
          * @param <Resp> Type of response.
          * @return A new {@link BlockingStreamingRoute} that attaches the passed {@code closeable} to the passed
          * {@code rawRoute}.
          */
         static <Req, Resp> BlockingStreamingRoute<Req, Resp> wrap(final BlockingStreamingRoute<Req, Resp> rawRoute,
-                                                                  final GracefulAutoCloseable closeable) {
+                                                                  final GracefulCloseable closeable) {
             return new BlockingStreamingRoute<Req, Resp>() {
                 @Override
                 public void handle(final GrpcServiceContext ctx, final BlockingIterable<Req> request,
@@ -859,12 +860,12 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
                 }
 
                 @Override
-                public void close() throws Exception {
+                public void close() throws IOException {
                     closeable.close();
                 }
 
                 @Override
-                public void closeGracefully() throws Exception {
+                public void closeGracefully() throws IOException {
                     closeable.closeGracefully();
                 }
             };
@@ -879,7 +880,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      */
     @FunctionalInterface
     protected interface BlockingRequestStreamingRoute<Req, Resp>
-            extends GracefulAutoCloseable {
+            extends GracefulCloseable {
 
         /**
          * Handles the passed {@link Req}.
@@ -892,23 +893,23 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
         Resp handle(GrpcServiceContext ctx, BlockingIterable<Req> request) throws Exception;
 
         @Override
-        default void close() throws Exception {
+        default void close() throws IOException {
             // No op
         }
 
         /**
          * Convenience method to wrap a raw {@link BlockingRequestStreamingRoute} instance with a passed detached close
-         * implementation of {@link GracefulAutoCloseable}.
+         * implementation of {@link GracefulCloseable}.
          *
          * @param rawRoute {@link BlockingRequestStreamingRoute} instance that has a detached close implementation.
-         * @param closeable {@link GracefulAutoCloseable} implementation for the passed {@code rawRoute}.
+         * @param closeable {@link GracefulCloseable} implementation for the passed {@code rawRoute}.
          * @param <Req> Type of request.
          * @param <Resp> Type of response.
          * @return A new {@link BlockingRequestStreamingRoute} that attaches the passed {@code closeable} to the passed
          * {@code rawRoute}.
          */
         static <Req, Resp> BlockingRequestStreamingRoute<Req, Resp> wrap(
-                final BlockingRequestStreamingRoute<Req, Resp> rawRoute, final GracefulAutoCloseable closeable) {
+                final BlockingRequestStreamingRoute<Req, Resp> rawRoute, final GracefulCloseable closeable) {
             return new BlockingRequestStreamingRoute<Req, Resp>() {
 
                 @Override
@@ -917,12 +918,12 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
                 }
 
                 @Override
-                public void close() throws Exception {
+                public void close() throws IOException {
                     closeable.close();
                 }
 
                 @Override
-                public void closeGracefully() throws Exception {
+                public void closeGracefully() throws IOException {
                     closeable.closeGracefully();
                 }
             };
@@ -937,7 +938,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      */
     @FunctionalInterface
     protected interface BlockingResponseStreamingRoute<Req, Resp>
-            extends GracefulAutoCloseable {
+            extends GracefulCloseable {
 
         /**
          * Handles the passed {@link Req}.
@@ -950,23 +951,23 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
         void handle(GrpcServiceContext ctx, Req request, GrpcPayloadWriter<Resp> responseWriter) throws Exception;
 
         @Override
-        default void close() throws Exception {
+        default void close() throws IOException {
             // No op
         }
 
         /**
          * Convenience method to wrap a raw {@link BlockingResponseStreamingRoute} instance with a passed detached close
-         * implementation of {@link GracefulAutoCloseable}.
+         * implementation of {@link GracefulCloseable}.
          *
          * @param rawRoute {@link BlockingResponseStreamingRoute} instance that has a detached close implementation.
-         * @param closeable {@link GracefulAutoCloseable} implementation for the passed {@code rawRoute}.
+         * @param closeable {@link GracefulCloseable} implementation for the passed {@code rawRoute}.
          * @param <Req> Type of request.
          * @param <Resp> Type of response.
          * @return A new {@link BlockingResponseStreamingRoute} that attaches the passed {@code closeable} to the passed
          * {@code rawRoute}.
          */
         static <Req, Resp> BlockingResponseStreamingRoute<Req, Resp> wrap(
-                final BlockingResponseStreamingRoute<Req, Resp> rawRoute, final GracefulAutoCloseable closeable) {
+                final BlockingResponseStreamingRoute<Req, Resp> rawRoute, final GracefulCloseable closeable) {
             return new BlockingResponseStreamingRoute<Req, Resp>() {
 
                 @Override
@@ -976,12 +977,12 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
                 }
 
                 @Override
-                public void close() throws Exception {
+                public void close() throws IOException {
                     closeable.close();
                 }
 
                 @Override
-                public void closeGracefully() throws Exception {
+                public void closeGracefully() throws IOException {
                     closeable.closeGracefully();
                 }
             };

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ClosureTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ClosureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.grpc.netty;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
 import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
@@ -162,8 +162,8 @@ public class ClosureTest {
         return autoCloseable;
     }
 
-    private <T extends GracefulAutoCloseable> T setupBlockingCloseMock(final T autoCloseable,
-                                                                       final AsyncCloseable closeSignal)
+    private <T extends GracefulCloseable> T setupBlockingCloseMock(final T autoCloseable,
+                                                                   final AsyncCloseable closeSignal)
             throws Exception {
         doAnswer(__ -> closeSignal.closeAsync().toFuture().get()).when(autoCloseable).close();
         doAnswer(__ -> closeSignal.closeAsyncGracefully().toFuture().get()).when(autoCloseable).closeGracefully();
@@ -181,11 +181,11 @@ public class ClosureTest {
         verifyNoMoreInteractions(closeable);
     }
 
-    private void verifyClosure(GracefulAutoCloseable closeable) throws Exception {
+    private void verifyClosure(GracefulCloseable closeable) throws Exception {
         verifyClosure(closeable, 1);
     }
 
-    private void verifyClosure(GracefulAutoCloseable closeable, int times) throws Exception {
+    private void verifyClosure(GracefulCloseable closeable, int times) throws Exception {
         if (closeGracefully) {
             verify(closeable, times(times)).closeGracefully();
         } else {

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -80,6 +80,7 @@ import org.junit.experimental.theories.Theory;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
@@ -1223,8 +1224,13 @@ public class ProtocolCompatibilityTest {
             }
 
             @Override
-            public void close() throws Exception {
-                channel.shutdown().awaitTermination(DEFAULT_TIMEOUT_SECONDS, SECONDS);
+            public void close() throws IOException {
+                try {
+                    channel.shutdown().awaitTermination(DEFAULT_TIMEOUT_SECONDS, SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException(e);
+                }
             }
 
             @Override

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
@@ -25,11 +25,13 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
 import javax.annotation.Nullable;
 import javax.lang.model.element.Modifier;
@@ -1144,7 +1146,7 @@ final class Generator {
                         .addStatement("return $L", client)
                         .build())
                 .addMethod(newDelegatingMethodSpec(executionContext, client, GrpcExecutionContext, null))
-                .addMethod(newDelegatingMethodSpec(close, client, null, ClassName.get(Exception.class)));
+                .addMethod(newDelegatingMethodSpec(close, client, null, ClassName.get(IOException.class)));
 
         state.clientMetaDatas.forEach(clientMetaData -> {
             final CodeBlock requestExpression = clientMetaData.methodProto.getClientStreaming() ?
@@ -1315,8 +1317,15 @@ final class Generator {
         return methodBuilder(blockingMethodName)
                 .addModifiers(PUBLIC)
                 .addAnnotation(Override.class)
-                .addException(Exception.class)
+                .addException(IOException.class)
+                .beginControlFlow("try")
                 .addStatement("$L.$L().toFuture().get()", fieldName, completableMethodName)
+                .nextControlFlow("catch ($T e)", InterruptedException.class)
+                .addStatement("Thread.currentThread().interrupt()")
+                .addStatement("throw new $T(e)", IOException.class)
+                .nextControlFlow("catch ($T e)", ExecutionException.class)
+                .addStatement("throw new $T(e)", IOException.class)
+                .endControlFlow()
                 .build();
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpRequester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,14 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
+
+import java.io.IOException;
 
 /**
  * The equivalent of {@link HttpRequester} with synchronous/blocking APIs instead of asynchronous APIs.
  */
-public interface BlockingHttpRequester extends HttpRequestFactory, GracefulAutoCloseable {
+public interface BlockingHttpRequester extends HttpRequestFactory, GracefulCloseable {
     /**
      * Send a {@code request} using the passed {@link HttpExecutionStrategy strategy}.
      *
@@ -49,7 +51,7 @@ public interface BlockingHttpRequester extends HttpRequestFactory, GracefulAutoC
     HttpResponseFactory httpResponseFactory();
 
     @Override
-    default void close() throws Exception {
+    default void close() throws IOException {
         // noop
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,16 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
 import io.servicetalk.concurrent.api.Single;
+
+import java.io.IOException;
 
 /**
  * The equivalent of {@link HttpService} but with synchronous/blocking APIs instead of asynchronous APIs.
  */
 @FunctionalInterface
-public interface BlockingHttpService extends GracefulAutoCloseable {
+public interface BlockingHttpService extends GracefulCloseable {
     /**
      * Handles a single HTTP request.
      *
@@ -36,7 +38,7 @@ public interface BlockingHttpService extends GracefulAutoCloseable {
             throws Exception;
 
     @Override
-    default void close() throws Exception {
+    default void close() throws IOException {
         // noop
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,14 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
+
+import java.io.IOException;
 
 /**
  * The equivalent of {@link StreamingHttpRequester} but with synchronous/blocking APIs instead of asynchronous APIs.
  */
-public interface BlockingStreamingHttpRequester extends BlockingStreamingHttpRequestFactory, GracefulAutoCloseable {
+public interface BlockingStreamingHttpRequester extends BlockingStreamingHttpRequestFactory, GracefulCloseable {
     /**
      * Send a {@code request} using the passed {@link HttpExecutionStrategy strategy}.
      *
@@ -50,7 +52,7 @@ public interface BlockingStreamingHttpRequester extends BlockingStreamingHttpReq
     BlockingStreamingHttpResponseFactory httpResponseFactory();
 
     @Override
-    default void close() throws Exception {
+    default void close() throws IOException {
         // noop
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,16 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
 import io.servicetalk.oio.api.PayloadWriter;
+
+import java.io.IOException;
 
 /**
  * The equivalent of {@link StreamingHttpService} but with synchronous/blocking APIs instead of asynchronous APIs.
  */
 @FunctionalInterface
-public interface BlockingStreamingHttpService extends GracefulAutoCloseable {
+public interface BlockingStreamingHttpService extends GracefulCloseable {
     /**
      * Handles a single HTTP request.
      *
@@ -36,7 +38,7 @@ public interface BlockingStreamingHttpService extends GracefulAutoCloseable {
                 BlockingStreamingHttpServerResponse response) throws Exception;
 
     @Override
-    default void close() throws Exception {
+    default void close() throws IOException {
         // noop
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,10 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
 import io.servicetalk.concurrent.api.Single;
+
+import java.io.IOException;
 
 import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 
@@ -24,7 +26,7 @@ import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
  * Provides a means to issue requests against HTTP service. The implementation is free to maintain a collection of
  * {@link HttpConnection} instances and distribute calls to {@link #request(HttpRequest)} amongst this collection.
  */
-public interface HttpClient extends HttpRequester, GracefulAutoCloseable {
+public interface HttpClient extends HttpRequester, GracefulCloseable {
     /**
      * Send a {@code request}.
      *
@@ -82,12 +84,12 @@ public interface HttpClient extends HttpRequester, GracefulAutoCloseable {
     }
 
     @Override
-    default void close() throws Exception {
+    default void close() throws IOException {
         awaitTermination(closeAsync().toFuture());
     }
 
     @Override
-    default void closeGracefully() throws Exception {
+    default void closeGracefully() throws IOException {
         awaitTermination(closeAsyncGracefully().toFuture());
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,19 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+
+import java.io.IOException;
 
 import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 
 /**
  * Represents a single fixed connection to a HTTP server.
  */
-public interface HttpConnection extends HttpRequester, GracefulAutoCloseable {
+public interface HttpConnection extends HttpRequester, GracefulCloseable {
     /**
      * Send a {@code request}.
      *
@@ -80,12 +82,12 @@ public interface HttpConnection extends HttpRequester, GracefulAutoCloseable {
     }
 
     @Override
-    default void close() throws Exception {
+    default void close() throws IOException {
         awaitTermination(closeAsync().toFuture());
     }
 
     @Override
-    default void closeGracefully() throws Exception {
+    default void closeGracefully() throws IOException {
         awaitTermination(closeAsyncGracefully().toFuture());
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,10 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
 import io.servicetalk.concurrent.api.Single;
+
+import java.io.IOException;
 
 import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 
@@ -24,7 +26,7 @@ import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
  * The equivalent of {@link HttpClient} but that accepts {@link StreamingHttpRequest} and returns
  * {@link StreamingHttpResponse}.
  */
-public interface StreamingHttpClient extends FilterableStreamingHttpClient, GracefulAutoCloseable {
+public interface StreamingHttpClient extends FilterableStreamingHttpClient, GracefulCloseable {
     /**
      * Send a {@code request}.
      *
@@ -75,12 +77,12 @@ public interface StreamingHttpClient extends FilterableStreamingHttpClient, Grac
     BlockingHttpClient asBlockingClient();
 
     @Override
-    default void close() throws Exception {
+    default void close() throws IOException {
         awaitTermination(closeAsync().toFuture());
     }
 
     @Override
-    default void closeGracefully() throws Exception {
+    default void closeGracefully() throws IOException {
         awaitTermination(closeAsyncGracefully().toFuture());
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingHttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.BlockingIterable;
+
+import java.io.IOException;
 
 import static io.servicetalk.http.api.BlockingUtils.blockingInvocation;
 import static io.servicetalk.http.api.RequestResponseFactories.toAggregated;
@@ -80,12 +82,12 @@ final class StreamingHttpClientToBlockingHttpClient implements BlockingHttpClien
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         client.close();
     }
 
     @Override
-    public void closeGracefully() throws Exception {
+    public void closeGracefully() throws IOException {
         client.closeGracefully();
     }
 
@@ -172,12 +174,12 @@ final class StreamingHttpClientToBlockingHttpClient implements BlockingHttpClien
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() throws IOException {
             connection.close();
         }
 
         @Override
-        public void closeGracefully() throws Exception {
+        public void closeGracefully() throws IOException {
             connection.closeGracefully();
         }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingStreamingHttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.BlockingIterable;
+
+import java.io.IOException;
 
 import static io.servicetalk.http.api.BlockingUtils.blockingInvocation;
 import static io.servicetalk.http.api.RequestResponseFactories.toBlockingStreaming;
@@ -84,12 +86,12 @@ final class StreamingHttpClientToBlockingStreamingHttpClient implements Blocking
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         client.close();
     }
 
     @Override
-    public void closeGracefully() throws Exception {
+    public void closeGracefully() throws IOException {
         client.closeGracefully();
     }
 
@@ -178,12 +180,12 @@ final class StreamingHttpClientToBlockingStreamingHttpClient implements Blocking
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() throws IOException {
             connection.close();
         }
 
         @Override
-        public void closeGracefully() throws Exception {
+        public void closeGracefully() throws IOException {
             connection.closeGracefully();
         }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToHttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package io.servicetalk.http.api;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+
+import java.io.IOException;
 
 import static io.servicetalk.http.api.RequestResponseFactories.toAggregated;
 import static io.servicetalk.http.api.StreamingHttpConnectionToHttpConnection.DEFAULT_CONNECTION_STRATEGY;
@@ -76,12 +78,12 @@ final class StreamingHttpClientToHttpClient implements HttpClient {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         client.close();
     }
 
     @Override
-    public void closeGracefully() throws Exception {
+    public void closeGracefully() throws IOException {
         client.closeGracefully();
     }
 
@@ -201,12 +203,12 @@ final class StreamingHttpClientToHttpClient implements HttpClient {
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() throws IOException {
             connection.close();
         }
 
         @Override
-        public void closeGracefully() throws Exception {
+        public void closeGracefully() throws IOException {
             connection.closeGracefully();
         }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,10 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
 import io.servicetalk.concurrent.api.Single;
+
+import java.io.IOException;
 
 import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 
@@ -24,7 +26,7 @@ import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
  * The equivalent of {@link HttpConnection} but that accepts {@link StreamingHttpRequest} and returns
  * {@link StreamingHttpResponse}.
  */
-public interface StreamingHttpConnection extends FilterableStreamingHttpConnection, GracefulAutoCloseable {
+public interface StreamingHttpConnection extends FilterableStreamingHttpConnection, GracefulCloseable {
     /**
      * Send a {@code request}.
      *
@@ -61,12 +63,12 @@ public interface StreamingHttpConnection extends FilterableStreamingHttpConnecti
     BlockingHttpConnection asBlockingConnection();
 
     @Override
-    default void close() throws Exception {
+    default void close() throws IOException {
         awaitTermination(closeAsync().toFuture());
     }
 
     @Override
-    default void closeGracefully() throws Exception {
+    default void closeGracefully() throws IOException {
         awaitTermination(closeAsyncGracefully().toFuture());
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToBlockingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToBlockingHttpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.BlockingIterable;
+
+import java.io.IOException;
 
 import static io.servicetalk.http.api.HttpExecutionStrategies.OFFLOAD_NONE_STRATEGY;
 import static io.servicetalk.http.api.RequestResponseFactories.toAggregated;
@@ -84,12 +86,12 @@ final class StreamingHttpConnectionToBlockingHttpConnection implements BlockingH
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         connection.close();
     }
 
     @Override
-    public void closeGracefully() throws Exception {
+    public void closeGracefully() throws IOException {
         connection.closeGracefully();
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToBlockingStreamingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToBlockingStreamingHttpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.BlockingIterable;
+
+import java.io.IOException;
 
 import static io.servicetalk.http.api.BlockingUtils.blockingInvocation;
 import static io.servicetalk.http.api.HttpExecutionStrategies.OFFLOAD_SEND_STRATEGY;
@@ -87,12 +89,12 @@ final class StreamingHttpConnectionToBlockingStreamingHttpConnection implements 
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         connection.close();
     }
 
     @Override
-    public void closeGracefully() throws Exception {
+    public void closeGracefully() throws IOException {
         connection.closeGracefully();
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToHttpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package io.servicetalk.http.api;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+
+import java.io.IOException;
 
 import static io.servicetalk.http.api.HttpExecutionStrategies.OFFLOAD_RECEIVE_DATA_STRATEGY;
 import static io.servicetalk.http.api.RequestResponseFactories.toAggregated;
@@ -90,12 +92,12 @@ final class StreamingHttpConnectionToHttpConnection implements HttpConnection {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         connection.close();
     }
 
     @Override
-    public void closeGracefully() throws Exception {
+    public void closeGracefully() throws IOException {
         connection.closeGracefully();
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToBlockingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToBlockingHttpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
  */
 package io.servicetalk.http.api;
 
+import java.io.IOException;
+
+import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 import static io.servicetalk.http.api.BlockingUtils.futureGetCancelOnInterrupt;
 import static java.util.Objects.requireNonNull;
 
@@ -35,7 +38,7 @@ final class StreamingHttpServiceToBlockingHttpService implements BlockingHttpSer
     }
 
     @Override
-    public void close() throws Exception {
-        original.closeAsync().toFuture().get();
+    public void close() throws IOException {
+        awaitTermination(original.closeAsync().toFuture());
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToBlockingStreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToBlockingStreamingHttpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 import static io.servicetalk.http.api.BlockingUtils.futureGetCancelOnInterrupt;
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.util.Objects.requireNonNull;
@@ -77,13 +78,13 @@ final class StreamingHttpServiceToBlockingStreamingHttpService implements Blocki
     }
 
     @Override
-    public void close() throws Exception {
-        original.closeAsync().toFuture().get();
+    public void close() throws IOException {
+        awaitTermination(original.closeAsync().toFuture());
     }
 
     @Override
-    public void closeGracefully() throws Exception {
-        original.closeAsyncGracefully().toFuture().get();
+    public void closeGracefully() throws IOException {
+        awaitTermination(original.closeAsyncGracefully().toFuture());
     }
 
     private static final class MessageBodyToPayloadWriter extends SubscribableCompletable {

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpRequesterFilterTest.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpRequesterFilterTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -305,7 +306,7 @@ public abstract class AbstractHttpRequesterFilterTest {
             }
 
             @Override
-            public void close() throws Exception {
+            public void close() throws IOException {
                 connection.close();
             }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
@@ -344,7 +344,7 @@ class HttpOffloadingTest {
             } catch (InterruptedException e) {
                 errors.add(e);
             }
-            Publisher responsePayload =
+            Publisher<Buffer> responsePayload =
                 from(ctx.executionContext().bufferAllocator().fromAscii("Hello"))
                     .beforeRequest(n -> {
                         if (inEventLoop().test(currentThread())) {

--- a/servicetalk-serialization-api/src/main/java/io/servicetalk/serialization/api/StreamingDeserializer.java
+++ b/servicetalk-serialization-api/src/main/java/io/servicetalk/serialization/api/StreamingDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.servicetalk.serialization.api;
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.BlockingIterable;
 import io.servicetalk.concurrent.BlockingIterator;
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -38,7 +38,7 @@ import java.util.List;
  *
  * @param <T> Type of object to be deserialized.
  */
-public interface StreamingDeserializer<T> extends GracefulAutoCloseable {
+public interface StreamingDeserializer<T> extends GracefulCloseable {
 
     /**
      * Deserialize the passed {@link Buffer} into an {@link Iterable} of {@link T}s. If this {@link Buffer} and any

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServerContext.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServerContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
  */
 package io.servicetalk.transport.api;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
+import io.servicetalk.concurrent.GracefulCloseable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 
+import java.io.IOException;
 import java.net.SocketAddress;
 
 import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
@@ -25,7 +26,7 @@ import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 /**
  * Context for servers.
  */
-public interface ServerContext extends ListenableAsyncCloseable, GracefulAutoCloseable {
+public interface ServerContext extends ListenableAsyncCloseable, GracefulCloseable {
 
     /**
      * Listen address for the server associated with this context.
@@ -51,12 +52,12 @@ public interface ServerContext extends ListenableAsyncCloseable, GracefulAutoClo
     }
 
     @Override
-    default void close() throws Exception {
+    default void close() throws IOException {
         awaitTermination(closeAsync().toFuture());
     }
 
     @Override
-    default void closeGracefully() throws Exception {
+    default void closeGracefully() throws IOException {
         awaitTermination(closeAsyncGracefully().toFuture());
     }
 }


### PR DESCRIPTION
Motivation:

`GracefulAutoCloseable` interface inherited from `AutoCloseable`, which has [certain limitations](https://docs.oracle.com/javase/8/docs/api/java/lang/AutoCloseable.html#close--) regarding thrown `Exception`s that are validated at compile-time. Compiling GRPC-generated classes yielded warnings, which turn to errors when compiled with `-Xlint:try` option.

Modification:

- `GracefulAutoCloseable` renamed to `GracefulCloseable`,
- `GracefulCloseable` extends `java.io.Closeable` instead of `java.lang.AutoCloseable` which declares `IOException` as thrown from the `close()` method. That in turn doesn't produce compilation warnings,
- `AutoCloseables` renamed to `Closeables` as it operated on `GracefulAutoCloseable`s only,
- `Generator` class generates code responsible for wrapping thrown exceptions from the `close()` and `closeGracefully()` methods into `IOException`.

Result:

Related code and GRPC-generated code don't produce compiler warnings for the try-with-resources blocks when `GracefulCloseable` is used.