### PR TITLE
Allow JUnit 5 tests to execute concurrently

### DIFF
--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletionStageTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletionStageTest.java
@@ -1038,7 +1038,8 @@ class SingleToCompletionStageTest {
     }
 
     private static void verifyInJUnitThread() {
-        if (!currentThread().getName().startsWith(JUNIT_THREAD_PREFIX)) {
+        if (!currentThread().getName().startsWith(JUNIT_THREAD_PREFIX) &&
+                !currentThread().getName().startsWith(JDK_FORK_JOIN_THREAD_NAME_PREFIX)) {
             throw new AssertionError("unexpected thread: " + currentThread());
         }
     }
@@ -1052,8 +1053,9 @@ class SingleToCompletionStageTest {
 
     private static void verifyInStOrJUnitThread() {
         if (!currentThread().getName().startsWith(ST_THREAD_PREFIX_NAME) &&
-                !currentThread().getName().startsWith(JUNIT_THREAD_PREFIX)) {
-            throw new IllegalStateException("unexpected thread: " + currentThread());
+                !currentThread().getName().startsWith(JUNIT_THREAD_PREFIX) &&
+                !currentThread().getName().startsWith(JDK_FORK_JOIN_THREAD_NAME_PREFIX)) {
+            throw new AssertionError("unexpected thread: " + currentThread());
         }
     }
 

--- a/servicetalk-test-resources/src/main/resources/junit-platform.properties
+++ b/servicetalk-test-resources/src/main/resources/junit-platform.properties
@@ -1,0 +1,8 @@
+#
+# See https://junit.org/junit5/docs/snapshot/user-guide/index.html#writing-tests-parallel-execution
+#
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = same_thread
+junit.jupiter.execution.parallel.mode.classes.default = same_thread
+junit.jupiter.execution.parallel.config.strategy = dynamic
+junit.jupiter.execution.parallel.config.dynamic.factor = 1.5

--- a/servicetalk-test-resources/src/main/resources/junit-platform.properties
+++ b/servicetalk-test-resources/src/main/resources/junit-platform.properties
@@ -5,4 +5,4 @@ junit.jupiter.execution.parallel.enabled = true
 junit.jupiter.execution.parallel.mode.default = same_thread
 junit.jupiter.execution.parallel.mode.classes.default = same_thread
 junit.jupiter.execution.parallel.config.strategy = dynamic
-junit.jupiter.execution.parallel.config.dynamic.factor = 1.5
+junit.jupiter.execution.parallel.config.dynamic.factor = 1.0


### PR DESCRIPTION
Motivation:
The JUnit5 tests are currently all run serially which is slower than
would generally be possible on most configurations.
Modifications:
Add junit-platform execution parameters for allowing tests to run
concurrently if suitably configured to improve test execution
performance.
Result:
Tests are annotated with `@Execution(CONCURRENT)` will execute
concurrently. There are no changes for existing un-annotated
tests which not explicitly opt-in to parallel execution.