### PR TITLE
Execute Gradle tasks in parallel

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+
+org.gradle.parallel=true
+
 group=io.servicetalk
 version=0.41.0-SNAPSHOT
 


### PR DESCRIPTION
Motivation:
The current Gradle build makes use of some parallelism for execution of tasks, but less than optimal. Builds would complete more quickly with full parallelism enabled.
Modifications:
Adds parallel configuration to Gradle settings. Some of the existing GitHub Actions already manually configure the parallel option so this change has already been in effect for some builds--this change just makes fully parallel builds the default.
Result:
On average, faster Gradle builds due to increased parallelism.