### PR TITLE
Make `http-api:testFixtures` usable in other modules

### DIFF
--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/SimpleHttpRequesterFilterTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/SimpleHttpRequesterFilterTest.java
@@ -17,7 +17,6 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.api.Single;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -46,18 +45,6 @@ import static org.mockito.Mockito.mock;
  * This is a test-case for the {@link AbstractHttpRequesterFilterTest} HTTP request filter test utilities.
  */
 public class SimpleHttpRequesterFilterTest extends AbstractHttpRequesterFilterTest {
-
-    private SSLSession session;
-
-    @BeforeEach
-    void setUp() {
-        session = mock(SSLSession.class);
-    }
-
-    @Override
-    protected SSLSession sslSession() {
-        return session;
-    }
 
     private static final class HeaderEnrichingRequestFilter implements StreamingHttpClientFilterFactory,
                                                                        StreamingHttpConnectionFilterFactory {
@@ -285,7 +272,7 @@ public class SimpleHttpRequesterFilterTest extends AbstractHttpRequesterFilterTe
         setUp(security);
         final Principal principal = mock(Principal.class);
         lenient().when(principal.getName()).thenReturn("unit.test.auth");
-        lenient().when(session.getPeerPrincipal()).thenReturn(principal);
+        lenient().when(sslSession().getPeerPrincipal()).thenReturn(principal);
 
         BlockingHttpRequester filter = asBlockingRequester(createFilter(type, new SecurityEnforcingFilter()));
         HttpResponse resp = filter.request(defaultStrategy(), filter.get("/"));

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpRequesterFilterTest.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpRequesterFilterTest.java
@@ -61,8 +61,8 @@ public abstract class AbstractHttpRequesterFilterTest {
 
     public enum RequesterType { Client, Connection, ReservedConnection }
 
+    private final SSLSession sslSession = mock(SSLSession.class);
     private final CompositeCloseable closeables = AsyncCloseables.newCompositeCloseable();
-
 
     @Mock
     private HttpExecutionContext mockExecutionContext;
@@ -82,7 +82,7 @@ public abstract class AbstractHttpRequesterFilterTest {
     }
 
     @BeforeEach
-    public final void setupContext() {
+    final void setupContext() {
         lenient().when(mockConnectionContext.remoteAddress()).thenAnswer(__ -> remoteAddress());
         lenient().when(mockConnectionContext.localAddress()).thenAnswer(__ -> localAddress());
     }
@@ -105,12 +105,12 @@ public abstract class AbstractHttpRequesterFilterTest {
     }
 
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
-    private InetSocketAddress localAddress() {
+    protected InetSocketAddress localAddress() {
         return InetSocketAddress.createUnresolved("127.0.1.2", 28080);
     }
 
     protected SSLSession sslSession() {
-        return mock(SSLSession.class);
+        return sslSession;
     }
 
     protected Publisher<Object> loadbalancerEvents() {
@@ -118,7 +118,7 @@ public abstract class AbstractHttpRequesterFilterTest {
     }
 
     @AfterEach
-    public final void closeClients() throws Exception {
+    final void closeClients() throws Exception {
         closeables.close();
     }
 
@@ -129,7 +129,7 @@ public abstract class AbstractHttpRequesterFilterTest {
      * @param <FF> type capture for the filter factory
      * @return a filtered {@link StreamingHttpRequester}
      */
-    final <FF extends StreamingHttpClientFilterFactory & StreamingHttpConnectionFilterFactory>
+    protected final <FF extends StreamingHttpClientFilterFactory & StreamingHttpConnectionFilterFactory>
         StreamingHttpRequester createFilter(RequesterType type, FF filterFactory) {
         return createFilter(type, RequestHandler.ok(), ok(), filterFactory);
     }
@@ -156,7 +156,7 @@ public abstract class AbstractHttpRequesterFilterTest {
      * @param <FF> type capture for the filter factory
      * @return a filtered {@link StreamingHttpRequester}
      */
-    final <FF extends StreamingHttpClientFilterFactory & StreamingHttpConnectionFilterFactory>
+    protected final <FF extends StreamingHttpClientFilterFactory & StreamingHttpConnectionFilterFactory>
         StreamingHttpRequester createFilter(RequesterType type, RequestHandler rh,
                                             RequestWithContextHandler rwch, FF filterFactory) {
         switch (type) {

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpServiceFilterTest.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpServiceFilterTest.java
@@ -29,8 +29,8 @@ import javax.net.ssl.SSLSession;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * This parameterized test facilitates running HTTP service filter tests under all calling variations:
@@ -52,14 +52,14 @@ public abstract class AbstractHttpServiceFilterTest {
     private HttpServiceContext mockConnectionContext;
 
     @BeforeEach
-    public void setUp() {
-        when(mockConnectionContext.executionContext()).thenReturn(executionContext);
-        when(mockConnectionContext.remoteAddress()).thenAnswer(__ -> remoteAddress());
-        when(mockConnectionContext.localAddress()).thenAnswer(__ -> localAddress());
+    void setUp() {
+        lenient().when(mockConnectionContext.executionContext()).thenReturn(executionContext);
+        lenient().when(mockConnectionContext.remoteAddress()).thenAnswer(__ -> remoteAddress());
+        lenient().when(mockConnectionContext.localAddress()).thenAnswer(__ -> localAddress());
     }
 
     protected void setUp(SecurityType security) {
-        when(mockConnectionContext.sslSession()).thenAnswer(__ -> {
+        lenient().when(mockConnectionContext.sslSession()).thenAnswer(__ -> {
             switch (security) {
                 case Secure:
                     return sslSession();
@@ -71,16 +71,16 @@ public abstract class AbstractHttpServiceFilterTest {
     }
 
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
-    private InetSocketAddress remoteAddress() {
+    protected InetSocketAddress remoteAddress() {
         return InetSocketAddress.createUnresolved("127.0.1.2", 28080);
     }
 
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
-    private InetSocketAddress localAddress() {
+    protected InetSocketAddress localAddress() {
         return InetSocketAddress.createUnresolved("127.0.1.1", 80);
     }
 
-    private SSLSession sslSession() {
+    protected SSLSession sslSession() {
         return mock(SSLSession.class);
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RedirectingClientAndConnectionFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RedirectingClientAndConnectionFilterTest.java
@@ -27,11 +27,8 @@ import io.servicetalk.http.utils.RedirectingHttpRequesterFilter;
 import io.servicetalk.transport.api.HostAndPort;
 
 import org.hamcrest.MatcherAssert;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import javax.net.ssl.SSLSession;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
@@ -43,25 +40,12 @@ import static io.servicetalk.http.api.HttpResponseStatus.PERMANENT_REDIRECT;
 import static io.servicetalk.transport.netty.internal.AddressUtils.hostHeader;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.mock;
 
 /**
  * This test-case is for integration testing the {@link RedirectingHttpRequesterFilter} with the various types
  * of {@link HttpClient} and {@link HttpConnection} builders.
  */
 public final class RedirectingClientAndConnectionFilterTest extends AbstractHttpRequesterFilterTest {
-
-    private SSLSession session;
-
-    @BeforeEach
-    void setUp() {
-        session = mock(SSLSession.class);
-    }
-
-    @Override
-    protected SSLSession sslSession() {
-        return session;
-    }
 
     @ParameterizedTest(name = "{displayName} [{index}] {0}-{1}")
     @MethodSource("requesterTypes")


### PR DESCRIPTION
Motivation:

`testFixtures` are expected to be used by other modules.
After #1521 refactoring, visibility of some methods was reduced.

Modifications:

- Revert `protected` modifiers for `AbstractHttpRequesterFilterTest` and
`AbstractHttpServiceFilterTest` methods;
- Do not override `sslSession()` without a special need;

Result:

Modules that depend on these testFixtures classes can continue to work.