### PR TITLE
Migrate servicetalk-buffer-netty tests to JUnit 5 (#1568)

### DIFF
--- a/servicetalk-buffer-netty/build.gradle
+++ b/servicetalk-buffer-netty/build.gradle
@@ -26,7 +26,10 @@ dependencies {
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation project(":servicetalk-test-resources")
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
+  testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-buffer-netty/src/test/java/io/servicetalk/buffer/netty/BufferAllocatorsTest.java
+++ b/servicetalk-buffer-netty/src/test/java/io/servicetalk/buffer/netty/BufferAllocatorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,80 +19,82 @@ import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.buffer.api.BufferAllocator;
 
 import io.netty.buffer.ByteBuf;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Collection;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.buffer.netty.BufferAllocators.PREFER_DIRECT_ALLOCATOR;
 import static io.servicetalk.buffer.netty.BufferAllocators.PREFER_HEAP_ALLOCATOR;
+import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(Parameterized.class)
-public class BufferAllocatorsTest {
+class BufferAllocatorsTest {
 
-    private final BufferAllocator allocator;
+    private static final String TEST_NAME_FORMAT = "{index}: allocator = {0}";
 
-    public BufferAllocatorsTest(BufferAllocator allocator) {
-        this.allocator = allocator;
+    @SuppressWarnings("unused")
+    private static Collection<BufferAllocator> allocators() {
+        return asList(DEFAULT_ALLOCATOR, PREFER_DIRECT_ALLOCATOR, PREFER_HEAP_ALLOCATOR);
     }
 
-    @Parameterized.Parameters(name = "{index}: allocators = {0}")
-    public static Collection<Object> data() {
-        return Arrays.asList(DEFAULT_ALLOCATOR, PREFER_DIRECT_ALLOCATOR, PREFER_HEAP_ALLOCATOR);
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("allocators")
+    void testNewBuffer(BufferAllocator allocator) {
+        assertBuffer(allocator, allocator.newBuffer());
     }
 
-    @Test
-    public void testNewBuffer() {
-        assertBuffer(allocator.newBuffer());
-    }
-
-    @Test
-    public void testNewBufferDirect() {
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("allocators")
+    void testNewBufferDirect(BufferAllocator allocator) {
         assertBuffer(allocator.newBuffer(true), true);
     }
 
-    @Test
-    public void testNewBufferHeap() {
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("allocators")
+    void testNewBufferHeap(BufferAllocator allocator) {
         assertBuffer(allocator.newBuffer(false), false);
     }
 
-    @Test
-    public void testNewCompositeBuffer() {
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("allocators")
+    void testNewCompositeBuffer(BufferAllocator allocator) {
         assertBufferIsUnreleasable(allocator.newCompositeBuffer());
     }
 
-    @Test
-    public void testReadOnlyDirectBuffer() {
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("allocators")
+    void testReadOnlyDirectBuffer(BufferAllocator allocator) {
         assertBuffer(allocator.wrap(ByteBuffer.allocateDirect(16).asReadOnlyBuffer()), true);
     }
 
-    @Test
-    public void testNewCompositeBufferWithSingleComponent() {
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("allocators")
+    void testNewCompositeBufferWithSingleComponent(BufferAllocator allocator) {
         assertBufferIsUnreleasable(allocator.newCompositeBuffer()
                 .addBuffer(allocator.fromAscii("test")));
     }
 
-    @Test
-    public void testNewCompositeBufferWithMultipleComponents() {
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("allocators")
+    void testNewCompositeBufferWithMultipleComponents(BufferAllocator allocator) {
         assertBufferIsUnreleasable(allocator.newCompositeBuffer()
                 .addBuffer(allocator.fromAscii("test1"))
                 .addBuffer(allocator.fromAscii("test2"))
                 .addBuffer(allocator.fromAscii("test3")));
     }
 
-    @Test
-    public void testNewConsolidatedCompositeBufferWithMultipleComponents() {
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("allocators")
+    void testNewConsolidatedCompositeBufferWithMultipleComponents(BufferAllocator allocator) {
         assertBufferIsUnreleasable(allocator.newCompositeBuffer()
                 .addBuffer(allocator.fromAscii("test1"))
                 .addBuffer(allocator.fromAscii("test2"))
@@ -100,52 +102,61 @@ public class BufferAllocatorsTest {
                 .consolidate());
     }
 
-    @Test
-    public void testFromAscii() {
-        assertBuffer(allocator.fromAscii("test"));
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("allocators")
+    void testFromAscii(BufferAllocator allocator) {
+        assertBuffer(allocator, allocator.fromAscii("test"));
     }
 
-    @Test
-    public void testFromAsciiDirect() {
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("allocators")
+    void testFromAsciiDirect(BufferAllocator allocator) {
         assertBuffer(allocator.fromAscii("test", true), true);
     }
 
-    @Test
-    public void testFromAsciiHeap() {
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("allocators")
+    void testFromAsciiHeap(BufferAllocator allocator) {
         assertBuffer(allocator.fromAscii("test", false), false);
     }
 
-    @Test
-    public void testFromUtf8() {
-        assertBuffer(allocator.fromUtf8("test"));
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("allocators")
+    void testFromUtf8(BufferAllocator allocator) {
+        assertBuffer(allocator, allocator.fromUtf8("test"));
     }
 
-    @Test
-    public void testFromUtf8Direct() {
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("allocators")
+    void testFromUtf8Direct(BufferAllocator allocator) {
         assertBuffer(allocator.fromUtf8("test", true), true);
     }
 
-    @Test
-    public void testFromUtf8Heap() {
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("allocators")
+    void testFromUtf8Heap(BufferAllocator allocator) {
         assertBuffer(allocator.fromUtf8("test", false), false);
     }
 
-    @Test
-    public void testFromSequence() {
-        assertBuffer(allocator.fromSequence("test", StandardCharsets.US_ASCII));
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("allocators")
+    void testFromSequence(BufferAllocator allocator) {
+        assertBuffer(allocator, allocator.fromSequence("test", StandardCharsets.US_ASCII));
     }
 
-    @Test
-    public void testFromSequenceDirect() {
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("allocators")
+    void testFromSequenceDirect(BufferAllocator allocator) {
         assertBuffer(allocator.fromSequence("test", StandardCharsets.US_ASCII, true), true);
     }
 
-    @Test
-    public void testFromSequenceHeap() {
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("allocators")
+    void testFromSequenceHeap(BufferAllocator allocator) {
         assertBuffer(allocator.fromSequence("test", StandardCharsets.US_ASCII, false), false);
     }
 
-    private void assertBuffer(Buffer buffer) {
+    private void assertBuffer(BufferAllocator allocator, Buffer buffer) {
         assertBuffer(buffer, allocator != PREFER_HEAP_ALLOCATOR);
     }
 

--- a/servicetalk-buffer-netty/src/test/java/io/servicetalk/buffer/netty/BufferUtilTest.java
+++ b/servicetalk-buffer-netty/src/test/java/io/servicetalk/buffer/netty/BufferUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,25 +17,25 @@ package io.servicetalk.buffer.netty;
 
 import io.servicetalk.buffer.api.Buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.buffer.api.EmptyBuffer.EMPTY_BUFFER;
 import static io.servicetalk.buffer.netty.BufferUtils.toByteBufNoThrow;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 
-public class BufferUtilTest {
+class BufferUtilTest {
 
     @Test
-    public void toByteBufNoThrowWrapped() {
+    void toByteBufNoThrowWrapped() {
         Buffer buffer = mock(Buffer.class);
         WrappedBuffer wrapped = new WrappedBuffer(buffer);
         assertNull(toByteBufNoThrow(wrapped));
     }
 
     @Test
-    public void emptyBufferCanBeConvertedToByteBuf() {
+    void emptyBufferCanBeConvertedToByteBuf() {
         assertNotNull(toByteBufNoThrow(EMPTY_BUFFER));
     }
 }

--- a/servicetalk-buffer-netty/src/test/java/io/servicetalk/buffer/netty/NettyAsciiBufferTest.java
+++ b/servicetalk-buffer-netty/src/test/java/io/servicetalk/buffer/netty/NettyAsciiBufferTest.java
@@ -15,17 +15,17 @@
  */
 package io.servicetalk.buffer.netty;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 // Netty counter-part for AsciiBufferTest
-public class NettyAsciiBufferTest {
+class NettyAsciiBufferTest {
 
     @Test
-    public void testSubSequence() {
+    void testSubSequence() {
         testSubSequence(newAsciiString(DEFAULT_ALLOCATOR.fromAscii("some-data")));
     }
 

--- a/servicetalk-buffer-netty/src/test/java/io/servicetalk/buffer/netty/ReadOnlyBufferTest.java
+++ b/servicetalk-buffer-netty/src/test/java/io/servicetalk/buffer/netty/ReadOnlyBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,30 +17,30 @@ package io.servicetalk.buffer.netty;
 
 import io.servicetalk.buffer.api.Buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ReadOnlyBufferTest {
+class ReadOnlyBufferTest {
 
     @Test
-    public void capacity() {
+    void capacity() {
         Buffer buffer = DEFAULT_ALLOCATOR.newBuffer(10).writeBytes("test".getBytes(US_ASCII));
         Buffer readOnly = buffer.asReadOnly();
         assertEquals(buffer.capacity(), readOnly.capacity());
     }
 
     @Test
-    public void maxCapacity() {
+    void maxCapacity() {
         Buffer buffer = DEFAULT_ALLOCATOR.newBuffer(10).writeBytes("test".getBytes(US_ASCII));
         Buffer readOnly = buffer.asReadOnly();
         assertEquals(buffer.maxCapacity(), readOnly.maxCapacity());
     }
 
     @Test
-    public void changeReaderIndexViaReadOnlyView() {
+    void changeReaderIndexViaReadOnlyView() {
         Buffer buffer = DEFAULT_ALLOCATOR.fromAscii("test");
         Buffer readOnly = buffer.asReadOnly();
         assertEquals(buffer.readerIndex(), readOnly.readerIndex());
@@ -50,7 +50,7 @@ public class ReadOnlyBufferTest {
     }
 
     @Test
-    public void changeWriterIndexViaReadOnlyView() {
+    void changeWriterIndexViaReadOnlyView() {
         Buffer buffer = DEFAULT_ALLOCATOR.fromAscii("test");
         Buffer readOnly = buffer.asReadOnly();
         assertEquals(buffer.writerIndex(), readOnly.writerIndex());


### PR DESCRIPTION
Motivation:

- JUnit 5 leverages features from Java 8 or later, such as lambda functions, making tests more powerful and easier to maintain.
- JUnit 5 has added some very useful new features for describing, organizing, and executing tests. For instance, tests get better display names and can be organized hierarchically.
- JUnit 5 is organized into multiple libraries, so only the features you need are imported into your project. With build systems such as Maven and Gradle, including the right libraries is easy.
- JUnit 5 can use more than one extension at a time, which JUnit 4 could not (only one runner could be used at a time). This means you can easily combine the Spring extension with other extensions (such as your own custom extension).

Modifications:

- Unit tests have been migrated from JUnit 4 to JUnit 5

Result:

Module servicetalk-buffer-netty now runs tests using JUnit 5