### PR TITLE
assertNoAsyncErrors more queue types and msg arg

### DIFF
--- a/servicetalk-test-resources/src/main/java/io/servicetalk/test/resources/TestUtils.java
+++ b/servicetalk-test-resources/src/main/java/io/servicetalk/test/resources/TestUtils.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.test.resources;
 
+import java.util.Objects;
 import java.util.Queue;
 
 /**
@@ -32,12 +33,23 @@ public final class TestUtils {
      * a suppressed error will be captured and surface through a single {@link AssertionError}.
      * @param errors The queue of captured errors.
      */
-    public static void assertNoAsyncErrors(final Queue<Throwable> errors) {
+    public static void assertNoAsyncErrors(final Queue<? extends Throwable> errors) {
+        assertNoAsyncErrors("Async errors occurred. See suppressed!", errors);
+    }
+
+    /**
+     * Helper method to check if a given {@link Queue} contains any errors,
+     * usually produced through async sources. For ALL {@link Throwable}s found in the queue,
+     * a suppressed error will be captured and surface through a single {@link AssertionError}.
+     * @param message message for the AssertionError.
+     * @param errors The queue of captured errors.
+     */
+    public static void assertNoAsyncErrors(final String message, final Queue<? extends Throwable> errors) {
         if (errors.isEmpty()) {
             return;
         }
 
-        final AssertionError error = new AssertionError("Async errors occurred. See suppressed!");
+        final AssertionError error = new AssertionError(Objects.requireNonNull(message, "message"));
         Throwable t;
         while ((t = errors.poll()) != null) {
             error.addSuppressed(t);

--- a/servicetalk-test-resources/src/main/java/io/servicetalk/test/resources/TestUtils.java
+++ b/servicetalk-test-resources/src/main/java/io/servicetalk/test/resources/TestUtils.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.test.resources;
 
-import java.util.Objects;
 import java.util.Queue;
 
 /**
@@ -49,7 +48,7 @@ public final class TestUtils {
             return;
         }
 
-        final AssertionError error = new AssertionError(Objects.requireNonNull(message, "message"));
+        final AssertionError error = null != message ? new AssertionError(message) : new AssertionError();
         Throwable t;
         while ((t = errors.poll()) != null) {
             error.addSuppressed(t);


### PR DESCRIPTION
Motivation:
Converting some existing code to use `assertNoAsyncErrors` I found
cases where the error queue was `AssertionError` not `Throwable` and
some cases where the message was used to provide more specific info
about the source/context of the errors.
Modifications:
Add additional overload for message and allow wildcard for queue type.
Result:
More useful `assertNoAsyncErrors`.