### PR TITLE
Migrate servicetalk-buffer-api tests to JUnit 5 (#1568)

### DIFF
--- a/servicetalk-buffer-api/build.gradle
+++ b/servicetalk-buffer-api/build.gradle
@@ -21,10 +21,11 @@ dependencies {
 
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
 
-  testImplementation "junit:junit:$junitVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testFixturesImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/AsciiBufferTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/AsciiBufferTest.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.buffer.api;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -26,13 +26,13 @@ import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.DEFAULT_RO_ALLOCATOR;
 import static java.lang.Character.toLowerCase;
 import static java.lang.Character.toUpperCase;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class AsciiBufferTest {
+class AsciiBufferTest {
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         for (int i = 0; i < 1000; ++i) {
             StringBuilder sb = new StringBuilder(i);
             for (int x = 0; x < i; ++x) {
@@ -61,38 +61,38 @@ public class AsciiBufferTest {
         CharSequence buffer2FlipCase = newAsciiString(DEFAULT_RO_ALLOCATOR.fromAscii(flipCase));
         verifyDifferentAsciiStringTypes(flipCase, bufferFlipCase, buffer2FlipCase);
         if (flipCase.equals(s)) {
-            assertEquals("failure for " + s + " and " + flipCase, buffer, bufferFlipCase);
-            assertEquals("failure for " + s + " and " + flipCase, buffer2, buffer2FlipCase);
+            assertEquals(buffer, bufferFlipCase, "failure for " + s + " and " + flipCase);
+            assertEquals(buffer2, buffer2FlipCase, "failure for " + s + " and " + flipCase);
         } else {
-            assertNotEquals("failure for " + s + " and " + flipCase, buffer, bufferFlipCase);
-            assertNotEquals("failure for " + s + " and " + flipCase, buffer2, buffer2FlipCase);
+            assertNotEquals(buffer, bufferFlipCase, "failure for " + s + " and " + flipCase);
+            assertNotEquals(buffer2, buffer2FlipCase, "failure for " + s + " and " + flipCase);
         }
-        assertTrue("failure for " + s + " and " + flipCase, contentEqualsIgnoreCase(buffer, bufferFlipCase));
-        assertTrue("failure for " + s + " and " + flipCase, contentEqualsIgnoreCase(buffer, buffer2FlipCase));
-        assertTrue("failure for " + s + " and " + flipCase, contentEqualsIgnoreCase(s, flipCase));
-        assertTrue("failure for " + s + " and " + flipCase, contentEqualsIgnoreCase(bufferFlipCase, buffer2FlipCase));
-        assertTrue("failure for " + s + " and " + flipCase, contentEqualsIgnoreCase(bufferFlipCase, s));
-        assertTrue("failure for " + s + " and " + flipCase, contentEqualsIgnoreCase(buffer2FlipCase, flipCase));
-        assertEquals("failure for " + s + " and " + flipCase, buffer.hashCode(), bufferFlipCase.hashCode());
-        assertEquals("failure for " + s + " and " + flipCase, buffer.hashCode(), buffer2FlipCase.hashCode());
-        assertEquals("failure for " + s + " and " + flipCase, buffer.hashCode(), caseInsensitiveHashCode(s));
-        assertEquals("failure for " + s + " and " + flipCase, buffer.hashCode(), caseInsensitiveHashCode(flipCase));
+        assertTrue(contentEqualsIgnoreCase(buffer, bufferFlipCase), "failure for " + s + " and " + flipCase);
+        assertTrue(contentEqualsIgnoreCase(buffer, buffer2FlipCase), "failure for " + s + " and " + flipCase);
+        assertTrue(contentEqualsIgnoreCase(s, flipCase), "failure for " + s + " and " + flipCase);
+        assertTrue(contentEqualsIgnoreCase(bufferFlipCase, buffer2FlipCase), "failure for " + s + " and " + flipCase);
+        assertTrue(contentEqualsIgnoreCase(bufferFlipCase, s), "failure for " + s + " and " + flipCase);
+        assertTrue(contentEqualsIgnoreCase(buffer2FlipCase, flipCase), "failure for " + s + " and " + flipCase);
+        assertEquals(buffer.hashCode(), bufferFlipCase.hashCode(), "failure for " + s + " and " + flipCase);
+        assertEquals(buffer.hashCode(), buffer2FlipCase.hashCode(), "failure for " + s + " and " + flipCase);
+        assertEquals(buffer.hashCode(), caseInsensitiveHashCode(s), "failure for " + s + " and " + flipCase);
+        assertEquals(buffer.hashCode(), caseInsensitiveHashCode(flipCase), "failure for " + s + " and " + flipCase);
     }
 
     private static void verifyDifferentAsciiStringTypes(String s, CharSequence buffer, CharSequence buffer2) {
-        assertEquals("failure for " + s, buffer.hashCode(), buffer2.hashCode());
-        assertEquals("failure for " + s, buffer.hashCode(), caseInsensitiveHashCode(s));
-        assertEquals("failure for " + s, buffer, buffer2);
-        assertTrue("failure for " + s, contentEqualsIgnoreCase(buffer, buffer2));
-        assertTrue("failure for " + s, contentEqualsIgnoreCase(buffer, s));
-        assertTrue("failure for " + s, contentEqualsIgnoreCase(buffer2, s));
-        assertTrue("failure for " + s, contentEquals(buffer, buffer2));
-        assertTrue("failure for " + s, contentEquals(buffer, s));
-        assertTrue("failure for " + s, contentEquals(buffer2, s));
+        assertEquals(buffer.hashCode(), buffer2.hashCode(), "failure for " + s);
+        assertEquals(buffer.hashCode(), caseInsensitiveHashCode(s), "failure for " + s);
+        assertEquals(buffer, buffer2, "failure for " + s);
+        assertTrue(contentEqualsIgnoreCase(buffer, buffer2), "failure for " + s);
+        assertTrue(contentEqualsIgnoreCase(buffer, s), "failure for " + s);
+        assertTrue(contentEqualsIgnoreCase(buffer2, s), "failure for " + s);
+        assertTrue(contentEquals(buffer, buffer2), "failure for " + s);
+        assertTrue(contentEquals(buffer, s), "failure for " + s);
+        assertTrue(contentEquals(buffer2, s), "failure for " + s);
     }
 
     @Test
-    public void testSubSequence() {
+    void testSubSequence() {
         testSubSequence(newAsciiString("some-data"));
         testSubSequence(newAsciiString(DEFAULT_RO_ALLOCATOR.fromAscii("some-data")));
     }

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/BufferInputStreamTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/BufferInputStreamTest.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.buffer.api;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 import java.util.Scanner;
@@ -25,43 +25,43 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class BufferInputStreamTest {
+class BufferInputStreamTest {
 
     private static final String DATA = "12345";
     private final InputStream is = new BufferInputStream(DEFAULT_RO_ALLOCATOR.fromAscii("12345"));
 
     @Test
-    public void skipNegative() throws Exception {
+    void skipNegative() throws Exception {
         testSkip(-1, 0, "12345");
     }
 
     @Test
-    public void skipZero() throws Exception {
+    void skipZero() throws Exception {
         testSkip(0, 0, "12345");
     }
 
     @Test
-    public void skipOne() throws Exception {
+    void skipOne() throws Exception {
         testSkip(1, 1, "2345");
     }
 
     @Test
-    public void skipFour() throws Exception {
+    void skipFour() throws Exception {
         testSkip(4, 4, "5");
     }
 
     @Test
-    public void skipAll() throws Exception {
+    void skipAll() throws Exception {
         testSkip(5, 5, "");
     }
 
     @Test
-    public void skipMore() throws Exception {
+    void skipMore() throws Exception {
         testSkip(10, DATA.length(), "");
     }
 
     @Test
-    public void skipMoreThanIntegerMax() throws Exception {
+    void skipMoreThanIntegerMax() throws Exception {
         testSkip(Long.MAX_VALUE, DATA.length(), "");
     }
 

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class CharSequencesTest {
+class CharSequencesTest {
 
     // Common strings
     public static final String GZIP = "gzip";
@@ -141,22 +141,22 @@ public class CharSequencesTest {
     }
 
     @Test
-    public void splitStringNoTrim() {
+    void splitStringNoTrim() {
         splitNoTrim(identity());
     }
 
     @Test
-    public void splitStringWithTrim() {
+    void splitStringWithTrim() {
         splitWithTrim(identity());
     }
 
     @Test
-    public void splitAsciiNoTrim() {
+    void splitAsciiNoTrim() {
         splitNoTrim(CharSequences::newAsciiString);
     }
 
     @Test
-    public void splitAsciiWithTrim() {
+    void splitAsciiWithTrim() {
         splitWithTrim(CharSequences::newAsciiString);
     }
 
@@ -164,7 +164,7 @@ public class CharSequencesTest {
     @ValueSource(longs = { Long.MIN_VALUE, Long.MIN_VALUE + 1,
             -101, -100, -99, -11, -10, -9, -1, 0, 1, 9, 10, 11, 99, 100, 101,
             Long.MAX_VALUE - 1, Long.MAX_VALUE })
-    public void parseLong(final long value) {
+    void parseLong(final long value) {
         final String strValue = String.valueOf(value);
         assertThat("Unexpected result for String representation", CharSequences.parseLong(strValue), is(value));
         assertThat("Unexpected result for AsciiBuffer representation",
@@ -173,7 +173,7 @@ public class CharSequencesTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "-0", "+0", "+1", "+10", "000" })
-    public void parseLongSigned(final String value) {
+    void parseLongSigned(final String value) {
         assertThat("Unexpected result for String representation",
                 CharSequences.parseLong(value), is(Long.parseLong(value)));
         assertThat("Unexpected result for AsciiBuffer representation",
@@ -182,7 +182,7 @@ public class CharSequencesTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "", "-", "+", "a", "0+", "0-", "--0", "++0", "0a0" })
-    public void parseLongFailure(final String value) {
+    void parseLongFailure(final String value) {
         assertThrows(NumberFormatException.class, () -> CharSequences.parseLong(value),
                 "Unexpected result for String representation");
         assertThrows(NumberFormatException.class, () -> CharSequences.parseLong(newAsciiString(value)),
@@ -190,7 +190,7 @@ public class CharSequencesTest {
     }
 
     @Test
-    public void parseLongFromSubSequence() {
+    void parseLongFromSubSequence() {
         String value = "text42text";
         assertThat("Unexpected result for String representation",
                 CharSequences.parseLong(value.subSequence(4, 6)), is(42L));
@@ -200,7 +200,7 @@ public class CharSequencesTest {
 
     @Test
     @Disabled("ReadOnlyByteBuffer#slice() does not account for the slice offset")
-    public void parseLongFromSlice() {
+    void parseLongFromSlice() {
         Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("text42text");
         assertThat("Unexpected result for AsciiBuffer representation",
                 CharSequences.parseLong(newAsciiString(buffer.slice(4, 2))), is(42L));

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/ReadOnlyByteBufferTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/ReadOnlyByteBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,19 @@
  */
 package io.servicetalk.buffer.api;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
 import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.DEFAULT_RO_ALLOCATOR;
 import static java.nio.ByteBuffer.allocateDirect;
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class ReadOnlyByteBufferTest {
+class ReadOnlyByteBufferTest {
     @Test
-    public void directFromString() {
+    void directFromString() {
         String expectedString = "testing";
         ByteBuffer expectedBuffer = allocateDirect(expectedString.length());
         expectedBuffer.put(expectedString.getBytes(US_ASCII));
@@ -46,7 +47,7 @@ public class ReadOnlyByteBufferTest {
     }
 
     @Test
-    public void getLong() {
+    void getLong() {
         ByteBuffer expectedBuffer = allocateDirect(8);
         expectedBuffer.putLong(Long.MAX_VALUE);
         expectedBuffer.flip();
@@ -55,37 +56,37 @@ public class ReadOnlyByteBufferTest {
     }
 
     @Test
-    public void copy() {
+    void copy() {
         Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("test");
         assertEquals(buffer, buffer.copy());
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
-    public void setNegativeReaderIndex() {
+    @Test
+    void setNegativeReaderIndex() {
         Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("test");
-        buffer.readerIndex(-1);
-    }
-
-    @Test(expected = IndexOutOfBoundsException.class)
-    public void setReaderIndexHigherThanWriterIndex() {
-        Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("test");
-        buffer.readerIndex(buffer.writerIndex() + 1);
-    }
-
-    @Test(expected = IndexOutOfBoundsException.class)
-    public void setWriterIndexLowerThanReaderIndex() {
-        Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("test");
-        buffer.writerIndex(buffer.readerIndex() - 1);
-    }
-
-    @Test(expected = IndexOutOfBoundsException.class)
-    public void setWriterIndexHigherThanCapacity() {
-        Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("test");
-        buffer.writerIndex(buffer.capacity() + 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.readerIndex(-1));
     }
 
     @Test
-    public void testIndexOf() {
+    void setReaderIndexHigherThanWriterIndex() {
+        Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("test");
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.readerIndex(buffer.writerIndex() + 1));
+    }
+
+    @Test
+    void setWriterIndexLowerThanReaderIndex() {
+        Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("test");
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.writerIndex(buffer.readerIndex() - 1));
+    }
+
+    @Test
+    void setWriterIndexHigherThanCapacity() {
+        Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("test");
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.writerIndex(buffer.capacity() + 1));
+    }
+
+    @Test
+    void testIndexOf() {
         Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("test");
 
         assertEquals(-1, buffer.indexOf(0, 4, (byte) 'a'));

--- a/servicetalk-buffer-api/src/testFixtures/java/io/servicetalk/buffer/api/Matchers.java
+++ b/servicetalk-buffer-api/src/testFixtures/java/io/servicetalk/buffer/api/Matchers.java
@@ -43,9 +43,6 @@ public final class Matchers {
 
             @Override
             protected boolean matchesSafely(final CharSequence item) {
-                if (item == null) {
-                    return false;
-                }
                 return contentEquals(expected, item);
             }
 


### PR DESCRIPTION
Motivation:

- JUnit 5 leverages features from Java 8 or later, such as lambda functions, making tests more powerful and easier to maintain.
- JUnit 5 has added some very useful new features for describing, organizing, and executing tests. For instance, tests get better display names and can be organized hierarchically.
- JUnit 5 is organized into multiple libraries, so only the features you need are imported into your project. With build systems such as Maven and Gradle, including the right libraries is easy.
- JUnit 5 can use more than one extension at a time, which JUnit 4 could not (only one runner could be used at a time). This means you can easily combine the Spring extension with other extensions (such as your own custom extension).

Modifications:

- Unit tests have been migrated from JUnit 4 to JUnit 5

Result:

Module servicetalk-buffer-api now runs tests using JUnit 5