### PR TITLE
Produce a TrailersOnly response when gRPC endpoints throw an error.

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,8 +74,8 @@ import static io.servicetalk.grpc.api.GrpcStatus.fromCodeValue;
 import static io.servicetalk.grpc.api.GrpcStatusCode.INVALID_ARGUMENT;
 import static io.servicetalk.grpc.api.GrpcStatusCode.UNIMPLEMENTED;
 import static io.servicetalk.grpc.api.GrpcUtils.negotiateAcceptedEncoding;
-import static io.servicetalk.grpc.api.GrpcUtils.newErrorResponse;
 import static io.servicetalk.grpc.api.GrpcUtils.newResponse;
+import static io.servicetalk.grpc.api.GrpcUtils.newTrailersOnlyErrorResponse;
 import static io.servicetalk.grpc.api.GrpcUtils.readGrpcMessageEncoding;
 import static io.servicetalk.grpc.api.GrpcUtils.setStatus;
 import static io.servicetalk.grpc.api.GrpcUtils.setStatusOk;
@@ -97,7 +97,7 @@ final class GrpcRouter {
 
     private static final GrpcStatus STATUS_UNIMPLEMENTED = fromCodeValue(UNIMPLEMENTED.value());
     private static final StreamingHttpService NOT_FOUND_SERVICE = (ctx, request, responseFactory) -> {
-        final StreamingHttpResponse response = newResponse(responseFactory, null, STATUS_UNIMPLEMENTED,
+        final StreamingHttpResponse response = newTrailersOnlyErrorResponse(responseFactory, STATUS_UNIMPLEMENTED,
                 ctx.executionContext().bufferAllocator());
         response.version(request.version());
         return succeeded(response);
@@ -264,10 +264,11 @@ final class GrpcRouter {
                                                 .payloadBody(rawResp,
                                                         serializationProvider.serializerFor(responseEncoding,
                                                                 responseClass)))
-                                        .onErrorReturn(cause -> newErrorResponse(responseFactory,
+                                        .onErrorReturn(cause ->
+                                                newTrailersOnlyErrorResponse(responseFactory,
                                                 finalServiceContext, cause, ctx.executionContext().bufferAllocator()));
                             } catch (Throwable t) {
-                                return succeeded(newErrorResponse(responseFactory, serviceContext, t,
+                                return succeeded(newTrailersOnlyErrorResponse(responseFactory, serviceContext, t,
                                         ctx.executionContext().bufferAllocator()));
                             }
                         }
@@ -320,7 +321,7 @@ final class GrpcRouter {
                                     serializationProvider.serializerFor(responseEncoding, responseClass),
                                     ctx.executionContext().bufferAllocator()));
                         } catch (Throwable t) {
-                            return succeeded(newErrorResponse(responseFactory, serviceContext, t,
+                            return succeeded(newTrailersOnlyErrorResponse(responseFactory, serviceContext, t,
                                     ctx.executionContext().bufferAllocator()));
                         }
                     }
@@ -465,7 +466,7 @@ final class GrpcRouter {
                                         ctx.executionContext().bufferAllocator()).payloadBody(response,
                                                 serializationProvider.serializerFor(responseEncoding, responseClass));
                             } catch (Throwable t) {
-                                return newErrorResponse(responseFactory, serviceContext, t,
+                                return newTrailersOnlyErrorResponse(responseFactory, serviceContext, t,
                                         ctx.executionContext().bufferAllocator());
                             }
                         }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -74,8 +74,8 @@ import static io.servicetalk.grpc.api.GrpcStatus.fromCodeValue;
 import static io.servicetalk.grpc.api.GrpcStatusCode.INVALID_ARGUMENT;
 import static io.servicetalk.grpc.api.GrpcStatusCode.UNIMPLEMENTED;
 import static io.servicetalk.grpc.api.GrpcUtils.negotiateAcceptedEncoding;
+import static io.servicetalk.grpc.api.GrpcUtils.newErrorResponse;
 import static io.servicetalk.grpc.api.GrpcUtils.newResponse;
-import static io.servicetalk.grpc.api.GrpcUtils.newTrailersOnlyErrorResponse;
 import static io.servicetalk.grpc.api.GrpcUtils.readGrpcMessageEncoding;
 import static io.servicetalk.grpc.api.GrpcUtils.setStatus;
 import static io.servicetalk.grpc.api.GrpcUtils.setStatusOk;
@@ -97,8 +97,8 @@ final class GrpcRouter {
 
     private static final GrpcStatus STATUS_UNIMPLEMENTED = fromCodeValue(UNIMPLEMENTED.value());
     private static final StreamingHttpService NOT_FOUND_SERVICE = (ctx, request, responseFactory) -> {
-        final StreamingHttpResponse response = newTrailersOnlyErrorResponse(responseFactory, STATUS_UNIMPLEMENTED,
-                ctx.executionContext().bufferAllocator());
+        final StreamingHttpResponse response = newErrorResponse(responseFactory, null, STATUS_UNIMPLEMENTED,
+                null, ctx.executionContext().bufferAllocator());
         response.version(request.version());
         return succeeded(response);
     };
@@ -264,11 +264,10 @@ final class GrpcRouter {
                                                 .payloadBody(rawResp,
                                                         serializationProvider.serializerFor(responseEncoding,
                                                                 responseClass)))
-                                        .onErrorReturn(cause ->
-                                                newTrailersOnlyErrorResponse(responseFactory,
-                                                finalServiceContext, cause, ctx.executionContext().bufferAllocator()));
+                                        .onErrorReturn(cause -> newErrorResponse(responseFactory, finalServiceContext,
+                                                null, cause, ctx.executionContext().bufferAllocator()));
                             } catch (Throwable t) {
-                                return succeeded(newTrailersOnlyErrorResponse(responseFactory, serviceContext, t,
+                                return succeeded(newErrorResponse(responseFactory, serviceContext, null, t,
                                         ctx.executionContext().bufferAllocator()));
                             }
                         }
@@ -321,7 +320,7 @@ final class GrpcRouter {
                                     serializationProvider.serializerFor(responseEncoding, responseClass),
                                     ctx.executionContext().bufferAllocator()));
                         } catch (Throwable t) {
-                            return succeeded(newTrailersOnlyErrorResponse(responseFactory, serviceContext, t,
+                            return succeeded(newErrorResponse(responseFactory, serviceContext, null, t,
                                     ctx.executionContext().bufferAllocator()));
                         }
                     }
@@ -466,7 +465,7 @@ final class GrpcRouter {
                                         ctx.executionContext().bufferAllocator()).payloadBody(response,
                                                 serializationProvider.serializerFor(responseEncoding, responseClass));
                             } catch (Throwable t) {
-                                return newTrailersOnlyErrorResponse(responseFactory, serviceContext, t,
+                                return newErrorResponse(responseFactory, serviceContext, null, t,
                                         ctx.executionContext().bufferAllocator());
                             }
                         }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -48,7 +48,7 @@ import java.util.function.Predicate;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.internal.FutureUtils.awaitResult;
-import static io.servicetalk.grpc.api.GrpcUtils.newTrailersOnlyErrorResponse;
+import static io.servicetalk.grpc.api.GrpcUtils.newErrorResponse;
 
 /**
  * A builder for building a <a href="https://www.grpc.io">gRPC</a> server.
@@ -414,8 +414,7 @@ public abstract class GrpcServerBuilder {
         private static StreamingHttpResponse convertToGrpcErrorResponse(
                 final HttpServiceContext ctx, final StreamingHttpResponseFactory responseFactory,
                 final Throwable cause) {
-            return newTrailersOnlyErrorResponse(responseFactory, null, cause,
-                    ctx.executionContext().bufferAllocator());
+            return newErrorResponse(responseFactory, null, null, cause, ctx.executionContext().bufferAllocator());
         }
     }
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -48,7 +48,7 @@ import java.util.function.Predicate;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.internal.FutureUtils.awaitResult;
-import static io.servicetalk.grpc.api.GrpcUtils.newErrorResponse;
+import static io.servicetalk.grpc.api.GrpcUtils.newTrailersOnlyErrorResponse;
 
 /**
  * A builder for building a <a href="https://www.grpc.io">gRPC</a> server.
@@ -414,7 +414,8 @@ public abstract class GrpcServerBuilder {
         private static StreamingHttpResponse convertToGrpcErrorResponse(
                 final HttpServiceContext ctx, final StreamingHttpResponseFactory responseFactory,
                 final Throwable cause) {
-            return newErrorResponse(responseFactory, null, cause, ctx.executionContext().bufferAllocator());
+            return newTrailersOnlyErrorResponse(responseFactory, null, cause,
+                    ctx.executionContext().bufferAllocator());
         }
     }
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
@@ -182,7 +182,7 @@ final class GrpcUtils {
     static StreamingHttpResponse newErrorResponse(
             final StreamingHttpResponseFactory responseFactory, @Nullable final GrpcServiceContext context,
             @Nullable final GrpcStatus status, @Nullable final Throwable cause, final BufferAllocator allocator) {
-        assert status != null || cause != null;
+        assert (status != null && cause == null) || (status == null && cause != null);
         final StreamingHttpResponse response = responseFactory.ok();
         initResponse(response, context);
         if (status != null) {

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
@@ -165,30 +165,31 @@ final class GrpcUtils {
         return response;
     }
 
-    static StreamingHttpResponse newTrailersOnlyErrorResponse(final StreamingHttpResponseFactory responseFactory,
-                                                     final GrpcStatus status,
-                                                     final BufferAllocator allocator) {
-        final StreamingHttpResponse response = responseFactory.ok();
-        initResponse(response, null);
-        setStatus(response.headers(), status, null, allocator);
-        return response;
-    }
-
-    static HttpResponse newTrailersOnlyErrorResponse(final HttpResponseFactory responseFactory,
-                                                     @Nullable final GrpcServiceContext context,
-                                                     final Throwable cause, final BufferAllocator allocator) {
+    static HttpResponse newErrorResponse(
+            final HttpResponseFactory responseFactory, @Nullable final GrpcServiceContext context,
+            @Nullable final GrpcStatus status, @Nullable final Throwable cause, final BufferAllocator allocator) {
+        assert status != null || cause != null;
         final HttpResponse response = responseFactory.ok();
         initResponse(response, context);
-        setStatus(response.headers(), cause, allocator);
+        if (status != null) {
+            setStatus(response.headers(), status, null, allocator);
+        } else {
+            setStatus(response.headers(), cause, allocator);
+        }
         return response;
     }
 
-    static StreamingHttpResponse newTrailersOnlyErrorResponse(final StreamingHttpResponseFactory responseFactory,
-                                                  @Nullable final GrpcServiceContext context, final Throwable cause,
-                                                  final BufferAllocator allocator) {
+    static StreamingHttpResponse newErrorResponse(
+            final StreamingHttpResponseFactory responseFactory, @Nullable final GrpcServiceContext context,
+            @Nullable final GrpcStatus status, @Nullable final Throwable cause, final BufferAllocator allocator) {
+        assert status != null || cause != null;
         final StreamingHttpResponse response = responseFactory.ok();
         initResponse(response, context);
-        setStatus(response.headers(), cause, allocator);
+        if (status != null) {
+            setStatus(response.headers(), status, null, allocator);
+        } else {
+            setStatus(response.headers(), cause, allocator);
+        }
         return response;
     }
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
@@ -51,8 +51,6 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
-import static io.servicetalk.concurrent.api.Publisher.empty;
-import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.encoding.api.Identity.identity;
 import static io.servicetalk.encoding.api.internal.HeaderUtils.encodingFor;
 import static io.servicetalk.grpc.api.GrpcStatusCode.CANCELLED;
@@ -167,18 +165,31 @@ final class GrpcUtils {
         return response;
     }
 
-    static HttpResponse newErrorResponse(final HttpResponseFactory responseFactory,
-                                         @Nullable final GrpcServiceContext context,
-                                         final Throwable cause, final BufferAllocator allocator) {
-        HttpResponse response = newResponse(responseFactory, context, allocator);
-        setStatus(response.trailers(), cause, allocator);
+    static StreamingHttpResponse newTrailersOnlyErrorResponse(final StreamingHttpResponseFactory responseFactory,
+                                                     final GrpcStatus status,
+                                                     final BufferAllocator allocator) {
+        final StreamingHttpResponse response = responseFactory.ok();
+        initResponse(response, null);
+        setStatus(response.headers(), status, null, allocator);
         return response;
     }
 
-    static StreamingHttpResponse newErrorResponse(final StreamingHttpResponseFactory responseFactory,
+    static HttpResponse newTrailersOnlyErrorResponse(final HttpResponseFactory responseFactory,
+                                                     @Nullable final GrpcServiceContext context,
+                                                     final Throwable cause, final BufferAllocator allocator) {
+        final HttpResponse response = responseFactory.ok();
+        initResponse(response, context);
+        setStatus(response.headers(), cause, allocator);
+        return response;
+    }
+
+    static StreamingHttpResponse newTrailersOnlyErrorResponse(final StreamingHttpResponseFactory responseFactory,
                                                   @Nullable final GrpcServiceContext context, final Throwable cause,
                                                   final BufferAllocator allocator) {
-        return newStreamingResponse(responseFactory, context).transform(new ErrorUpdater(cause, allocator));
+        final StreamingHttpResponse response = responseFactory.ok();
+        initResponse(response, context);
+        setStatus(response.headers(), cause, allocator);
+        return response;
     }
 
     private static StreamingHttpResponse newStreamingResponse(final StreamingHttpResponseFactory responseFactory,
@@ -243,13 +254,19 @@ final class GrpcUtils {
         // HTTP1-based implementation translates them into response headers so we need to look for a grpc-status in both
         // headers and trailers. Since this is streaming response and we have the headers now, we check for the
         // grpc-status here first. If there is no grpc-status in headers, we look for it in trailers later.
+
         final HttpHeaders headers = response.headers();
         ensureGrpcContentType(response.status(), headers);
         final GrpcStatusCode grpcStatusCode = extractGrpcStatusCodeFromHeaders(headers);
         if (grpcStatusCode != null) {
             final GrpcStatusException grpcStatusException = convertToGrpcStatusException(grpcStatusCode, headers);
-            return response.messageBody().ignoreElements()
-                    .concat(grpcStatusException != null ? failed(grpcStatusException) : empty());
+            if (grpcStatusException != null) {
+                // Give priority to the error if it happens, to allow delayed requests or streams to terminate.
+                return Publisher.<Resp>failed(grpcStatusException)
+                        .concat(response.messageBody().ignoreElements());
+            } else {
+                return response.messageBody().ignoreElements().toPublisher();
+            }
         }
 
         response.transform(ENSURE_GRPC_STATUS_RECEIVED);
@@ -493,22 +510,6 @@ final class GrpcUtils {
         protected HttpHeaders payloadFailed(final Throwable cause, final HttpHeaders trailers) {
             setStatus(trailers, cause, allocator);
             // Swallow exception as we are converting it to the trailers.
-            return trailers;
-        }
-    }
-
-    private static final class ErrorUpdater extends StatelessTrailersTransformer<Buffer> {
-        private final Throwable cause;
-        private final BufferAllocator allocator;
-
-        ErrorUpdater(final Throwable cause, final BufferAllocator allocator) {
-            this.cause = cause;
-            this.allocator = allocator;
-        }
-
-        @Override
-        protected HttpHeaders payloadComplete(final HttpHeaders trailers) {
-            setStatus(trailers, cause, allocator);
             return trailers;
         }
     }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/TrailersOnlyErrorTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/TrailersOnlyErrorTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.netty;
+
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.grpc.api.GrpcClientBuilder;
+import io.servicetalk.grpc.api.GrpcStatusCode;
+import io.servicetalk.grpc.api.GrpcStatusException;
+import io.servicetalk.http.api.FilterableStreamingHttpClient;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpResponseMetaData;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.StreamingHttpClientFilter;
+import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequester;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.ServerContext;
+
+import io.grpc.examples.helloworld.Greeter;
+import io.grpc.examples.helloworld.HelloRequest;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingDeque;
+
+import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
+import static io.servicetalk.concurrent.api.Completable.completed;
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.concurrent.api.Publisher.never;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.grpc.api.GrpcStatusCode.UNIMPLEMENTED;
+import static io.servicetalk.grpc.api.GrpcStatusCode.UNKNOWN;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TrailersOnlyErrorTest {
+
+    private static final CharSequence GRPC_STATUS_HEADER = newAsciiString("grpc-status");
+
+    @Test
+    public void testRouteThrows() throws Exception {
+        final BlockingQueue<Throwable> asyncErrors = new LinkedBlockingDeque<>();
+        final ServerContext serverContext = GrpcServers.forAddress(localAddress(0))
+                .listenAndAwait(new TesterProto.Tester.ServiceFactory(mockTesterService()));
+
+        final GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
+                GrpcClients.forAddress(serverHostAndPort(serverContext))
+                .appendHttpClientFilter(__ -> true, setupResponseVerifierFilter(asyncErrors));
+
+        Greeter.GreeterClient client = clientBuilder.build(new Greeter.ClientFactory());
+        assertNoErrors(asyncErrors);
+        verifyException(client.sayHello(HelloRequest.newBuilder().build()).toFuture(), UNIMPLEMENTED);
+    }
+
+    @Test
+    public void testServiceThrows() throws Exception {
+        final BlockingQueue<Throwable> asyncErrors = new LinkedBlockingDeque<>();
+        final TesterProto.Tester.TesterService service = mockTesterService();
+        setupServiceThrows(service);
+
+        final ServerContext serverContext = GrpcServers.forAddress(localAddress(0))
+                .listenAndAwait(new TesterProto.Tester.ServiceFactory(service));
+
+        final GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
+                GrpcClients.forAddress(serverHostAndPort(serverContext))
+                        .appendHttpClientFilter(__ -> true, setupResponseVerifierFilter(asyncErrors));
+
+        TesterProto.Tester.TesterClient client = clientBuilder.build(new TesterProto.Tester.ClientFactory());
+        verifyException(client.test(TesterProto.TestRequest.newBuilder()
+                .build()).toFuture(), UNKNOWN);
+        assertNoErrors(asyncErrors);
+
+        verifyException(client.testRequestStream(Publisher.from(TesterProto.TestRequest.newBuilder()
+                .build())).toFuture(), UNKNOWN);
+        assertNoErrors(asyncErrors);
+
+        verifyException(client.testBiDiStream(from(TesterProto.TestRequest.newBuilder()
+                .build()).concat(never())).toFuture(), UNKNOWN);
+        assertNoErrors(asyncErrors);
+
+        verifyException(client.testBiDiStream(from(TesterProto.TestRequest.newBuilder()
+                .build())).toFuture(), UNKNOWN);
+        assertNoErrors(asyncErrors);
+    }
+
+    @Test
+    public void testServiceSingleThrows() throws Exception {
+        final BlockingQueue<Throwable> asyncErrors = new LinkedBlockingDeque<>();
+        final TesterProto.Tester.TesterService service = mockTesterService();
+        setupServiceSingleThrows(service);
+
+        final ServerContext serverContext = GrpcServers.forAddress(localAddress(0))
+                .listenAndAwait(new TesterProto.Tester.ServiceFactory(service));
+
+        final GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
+                GrpcClients.forAddress(serverHostAndPort(serverContext))
+                        .appendHttpClientFilter(__ -> true, setupResponseVerifierFilter(asyncErrors));
+
+        TesterProto.Tester.TesterClient client = clientBuilder.build(new TesterProto.Tester.ClientFactory());
+        verifyException(client.test(TesterProto.TestRequest.newBuilder()
+                .build()).toFuture(), UNKNOWN);
+        assertNoErrors(asyncErrors);
+    }
+
+    @Test
+    public void testServiceFilterThrows() throws Exception {
+        final BlockingQueue<Throwable> asyncErrors = new LinkedBlockingDeque<>();
+        final TesterProto.Tester.TesterService service = mockTesterService();
+
+        final ServerContext serverContext = GrpcServers.forAddress(localAddress(0))
+                .appendHttpServiceFilter(svc -> new StreamingHttpServiceFilter(svc) {
+                    @Override
+                    public Single<StreamingHttpResponse> handle(
+                            final HttpServiceContext ctx, final StreamingHttpRequest request,
+                            final StreamingHttpResponseFactory responseFactory) {
+                        throw DELIBERATE_EXCEPTION;
+                    }
+                })
+                .listenAndAwait(new TesterProto.Tester.ServiceFactory(service));
+
+        final GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
+                GrpcClients.forAddress(serverHostAndPort(serverContext))
+                        .appendHttpClientFilter(__ -> true, setupResponseVerifierFilter(asyncErrors));
+
+        TesterProto.Tester.TesterClient client = clientBuilder.build(new TesterProto.Tester.ClientFactory());
+        verifyException(client.test(TesterProto.TestRequest.newBuilder()
+                .build()).toFuture(), UNKNOWN);
+        assertNoErrors(asyncErrors);
+
+        verifyException(client.testRequestStream(Publisher.from(TesterProto.TestRequest.newBuilder()
+                .build())).toFuture(), UNKNOWN);
+        assertNoErrors(asyncErrors);
+
+        verifyException(client.testResponseStream(TesterProto.TestRequest.newBuilder().build()).toFuture(), UNKNOWN);
+        assertNoErrors(asyncErrors);
+
+        verifyException(client.testBiDiStream(from(TesterProto.TestRequest.newBuilder()
+                .build()).concat(never())).toFuture(), UNKNOWN);
+        assertNoErrors(asyncErrors);
+
+        verifyException(client.testBiDiStream(from(TesterProto.TestRequest.newBuilder()
+                .build())).toFuture(), UNKNOWN);
+        assertNoErrors(asyncErrors);
+    }
+
+    private static void assertNoErrors(final BlockingQueue<Throwable> errors) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (PrintStream ps = new PrintStream(baos, true, UTF_8.name())) {
+            Throwable t;
+            while ((t = errors.poll()) != null) {
+                t.printStackTrace(ps);
+                ps.println();
+            }
+            String data = new String(baos.toByteArray(), 0, baos.size(), UTF_8);
+            if (!data.isEmpty()) {
+                throw new AssertionError(data);
+            }
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void verifyException(final Future<?> result, final GrpcStatusCode expectedCode) {
+        verifyException(assertThrows(ExecutionException.class, result::get).getCause(), expectedCode);
+    }
+
+    private static void verifyException(final Throwable cause, final GrpcStatusCode expectedCode) {
+        assertNotNull(cause);
+        assertThat(assertThrows(GrpcStatusException.class, () -> {
+            throw cause;
+        }).status().code(), equalTo(expectedCode));
+    }
+
+    private static TesterProto.Tester.TesterService mockTesterService() {
+        TesterProto.Tester.TesterService filter = mock(TesterProto.Tester.TesterService.class);
+        when(filter.closeAsync()).thenReturn(completed());
+        when(filter.closeAsyncGracefully()).thenReturn(completed());
+        return filter;
+    }
+
+    private static void setupServiceThrows(final TesterProto.Tester.TesterService service) {
+        when(service.test(any(), any())).thenThrow(DELIBERATE_EXCEPTION);
+        when(service.testBiDiStream(any(), any())).thenThrow(DELIBERATE_EXCEPTION);
+        when(service.testRequestStream(any(), any())).thenThrow(DELIBERATE_EXCEPTION);
+        when(service.testResponseStream(any(), any())).thenThrow(DELIBERATE_EXCEPTION);
+    }
+
+    private static void setupServiceSingleThrows(final TesterProto.Tester.TesterService service) {
+        when(service.test(any(), any())).thenReturn(Single.failed(DELIBERATE_EXCEPTION));
+    }
+
+    private static StreamingHttpClientFilterFactory setupResponseVerifierFilter(final BlockingQueue<Throwable> errors) {
+        return new StreamingHttpClientFilterFactory() {
+            @Override
+            public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
+                return new StreamingHttpClientFilter(client) {
+                    @Override
+                    protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
+                                                                    final HttpExecutionStrategy strategy,
+                                                                    final StreamingHttpRequest request) {
+                        return super.request(delegate, strategy, request)
+                                .map(response -> {
+                                    assertGrpcStatusInHeaders(response, errors);
+                                    return response;
+                                });
+                    }
+                };
+            }
+        };
+    }
+
+    private static void assertGrpcStatusInHeaders(final HttpResponseMetaData metaData,
+                                                  final BlockingQueue<Throwable> errors) {
+        try {
+            assertThat("GRPC_STATUS not present in headers.", metaData.headers().get(GRPC_STATUS_HEADER),
+                    notNullValue());
+        } catch (Throwable t) {
+            errors.add(t);
+        }
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpPayloadHolder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpPayloadHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,8 +135,9 @@ final class StreamingHttpPayloadHolder implements PayloadInfo {
 
     <T> void transform(final TrailersTransformer<T, Buffer> trailersTransformer) {
         if (messageBody == null) {
-            messageBody = from(trailersTransformer.payloadComplete(trailersTransformer.newState(),
-                    headersFactory.newEmptyTrailers()));
+            messageBody = defer(() ->
+                from(trailersTransformer.payloadComplete(trailersTransformer.newState(),
+                        headersFactory.newEmptyTrailers())));
         } else {
             payloadInfo.setEmpty(false);    // transformer may add payload content
             messageBody = messageBody.scanWith(() -> new ScanWithMapper<Object, Object>() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpPayloadHolder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpPayloadHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,9 +135,8 @@ final class StreamingHttpPayloadHolder implements PayloadInfo {
 
     <T> void transform(final TrailersTransformer<T, Buffer> trailersTransformer) {
         if (messageBody == null) {
-            messageBody = defer(() ->
-                from(trailersTransformer.payloadComplete(trailersTransformer.newState(),
-                        headersFactory.newEmptyTrailers())));
+            messageBody = from(trailersTransformer.payloadComplete(trailersTransformer.newState(),
+                    headersFactory.newEmptyTrailers()));
         } else {
             payloadInfo.setEmpty(false);    // transformer may add payload content
             messageBody = messageBody.scanWith(() -> new ScanWithMapper<Object, Object>() {

--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -62,5 +62,6 @@ dependencies {
 
   testFixturesImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testFixturesImplementation project(":servicetalk-http-utils")
+  testFixturesImplementation project(":servicetalk-test-resources")
   testFixturesImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -87,12 +87,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -142,6 +139,7 @@ import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h2Default;
 import static io.servicetalk.http.netty.HttpTestExecutionStrategy.CACHED;
 import static io.servicetalk.http.netty.HttpTestExecutionStrategy.NO_OFFLOAD;
+import static io.servicetalk.test.resources.TestUtils.assertNoAsyncErrors;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.BuilderUtils.serverChannel;
 import static io.servicetalk.transport.netty.internal.NettyIoExecutors.createEventLoopGroup;
@@ -1119,7 +1117,7 @@ class H2PriorKnowledgeFeatureParityTest {
             HttpResponse response = client.request(client.post("/0")
                     .payloadBody(responseBody, textSerializer()));
             assertEquals(responseBody, response.payloadBody(textDeserializer()));
-            assertEmpty(errorQueue);
+            assertNoAsyncErrors(errorQueue);
         }
     }
 
@@ -1145,7 +1143,7 @@ class H2PriorKnowledgeFeatureParityTest {
             final String responseBody = "foo";
             HttpResponse response = client.request(client.post("/0").payloadBody(responseBody, textSerializer()));
             assertEquals(responseBody, response.payloadBody(textDeserializer()));
-            assertEmpty(errorQueue);
+            assertNoAsyncErrors(errorQueue);
         }
     }
 
@@ -1671,23 +1669,6 @@ class H2PriorKnowledgeFeatureParityTest {
                 });
             });
         });
-    }
-
-    private static void assertEmpty(Queue<Throwable> errorQueue) {
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (PrintStream ps = new PrintStream(baos, true, UTF_8.name())) {
-            Throwable t;
-            while ((t = errorQueue.poll()) != null) {
-                t.printStackTrace(ps);
-                ps.println(' ');
-            }
-            String data = new String(baos.toByteArray(), UTF_8);
-            if (!data.isEmpty()) {
-                throw new AssertionError(data);
-            }
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     private static <T> void assertAsyncContext(AsyncContextMap.Key<T> key, T expectedValue,

--- a/servicetalk-http-netty/src/testFixtures/java/io/servicetalk/http/netty/AsyncContextHttpFilterVerifier.java
+++ b/servicetalk-http-netty/src/testFixtures/java/io/servicetalk/http/netty/AsyncContextHttpFilterVerifier.java
@@ -33,9 +33,6 @@ import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
 import io.servicetalk.http.utils.BeforeFinallyHttpOperator;
 import io.servicetalk.transport.api.ServerContext;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -46,9 +43,9 @@ import static io.servicetalk.http.api.HttpSerializationProviders.textDeserialize
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
 import static io.servicetalk.http.netty.HttpServers.forAddress;
+import static io.servicetalk.test.resources.TestUtils.assertNoAsyncErrors;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -92,7 +89,7 @@ public final class AsyncContextHttpFilterVerifier {
         final HttpResponse resp = client.request(request);
         assertThat(resp.status(), is(OK));
         assertThat(resp.payloadBody(textDeserializer()), is(payload));
-        assertEmpty(errors);
+        assertNoAsyncErrors(errors);
     }
 
     private static StreamingHttpService asyncContextRequestHandler(final BlockingQueue<Throwable> errorQueue) {
@@ -154,23 +151,6 @@ public final class AsyncContextHttpFilterVerifier {
             AssertionError e = new AssertionError("unexpected value for " + key + ": " +
                     actualValue + ", expected: " + expectedValue);
             errorQueue.add(e);
-        }
-    }
-
-    private static void assertEmpty(Queue<Throwable> errorQueue) {
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (PrintStream ps = new PrintStream(baos, true, UTF_8.name())) {
-            Throwable t;
-            while ((t = errorQueue.poll()) != null) {
-                t.printStackTrace(ps);
-                ps.println();
-            }
-            String data = new String(baos.toByteArray(), 0, baos.size(), UTF_8);
-            if (!data.isEmpty()) {
-                throw new AssertionError(data);
-            }
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
         }
     }
 

--- a/servicetalk-test-resources/src/main/java/io/servicetalk/test/resources/TestUtils.java
+++ b/servicetalk-test-resources/src/main/java/io/servicetalk/test/resources/TestUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.test.resources;
+
+import java.util.Queue;
+
+/**
+ * Test utility methods / helpers.
+ */
+public final class TestUtils {
+
+    private TestUtils() {
+        // No instances
+    }
+
+    /**
+     * Helper method to check if a given {@link Queue} contains any errors,
+     * usually produced through async sources. For ALL {@link Throwable}s found in the queue,
+     * a suppressed error will be captured and surface through a single {@link AssertionError}.
+     * @param errors The queue of captured errors.
+     */
+    public static void assertNoAsyncErrors(final Queue<Throwable> errors) {
+        if (errors.isEmpty()) {
+            return;
+        }
+
+        final AssertionError error = new AssertionError("Async errors occurred. See suppressed!");
+        Throwable t;
+        while ((t = errors.poll()) != null) {
+            error.addSuppressed(t);
+        }
+
+        throw error;
+    }
+}


### PR DESCRIPTION
Motivation:
On some erroneous cases we can optimise the gRPC response to return TrailerOnly [1] when headers aren't written to the wire yet. 

Modifications:
gRPC router was altered to generate a TrailersOnly response when an error happens before headers are sent out.

Result:
An optimised response that contains only a single frame.

[1] https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md