### PR TITLE
`DefaultServiceDiscoveryRetryStrategy` may emit duplicated SD events

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategy.java
@@ -246,26 +246,22 @@ public final class DefaultServiceDiscoveryRetryStrategy<ResolvedAddress,
 
             // we have seen an error, replace cache with new addresses and deactivate the ones which are not present
             // in the new list.
-            for (E event : events) {
-                if (event.isAvailable()) {
-                    activeAddresses.put(event.address(), event);
-                } else {
-                    activeAddresses.remove(event.address());
-                }
-            }
-
-            // Worst case size is a sum of activeAddresses and retainedAddresses
             List<E> toReturn = new ArrayList<>(activeAddresses.size() + retainedAddresses.size());
-            for (Map.Entry<R, E> entry : activeAddresses.entrySet()) {
-                if (retainedAddresses.remove(entry.getKey()) == null) {
-                    toReturn.add(entry.getValue()); // Add only those new addresses that were not retained before
+            for (E event : events) {
+                final R address = event.address();
+                if (event.isAvailable()) {
+                    activeAddresses.put(address, event);
+                    if (retainedAddresses.remove(address) == null) {
+                        toReturn.add(event);
+                    }
+                    // bitwise inclusive | intentional because removal from both collections is required
+                } else if (activeAddresses.remove(address) != null | retainedAddresses.remove(address) != null) {
+                    toReturn.add(event);
                 }
             }
 
-            if (!retainedAddresses.isEmpty()) {
-                for (E evt : retainedAddresses.values()) {
-                    toReturn.add(flipAvailability.apply(evt));
-                }
+            for (E event : retainedAddresses.values()) {
+                toReturn.add(flipAvailability.apply(event));
             }
 
             retainedAddresses = noneRetained();

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategy.java
@@ -254,8 +254,7 @@ public final class DefaultServiceDiscoveryRetryStrategy<ResolvedAddress,
                     if (retainedAddresses.remove(address) == null) {
                         toReturn.add(event);
                     }
-                    // bitwise inclusive | intentional because removal from both collections is required
-                } else if (activeAddresses.remove(address) != null | retainedAddresses.remove(address) != null) {
+                } else if (activeAddresses.remove(address) != null || retainedAddresses.remove(address) != null) {
                     toReturn.add(event);
                 }
             }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
@@ -202,6 +202,7 @@ abstract class HttpClientBuilder<U, R, SDE extends ServiceDiscovererEvent<R>> ex
      *
      * @param retryStrategy a retry strategy to retry errors emitted by {@link ServiceDiscoverer}.
      * @return {@code this}.
+     * @see DefaultServiceDiscoveryRetryStrategy.Builder
      */
     public abstract HttpClientBuilder<U, R, SDE> retryServiceDiscoveryErrors(
             ServiceDiscoveryRetryStrategy<R, SDE> retryStrategy);

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategyTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategyTest.java
@@ -25,12 +25,10 @@ import io.servicetalk.http.api.DefaultServiceDiscoveryRetryStrategy.Builder;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.params.provider.Arguments;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.stream.Stream;
 
 import static io.servicetalk.concurrent.api.ExecutorExtension.withTestExecutor;
 import static io.servicetalk.concurrent.api.Publisher.defer;
@@ -55,14 +53,6 @@ class DefaultServiceDiscoveryRetryStrategyTest {
     @RegisterExtension
     final ExecutorExtension<TestExecutor> executorExtension = withTestExecutor();
 
-    private static Stream<Arguments> booleanMatrix() {
-        return Stream.of(
-                Arguments.of(false, false),
-                Arguments.of(false, true),
-                Arguments.of(true, false),
-                Arguments.of(true, true));
-    }
-
     @Test
     void errorWithNoAddresses() throws Exception {
         State state = new State(true);
@@ -77,7 +67,7 @@ class DefaultServiceDiscoveryRetryStrategyTest {
         State state = new State(true);
         TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents = state.pubs.take();
 
-        final ServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive(state, "addr1", sdEvents);
+        final DefaultServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive(state, "addr1", sdEvents);
 
         sdEvents = triggerRetry(state, sdEvents);
 
@@ -95,15 +85,15 @@ class DefaultServiceDiscoveryRetryStrategyTest {
         State state = new State(true);
         TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents = state.pubs.take();
 
-        final ServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive(state, "addr1", sdEvents);
-        final ServiceDiscovererEvent<String> evt2 = sendUpAndVerifyReceive(state, "addr2", sdEvents);
-        final ServiceDiscovererEvent<String> evt3 = sendUpAndVerifyReceive(state, "addr3", sdEvents);
+        final DefaultServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive(state, "addr1", sdEvents);
+        final DefaultServiceDiscovererEvent<String> evt2 = sendUpAndVerifyReceive(state, "addr2", sdEvents);
+        final DefaultServiceDiscovererEvent<String> evt3 = sendUpAndVerifyReceive(state, "addr3", sdEvents);
 
         sdEvents = triggerRetry(state, sdEvents);
 
         verifyNoEventsReceived(state);
 
-        final ServiceDiscovererEvent<String> evt4 = new DefaultServiceDiscovererEvent<>("addr4", true);
+        final DefaultServiceDiscovererEvent<String> evt4 = new DefaultServiceDiscovererEvent<>("addr4", true);
         sdEvents.onNext(asList(evt2, evt4));
 
         final List<Collection<ServiceDiscovererEvent<String>>> items = state.subscriber.takeOnNext(1);
@@ -117,12 +107,12 @@ class DefaultServiceDiscoveryRetryStrategyTest {
         State state = new State(true);
         TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents = state.pubs.take();
         final String addr = "addr1";
-        final ServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive(state, addr, sdEvents);
+        final DefaultServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive(state, addr, sdEvents);
 
         sdEvents = triggerRetry(state, sdEvents);
         verifyNoEventsReceived(state);
 
-        final ServiceDiscovererEvent<String> evt1Un = new DefaultServiceDiscovererEvent<>(addr, false);
+        final DefaultServiceDiscovererEvent<String> evt1Un = new DefaultServiceDiscovererEvent<>(addr, false);
         sdEvents.onNext(asList(evt1, evt1Un, evt1));
         final List<Collection<ServiceDiscovererEvent<String>>> items = state.subscriber.takeOnNext(1);
         assertThat("Unexpected items received.", items, hasSize(1));
@@ -133,7 +123,7 @@ class DefaultServiceDiscoveryRetryStrategyTest {
     void addRemoveBeforeRetry() throws Exception {
         State state = new State(true);
         TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents = state.pubs.take();
-        final ServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive(state, "addr1", sdEvents);
+        final DefaultServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive(state, "addr1", sdEvents);
         sdEvents.onNext(singletonList(flipAvailable(evt1)));
         final List<Collection<ServiceDiscovererEvent<String>>> items = state.subscriber.takeOnNext(1);
         assertThat("Unexpected items received.", items, hasSize(1));
@@ -149,7 +139,7 @@ class DefaultServiceDiscoveryRetryStrategyTest {
     void removeAfterRetry() throws Exception {
         State state = new State(true);
         TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents = state.pubs.take();
-        final ServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive(state, "addr1", sdEvents);
+        final DefaultServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive(state, "addr1", sdEvents);
 
         sdEvents = triggerRetry(state, sdEvents);
         verifyNoEventsReceived(state);
@@ -165,8 +155,8 @@ class DefaultServiceDiscoveryRetryStrategyTest {
     void addAndRemovePostRetry() throws Exception {
         State state = new State(true);
         TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents = state.pubs.take();
-        final ServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive(state, "addr1", sdEvents);
-        final ServiceDiscovererEvent<String> evt2 = sendUpAndVerifyReceive(state, "addr2", sdEvents);
+        final DefaultServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive(state, "addr1", sdEvents);
+        final DefaultServiceDiscovererEvent<String> evt2 = sendUpAndVerifyReceive(state, "addr2", sdEvents);
 
         sdEvents = triggerRetry(state, sdEvents);
         verifyNoEventsReceived(state);
@@ -182,8 +172,8 @@ class DefaultServiceDiscoveryRetryStrategyTest {
     void noRetainActiveAddresses() throws Exception {
         State state = new State(false);
         TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents = state.pubs.take();
-        final ServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive(state, "addr1", sdEvents);
-        final ServiceDiscovererEvent<String> evt2 = sendUpAndVerifyReceive(state, "addr2", sdEvents);
+        final DefaultServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive(state, "addr1", sdEvents);
+        final DefaultServiceDiscovererEvent<String> evt2 = sendUpAndVerifyReceive(state, "addr2", sdEvents);
 
         triggerRetry(state, sdEvents);
         final List<Collection<ServiceDiscovererEvent<String>>> items = state.subscriber.takeOnNext(1);
@@ -207,8 +197,8 @@ class DefaultServiceDiscoveryRetryStrategyTest {
     void noRetainActiveAddressesTwoSequentialErrors() throws Exception {
         State state = new State(false);
         TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents = state.pubs.take();
-        final ServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive(state, "addr1", sdEvents);
-        final ServiceDiscovererEvent<String> evt2 = sendUpAndVerifyReceive(state, "addr2", sdEvents);
+        final DefaultServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive(state, "addr1", sdEvents);
+        final DefaultServiceDiscovererEvent<String> evt2 = sendUpAndVerifyReceive(state, "addr2", sdEvents);
 
         sdEvents = triggerRetry(state, sdEvents);
         final List<Collection<ServiceDiscovererEvent<String>>> items = state.subscriber.takeOnNext(1);
@@ -232,25 +222,19 @@ class DefaultServiceDiscoveryRetryStrategyTest {
         return state.pubs.take();
     }
 
-    private ServiceDiscovererEvent<String> sendUpAndVerifyReceive(
+    private DefaultServiceDiscovererEvent<String> sendUpAndVerifyReceive(
             final State state, final String addr,
             final TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents) {
         final DefaultServiceDiscovererEvent<String> evt = new DefaultServiceDiscovererEvent<>(addr, true);
         sdEvents.onNext(singletonList(evt));
-        return verifyReceive(state, addr, true);
-    }
-
-    private ServiceDiscovererEvent<String> verifyReceive(final State state, final String addr,
-                                                         final boolean available) {
         final Collection<ServiceDiscovererEvent<String>> received = state.subscriber.takeOnNext(1)
                 .stream()
                 .flatMap(Collection::stream)
                 .collect(toList());
         assertThat("Event not received.", received, hasSize(1));
-        final ServiceDiscovererEvent<String> receivedEvent = received.iterator().next();
-        assertThat("Unexpected event received.", receivedEvent.address(), is(addr));
-        assertThat("Unexpected event received.", receivedEvent.isAvailable(), is(available));
-        return receivedEvent;
+        assertThat("Unexpected event received.", received.iterator().next().address(), is(addr));
+        assertThat("Unexpected event received.", received.iterator().next().isAvailable(), is(true));
+        return evt;
     }
 
     private static ServiceDiscovererEvent<String> flipAvailable(final ServiceDiscovererEvent<String> evt) {

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategyTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategyTest.java
@@ -116,12 +116,13 @@ class DefaultServiceDiscoveryRetryStrategyTest {
     void sameAddressPostRetry() throws Exception {
         State state = new State(true);
         TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents = state.pubs.take();
-        final ServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive(state, "addr1", sdEvents);
+        final String addr = "addr1";
+        final ServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceive(state, addr, sdEvents);
 
         sdEvents = triggerRetry(state, sdEvents);
         verifyNoEventsReceived(state);
 
-        final ServiceDiscovererEvent<String> evt1Un = new DefaultServiceDiscovererEvent<>("addr1", false);
+        final ServiceDiscovererEvent<String> evt1Un = new DefaultServiceDiscovererEvent<>(addr, false);
         sdEvents.onNext(asList(evt1, evt1Un, evt1));
         final List<Collection<ServiceDiscovererEvent<String>>> items = state.subscriber.takeOnNext(1);
         assertThat("Unexpected items received.", items, hasSize(1));

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategyTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategyTest.java
@@ -25,9 +25,7 @@ import io.servicetalk.http.api.DefaultServiceDiscoveryRetryStrategy.Builder;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collection;
 import java.util.List;
@@ -203,22 +201,6 @@ class DefaultServiceDiscoveryRetryStrategyTest {
 
         triggerRetry(state, sdEvents);
         verifyNoEventsReceived(state);
-    }
-
-    @ParameterizedTest(name = "{displayName} [{index}]: retainAddressesTillSuccess={0}, available={1}")
-    @MethodSource("booleanMatrix")
-    void duplicatedAddresses(final boolean retainAddressesTillSuccess, final boolean available) throws Exception {
-        State state = new State(retainAddressesTillSuccess);
-        TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents = state.pubs.take();
-        final String addr = "addr1";
-        if (!available) {
-            // First, emit available event for the same address
-            sendUpAndVerifyReceive(state, addr, sdEvents);
-        }
-        final DefaultServiceDiscovererEvent<String> evt1 = new DefaultServiceDiscovererEvent<>(addr, available);
-        final DefaultServiceDiscovererEvent<String> evt2 = new DefaultServiceDiscovererEvent<>(addr, available);
-        sdEvents.onNext(asList(evt1, evt2));
-        verifyReceive(state, addr, available);
     }
 
     private void verifyNoEventsReceived(final State state) {

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategyTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultServiceDiscoveryRetryStrategyTest.java
@@ -47,7 +47,6 @@ import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -126,7 +125,7 @@ class DefaultServiceDiscoveryRetryStrategyTest {
         sdEvents.onNext(asList(evt1, evt1Un, evt1));
         final List<Collection<ServiceDiscovererEvent<String>>> items = state.subscriber.takeOnNext(1);
         assertThat("Unexpected items received.", items, hasSize(1));
-        assertThat("Unexpected event received", items.get(0), empty());
+        assertThat("Unexpected event received", items.get(0), contains(evt1Un, evt1));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

When `DefaultServiceDiscoveryRetryStrategy` retains addresses till
success and recovers from the previous SD error, it doesn't check which
of new addresses were previously retained. As the result, it may
propagate duplicated "available" events to `RoundRobinLoadBalancer`.
RRLB does not support duplicated entries. It may lead to retaining
duplicated addresses after they become unavailable, causing failures
of requests.

Modifications:

- Filter out previously retained events when we recover from SD-error;
- Do not return duplicated `unavailable` events on subsequent SD-errors;
- Enhance tests to catch these use-cases;

Result:

`DefaultServiceDiscoveryRetryStrategyTest` does not emit duplicated SD
events for the same availability state => RRLB does not retain duplicated
entries.