### PR TITLE
Force a check for updated snapshots on remote repositories for japicmp

### DIFF
--- a/scripts/japicmp.sh
+++ b/scripts/japicmp.sh
@@ -46,9 +46,9 @@ ARTIFACTS="$(ls -d -- */ | grep '^servicetalk-' | sed 's/.$//' | \
 
 for ARTIFACT_ID in $ARTIFACTS
 do
-  mvn -N dependency:get -DgroupId=$GROUP_ID -DartifactId=$ARTIFACT_ID -Dversion=$OLD_ST_VERSION \
+  mvn -N -U dependency:get -DgroupId=$GROUP_ID -DartifactId=$ARTIFACT_ID -Dversion=$OLD_ST_VERSION \
       -Dtransitive=false >/dev/null
-  mvn -N dependency:get -DgroupId=$GROUP_ID -DartifactId=$ARTIFACT_ID -Dversion=$NEW_ST_VERSION \
+  mvn -N -U dependency:get -DgroupId=$GROUP_ID -DartifactId=$ARTIFACT_ID -Dversion=$NEW_ST_VERSION \
       -Dtransitive=false >/dev/null
   java -jar "$JAR_FILE" -b --ignore-missing-classes \
       --old $BASEPATH/$ARTIFACT_ID/$OLD_ST_VERSION/$ARTIFACT_ID-$OLD_ST_VERSION.jar \


### PR DESCRIPTION
Motivation:

If we check API compatibility with a snapshot, always force maven to
check for updated snapshots on remote repositories.