### PR TITLE
Deprecate `append` method on all filter factories

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionFactoryFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,9 +48,12 @@ public interface ConnectionFactoryFilter<ResolvedAddress, C extends ListenableAs
      * <pre>
      *     filter1 =&gt; filter2 =&gt; filter3 =&gt; original connection factory
      * </pre>
+     *
+     * @deprecated Use {@code appendConnectionFactoryFilter(ConnectionFactoryFilter)} at the builder of a client
      * @param before the function to apply before this function is applied
      * @return a composed function that first applies the {@code before} function and then applies this function.
      */
+    @Deprecated
     default ConnectionFactoryFilter<ResolvedAddress, C> append(ConnectionFactoryFilter<ResolvedAddress, C> before) {
         requireNonNull(before);
         return original -> create(before.create(original));

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -253,8 +253,14 @@ public final class DefaultDnsServiceDiscovererBuilder {
      */
     DefaultDnsServiceDiscovererBuilder appendFilter(final DnsClientFilterFactory factory) {
         requireNonNull(factory);
-        filterFactory = filterFactory == null ? factory : dnsClient -> filterFactory.create(factory.create(dnsClient));
+        filterFactory = appendFilter(filterFactory, factory);
         return this;
+    }
+
+    // Use another method to keep final references and avoid StackOverflowError
+    private static DnsClientFilterFactory appendFilter(@Nullable final DnsClientFilterFactory current,
+                                                       final DnsClientFilterFactory next) {
+        return current == null ? next : dnsClient -> current.create(next.create(dnsClient));
     }
 
     /**

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -252,7 +252,8 @@ public final class DefaultDnsServiceDiscovererBuilder {
      * @return {@code this}
      */
     DefaultDnsServiceDiscovererBuilder appendFilter(final DnsClientFilterFactory factory) {
-        filterFactory = filterFactory == null ? requireNonNull(factory) : filterFactory.append(factory);
+        requireNonNull(factory);
+        filterFactory = filterFactory == null ? factory : dnsClient -> filterFactory.create(factory.create(dnsClient));
         return this;
     }
 

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsClientFilterFactory.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsClientFilterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  */
 package io.servicetalk.dns.discovery.netty;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * Factory to apply a {@link DnsClientFilter}s.
  */
@@ -29,27 +27,4 @@ interface DnsClientFilterFactory {
      * @return {@link DnsClientFilter} using the provided {@link DnsClient}.
      */
     DnsClientFilter create(DnsClient dnsClient);
-
-    /**
-     * Returns a composed function that first applies the {@code before} function to its input, and then applies
-     * this function to the result.
-     * <p>
-     * The order of execution of these filters are in order of append. If 3 filters are added as follows:
-     * <pre>
-     *     filter1.append(filter2).append(filter3)
-     * </pre>
-     * making a request to a service discoverer wrapped by this filter chain the order of invocation of these filters
-     * will be:
-     * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; service discoverer
-     * </pre>
-     *
-     * @param before the function to apply before this function is applied
-     * @return a composed function that first applies the {@code before}
-     * function and then applies this function
-     */
-    default DnsClientFilterFactory append(DnsClientFilterFactory before) {
-        requireNonNull(before);
-        return serviceDiscoverer -> create(before.create(serviceDiscoverer));
-    }
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceFactory.java
@@ -100,10 +100,11 @@ public abstract class GrpcServiceFactory<Filter extends Service, Service extends
      * @return {@code this}
      */
     public GrpcServiceFactory<Filter, Service, FilterFactory> appendServiceFilter(FilterFactory before) {
+        requireNonNull(before);
         if (filterFactory == null) {
-            filterFactory = requireNonNull(before);
+            filterFactory = before;
         } else {
-            this.filterFactory = appendServiceFilterFactory(filterFactory, requireNonNull(before));
+            this.filterFactory = appendServiceFilterFactory(filterFactory, before);
         }
         return this;
     }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ public abstract class GrpcServiceFactory<Filter extends Service, Service extends
      */
     public GrpcServiceFactory<Filter, Service, FilterFactory> appendServiceFilter(FilterFactory before) {
         if (filterFactory == null) {
-            filterFactory = before;
+            filterFactory = requireNonNull(before);
         } else {
             this.filterFactory = appendServiceFilterFactory(filterFactory, requireNonNull(before));
         }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceFilterFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceFilterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,9 +47,11 @@ public interface GrpcServiceFilterFactory<Filter extends Service, Service> {
      *     filter1 =&gt; filter2 =&gt; filter3 =&gt; service
      * </pre>
      *
+     * @deprecated Use {@link GrpcServiceFactory#appendServiceFilter(GrpcServiceFilterFactory)}
      * @param before the factory to apply before this factory is applied.
      * @return a composed factory that first applies the {@code before} factory and then applies this factory.
      */
+    @Deprecated
     default GrpcServiceFilterFactory<Filter, Service> append(
             GrpcServiceFilterFactory<Filter, Service> before) {
         requireNonNull(before);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpExecutionStrategyInfluencer.defaultStreamingInfluencer;
 import static io.servicetalk.http.api.StrategyInfluencerAwareConversions.toConditionalServiceFilterFactory;
 import static io.servicetalk.transport.api.ConnectionAcceptor.ACCEPT_ALL;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A builder for building HTTP Servers.
@@ -239,11 +240,8 @@ public abstract class HttpServerBuilder {
      * @return {@code this}
      */
     public final HttpServerBuilder appendServiceFilter(final StreamingHttpServiceFilterFactory factory) {
-        if (serviceFilter == null) {
-            serviceFilter = factory;
-        } else {
-            serviceFilter = serviceFilter.append(factory);
-        }
+        requireNonNull(factory);
+        serviceFilter = appendFilter(serviceFilter, factory);
         if (!influencerChainBuilder.appendIfInfluencer(factory)) {
             influencerChainBuilder.append(defaultStreamingInfluencer());
         }
@@ -451,11 +449,17 @@ public abstract class HttpServerBuilder {
         StreamingHttpServiceFilterFactory currServiceFilter = serviceFilter;
         if (!AsyncContext.isDisabled()) {
             StreamingHttpServiceFilterFactory asyncContextFilter = new AsyncContextAwareHttpServiceFilter();
-            currServiceFilter = currServiceFilter == null ?
-                    asyncContextFilter : asyncContextFilter.append(currServiceFilter);
+            currServiceFilter = currServiceFilter == null ? asyncContextFilter :
+                    appendFilter(asyncContextFilter, currServiceFilter);
         }
         StreamingHttpService filteredService = currServiceFilter != null ?
                 currServiceFilter.create(rawService) : rawService;
         return doListen(connectionAcceptor, filteredService, strategy, drainRequestPayloadBody);
+    }
+
+    private static StreamingHttpServiceFilterFactory appendFilter(
+            @Nullable final StreamingHttpServiceFilterFactory current,
+            final StreamingHttpServiceFilterFactory next) {
+        return current == null ? next : service -> current.create(next.create(service));
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientFilterFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientFilterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,9 +54,12 @@ public interface MultiAddressHttpClientFilterFactory<U> {
      * <pre>
      *     filter1 =&gt; filter2 =&gt; filter3 =&gt; client
      * </pre>
+     *
+     * @deprecated Use {@link MultiAddressHttpClientBuilder#appendClientFilter(MultiAddressHttpClientFilterFactory)}
      * @param before the function to apply before this function is applied
      * @return a composed function that first applies the {@code before} function and then applies this function
      */
+    @Deprecated
     default MultiAddressHttpClientFilterFactory<U> append(MultiAddressHttpClientFilterFactory<U> before) {
         requireNonNull(before);
         return (group, client) -> create(group, before.create(group, client));

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilterFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,10 +44,13 @@ public interface StreamingHttpClientFilterFactory {
      * <pre>
      *     filter1 =&gt; filter2 =&gt; filter3 =&gt; client
      * </pre>
+     *
+     * @deprecated Use {@link HttpClientBuilder#appendClientFilter(StreamingHttpClientFilterFactory)}
      * @param before the function to apply before this function is applied
      * @return a composed function that first applies the {@code before}
      * function and then applies this function
      */
+    @Deprecated
     default StreamingHttpClientFilterFactory append(StreamingHttpClientFilterFactory before) {
         requireNonNull(before);
         return client -> create(before.create(client));

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionFilterFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionFilterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,10 +44,13 @@ public interface StreamingHttpConnectionFilterFactory {
      * <pre>
      *     filter1 =&gt; filter2 =&gt; filter3 =&gt; connection
      * </pre>
+     *
+     * @deprecated Use {@link HttpClientBuilder#appendConnectionFilter(StreamingHttpConnectionFilterFactory)}
      * @param before the function to apply before this function is applied
      * @return a composed function that first applies the {@code before}
      * function and then applies this function
      */
+    @Deprecated
     default StreamingHttpConnectionFilterFactory append(StreamingHttpConnectionFilterFactory before) {
         requireNonNull(before);
         return connection -> create(before.create(connection));

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceFilterFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceFilterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,10 +43,13 @@ public interface StreamingHttpServiceFilterFactory {
      * <pre>
      *     filter1 =&gt; filter2 =&gt; filter3 =&gt; service
      * </pre>
+     *
+     * @deprecated Use {@link HttpServerBuilder#appendServiceFilter(StreamingHttpServiceFilterFactory)}
      * @param before the function to apply before this function is applied
      * @return a composed function that first applies the {@code before}
      * function and then applies this function
      */
+    @Deprecated
     default StreamingHttpServiceFilterFactory append(StreamingHttpServiceFilterFactory before) {
         requireNonNull(before);
         return service -> create(before.create(service));

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/ConditionalHttpClientFilterTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/ConditionalHttpClientFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.servicetalk.http.api.FilterFactoryUtils.appendClientFilterFactory;
 
 public class ConditionalHttpClientFilterTest extends AbstractConditionalHttpFilterTest {
 
@@ -64,7 +66,7 @@ public class ConditionalHttpClientFilterTest extends AbstractConditionalHttpFilt
 
     public static StreamingHttpClient newClient(AtomicBoolean closed) {
         return TestStreamingHttpClient.from(REQ_RES_FACTORY, testHttpExecutionContext(),
-                new TestCondFilterFactory(closed).append(REQ_FILTER));
+                appendClientFilterFactory(new TestCondFilterFactory(closed), REQ_FILTER));
     }
 
     @Override

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/ConditionalHttpConnectionFilterTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/ConditionalHttpConnectionFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import io.servicetalk.concurrent.api.Single;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static io.servicetalk.http.api.FilterFactoryUtils.appendConnectionFilterFactory;
 import static org.mockito.Mockito.mock;
 
 public class ConditionalHttpConnectionFilterTest extends AbstractConditionalHttpFilterTest {
@@ -65,9 +66,10 @@ public class ConditionalHttpConnectionFilterTest extends AbstractConditionalHttp
         }
     }
 
-    private StreamingHttpConnection newConnection(AtomicBoolean closed) {
+    private static StreamingHttpConnection newConnection(AtomicBoolean closed) {
         return TestStreamingHttpConnection.from(REQ_RES_FACTORY, testHttpExecutionContext(),
-                mock(HttpConnectionContext.class), new TestCondFilterFactory(closed).append(REQ_FILTER));
+                mock(HttpConnectionContext.class),
+                appendConnectionFilterFactory(new TestCondFilterFactory(closed), REQ_FILTER));
     }
 
     @Override

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpRequesterFilterTest.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpRequesterFilterTest.java
@@ -42,6 +42,8 @@ import static io.servicetalk.http.api.AbstractHttpRequesterFilterTest.RequesterT
 import static io.servicetalk.http.api.AbstractHttpRequesterFilterTest.RequesterType.ReservedConnection;
 import static io.servicetalk.http.api.AbstractHttpRequesterFilterTest.SecurityType.Insecure;
 import static io.servicetalk.http.api.AbstractHttpRequesterFilterTest.SecurityType.Secure;
+import static io.servicetalk.http.api.FilterFactoryUtils.appendClientFilterFactory;
+import static io.servicetalk.http.api.FilterFactoryUtils.appendConnectionFilterFactory;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -332,12 +334,13 @@ public abstract class AbstractHttpRequesterFilterTest {
             @Override
             public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
                                                             final StreamingHttpRequest request) {
-                return rwch.request(AbstractHttpRequesterFilterTest.REQ_RES_FACTORY, connectionContext(), request);
+                return rwch.request(REQ_RES_FACTORY, connectionContext(), request);
             }
         };
 
-        return TestStreamingHttpConnection.from(AbstractHttpRequesterFilterTest.REQ_RES_FACTORY, mockExecutionContext,
-                mockConnectionContext, filterFactory == null ? handlerFilter : filterFactory.append(handlerFilter));
+        return TestStreamingHttpConnection.from(REQ_RES_FACTORY, mockExecutionContext,
+                mockConnectionContext, filterFactory == null ? handlerFilter :
+                        appendConnectionFilterFactory(filterFactory, handlerFilter));
     }
 
     private <FF extends StreamingHttpClientFilterFactory & StreamingHttpConnectionFilterFactory> StreamingHttpClient
@@ -348,7 +351,7 @@ public abstract class AbstractHttpRequesterFilterTest {
                     protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                                     final HttpExecutionStrategy strategy,
                                                                     final StreamingHttpRequest request) {
-                        return rh.request(AbstractHttpRequesterFilterTest.REQ_RES_FACTORY, request);
+                        return rh.request(REQ_RES_FACTORY, request);
                     }
 
                     @Override
@@ -368,6 +371,7 @@ public abstract class AbstractHttpRequesterFilterTest {
                     }
                 };
 
-        return TestStreamingHttpClient.from(REQ_RES_FACTORY, mockExecutionContext, filterFactory.append(handlerFilter));
+        return TestStreamingHttpClient.from(REQ_RES_FACTORY, mockExecutionContext,
+                appendClientFilterFactory(filterFactory, handlerFilter));
     }
 }

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/ConditionalFilterFactory.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/ConditionalFilterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 package io.servicetalk.http.api;
 
 import java.util.function.Predicate;
+
+import static io.servicetalk.http.api.FilterFactoryUtils.appendClientFilterFactory;
+import static io.servicetalk.http.api.FilterFactoryUtils.appendConnectionFilterFactory;
 
 public final class ConditionalFilterFactory
         implements StreamingHttpConnectionFilterFactory, StreamingHttpClientFilterFactory {
@@ -39,8 +42,8 @@ public final class ConditionalFilterFactory
     }
 
     public FilterFactory append(FilterFactory append) {
-        StreamingHttpClientFilterFactory clientFactory = append((StreamingHttpClientFilterFactory) append);
-        StreamingHttpConnectionFilterFactory connectionFactory = append((StreamingHttpConnectionFilterFactory) append);
+        StreamingHttpClientFilterFactory clientFactory = appendClientFilterFactory(this, append);
+        StreamingHttpConnectionFilterFactory connectionFactory = appendConnectionFilterFactory(this, append);
         return new FilterFactory() {
             @Override
             public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/FilterFactoryUtils.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/FilterFactoryUtils.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Utilities for filter factories.
+ */
+public final class FilterFactoryUtils {
+
+    private FilterFactoryUtils() {
+        // No instances
+    }
+
+    /**
+     * Returns a composed function of two sequential
+     * {@link StreamingHttpClientFilterFactory client filter factories}.
+     * <p>
+     * The order of execution of these filters are in order of append. If 2 filters are appended as follows:
+     * <pre>
+     *     StreamingHttpClientFilterFactory result = appendClientFilterFactory(filter1, filter2);
+     * </pre>
+     * making a request to a client wrapped by this filter chain the order of invocation of these filters will
+     * be:
+     * <pre>
+     *     filter1 =&gt; filter2 =&gt; client
+     * </pre>
+     *
+     * @param first the factory for the first filter in execution chain
+     * @param second the factory for the second filter in execution chain
+     * @return a composed function of two sequential filters
+     */
+    public static StreamingHttpClientFilterFactory appendClientFilterFactory(
+            StreamingHttpClientFilterFactory first, StreamingHttpClientFilterFactory second) {
+        requireNonNull(first);
+        requireNonNull(second);
+        return connection -> first.create(second.create(connection));
+    }
+
+    /**
+     * Returns a composed function of two sequential
+     * {@link StreamingHttpConnectionFilterFactory connection filter factories}.
+     * <p>
+     * The order of execution of these filters are in order of append. If 2 filters are appended as follows:
+     * <pre>
+     *     StreamingHttpConnectionFilterFactory result = appendConnectionFilterFactory(filter1, filter2);
+     * </pre>
+     * making a request to a connection wrapped by this filter chain the order of invocation of these filters will
+     * be:
+     * <pre>
+     *     filter1 =&gt; filter2 =&gt; connection
+     * </pre>
+     *
+     * @param first the factory for the first filter in execution chain
+     * @param second the factory for the second filter in execution chain
+     * @return a composed function of two sequential filters
+     */
+    public static StreamingHttpConnectionFilterFactory appendConnectionFilterFactory(
+            StreamingHttpConnectionFilterFactory first, StreamingHttpConnectionFilterFactory second) {
+        requireNonNull(first);
+        requireNonNull(second);
+        return connection -> first.create(second.create(connection));
+    }
+
+    /**
+     * Returns a composed function of two sequential
+     * {@link StreamingHttpServiceFilterFactory service filter factories}.
+     * <p>
+     * The order of execution of these filters are in order of append. If 2 filters are appended as follows:
+     * <pre>
+     *     StreamingHttpServiceFilterFactory result = appendServiceFilterFactory(filter1, filter2);
+     * </pre>
+     * making a request to a client wrapped by this filter chain the order of invocation of these filters will
+     * be:
+     * <pre>
+     *     filter1 =&gt; filter2 =&gt; client
+     * </pre>
+     *
+     * @param first the factory for the first filter in execution chain
+     * @param second the factory for the second filter in execution chain
+     * @return a composed function of two sequential filters
+     */
+    public static StreamingHttpServiceFilterFactory appendServiceFilterFactory(
+            StreamingHttpServiceFilterFactory first, StreamingHttpServiceFilterFactory second) {
+        requireNonNull(first);
+        requireNonNull(second);
+        return connection -> first.create(second.create(connection));
+    }
+}

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/FilterFactoryUtils.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/FilterFactoryUtils.java
@@ -37,7 +37,7 @@ public final class FilterFactoryUtils {
      * making a request to a client wrapped by this filter chain the order of invocation of these filters will
      * be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; client
+     *     filter1 ⇒ filter2 ⇒ client
      * </pre>
      *
      * @param first the factory for the first filter in execution chain
@@ -48,7 +48,7 @@ public final class FilterFactoryUtils {
             StreamingHttpClientFilterFactory first, StreamingHttpClientFilterFactory second) {
         requireNonNull(first);
         requireNonNull(second);
-        return connection -> first.create(second.create(connection));
+        return client -> first.create(second.create(client));
     }
 
     /**
@@ -62,7 +62,7 @@ public final class FilterFactoryUtils {
      * making a request to a connection wrapped by this filter chain the order of invocation of these filters will
      * be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; connection
+     *     filter1 ⇒ filter2 ⇒ connection
      * </pre>
      *
      * @param first the factory for the first filter in execution chain
@@ -84,10 +84,10 @@ public final class FilterFactoryUtils {
      * <pre>
      *     StreamingHttpServiceFilterFactory result = appendServiceFilterFactory(filter1, filter2);
      * </pre>
-     * making a request to a client wrapped by this filter chain the order of invocation of these filters will
+     * accepting a request by a service wrapped by this filter chain, the order of invocation of these filters will be:
      * be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; client
+     *     filter1 ⇒ filter2 ⇒ service
      * </pre>
      *
      * @param first the factory for the first filter in execution chain
@@ -98,6 +98,6 @@ public final class FilterFactoryUtils {
             StreamingHttpServiceFilterFactory first, StreamingHttpServiceFilterFactory second) {
         requireNonNull(first);
         requireNonNull(second);
-        return connection -> first.create(second.create(connection));
+        return service -> first.create(second.create(service));
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -460,10 +460,16 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
     public DefaultSingleAddressHttpClientBuilder<U, R> appendConnectionFilter(
             final StreamingHttpConnectionFilterFactory factory) {
         requireNonNull(factory);
-        connectionFilterFactory = connectionFilterFactory == null ? factory :
-                connection -> connectionFilterFactory.create(factory.create(connection));
+        connectionFilterFactory = appendConnectionFilter(connectionFilterFactory, factory);
         influencerChainBuilder.add(factory);
         return this;
+    }
+
+    // Use another method to keep final references and avoid StackOverflowError
+    private static StreamingHttpConnectionFilterFactory appendConnectionFilter(
+            @Nullable final StreamingHttpConnectionFilterFactory current,
+            final StreamingHttpConnectionFilterFactory next) {
+        return current == null ? next : connection -> current.create(next.create(connection));
     }
 
     @Override
@@ -476,9 +482,9 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
     }
 
     private static <R> ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> appendConnectionFactoryFilter(
-            final ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> first,
-            final ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> second) {
-        return connection -> first.create(second.create(connection));
+            final ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> current,
+            final ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> next) {
+        return connection -> current.create(next.create(connection));
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BasicAuthHttpServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BasicAuthHttpServiceFilterTest.java
@@ -29,7 +29,9 @@ import io.servicetalk.http.utils.auth.BasicAuthHttpServiceFilter.CredentialsVeri
 
 import org.junit.jupiter.api.Test;
 
+import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.api.FilterFactoryUtils.appendServiceFilterFactory;
 import static io.servicetalk.http.api.HttpHeaderNames.AUTHORIZATION;
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
@@ -55,7 +57,7 @@ public class BasicAuthHttpServiceFilterTest {
 
     @Test
     public void verifyAsyncContext() throws Exception {
-        verifyServerFilterAsyncContextVisibility(
+        verifyServerFilterAsyncContextVisibility(appendServiceFilterFactory(
                 new StreamingHttpServiceFilterFactory() {
                     @Override
                     public StreamingHttpServiceFilter create(final StreamingHttpService service) {
@@ -69,17 +71,18 @@ public class BasicAuthHttpServiceFilterTest {
                             }
                         };
                     }
-                }.append(new BasicAuthHttpServiceFilter.Builder<>(new CredentialsVerifier<Object>() {
-                            @Override
-                            public Completable closeAsync() {
-                                return Completable.completed();
-                            }
+                },
+                new BasicAuthHttpServiceFilter.Builder<>(new CredentialsVerifier<Object>() {
+                    @Override
+                    public Completable closeAsync() {
+                        return completed();
+                    }
 
-                            @Override
-                            public Single<Object> apply(final String userId, final String password) {
-                                return succeeded(new BasicUserInfo(userId));
-                            }
-                        }, REALM_VALUE).buildServer()));
+                    @Override
+                    public Single<Object> apply(final String userId, final String password) {
+                        return succeeded(new BasicUserInfo(userId));
+                    }
+                }, REALM_VALUE).buildServer()));
     }
 
     private static String userPassBase64() {

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.api.FilterFactoryUtils.appendClientFilterFactory;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.HttpHeaderNames.LOCATION;
@@ -131,7 +132,8 @@ public class RedirectingHttpRequesterFilterTest {
                     }
                 };
 
-        return from(reqRespFactory, mock(HttpExecutionContext.class), customFilter.append(mockResponse));
+        return from(reqRespFactory, mock(HttpExecutionContext.class),
+                appendClientFilterFactory(customFilter, mockResponse));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

All `*FilterFactory` interfaces currently implement default `append`
method that helps to chain filters in order of append. Because
internally it uses wrapping approach, it can hide
`HttpExecutionStrategyInfluencer` implementation of the passed filter
factory. To avoid that, users have to use a method on the client/server
builder instead.

Modifications:

- Deprecate `append` method on all filter factories;
- Add `FilterFactoryUtils` test fixture as the replacement utility for
tests;

Result:

Users won't hide `HttpExecutionStrategyInfluencer` impl when they chain
filters.