### PR TITLE
Do not hardcode netty-tcnative version in docs

### DIFF
--- a/docs/modules/ROOT/pages/performance.adoc
+++ b/docs/modules/ROOT/pages/performance.adoc
@@ -585,13 +585,16 @@ link:https://wiki.mozilla.org/Security/Server_Side_TLS[Mozilla Server Side TLS])
 [source, java]
 ----
 
-// add the netty dependency to your build, eg: "io.netty:netty-tcnative-boringssl-static:2.0.25.Final"
+// add the netty dependency to your build, eg: "io.netty:netty-tcnative-boringssl-static:$tcnativeVersion"
 
 BlockingHttpClient client = HttpClients.forSingleAddress("servicetalk.io", 443)
         .secure().provider(SecurityConfigurator.SslProvider.OPENSSL).commit()
         .buildBlocking();
 HttpResponse resp = client.request(client.get("/"));
 ----
+
+Latest `netty-tcnative-boringssl-static` version can be found
+link:https://mvnrepository.com/artifact/io.netty/netty-tcnative-boringssl-static[here].
 
 === Netty LEAK-detection
 ServiceTalk is built on top of Netty. Netty supports

--- a/docs/modules/ROOT/pages/performance.adoc
+++ b/docs/modules/ROOT/pages/performance.adoc
@@ -593,8 +593,8 @@ BlockingHttpClient client = HttpClients.forSingleAddress("servicetalk.io", 443)
 HttpResponse resp = client.request(client.get("/"));
 ----
 
-Latest `netty-tcnative-boringssl-static` version can be found
-link:https://mvnrepository.com/artifact/io.netty/netty-tcnative-boringssl-static[here].
+Latest `netty-tcnative-boringssl-static` version can be found in
+link:https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static[Maven Central Repository].
 
 === Netty LEAK-detection
 ServiceTalk is built on top of Netty. Netty supports


### PR DESCRIPTION
Motivation:

Existing `performance.adoc` has hardcoded version of netty-tcnative
which is already outdated.

Modifications:

- Change the hardcoded version number to a parameter and link where
users can find the latest version number;

Result:

No outdated version constant in docs.