### PR TITLE
Defer trailer transformer callbacks on null msg-body to subscription.

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpPayloadHolder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpPayloadHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,8 +135,9 @@ final class StreamingHttpPayloadHolder implements PayloadInfo {
 
     <T> void transform(final TrailersTransformer<T, Buffer> trailersTransformer) {
         if (messageBody == null) {
-            messageBody = from(trailersTransformer.payloadComplete(trailersTransformer.newState(),
-                    headersFactory.newEmptyTrailers()));
+            messageBody = defer(() ->
+                from(trailersTransformer.payloadComplete(trailersTransformer.newState(),
+                        headersFactory.newEmptyTrailers())).subscribeShareContext());
         } else {
             payloadInfo.setEmpty(false);    // transformer may add payload content
             messageBody = messageBody.scanWith(() -> new ScanWithMapper<Object, Object>() {

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/StreamingHttpPayloadHolderTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/StreamingHttpPayloadHolderTest.java
@@ -68,7 +68,8 @@ public class StreamingHttpPayloadHolderTest {
         SetWithSerializer,
         Transform,
         TransformWithTrailer,
-        TransformWithSerializer
+        TransformWithSerializer,
+        TransformWithErrorInTrailer
     }
 
     private enum SourceType {
@@ -133,6 +134,7 @@ public class StreamingHttpPayloadHolderTest {
             case Transform:
             case TransformWithTrailer:
             case TransformWithSerializer:
+            case TransformWithErrorInTrailer:
                 transformFunctions.setupFor(updateMode, payloadHolder, sourceTypeTrailers);
                 if (doubleTransform) {
                     secondTransformFunctions.setupFor(updateMode, payloadHolder, sourceTypeTrailers);
@@ -219,7 +221,10 @@ public class StreamingHttpPayloadHolderTest {
                 (updateMode == UpdateMode.Set || updateMode == UpdateMode.SetWithSerializer)) {
             payloadSource.onComplete(); // Original source should complete for us to emit trailers
         }
-        getPayloadSource().onComplete();
+        if (updateMode != UpdateMode.TransformWithErrorInTrailer) {
+            getPayloadSource().onComplete();
+        }
+
         verifyTrailersReceived();
     }
 
@@ -315,7 +320,10 @@ public class StreamingHttpPayloadHolderTest {
         if (sourceType == SourceType.Trailers) {
             assert payloadSource != null;
             payloadSource.onNext(mock(HttpHeaders.class));
-            payloadSource.onComplete();
+            if (updateMode != UpdateMode.TransformWithErrorInTrailer) {
+                // If trailers with error, the publisher is already terminated by the error
+                payloadSource.onComplete();
+            }
             tryCompletePayloadSource();
         } else {
             if (payloadSource != null) {
@@ -336,11 +344,15 @@ public class StreamingHttpPayloadHolderTest {
     }
 
     private void verifyTrailersReceived() {
-        List<Object> items = payloadAndTrailersSubscriber.takeOnNext(1);
-        assertThat("Unexpected trailer", items, hasSize(1));
-        assertThat("Unexpected trailer", items.get(0), is(instanceOf(HttpHeaders.class)));
-        payloadAndTrailersSubscriber.awaitOnComplete();
-        if (updateMode == UpdateMode.TransformWithTrailer) {
+        if (updateMode == UpdateMode.TransformWithErrorInTrailer) {
+            payloadAndTrailersSubscriber.awaitOnError();
+        } else {
+            List<Object> items = payloadAndTrailersSubscriber.takeOnNext(1);
+            assertThat("Unexpected trailer", items, hasSize(1));
+            assertThat("Unexpected trailer", items.get(0), is(instanceOf(HttpHeaders.class)));
+            payloadAndTrailersSubscriber.awaitOnComplete();
+        }
+        if (updateMode == UpdateMode.TransformWithTrailer || updateMode == UpdateMode.TransformWithErrorInTrailer) {
             verify(transformFunctions.trailerTransformer).payloadComplete(any(), any());
         }
     }
@@ -349,14 +361,18 @@ public class StreamingHttpPayloadHolderTest {
         if (canControlPayload()) {
             getPayloadSource().onComplete();
         }
-        if (updateMode == UpdateMode.TransformWithTrailer) {
+        if (updateMode == UpdateMode.TransformWithTrailer || updateMode == UpdateMode.TransformWithErrorInTrailer) {
             subscriber.awaitSubscription().request(1);
         }
         if (payloadSource != null && (updateMode == UpdateMode.Set || updateMode == UpdateMode.SetWithSerializer)) {
             // A set operation was done with a prior Publisher, we need to complete the prior Publisher.
             payloadSource.onComplete();
         }
-        subscriber.awaitOnComplete();
+        if (updateMode == UpdateMode.TransformWithErrorInTrailer) {
+            subscriber.awaitOnError();
+        } else {
+            subscriber.awaitOnComplete();
+        }
     }
 
     private TestPublisher<Object> getPayloadSource() {
@@ -438,6 +454,12 @@ public class StreamingHttpPayloadHolderTest {
                     assertThat(payloadHolder.mayHaveTrailers(), is(true));
                     assertThat(payloadHolder.isGenericTypeBuffer(), is(false));
                     break;
+                case TransformWithErrorInTrailer:
+                    when(trailerTransformer.payloadComplete(any(), any())).thenThrow(DELIBERATE_EXCEPTION);
+                    payloadHolder.transform(trailerTransformer);
+                    assertThat(payloadHolder.mayHaveTrailers(), is(true));
+                    assertThat(payloadHolder.isGenericTypeBuffer(), is(false));
+                    break;
                 case TransformWithSerializer:
                     payloadHolder.transformPayloadBody(stringTransformer, textSerializer());
                     assertThat(payloadHolder.isGenericTypeBuffer(), is(not(sourceTypeTrailers)));
@@ -455,6 +477,7 @@ public class StreamingHttpPayloadHolderTest {
                     verify(transformer).apply(any());
                     break;
                 case TransformWithTrailer:
+                case TransformWithErrorInTrailer:
                     verify(trailerTransformer).newState();
                     if (canControlPayload) {
                         verify(trailerTransformer).accept(any(), any());


### PR DESCRIPTION
Motivation:

When we have a null msg-body and call transform, then the callbacks of the trailer
transformer are invoked on the calling thread rather than the subsciption.

Modifications:

Used defer to defer the invocation.

Result:

Better error handling in case of erroneous trailer transformer (ie. trailers validations)
and deferred execution of the callbacks.

Fix: https://github.com/apple/servicetalk/issues/1576