### PR TITLE
`DefaultDnsServiceDiscovererBuilder#maxUdpPayloadSize` validation msg fix

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -111,7 +111,7 @@ public final class DefaultDnsServiceDiscovererBuilder {
      */
     public DefaultDnsServiceDiscovererBuilder maxUdpPayloadSize(final int maxUdpPayloadSize) {
         if (maxUdpPayloadSize <= 0) {
-            throw new IllegalArgumentException("maxUdpPayloadSize: " + minTTLSeconds + " (expected > 0)");
+            throw new IllegalArgumentException("maxUdpPayloadSize: " + maxUdpPayloadSize + " (expected > 0)");
         }
         this.maxUdpPayloadSize = maxUdpPayloadSize;
         return this;


### PR DESCRIPTION
Motivation:

`DefaultDnsServiceDiscovererBuilder#maxUdpPayloadSize` throws an
`IllegalArgumentException` with incorrect value in the message.

Modifications:

- Use `maxUdpPayloadSize` instead of `minTTLSeconds`;

Result:

Correct value in `IllegalArgumentException` msg for `maxUdpPayloadSize`
validation.