### PR TITLE
New PMD rules introduced in PMD 6.35

### DIFF
--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
@@ -31,12 +31,12 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class CharSequencesTest {
+class CharSequencesTest {
 
     // Common strings
-    public static final String GZIP = "gzip";
-    public static final String DEFLATE = "deflate";
-    public static final String COMPRESS = "compress";
+    static final String GZIP = "gzip";
+    static final String DEFLATE = "deflate";
+    static final String COMPRESS = "compress";
 
     private static void splitNoTrim(Function<String, ? extends CharSequence> f) {
         assertThat(split(f.apply(" ,      "), ',', false),
@@ -141,22 +141,22 @@ public class CharSequencesTest {
     }
 
     @Test
-    public void splitStringNoTrim() {
+    void splitStringNoTrim() {
         splitNoTrim(identity());
     }
 
     @Test
-    public void splitStringWithTrim() {
+    void splitStringWithTrim() {
         splitWithTrim(identity());
     }
 
     @Test
-    public void splitAsciiNoTrim() {
+    void splitAsciiNoTrim() {
         splitNoTrim(CharSequences::newAsciiString);
     }
 
     @Test
-    public void splitAsciiWithTrim() {
+    void splitAsciiWithTrim() {
         splitWithTrim(CharSequences::newAsciiString);
     }
 
@@ -164,7 +164,7 @@ public class CharSequencesTest {
     @ValueSource(longs = { Long.MIN_VALUE, Long.MIN_VALUE + 1,
             -101, -100, -99, -11, -10, -9, -1, 0, 1, 9, 10, 11, 99, 100, 101,
             Long.MAX_VALUE - 1, Long.MAX_VALUE })
-    public void parseLong(final long value) {
+    void parseLong(final long value) {
         final String strValue = String.valueOf(value);
         assertThat("Unexpected result for String representation", CharSequences.parseLong(strValue), is(value));
         assertThat("Unexpected result for AsciiBuffer representation",
@@ -173,7 +173,7 @@ public class CharSequencesTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "-0", "+0", "+1", "+10", "000" })
-    public void parseLongSigned(final String value) {
+    void parseLongSigned(final String value) {
         assertThat("Unexpected result for String representation",
                 CharSequences.parseLong(value), is(Long.parseLong(value)));
         assertThat("Unexpected result for AsciiBuffer representation",
@@ -182,7 +182,7 @@ public class CharSequencesTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "", "-", "+", "a", "0+", "0-", "--0", "++0", "0a0" })
-    public void parseLongFailure(final String value) {
+    void parseLongFailure(final String value) {
         assertThrows(NumberFormatException.class, () -> CharSequences.parseLong(value),
                 "Unexpected result for String representation");
         assertThrows(NumberFormatException.class, () -> CharSequences.parseLong(newAsciiString(value)),
@@ -190,7 +190,7 @@ public class CharSequencesTest {
     }
 
     @Test
-    public void parseLongFromSubSequence() {
+    void parseLongFromSubSequence() {
         String value = "text42text";
         assertThat("Unexpected result for String representation",
                 CharSequences.parseLong(value.subSequence(4, 6)), is(42L));
@@ -200,7 +200,7 @@ public class CharSequencesTest {
 
     @Test
     @Disabled("ReadOnlyByteBuffer#slice() does not account for the slice offset")
-    public void parseLongFromSlice() {
+    void parseLongFromSlice() {
         Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("text42text");
         assertThat("Unexpected result for AsciiBuffer representation",
                 CharSequences.parseLong(newAsciiString(buffer.slice(4, 2))), is(42L));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractCompositeCancellableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractCompositeCancellableTest.java
@@ -39,7 +39,7 @@ public abstract class AbstractCompositeCancellableTest<T extends Cancellable> {
     protected abstract boolean add(T composite, Cancellable c);
 
     @Test
-    public void testCancel() {
+    void testCancel() {
         T c = newCompositeCancellable();
         Cancellable cancellable = mock(Cancellable.class);
         add(c, cancellable);
@@ -48,7 +48,7 @@ public abstract class AbstractCompositeCancellableTest<T extends Cancellable> {
     }
 
     @Test
-    public void testAddPostCancel() {
+    void testAddPostCancel() {
         T c = newCompositeCancellable();
         c.cancel();
         Cancellable cancellable = mock(Cancellable.class);
@@ -57,7 +57,7 @@ public abstract class AbstractCompositeCancellableTest<T extends Cancellable> {
     }
 
     @Test
-    public void multiThreadedAddCancel() throws Exception {
+    void multiThreadedAddCancel() throws Exception {
         final int addThreads = 1000;
         final CyclicBarrier barrier = new CyclicBarrier(addThreads + 1);
         final List<Single<Cancellable>> cancellableSingles = new ArrayList<>(addThreads);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractToFutureTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractToFutureTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.verify;
 public abstract class AbstractToFutureTest<T> {
 
     @RegisterExtension
-    public final ExecutorExtension<Executor> exec = ExecutorExtension.withCachedExecutor();
+    protected final ExecutorExtension<Executor> exec = ExecutorExtension.withCachedExecutor();
 
     protected final Cancellable mockCancellable = Mockito.mock(Cancellable.class);
 
@@ -60,14 +60,14 @@ public abstract class AbstractToFutureTest<T> {
     protected abstract T expectedResult();
 
     @Test
-    public void testSubscribed() {
+    void testSubscribed() {
         assertThat(isSubscribed(), is(false));
         toFuture();
         assertThat(isSubscribed(), is(true));
     }
 
     @Test
-    public void testSucceeded() throws Exception {
+    void testSucceeded() throws Exception {
         Future<T> future = toFuture();
         assertThat(future.isDone(), is(false));
         completeSource();
@@ -79,7 +79,7 @@ public abstract class AbstractToFutureTest<T> {
     }
 
     @Test
-    public void testSucceededAfterGet() throws Exception {
+    void testSucceededAfterGet() throws Exception {
         Future<T> future = toFuture();
         exec.executor().schedule(this::completeSource, 10, MILLISECONDS);
         assertThat(future.get(), is(expectedResult()));
@@ -89,7 +89,7 @@ public abstract class AbstractToFutureTest<T> {
     }
 
     @Test
-    public void testSucceededAfterGetWithTimeout() throws Exception {
+    void testSucceededAfterGetWithTimeout() throws Exception {
         Future<T> future = toFuture();
         exec.executor().schedule(this::completeSource, 10, MILLISECONDS);
         assertThat(future.get(3, SECONDS), is(expectedResult()));
@@ -99,7 +99,7 @@ public abstract class AbstractToFutureTest<T> {
     }
 
     @Test
-    public void testSucceededAfterGetWithEnoughTimeout() throws Exception {
+    void testSucceededAfterGetWithEnoughTimeout() throws Exception {
         Future<T> future = toFuture();
 
         CountDownLatch latch = new CountDownLatch(1);
@@ -126,7 +126,7 @@ public abstract class AbstractToFutureTest<T> {
     }
 
     @Test
-    public void testFailed() throws Exception {
+    void testFailed() throws Exception {
         Future<T> future = toFuture();
         assertThat(future.isDone(), is(false));
         failSource(DELIBERATE_EXCEPTION);
@@ -148,14 +148,14 @@ public abstract class AbstractToFutureTest<T> {
     }
 
     @Test
-    public void testFailedWithNull() {
+    void testFailedWithNull() {
         Future<T> future = toFuture();
         assertThat(future.isDone(), is(false));
         assertThrows(NullPointerException.class, () -> failSource(null));
     }
 
     @Test
-    public void testFailedAfterGet() throws Exception {
+    void testFailedAfterGet() throws Exception {
         Future<T> future = toFuture();
         exec.executor().schedule(() -> failSource(DELIBERATE_EXCEPTION), 10, MILLISECONDS);
         try {
@@ -170,7 +170,7 @@ public abstract class AbstractToFutureTest<T> {
     }
 
     @Test
-    public void testFailedAfterGetWithTimeout() throws Exception {
+    void testFailedAfterGetWithTimeout() throws Exception {
         Future<T> future = toFuture();
         exec.executor().schedule(() -> failSource(DELIBERATE_EXCEPTION), 10, MILLISECONDS);
         try {
@@ -185,14 +185,14 @@ public abstract class AbstractToFutureTest<T> {
     }
 
     @Test
-    public void testGetTimeoutException() {
+    void testGetTimeoutException() {
         Future<T> future = toFuture();
         assertThat(future.isDone(), is(false));
         assertThrows(TimeoutException.class, () -> future.get(10, MILLISECONDS));
     }
 
     @Test
-    public void testMultipleGets() throws Exception {
+    void testMultipleGets() throws Exception {
         Future<T> future = toFuture();
 
         CountDownLatch latch = new CountDownLatch(3);
@@ -214,17 +214,17 @@ public abstract class AbstractToFutureTest<T> {
     }
 
     @Test
-    public void testCancelWithMayInterruptIfRunning() {
+    void testCancelWithMayInterruptIfRunning() {
         testCancel(true, future -> { });
     }
 
     @Test
-    public void testCancelWithoutMayInterruptIfRunning() {
+    void testCancelWithoutMayInterruptIfRunning() {
         testCancel(false, future -> { });
     }
 
     @Test
-    public void testOnSuccessResultIsIgnoredAfterCancel() {
+    void testOnSuccessResultIsIgnoredAfterCancel() {
         testCancel(true, future -> {
             completeSource();
             assertThat(future.isCancelled(), is(true));
@@ -233,7 +233,7 @@ public abstract class AbstractToFutureTest<T> {
     }
 
     @Test
-    public void testOnErrorResultIsIgnoredAfterCancel() {
+    void testOnErrorResultIsIgnoredAfterCancel() {
         testCancel(true, future -> {
             failSource(DELIBERATE_EXCEPTION);
             assertThat(future.isCancelled(), is(true));
@@ -259,7 +259,7 @@ public abstract class AbstractToFutureTest<T> {
     }
 
     @Test
-    public void testCancelIsIgnoredAfterOnSuccess() throws Exception {
+    void testCancelIsIgnoredAfterOnSuccess() throws Exception {
         Future<T> future = toFuture();
         assertThat(future.isDone(), is(false));
         assertThat(future.isCancelled(), is(false));
@@ -272,7 +272,7 @@ public abstract class AbstractToFutureTest<T> {
     }
 
     @Test
-    public void testCancelIsIgnoredAfterOnError() throws Exception {
+    void testCancelIsIgnoredAfterOnError() throws Exception {
         Future<T> future = toFuture();
         assertThat(future.isDone(), is(false));
         assertThat(future.isCancelled(), is(false));
@@ -290,7 +290,7 @@ public abstract class AbstractToFutureTest<T> {
     }
 
     @Test
-    public void testSubsequentCancelsAreIgnored() {
+    void testSubsequentCancelsAreIgnored() {
         Future<T> future = toFuture();
         assertThat(future.isDone(), is(false));
         assertThat(future.isCancelled(), is(false));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AsyncContextDisableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AsyncContextDisableTest.java
@@ -25,11 +25,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class AsyncContextDisableTest {
+class AsyncContextDisableTest {
     private static final Key<String> K1 = Key.newKey("k1");
 
     @Test
-    public void testDisableAsyncContext() throws Exception {
+    void testDisableAsyncContext() throws Exception {
         synchronized (K1) { // prevent parallel execution because these tests rely upon static state
             Executor executor = Executors.newCachedThreadExecutor();
             Executor executor2 = null;
@@ -72,7 +72,7 @@ public class AsyncContextDisableTest {
     }
 
     @Test
-    public void testAutoEnableDoesNotOverrideDisable() throws Exception {
+    void testAutoEnableDoesNotOverrideDisable() throws Exception {
         synchronized (K1) { // prevent parallel execution because these tests rely upon static state
             AsyncContext.disable();
             try {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/BlockingProcessorSignalsHolderTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/BlockingProcessorSignalsHolderTest.java
@@ -29,17 +29,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
-public class BlockingProcessorSignalsHolderTest {
+class BlockingProcessorSignalsHolderTest {
     private final DefaultBlockingProcessorSignalsHolder<Integer> buffer;
     @SuppressWarnings("unchecked")
     private final ProcessorSignalsConsumer<Integer> consumer = mock(ProcessorSignalsConsumer.class);
 
-    public BlockingProcessorSignalsHolderTest() {
+    BlockingProcessorSignalsHolderTest() {
         buffer = new DefaultBlockingProcessorSignalsHolder<>(1);
     }
 
     @Test
-    public void consumeItem() throws Exception {
+    void consumeItem() throws Exception {
         buffer.add(1);
         assertThat("Item not consumed.", buffer.consume(consumer), is(true));
         verify(consumer).consumeItem(1);
@@ -47,14 +47,14 @@ public class BlockingProcessorSignalsHolderTest {
     }
 
     @Test
-    public void consumeEmpty() {
+    void consumeEmpty() {
         assertThrows(TimeoutException.class,
                 () -> buffer.consume(consumer, 1, MILLISECONDS), "Unexpected consume when empty.");
         verifyZeroInteractions(consumer);
     }
 
     @Test
-    public void consumeTerminal() throws Exception {
+    void consumeTerminal() throws Exception {
         buffer.terminate();
         assertThat("Item not consumed.", buffer.consume(consumer), is(true));
         verify(consumer).consumeTerminal();
@@ -62,7 +62,7 @@ public class BlockingProcessorSignalsHolderTest {
     }
 
     @Test
-    public void consumeTerminalError() throws Exception {
+    void consumeTerminalError() throws Exception {
         buffer.terminate(DELIBERATE_EXCEPTION);
         assertThat("Item not consumed.", buffer.consume(consumer), is(true));
         verify(consumer).consumeTerminal(DELIBERATE_EXCEPTION);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/BufferStrategiesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/BufferStrategiesTest.java
@@ -45,12 +45,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BufferStrategiesTest {
+class BufferStrategiesTest {
     private final BlockingQueue<TestCompletable> timers = new LinkedBlockingDeque<>();
     private final Executor executor = mock(Executor.class);
     private final java.util.concurrent.ExecutorService jdkExecutor = Executors.newCachedThreadPool();
 
-    public BufferStrategiesTest() {
+    BufferStrategiesTest() {
         when(executor.timer(any(Duration.class))).thenAnswer(invocation -> defer(() -> {
             TestCompletable timer = new TestCompletable();
             timers.add(timer);
@@ -59,13 +59,13 @@ public class BufferStrategiesTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         jdkExecutor.shutdownNow();
     }
 
     @Disabled("https://github.com/apple/servicetalk/issues/1259")
     @Test
-    public void sizeOrDurationConcurrent() throws Exception {
+    void sizeOrDurationConcurrent() throws Exception {
         final int maxBoundaries = 1_000;
         final Collection<Integer> items = unmodifiableCollection(range(1, 1_000).toFuture().get());
         final List<Integer> receivedFromBoundaries = new ArrayList<>(items.size());

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CancellableSetTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CancellableSetTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
-public class CancellableSetTest extends AbstractCompositeCancellableTest<CancellableSet> {
+class CancellableSetTest extends AbstractCompositeCancellableTest<CancellableSet> {
     @Override
     protected CancellableSet newCompositeCancellable() {
         return new CancellableSet();
@@ -37,7 +37,7 @@ public class CancellableSetTest extends AbstractCompositeCancellableTest<Cancell
     }
 
     @Test
-    public void testAddAndRemove() {
+    void testAddAndRemove() {
         CancellableSet c = newCompositeCancellable();
         Cancellable cancellable = mock(Cancellable.class);
         add(c, cancellable);
@@ -47,7 +47,7 @@ public class CancellableSetTest extends AbstractCompositeCancellableTest<Cancell
     }
 
     @Test
-    public void duplicateAddDoesNotCancel() {
+    void duplicateAddDoesNotCancel() {
         CancellableSet c = newCompositeCancellable();
         Cancellable cancellable = mock(Cancellable.class);
         int addCount = 0;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CancellableStackTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CancellableStackTest.java
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.Cancellable;
 
-public class CancellableStackTest extends AbstractCompositeCancellableTest<CancellableStack> {
+class CancellableStackTest extends AbstractCompositeCancellableTest<CancellableStack> {
     @Override
     protected CancellableStack newCompositeCancellable() {
         return new CancellableStack();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ClosableConcurrentStackTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ClosableConcurrentStackTest.java
@@ -41,12 +41,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class ClosableConcurrentStackTest {
+class ClosableConcurrentStackTest {
     @RegisterExtension
     static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
 
     @Test
-    public void singleThreadPushClose() {
+    void singleThreadPushClose() {
         ClosableConcurrentStack<Integer> stack = new ClosableConcurrentStack<>();
         final int itemCount = 1000;
         for (int i = 0; i < itemCount; ++i) {
@@ -63,7 +63,7 @@ public class ClosableConcurrentStackTest {
     }
 
     @Test
-    public void singleThreadPushRemove() {
+    void singleThreadPushRemove() {
         ClosableConcurrentStack<Integer> stack = new ClosableConcurrentStack<>();
         final int itemCount = 1000;
         for (int i = 0; i < itemCount; ++i) {
@@ -77,7 +77,7 @@ public class ClosableConcurrentStackTest {
     }
 
     @Test
-    public void concurrentPushClose() throws Exception {
+    void concurrentPushClose() throws Exception {
         ClosableConcurrentStack<Integer> stack = new ClosableConcurrentStack<>();
         final int itemCount = 1000;
         CyclicBarrier barrier = new CyclicBarrier(itemCount + 1);
@@ -106,7 +106,7 @@ public class ClosableConcurrentStackTest {
     }
 
     @Test
-    public void concurrentPushRemove() throws Exception {
+    void concurrentPushRemove() throws Exception {
         ClosableConcurrentStack<Integer> stack = new ClosableConcurrentStack<>();
         final int itemCount = 1000;
         CyclicBarrier barrier = new CyclicBarrier(itemCount + 1);
@@ -131,7 +131,7 @@ public class ClosableConcurrentStackTest {
     }
 
     @Test
-    public void concurrentPushRemoveDifferentThread() throws Exception {
+    void concurrentPushRemoveDifferentThread() throws Exception {
         ClosableConcurrentStack<Integer> stack = new ClosableConcurrentStack<>();
         final int itemCount = 1000;
         CyclicBarrier barrier = new CyclicBarrier(itemCount + 1);
@@ -156,7 +156,7 @@ public class ClosableConcurrentStackTest {
     }
 
     @Test
-    public void concurrentClosePushRemove() throws Exception {
+    void concurrentClosePushRemove() throws Exception {
         ClosableConcurrentStack<Cancellable> stack = new ClosableConcurrentStack<>();
         final int itemCount = 1000;
         CyclicBarrier barrier = new CyclicBarrier(itemCount + 1);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CollectingPublisherSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CollectingPublisherSubscriberTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CollectingPublisherSubscriberTest {
+class CollectingPublisherSubscriberTest {
 
     private final CollectingPublisherSubscriber<String> subscriber = new CollectingPublisherSubscriber<>();
     private final TestPublisher<String> source = new TestPublisher.Builder<String>()
@@ -38,7 +38,7 @@ public class CollectingPublisherSubscriberTest {
             .build();
 
     @Test
-    public void testAssertItems() {
+    void testAssertItems() {
         source.subscribe(subscriber);
         assertThat(subscriber.items(), hasSize(0));
 
@@ -50,7 +50,7 @@ public class CollectingPublisherSubscriberTest {
     }
 
     @Test
-    public void testSubscriptionReceived() {
+    void testSubscriptionReceived() {
         assertFalse(subscriber.subscriptionReceived());
 
         source.subscribe(subscriber);
@@ -59,7 +59,7 @@ public class CollectingPublisherSubscriberTest {
     }
 
     @Test
-    public void testComplete() {
+    void testComplete() {
         source.subscribe(subscriber);
 
         assertNull(subscriber.terminal());
@@ -73,7 +73,7 @@ public class CollectingPublisherSubscriberTest {
     }
 
     @Test
-    public void testError() {
+    void testError() {
         source.subscribe(subscriber);
 
         assertThat(subscriber.terminal(), nullValue());

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableAmbTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableAmbTest.java
@@ -30,7 +30,7 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class CompletableAmbTest {
+class CompletableAmbTest {
 
     private TestCompletable first;
     private TestCompletable second;
@@ -77,7 +77,7 @@ public class CompletableAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void successFirst(final AmbParam ambParam) {
+    void successFirst(final AmbParam ambParam) {
         setUp(ambParam.get());
         sendSuccessToAndVerify(first);
         verifyCancelled(second);
@@ -85,7 +85,7 @@ public class CompletableAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void successSecond(final AmbParam ambParam) {
+    void successSecond(final AmbParam ambParam) {
         setUp(ambParam.get());
         sendSuccessToAndVerify(second);
         verifyCancelled(first);
@@ -93,7 +93,7 @@ public class CompletableAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void failFirst(final AmbParam ambParam) {
+    void failFirst(final AmbParam ambParam) {
         setUp(ambParam.get());
         sendErrorToAndVerify(first);
         verifyCancelled(second);
@@ -101,7 +101,7 @@ public class CompletableAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void failSecond(final AmbParam ambParam) {
+    void failSecond(final AmbParam ambParam) {
         setUp(ambParam.get());
         sendErrorToAndVerify(second);
         verifyCancelled(first);
@@ -109,7 +109,7 @@ public class CompletableAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void successFirstThenSecond(final AmbParam ambParam) {
+    void successFirstThenSecond(final AmbParam ambParam) {
         setUp(ambParam.get());
         sendSuccessToAndVerify(first);
         verifyCancelled(second);
@@ -118,7 +118,7 @@ public class CompletableAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void successSecondThenFirst(final AmbParam ambParam) {
+    void successSecondThenFirst(final AmbParam ambParam) {
         setUp(ambParam.get());
         sendSuccessToAndVerify(second);
         verifyCancelled(first);
@@ -127,7 +127,7 @@ public class CompletableAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void failFirstThenSecond(final AmbParam ambParam) {
+    void failFirstThenSecond(final AmbParam ambParam) {
         setUp(ambParam.get());
         sendErrorToAndVerify(first);
         verifyCancelled(second);
@@ -136,7 +136,7 @@ public class CompletableAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void failSecondThenFirst(final AmbParam ambParam) {
+    void failSecondThenFirst(final AmbParam ambParam) {
         setUp(ambParam.get());
         sendErrorToAndVerify(second);
         verifyCancelled(first);
@@ -145,7 +145,7 @@ public class CompletableAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void successFirstThenSecondFail(final AmbParam ambParam) {
+    void successFirstThenSecondFail(final AmbParam ambParam) {
         setUp(ambParam.get());
         sendSuccessToAndVerify(first);
         verifyCancelled(second);
@@ -154,7 +154,7 @@ public class CompletableAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void successSecondThenFirstFail(final AmbParam ambParam) {
+    void successSecondThenFirstFail(final AmbParam ambParam) {
         setUp(ambParam.get());
         sendSuccessToAndVerify(second);
         verifyCancelled(first);
@@ -163,7 +163,7 @@ public class CompletableAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void failFirstThenSecondSuccess(final AmbParam ambParam) {
+    void failFirstThenSecondSuccess(final AmbParam ambParam) {
         setUp(ambParam.get());
         sendErrorToAndVerify(first);
         verifyCancelled(second);
@@ -172,7 +172,7 @@ public class CompletableAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void failSecondThenFirstSuccess(final AmbParam ambParam) {
+    void failSecondThenFirstSuccess(final AmbParam ambParam) {
         setUp(ambParam.get());
         sendErrorToAndVerify(second);
         verifyCancelled(first);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableExecutorPreservationTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableExecutorPreservationTest.java
@@ -25,25 +25,25 @@ import static io.servicetalk.concurrent.api.Completable.completed;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public class CompletableExecutorPreservationTest {
+class CompletableExecutorPreservationTest {
     @RegisterExtension
     static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor("test");
 
     private Completable completable;
 
     @BeforeEach
-    public void setupCompletable() {
+    void setupCompletable() {
         completable = completed().publishAndSubscribeOnOverride(EXEC.executor());
     }
 
     @Test
-    public void testTimeoutCompletable() {
+    void testTimeoutCompletable() {
         assertSame(EXEC.executor(), completable.timeout(1, MILLISECONDS).executor());
         assertSame(EXEC.executor(), completable.timeout(Duration.ofMillis(1)).executor());
     }
 
     @Test
-    public void testBeforeFinallyCompletable() {
+    void testBeforeFinallyCompletable() {
         assertSame(EXEC.executor(), completable.beforeFinally(() -> { /* NOOP */ }).executor());
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableMergeWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableMergeWithPublisherTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class CompletableMergeWithPublisherTest {
+class CompletableMergeWithPublisherTest {
     @RegisterExtension
     final ExecutorExtension<Executor> executorExtension = withCachedExecutor();
     private final TestSubscription subscription = new TestSubscription();
@@ -59,12 +59,12 @@ public class CompletableMergeWithPublisherTest {
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
 
     @Test
-    public void testDelayedPublisherSubscriptionForReqNBuffering() {
+    void testDelayedPublisherSubscriptionForReqNBuffering() {
         testDelayedPublisherSubscriptionForReqNBuffering(false);
     }
 
     @Test
-    public void delayErrorDelayedPublisherSubscriptionForReqNBuffering() {
+    void delayErrorDelayedPublisherSubscriptionForReqNBuffering() {
         testDelayedPublisherSubscriptionForReqNBuffering(true);
     }
 
@@ -91,12 +91,12 @@ public class CompletableMergeWithPublisherTest {
     }
 
     @Test
-    public void testDelayedPublisherSubscriptionForCancelBuffering() {
+    void testDelayedPublisherSubscriptionForCancelBuffering() {
         testDelayedPublisherSubscriptionForCancelBuffering(false);
     }
 
     @Test
-    public void delayErrorDelayedPublisherSubscriptionForCancelBuffering() {
+    void delayErrorDelayedPublisherSubscriptionForCancelBuffering() {
         testDelayedPublisherSubscriptionForCancelBuffering(true);
     }
 
@@ -111,12 +111,12 @@ public class CompletableMergeWithPublisherTest {
     }
 
     @Test
-    public void testDelayedCompletableSubscriptionForCancelBuffering() {
+    void testDelayedCompletableSubscriptionForCancelBuffering() {
         testDelayedCompletableSubscriptionForCancelBuffering(false);
     }
 
     @Test
-    public void delayErrorDelayedCompletableSubscriptionForCancelBuffering() {
+    void delayErrorDelayedCompletableSubscriptionForCancelBuffering() {
         testDelayedCompletableSubscriptionForCancelBuffering(true);
     }
 
@@ -134,7 +134,7 @@ public class CompletableMergeWithPublisherTest {
     }
 
     @Test
-    public void testCompletableFailCancelsPublisher() {
+    void testCompletableFailCancelsPublisher() {
         TestCompletable completable = new TestCompletable();
         toSource(completable.merge(publisher)).subscribe(subscriber);
         publisher.onSubscribe(subscription);
@@ -144,12 +144,12 @@ public class CompletableMergeWithPublisherTest {
     }
 
     @Test
-    public void delayErrorCompletableFailDoesNotCancelPublisherFail() {
+    void delayErrorCompletableFailDoesNotCancelPublisherFail() {
         delayErrorCompletableFailDoesNotCancelPublisher(true);
     }
 
     @Test
-    public void delayErrorCompletableFailDoesNotCancelPublisher() {
+    void delayErrorCompletableFailDoesNotCancelPublisher() {
         delayErrorCompletableFailDoesNotCancelPublisher(false);
     }
 
@@ -169,7 +169,7 @@ public class CompletableMergeWithPublisherTest {
     }
 
     @Test
-    public void testPublisherFailCancelsCompletable() {
+    void testPublisherFailCancelsCompletable() {
         TestCompletable completable = new TestCompletable.Builder().disableAutoOnSubscribe().build();
         TestCancellable cancellable = new TestCancellable();
         toSource(completable.merge(publisher)).subscribe(subscriber);
@@ -183,12 +183,12 @@ public class CompletableMergeWithPublisherTest {
     }
 
     @Test
-    public void delayErrorPublisherFailDoesNotCancelCompletableFail() {
+    void delayErrorPublisherFailDoesNotCancelCompletableFail() {
         delayErrorPublisherFailDoesNotCancelCompletable(true);
     }
 
     @Test
-    public void delayErrorPublisherFailDoesNotCancelCompletable() {
+    void delayErrorPublisherFailDoesNotCancelCompletable() {
         delayErrorPublisherFailDoesNotCancelCompletable(false);
     }
 
@@ -212,12 +212,12 @@ public class CompletableMergeWithPublisherTest {
     }
 
     @Test
-    public void testCancelCancelsPendingSourceSubscription() {
+    void testCancelCancelsPendingSourceSubscription() {
         testCancelCancelsPendingSourceSubscription(false);
     }
 
     @Test
-    public void delayErrorCancelCancelsPendingSourceSubscription() {
+    void delayErrorCancelCancelsPendingSourceSubscription() {
         testCancelCancelsPendingSourceSubscription(true);
     }
 
@@ -235,12 +235,12 @@ public class CompletableMergeWithPublisherTest {
     }
 
     @Test
-    public void testCancelCompletableCompletePublisherPendingCancelsNoMoreInteraction() {
+    void testCancelCompletableCompletePublisherPendingCancelsNoMoreInteraction() {
         testCancelCompletableCompletePublisherPendingCancelsNoMoreInteraction(false);
     }
 
     @Test
-    public void delayErrorCancelCompletableCompletePublisherPendingCancelsNoMoreInteraction() {
+    void delayErrorCancelCompletableCompletePublisherPendingCancelsNoMoreInteraction() {
         testCancelCompletableCompletePublisherPendingCancelsNoMoreInteraction(true);
     }
 
@@ -259,12 +259,12 @@ public class CompletableMergeWithPublisherTest {
     }
 
     @Test
-    public void testCancelPublisherCompleteCompletablePendingCancelsNoMoreInteraction() {
+    void testCancelPublisherCompleteCompletablePendingCancelsNoMoreInteraction() {
         testCancelPublisherCompleteCompletablePendingCancelsNoMoreInteraction(false);
     }
 
     @Test
-    public void delayErrorCancelPublisherCompleteCompletablePendingCancelsNoMoreInteraction() {
+    void delayErrorCancelPublisherCompleteCompletablePendingCancelsNoMoreInteraction() {
         testCancelPublisherCompleteCompletablePendingCancelsNoMoreInteraction(true);
     }
 
@@ -285,12 +285,12 @@ public class CompletableMergeWithPublisherTest {
     }
 
     @Test
-    public void testCompletableAndPublisherCompleteSingleCompleteSignal() {
+    void testCompletableAndPublisherCompleteSingleCompleteSignal() {
         testCompletableAndPublisherCompleteSingleCompleteSignal(false);
     }
 
     @Test
-    public void delayErrorCompletableAndPublisherCompleteSingleCompleteSignal() {
+    void delayErrorCompletableAndPublisherCompleteSingleCompleteSignal() {
         testCompletableAndPublisherCompleteSingleCompleteSignal(true);
     }
 
@@ -307,12 +307,12 @@ public class CompletableMergeWithPublisherTest {
     }
 
     @Test
-    public void testCompletableAndPublisherFailOnlySingleErrorSignal() {
+    void testCompletableAndPublisherFailOnlySingleErrorSignal() {
         testCompletableAndPublisherFailOnlySingleErrorSignal(false);
     }
 
     @Test
-    public void delayErrorCompletableAndPublisherFailOnlySingleErrorSignal() {
+    void delayErrorCompletableAndPublisherFailOnlySingleErrorSignal() {
         testCompletableAndPublisherFailOnlySingleErrorSignal(true);
     }
 
@@ -332,12 +332,12 @@ public class CompletableMergeWithPublisherTest {
     }
 
     @Test
-    public void testCompletableFailsAndPublisherCompletesSingleErrorSignal() {
+    void testCompletableFailsAndPublisherCompletesSingleErrorSignal() {
         testCompletableFailsAndPublisherCompletesSingleErrorSignal(false);
     }
 
     @Test
-    public void delayErrorCompletableFailsAndPublisherCompletesSingleErrorSignal() {
+    void delayErrorCompletableFailsAndPublisherCompletesSingleErrorSignal() {
         testCompletableFailsAndPublisherCompletesSingleErrorSignal(true);
     }
 
@@ -354,12 +354,12 @@ public class CompletableMergeWithPublisherTest {
     }
 
     @Test
-    public void testPublisherFailsAndCompletableCompletesSingleErrorSignal() {
+    void testPublisherFailsAndCompletableCompletesSingleErrorSignal() {
         testPublisherFailsAndCompletableCompletesSingleErrorSignal(false);
     }
 
     @Test
-    public void delayErrorPublisherFailsAndCompletableCompletesSingleErrorSignal() {
+    void delayErrorPublisherFailsAndCompletableCompletesSingleErrorSignal() {
         testPublisherFailsAndCompletableCompletesSingleErrorSignal(true);
     }
 
@@ -377,12 +377,12 @@ public class CompletableMergeWithPublisherTest {
     }
 
     @Test
-    public void offloadingWaitsForPublisherSignalsEvenIfCompletableTerminates() throws Exception {
+    void offloadingWaitsForPublisherSignalsEvenIfCompletableTerminates() throws Exception {
         offloadingWaitsForPublisherSignalsEvenIfCompletableTerminates(false);
     }
 
     @Test
-    public void delayErrorOffloadingWaitsForPublisherSignalsEvenIfCompletableTerminates() throws Exception {
+    void delayErrorOffloadingWaitsForPublisherSignalsEvenIfCompletableTerminates() throws Exception {
         offloadingWaitsForPublisherSignalsEvenIfCompletableTerminates(true);
     }
 
@@ -421,12 +421,12 @@ public class CompletableMergeWithPublisherTest {
     }
 
     @Test
-    public void publisherAndCompletableErrorDoesNotDuplicateErrorDownstream() throws Exception {
+    void publisherAndCompletableErrorDoesNotDuplicateErrorDownstream() throws Exception {
         publisherAndCompletableErrorDoesNotDuplicateErrorDownstream(false);
     }
 
     @Test
-    public void delayErrorPublisherAndCompletableErrorDoesNotDuplicateErrorDownstream() throws Exception {
+    void delayErrorPublisherAndCompletableErrorDoesNotDuplicateErrorDownstream() throws Exception {
         publisherAndCompletableErrorDoesNotDuplicateErrorDownstream(true);
     }
 
@@ -452,12 +452,12 @@ public class CompletableMergeWithPublisherTest {
     }
 
     @Test
-    public void onNextConcurrentWithCompletableError() throws Exception {
+    void onNextConcurrentWithCompletableError() throws Exception {
         onNextConcurrentWithCompletableError(false);
     }
 
     @Test
-    public void delayErrorOnNextConcurrentWithCompletableError() throws Exception {
+    void delayErrorOnNextConcurrentWithCompletableError() throws Exception {
         onNextConcurrentWithCompletableError(true);
     }
 
@@ -503,42 +503,42 @@ public class CompletableMergeWithPublisherTest {
     }
 
     @Test
-    public void onNextReentryCompleteConcurrentWithCompletable() throws Exception {
+    void onNextReentryCompleteConcurrentWithCompletable() throws Exception {
         onNextReentryCompleteConcurrentWithCompletable(false, true, true);
     }
 
     @Test
-    public void onNextReentryErrorConcurrentWithCompletable() throws Exception {
+    void onNextReentryErrorConcurrentWithCompletable() throws Exception {
         onNextReentryCompleteConcurrentWithCompletable(false, false, true);
     }
 
     @Test
-    public void onNextReentryCompleteConcurrentWithCompletableError() throws Exception {
+    void onNextReentryCompleteConcurrentWithCompletableError() throws Exception {
         onNextReentryCompleteConcurrentWithCompletable(false, true, false);
     }
 
     @Test
-    public void onNextReentryErrorConcurrentWithCompletableError() throws Exception {
+    void onNextReentryErrorConcurrentWithCompletableError() throws Exception {
         onNextReentryCompleteConcurrentWithCompletable(false, false, false);
     }
 
     @Test
-    public void delayErrorOnNextReentryCompleteConcurrentWithCompletable() throws Exception {
+    void delayErrorOnNextReentryCompleteConcurrentWithCompletable() throws Exception {
         onNextReentryCompleteConcurrentWithCompletable(true, true, true);
     }
 
     @Test
-    public void delayErrorOnNextReentryErrorConcurrentWithCompletable() throws Exception {
+    void delayErrorOnNextReentryErrorConcurrentWithCompletable() throws Exception {
         onNextReentryCompleteConcurrentWithCompletable(true, false, true);
     }
 
     @Test
-    public void delayErrorOnNextReentryCompleteConcurrentWithCompletableError() throws Exception {
+    void delayErrorOnNextReentryCompleteConcurrentWithCompletableError() throws Exception {
         onNextReentryCompleteConcurrentWithCompletable(true, true, false);
     }
 
     @Test
-    public void delayErrorOnNextReentryErrorConcurrentWithCompletableError() throws Exception {
+    void delayErrorOnNextReentryErrorConcurrentWithCompletableError() throws Exception {
         onNextReentryCompleteConcurrentWithCompletable(true, false, false);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableProcessorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableProcessorTest.java
@@ -42,14 +42,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class CompletableProcessorTest {
+class CompletableProcessorTest {
     @RegisterExtension
     static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
     private final TestCompletableSubscriber rule = new TestCompletableSubscriber();
     private final TestCompletableSubscriber rule2 = new TestCompletableSubscriber();
 
     @Test
-    public void testCompleteBeforeListen() {
+    void testCompleteBeforeListen() {
         CompletableProcessor processor = new CompletableProcessor();
         processor.onComplete();
         toSource(processor).subscribe(rule);
@@ -57,7 +57,7 @@ public class CompletableProcessorTest {
     }
 
     @Test
-    public void testErrorBeforeListen() {
+    void testErrorBeforeListen() {
         CompletableProcessor processor = new CompletableProcessor();
         processor.onError(DELIBERATE_EXCEPTION);
         toSource(processor).subscribe(rule);
@@ -65,7 +65,7 @@ public class CompletableProcessorTest {
     }
 
     @Test
-    public void testCompleteAfterListen() {
+    void testCompleteAfterListen() {
         CompletableProcessor processor = new CompletableProcessor();
         toSource(processor).subscribe(rule);
         assertThat(rule.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -74,7 +74,7 @@ public class CompletableProcessorTest {
     }
 
     @Test
-    public void testErrorAfterListen() {
+    void testErrorAfterListen() {
         CompletableProcessor processor = new CompletableProcessor();
         toSource(processor).subscribe(rule);
         assertThat(rule.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -83,7 +83,7 @@ public class CompletableProcessorTest {
     }
 
     @Test
-    public void testCompleteThenError() {
+    void testCompleteThenError() {
         CompletableProcessor processor = new CompletableProcessor();
         processor.onComplete();
         processor.onError(DELIBERATE_EXCEPTION);
@@ -92,7 +92,7 @@ public class CompletableProcessorTest {
     }
 
     @Test
-    public void testErrorThenComplete() {
+    void testErrorThenComplete() {
         CompletableProcessor processor = new CompletableProcessor();
         processor.onError(DELIBERATE_EXCEPTION);
         processor.onComplete();
@@ -101,7 +101,7 @@ public class CompletableProcessorTest {
     }
 
     @Test
-    public void cancelRemovesListenerAndStillAllowsOtherListenersToBeNotified() {
+    void cancelRemovesListenerAndStillAllowsOtherListenersToBeNotified() {
         CompletableProcessor processor = new CompletableProcessor();
         toSource(processor).subscribe(rule);
         assertThat(rule.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -114,7 +114,7 @@ public class CompletableProcessorTest {
     }
 
     @Test
-    public void synchronousCancelStillAllowsForGC() throws InterruptedException {
+    void synchronousCancelStillAllowsForGC() throws InterruptedException {
         CompletableProcessor processor = new CompletableProcessor();
         ReferenceQueue<Subscriber> queue = new ReferenceQueue<>();
         WeakReference<Subscriber> subscriberRef =
@@ -145,12 +145,12 @@ public class CompletableProcessorTest {
     }
 
     @Test
-    public void multiThreadedAddAlwaysTerminatesError() throws Exception {
+    void multiThreadedAddAlwaysTerminatesError() throws Exception {
         multiThreadedAddAlwaysTerminates(DELIBERATE_EXCEPTION);
     }
 
     @Test
-    public void multiThreadedAddAlwaysTerminatesComplete() throws Exception {
+    void multiThreadedAddAlwaysTerminatesComplete() throws Exception {
         multiThreadedAddAlwaysTerminates(null);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompositeCancellableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompositeCancellableTest.java
@@ -30,46 +30,46 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
-public class CompositeCancellableTest {
+class CompositeCancellableTest {
 
 
     @RegisterExtension
-    public final MockedCancellableHolder holder = new MockedCancellableHolder();
+    final MockedCancellableHolder holder = new MockedCancellableHolder();
 
     @Test
-    public void testEmpty() {
+    void testEmpty() {
         assertThrows(IllegalArgumentException.class, () -> holder.init(0));
     }
 
     @Test
-    public void testOne() {
+    void testOne() {
         Cancellable composite = holder.init(1);
         assertThat("Composite of 1 must not create a new instance.", composite, is(holder.components[0]));
         composite.cancel();
     }
 
     @Test
-    public void testTwo() {
+    void testTwo() {
         holder.init(2).cancel();
     }
 
     @Test
-    public void testMany() {
+    void testMany() {
         holder.init(5).cancel();
     }
 
     @Test
-    public void cancelThrowsForTwo() {
+    void cancelThrowsForTwo() {
         testCancelThrows(holder.init(2));
     }
 
     @Test
-    public void cancelThrowsForMany() {
+    void cancelThrowsForMany() {
         testCancelThrows(holder.init(5));
     }
 
     @Test
-    public void cancellablesMayContainNull() {
+    void cancellablesMayContainNull() {
         Cancellable cancellable = holder.init(5);
         holder.components[3] = null;
         cancellable.cancel();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcatPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcatPublisherTest.java
@@ -25,14 +25,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class ConcatPublisherTest {
+class ConcatPublisherTest {
 
     private final TestPublisher<String> first = new TestPublisher<>();
     private final TestPublisher<String> second = new TestPublisher<>();
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
 
     @Test
-    public void testEnoughRequests() {
+    void testEnoughRequests() {
         Publisher<String> p = first.concat(second);
         toSource(p).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
@@ -46,7 +46,7 @@ public class ConcatPublisherTest {
     }
 
     @Test
-    public void testFirstEmitsError() {
+    void testFirstEmitsError() {
         Publisher<String> p = first.concat(second);
         toSource(p).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
@@ -57,7 +57,7 @@ public class ConcatPublisherTest {
     }
 
     @Test
-    public void testSecondEmitsError() {
+    void testSecondEmitsError() {
         Publisher<String> p = first.concat(second);
         toSource(p).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcatWithOrderingTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcatWithOrderingTest.java
@@ -20,12 +20,12 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class ConcatWithOrderingTest {
+class ConcatWithOrderingTest {
 
     protected final StringBuilder sb = new StringBuilder();
 
     @Test
-    public void completablesOnly() throws Exception {
+    void completablesOnly() throws Exception {
         completable(1)
                 .concat(completable(2))
                 .concat(completable(3))
@@ -37,7 +37,7 @@ public class ConcatWithOrderingTest {
     }
 
     @Test
-    public void completableSingeCompletables() throws Exception {
+    void completableSingeCompletables() throws Exception {
         completable(1)
                 .concat(single(2))
                 .concat(completable(3))
@@ -49,7 +49,7 @@ public class ConcatWithOrderingTest {
     }
 
     @Test
-    public void completableTwoSingesCompletables() throws Exception {
+    void completableTwoSingesCompletables() throws Exception {
         completable(1)
                 .concat(single(2))
                 .concat(single(3))
@@ -61,7 +61,7 @@ public class ConcatWithOrderingTest {
     }
 
     @Test
-    public void completablePublisherCompletables() throws Exception {
+    void completablePublisherCompletables() throws Exception {
         completable(1)
                 .concat(publisher(2))
                 .concat(completable(3))
@@ -73,7 +73,7 @@ public class ConcatWithOrderingTest {
     }
 
     @Test
-    public void singlesOnly() throws Exception {
+    void singlesOnly() throws Exception {
         single(1)
                 .concat(single(2))
                 .concat(single(3))
@@ -85,7 +85,7 @@ public class ConcatWithOrderingTest {
     }
 
     @Test
-    public void singleCompletableSingles() throws Exception {
+    void singleCompletableSingles() throws Exception {
         single(1)
                 .concat(completable(2))
                 .concat(single(3))
@@ -97,7 +97,7 @@ public class ConcatWithOrderingTest {
     }
 
     @Test
-    public void singleTwoCompletablesSingles() throws Exception {
+    void singleTwoCompletablesSingles() throws Exception {
         single(1)
                 .concat(completable(2))
                 .concat(completable(3))
@@ -109,7 +109,7 @@ public class ConcatWithOrderingTest {
     }
 
     @Test
-    public void singlePublisherSingles() throws Exception {
+    void singlePublisherSingles() throws Exception {
         single(1)
                 .concat(publisher(2))
                 .concat(single(3))
@@ -121,7 +121,7 @@ public class ConcatWithOrderingTest {
     }
 
     @Test
-    public void publishersOnly() throws Exception {
+    void publishersOnly() throws Exception {
         publisher(1)
                 .concat(publisher(2))
                 .concat(publisher(3))
@@ -133,7 +133,7 @@ public class ConcatWithOrderingTest {
     }
 
     @Test
-    public void publisherCompletablePublishers() throws Exception {
+    void publisherCompletablePublishers() throws Exception {
         publisher(1)
                 .concat(completable(2))
                 .concat(publisher(3))
@@ -145,7 +145,7 @@ public class ConcatWithOrderingTest {
     }
 
     @Test
-    public void publisherSinglePublishers() throws Exception {
+    void publisherSinglePublishers() throws Exception {
         publisher(1)
                 .concat(single(2))
                 .concat(publisher(3))
@@ -157,7 +157,7 @@ public class ConcatWithOrderingTest {
     }
 
     @Test
-    public void completableSinglePublisherSingleCompletable() throws Exception {
+    void completableSinglePublisherSingleCompletable() throws Exception {
         completable(1)
                 .concat(single(2))
                 .concat(publisher(3))
@@ -169,7 +169,7 @@ public class ConcatWithOrderingTest {
     }
 
     @Test
-    public void publisherSingleCompletableSinglePublisher() throws Exception {
+    void publisherSingleCompletableSinglePublisher() throws Exception {
         publisher(1)
                 .concat(single(2))
                 .concat(completable(3))

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcurrentUtilsTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ConcurrentUtilsTest.java
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public final class ConcurrentUtilsTest {
+final class ConcurrentUtilsTest {
     private static final AtomicIntegerFieldUpdater<ConcurrentUtilsTest> lockUpdater =
             AtomicIntegerFieldUpdater.newUpdater(ConcurrentUtilsTest.class, "lock");
     private static final AtomicLongFieldUpdater<ConcurrentUtilsTest> reentrantLockUpdater =
@@ -48,24 +48,24 @@ public final class ConcurrentUtilsTest {
     private ExecutorService executor;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         executor = newCachedThreadPool();
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         executor.shutdown();
         executor.awaitTermination(DEFAULT_TIMEOUT_SECONDS, SECONDS);
     }
 
     @Test
-    public void lockSingleThread() {
+    void lockSingleThread() {
         assertTrue(tryAcquireLock(lockUpdater, this));
         assertTrue(releaseLock(lockUpdater, this));
     }
 
     @Test
-    public void reentrantLockSingleThread() {
+    void reentrantLockSingleThread() {
         long acquireId = tryAcquireReentrantLock(reentrantLockUpdater, this);
         assertThat(acquireId, greaterThan(0L));
         long acquireId2 = tryAcquireReentrantLock(reentrantLockUpdater, this);
@@ -75,7 +75,7 @@ public final class ConcurrentUtilsTest {
     }
 
     @Test
-    public void lockFromDifferentThread() throws Exception {
+    void lockFromDifferentThread() throws Exception {
         assertTrue(tryAcquireLock(lockUpdater, this));
         executor.submit(() -> assertFalse(tryAcquireLock(lockUpdater, this))).get();
 
@@ -88,7 +88,7 @@ public final class ConcurrentUtilsTest {
     }
 
     @Test
-    public void reentrantLockFromDifferentThread() throws Exception {
+    void reentrantLockFromDifferentThread() throws Exception {
         long acquireId = tryAcquireReentrantLock(reentrantLockUpdater, this);
         assertThat(acquireId, greaterThan(0L));
         executor.submit(() -> assertThat(tryAcquireReentrantLock(reentrantLockUpdater, this), is(0L))).get();
@@ -103,7 +103,7 @@ public final class ConcurrentUtilsTest {
     }
 
     @Test
-    public void lockFromDifferentThreadReAcquireFromDifferentThread() throws Exception {
+    void lockFromDifferentThreadReAcquireFromDifferentThread() throws Exception {
         assertTrue(tryAcquireLock(lockUpdater, this));
         executor.submit(() -> assertFalse(tryAcquireLock(lockUpdater, this))).get();
 
@@ -118,7 +118,7 @@ public final class ConcurrentUtilsTest {
     }
 
     @Test
-    public void reentrantLockFromDifferentThreadReAcquireFromDifferentThread() throws Exception {
+    void reentrantLockFromDifferentThreadReAcquireFromDifferentThread() throws Exception {
         long acquireId = tryAcquireReentrantLock(reentrantLockUpdater, this);
         assertThat(acquireId, greaterThan(0L));
         executor.submit(() -> assertThat(tryAcquireReentrantLock(reentrantLockUpdater, this), is(0L))).get();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultAsyncContextProviderTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultAsyncContextProviderTest.java
@@ -61,7 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DefaultAsyncContextProviderTest {
+class DefaultAsyncContextProviderTest {
     private static final Key<String> K1 = Key.newKey("k1");
     private static final Key<String> K2 = Key.newKey("k2");
     private static final Key<String> K3 = Key.newKey("k3");
@@ -74,19 +74,19 @@ public class DefaultAsyncContextProviderTest {
     private static ScheduledExecutorService executor;
 
     @BeforeAll
-    public static void beforeClass() {
+    static void beforeClass() {
         AsyncContext.autoEnable();
         executor = Executors.newScheduledThreadPool(4);
     }
 
     @AfterAll
-    public static void afterClass() throws Exception {
+    static void afterClass() throws Exception {
         executor.shutdown();
         executor.awaitTermination(DEFAULT_TIMEOUT_SECONDS, SECONDS);
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         AsyncContext.clear();
     }
 
@@ -105,7 +105,7 @@ public class DefaultAsyncContextProviderTest {
     }
 
     @Test
-    public void testContextInCompletableListener() throws Exception {
+    void testContextInCompletableListener() throws Exception {
         Completable completable = new Completable() {
             @Override
             protected void handleSubscribe(CompletableSource.Subscriber completableSubscriber) {
@@ -132,7 +132,7 @@ public class DefaultAsyncContextProviderTest {
     }
 
     @Test
-    public void testContextInCompletableOperators() throws Exception {
+    void testContextInCompletableOperators() throws Exception {
         CompletableFuture<AsyncContextMap> f1 = new CompletableFuture<>();
         CompletableFuture<AsyncContextMap> f2 = new CompletableFuture<>();
         CompletableFuture<AsyncContextMap> f3 = new CompletableFuture<>();
@@ -170,7 +170,7 @@ public class DefaultAsyncContextProviderTest {
     }
 
     @Test
-    public void testContextInSingleListener() throws Exception {
+    void testContextInSingleListener() throws Exception {
         Single<String> single = new Single<String>() {
             @Override
             protected void handleSubscribe(SingleSource.Subscriber<? super String> singleSubscriber) {
@@ -197,7 +197,7 @@ public class DefaultAsyncContextProviderTest {
     }
 
     @Test
-    public void testContextInSingleOperators() throws Exception {
+    void testContextInSingleOperators() throws Exception {
         CompletableFuture<AsyncContextMap> f1 = new CompletableFuture<>();
         CompletableFuture<AsyncContextMap> f2 = new CompletableFuture<>();
         CompletableFuture<AsyncContextMap> f3 = new CompletableFuture<>();
@@ -248,7 +248,7 @@ public class DefaultAsyncContextProviderTest {
     }
 
     @Test
-    public void testContextInSingleConversions() throws Exception {
+    void testContextInSingleConversions() throws Exception {
         CompletableFuture<AsyncContextMap> f1 = new CompletableFuture<>();
         CompletableFuture<AsyncContextMap> f2 = new CompletableFuture<>();
         CompletableFuture<AsyncContextMap> f3 = new CompletableFuture<>();
@@ -284,7 +284,7 @@ public class DefaultAsyncContextProviderTest {
     }
 
     @Test
-    public void testContextInSubscriber() throws Exception {
+    void testContextInSubscriber() throws Exception {
         ContextCaptureTestPublisher publisher1 = new ContextCaptureTestPublisher();
         AsyncContext.put(K1, "v1");
         new ContextCaptureSubscriber<String>()
@@ -314,7 +314,7 @@ public class DefaultAsyncContextProviderTest {
     }
 
     @Test
-    public void testContextInPublisherOperators() throws Exception {
+    void testContextInPublisherOperators() throws Exception {
         CompletableFuture<AsyncContextMap> f1 = new CompletableFuture<>();
         CompletableFuture<AsyncContextMap> f2 = new CompletableFuture<>();
         CompletableFuture<AsyncContextMap> f3 = new CompletableFuture<>();
@@ -359,7 +359,7 @@ public class DefaultAsyncContextProviderTest {
     }
 
     @Test
-    public void testWrapExecutor() throws Exception {
+    void testWrapExecutor() throws Exception {
         AsyncContext.put(K1, "v1");
         Consumer<AsyncContextMap> verifier = map -> {
             assertEquals("v1", map.get(K1));
@@ -384,7 +384,7 @@ public class DefaultAsyncContextProviderTest {
     }
 
     @Test
-    public void testWrapFunctions() throws Exception {
+    void testWrapFunctions() throws Exception {
         AsyncContext.put(K1, "v1");
         Consumer<AsyncContextMap> verifier = map -> {
             assertEquals("v1", map.get(K1));
@@ -430,7 +430,7 @@ public class DefaultAsyncContextProviderTest {
     }
 
     @Test
-    public void testSinglePutAndRemove() {
+    void testSinglePutAndRemove() {
         assertContextSize(0);
 
         AsyncContext.put(K1, "v1");
@@ -590,7 +590,7 @@ public class DefaultAsyncContextProviderTest {
     }
 
     @Test
-    public void testMultiPutAndRemove() {
+    void testMultiPutAndRemove() {
         AsyncContext.putAll(newMap(K1, "v1"));
         assertContains(K1, "v1");
         assertContextSize(1);
@@ -669,42 +669,42 @@ public class DefaultAsyncContextProviderTest {
     }
 
     @Test
-    public void oneRemoveMultiplePermutations() {
+    void oneRemoveMultiplePermutations() {
         testRemoveMultiplePermutations(asList(K1));
     }
 
     @Test
-    public void twoRemoveMultiplePermutations() {
+    void twoRemoveMultiplePermutations() {
         testRemoveMultiplePermutations(asList(K1, K2));
     }
 
     @Test
-    public void threeRemoveMultiplePermutations() {
+    void threeRemoveMultiplePermutations() {
         testRemoveMultiplePermutations(asList(K1, K2, K3));
     }
 
     @Test
-    public void fourRemoveMultiplePermutations() {
+    void fourRemoveMultiplePermutations() {
         testRemoveMultiplePermutations(asList(K1, K2, K3, K4));
     }
 
     @Test
-    public void fiveRemoveMultiplePermutations() {
+    void fiveRemoveMultiplePermutations() {
         testRemoveMultiplePermutations(asList(K1, K2, K3, K4, K5));
     }
 
     @Test
-    public void sixRemoveMultiplePermutations() {
+    void sixRemoveMultiplePermutations() {
         testRemoveMultiplePermutations(asList(K1, K2, K3, K4, K5, K6));
     }
 
     @Test
-    public void sevenRemoveMultiplePermutations() {
+    void sevenRemoveMultiplePermutations() {
         testRemoveMultiplePermutations(asList(K1, K2, K3, K4, K5, K6, K7));
     }
 
     @Test
-    public void eightRemoveMultiplePermutations() {
+    void eightRemoveMultiplePermutations() {
         testRemoveMultiplePermutations(asList(K1, K2, K3, K4, K5, K6, K7, K8));
     }
 
@@ -759,47 +759,47 @@ public class DefaultAsyncContextProviderTest {
     }
 
     @Test
-    public void emptyPutMultiplePermutations() {
+    void emptyPutMultiplePermutations() {
         testPutMultiplePermutations(emptyList());
     }
 
     @Test
-    public void onePutMultiplePermutations() {
+    void onePutMultiplePermutations() {
         testPutMultiplePermutations(asList(K1));
     }
 
     @Test
-    public void twoPutMultiplePermutations() {
+    void twoPutMultiplePermutations() {
         testPutMultiplePermutations(asList(K1, K2));
     }
 
     @Test
-    public void threePutMultiplePermutations() {
+    void threePutMultiplePermutations() {
         testPutMultiplePermutations(asList(K1, K2, K3));
     }
 
     @Test
-    public void fourPutMultiplePermutations() {
+    void fourPutMultiplePermutations() {
         testPutMultiplePermutations(asList(K1, K2, K3, K4));
     }
 
     @Test
-    public void fivePutMultiplePermutations() {
+    void fivePutMultiplePermutations() {
         testPutMultiplePermutations(asList(K1, K2, K3, K4, K5));
     }
 
     @Test
-    public void sixPutMultiplePermutations() {
+    void sixPutMultiplePermutations() {
         testPutMultiplePermutations(asList(K1, K2, K3, K4, K5, K6));
     }
 
     @Test
-    public void sevenPutMultiplePermutations() {
+    void sevenPutMultiplePermutations() {
         testPutMultiplePermutations(asList(K1, K2, K3, K4, K5, K6, K7));
     }
 
     @Test
-    public void eightPutMultiplePermutations() {
+    void eightPutMultiplePermutations() {
         testPutMultiplePermutations(asList(K1, K2, K3, K4, K5, K6, K7, K8));
     }
 
@@ -864,7 +864,7 @@ public class DefaultAsyncContextProviderTest {
         }
     }
 
-    public static Map<Key<?>, Object> newMap(Key<?>... keys) {
+    static Map<Key<?>, Object> newMap(Key<?>... keys) {
         HashMap<Key<?>, Object> map = new HashMap<>();
         for (int i = 0; i < keys.length; ++i) {
             map.put(keys[i], "permutation" + (i + 1));
@@ -872,20 +872,20 @@ public class DefaultAsyncContextProviderTest {
         return map;
     }
 
-    public static Map<Key<?>, Object> newMap(Key<?> k1, Object v1) {
+    static Map<Key<?>, Object> newMap(Key<?> k1, Object v1) {
         HashMap<Key<?>, Object> map = new HashMap<>();
         map.put(k1, v1);
         return map;
     }
 
-    public static Map<Key<?>, Object> newMap(Key<?> k1, Object v1, Key<?> k2, Object v2) {
+    static Map<Key<?>, Object> newMap(Key<?> k1, Object v1, Key<?> k2, Object v2) {
         HashMap<Key<?>, Object> map = new HashMap<>();
         map.put(k1, v1);
         map.put(k2, v2);
         return map;
     }
 
-    public static Map<Key<?>, Object> newMap(Key<?> k1, Object v1, Key<?> k2, Object v2, Key<?> k3, Object v3) {
+    static Map<Key<?>, Object> newMap(Key<?> k1, Object v1, Key<?> k2, Object v2, Key<?> k3, Object v3) {
         HashMap<Key<?>, Object> map = new HashMap<>();
         map.put(k1, v1);
         map.put(k2, v2);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultBlockingIterableProcessorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultBlockingIterableProcessorTest.java
@@ -30,16 +30,16 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class DefaultBlockingIterableProcessorTest {
+class DefaultBlockingIterableProcessorTest {
 
     private final BlockingIterable.Processor<Integer> processor;
 
-    public DefaultBlockingIterableProcessorTest() {
+    DefaultBlockingIterableProcessorTest() {
         processor = Processors.newBlockingIterableProcessor(2);
     }
 
     @Test
-    public void emitBuffersNoIterator() throws Exception {
+    void emitBuffersNoIterator() throws Exception {
         processor.next(1);
         processor.next(2);
         BlockingIterator<Integer> iterator = processor.iterator();
@@ -50,7 +50,7 @@ public class DefaultBlockingIterableProcessorTest {
     }
 
     @Test
-    public void emitBuffersNoDemand() throws Exception {
+    void emitBuffersNoDemand() throws Exception {
         BlockingIterator<Integer> iterator = processor.iterator();
         processor.next(1);
         processor.next(2);
@@ -61,26 +61,26 @@ public class DefaultBlockingIterableProcessorTest {
     }
 
     @Test
-    public void hasNextTimesout() {
+    void hasNextTimesout() {
         BlockingIterator<Integer> iterator = processor.iterator();
         assertThrows(TimeoutException.class, () -> iterator.hasNext(10, TimeUnit.MILLISECONDS));
     }
 
     @Test
-    public void nextTimesout() {
+    void nextTimesout() {
         BlockingIterator<Integer> iterator = processor.iterator();
         assertThrows(TimeoutException.class, () -> iterator.next(10, TimeUnit.MILLISECONDS));
     }
 
     @Test
-    public void emitNull() throws Exception {
+    void emitNull() throws Exception {
         BlockingIterator<Integer> iterator = processor.iterator();
         processor.next(null);
         assertThat("Unexpected item received.", iterator.next(), is(nullValue()));
     }
 
     @Test
-    public void iteratorCloseAfterProcessorTermination() throws Exception {
+    void iteratorCloseAfterProcessorTermination() throws Exception {
         BlockingIterator<Integer> iterator = processor.iterator();
         processor.close();
         iterator.close();
@@ -88,7 +88,7 @@ public class DefaultBlockingIterableProcessorTest {
     }
 
     @Test
-    public void iteratorCloseAfterProcessorFail() throws Exception {
+    void iteratorCloseAfterProcessorFail() throws Exception {
         BlockingIterator<Integer> iterator = processor.iterator();
         processor.fail(DELIBERATE_EXCEPTION);
         iterator.close();
@@ -96,14 +96,14 @@ public class DefaultBlockingIterableProcessorTest {
     }
 
     @Test
-    public void postIteratorCloseHasNextThrows() throws Exception {
+    void postIteratorCloseHasNextThrows() throws Exception {
         BlockingIterator<Integer> iterator = processor.iterator();
         iterator.close();
         assertThrows(CancellationException.class, () -> iterator.hasNext());
     }
 
     @Test
-    public void postIteratorCloseNextThrows() throws Exception {
+    void postIteratorCloseNextThrows() throws Exception {
         BlockingIterator<Integer> iterator = processor.iterator();
         iterator.close();
         assertThrows(CancellationException.class, () -> iterator.next());

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultExecutorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultExecutorTest.java
@@ -61,7 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public final class DefaultExecutorTest {
+final class DefaultExecutorTest {
 
     private static final int UNBOUNDED = -1;
     private Executor executor;
@@ -159,13 +159,13 @@ public final class DefaultExecutorTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         executor.closeAsync().subscribe();
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void execution(ExecutorParam executorParam) throws Throwable {
+    void execution(ExecutorParam executorParam) throws Throwable {
         executor = executorParam.get();
         Task task = new Task();
         executor.execute(task);
@@ -174,7 +174,7 @@ public final class DefaultExecutorTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void longRunningTasksDoesNotHaltOthers(ExecutorParam executorParam) throws Throwable {
+    void longRunningTasksDoesNotHaltOthers(ExecutorParam executorParam) throws Throwable {
         executor = executorParam.get();
         Task awaitForever = Task.newAwaitForeverTask();
         executor.execute(awaitForever);
@@ -185,7 +185,7 @@ public final class DefaultExecutorTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void interDependentTasksCanRun(ExecutorParam executorParam) throws Throwable {
+    void interDependentTasksCanRun(ExecutorParam executorParam) throws Throwable {
         executor = executorParam.get();
         Task first = new Task();
         Task second = new Task(() -> {
@@ -202,7 +202,7 @@ public final class DefaultExecutorTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void scheduledTasks(ExecutorParam executorParam) throws Throwable {
+    void scheduledTasks(ExecutorParam executorParam) throws Throwable {
         executor = executorParam.get();
         Task scheduled = new Task();
         executor.schedule(scheduled, 1, MILLISECONDS);
@@ -211,7 +211,7 @@ public final class DefaultExecutorTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void cancelExecute(ExecutorParam executorParam) throws Throwable {
+    void cancelExecute(ExecutorParam executorParam) throws Throwable {
         executor = executorParam.get();
         assumeTrue(executorParam.supportsCancellation(),
                 () -> "Ignoring executor: " + executorParam + ", it does not support cancellation.");
@@ -227,7 +227,7 @@ public final class DefaultExecutorTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void executeRejection(ExecutorParam executorParam) {
+    void executeRejection(ExecutorParam executorParam) {
         executor = executorParam.get();
         assumeTrue(executorParam.size() > 0,
                 () -> "Ignoring executor: " + executorParam + ", it has an unbounded thread pool.");
@@ -240,7 +240,7 @@ public final class DefaultExecutorTest {
     }
 
     @Test
-    public void rejectSchedule() {
+    void rejectSchedule() {
         executor = from(new RejectAllScheduler());
         assertThrows(RejectedExecutionException.class, () -> executor.schedule(() -> {
         }, 1, SECONDS));
@@ -248,28 +248,28 @@ public final class DefaultExecutorTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void timerRaw(ExecutorParam executorParam) throws Exception {
+    void timerRaw(ExecutorParam executorParam) throws Exception {
         executor = executorParam.get();
         executor.timer(1, NANOSECONDS).toFuture().get();
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void timerDuration(ExecutorParam executorParam) throws Exception {
+    void timerDuration(ExecutorParam executorParam) throws Exception {
         executor = executorParam.get();
         executor.timer(ofNanos(1)).toFuture().get();
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void timerRawCancel(ExecutorParam executorParam) throws InterruptedException {
+    void timerRawCancel(ExecutorParam executorParam) throws InterruptedException {
         executor = executorParam.get();
         timerCancel(executor.timer(100, MILLISECONDS));
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void timerDurationCancel(ExecutorParam executorParam) throws InterruptedException {
+    void timerDurationCancel(ExecutorParam executorParam) throws InterruptedException {
         executor = executorParam.get();
         timerCancel(executor.timer(ofNanos(1)));
     }
@@ -305,14 +305,14 @@ public final class DefaultExecutorTest {
     }
 
     @Test
-    public void timerRawRejected() {
+    void timerRawRejected() {
         executor = from(new RejectAllScheduler());
         Executable executable = () -> executor.timer(1, NANOSECONDS).toFuture().get();
         assertThrowsExecutionException(executable, RejectedExecutionException.class);
     }
 
     @Test
-    public void timerDurationRejected() {
+    void timerDurationRejected() {
         executor = from(new RejectAllScheduler());
         Executable executable = () -> executor.timer(ofNanos(1)).toFuture().get();
         assertThrowsExecutionException(executable, RejectedExecutionException.class);
@@ -320,7 +320,7 @@ public final class DefaultExecutorTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void submitRunnable(ExecutorParam executorParam) throws Throwable {
+    void submitRunnable(ExecutorParam executorParam) throws Throwable {
         executor = executorParam.get();
         Task submitted = new Task();
         executor.submit(submitted).toFuture().get();
@@ -329,7 +329,7 @@ public final class DefaultExecutorTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void submitRunnableSupplier(ExecutorParam executorParam) throws Throwable {
+    void submitRunnableSupplier(ExecutorParam executorParam) throws Throwable {
         executor = executorParam.get();
         Task submitted1 = new Task();
         Task submitted2 = new Task();
@@ -342,14 +342,14 @@ public final class DefaultExecutorTest {
     }
 
     @Test
-    public void submitRunnableRejected() {
+    void submitRunnableRejected() {
         executor = from(new RejectAllExecutor());
         Executable executable = () -> executor.submit(() -> { }).toFuture().get();
         assertThrowsExecutionException(executable, RejectedExecutionException.class);
     }
 
     @Test
-    public void submitRunnableSupplierRejected() {
+    void submitRunnableSupplierRejected() {
         executor = from(new RejectAllExecutor());
         Executable executable = () -> executor.submitRunnable(() -> () -> { }).toFuture().get();
         assertThrowsExecutionException(executable, RejectedExecutionException.class);
@@ -357,7 +357,7 @@ public final class DefaultExecutorTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void submitRunnableThrows(ExecutorParam executorParam) {
+    void submitRunnableThrows(ExecutorParam executorParam) {
         executor = executorParam.get();
         Executable executable = () -> executor.submit((Runnable) () -> {
             throw DELIBERATE_EXCEPTION;
@@ -367,7 +367,7 @@ public final class DefaultExecutorTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void submitRunnableSupplierThrows(ExecutorParam executorParam) {
+    void submitRunnableSupplierThrows(ExecutorParam executorParam) {
         executor = executorParam.get();
         Executable executable = () -> executor.submitRunnable(() -> () -> {
             throw DELIBERATE_EXCEPTION;
@@ -377,7 +377,7 @@ public final class DefaultExecutorTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void submitCallable(ExecutorParam executorParam) throws Throwable {
+    void submitCallable(ExecutorParam executorParam) throws Throwable {
         executor = executorParam.get();
         CallableTask<Integer> submitted = new CallableTask<>(() -> 1);
         Integer result = awaitIndefinitelyNonNull(executor.submit(submitted));
@@ -387,7 +387,7 @@ public final class DefaultExecutorTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void submitCallableSupplier(ExecutorParam executorParam) throws Throwable {
+    void submitCallableSupplier(ExecutorParam executorParam) throws Throwable {
         executor = executorParam.get();
         CallableTask<Integer> submitted1 = new CallableTask<>(() -> 1);
         CallableTask<Integer> submitted2 = new CallableTask<>(() -> 2);
@@ -403,14 +403,14 @@ public final class DefaultExecutorTest {
     }
 
     @Test
-    public void submitCallableRejected() {
+    void submitCallableRejected() {
         executor = from(new RejectAllExecutor());
         Executable executable = () -> executor.submit(() -> 1).toFuture().get();
         assertThrowsExecutionException(executable, RejectedExecutionException.class);
     }
 
     @Test
-    public void submitCallableSupplierRejected() {
+    void submitCallableSupplierRejected() {
         executor = from(new RejectAllExecutor());
         Executable executable = () -> executor.submitCallable(() -> () -> 1).toFuture().get();
         assertThrowsExecutionException(executable, RejectedExecutionException.class);
@@ -418,7 +418,7 @@ public final class DefaultExecutorTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void submitCallableThrows(ExecutorParam executorParam) {
+    void submitCallableThrows(ExecutorParam executorParam) {
         executor = executorParam.get();
         Executable executable = () -> executor.submit((Callable<Integer>) () -> {
             throw DELIBERATE_EXCEPTION;
@@ -428,7 +428,7 @@ public final class DefaultExecutorTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(ExecutorParam.class)
-    public void submitCallableSupplierThrows(ExecutorParam executorParam) {
+    void submitCallableSupplierThrows(ExecutorParam executorParam) {
         executor = executorParam.get();
         Executable executable = () -> executor.submitCallable(() -> (Callable<Integer>) () -> {
             throw DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/From2PublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/From2PublisherTest.java
@@ -40,11 +40,11 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class From2PublisherTest {
+class From2PublisherTest {
     private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
 
     @Test
-    public void request2Complete() {
+    void request2Complete() {
         toSource(fromPublisher()).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
         assertThat(subscriber.takeOnNext(2), contains(1, 2));
@@ -52,7 +52,7 @@ public class From2PublisherTest {
     }
 
     @Test
-    public void request1Complete() {
+    void request1Complete() {
         toSource(fromPublisher()).subscribe(subscriber);
         Subscription s = subscriber.awaitSubscription();
         s.request(1);
@@ -65,7 +65,7 @@ public class From2PublisherTest {
     }
 
     @Test
-    public void request1Cancel() {
+    void request1Cancel() {
         toSource(fromPublisher()).subscribe(subscriber);
         Subscription s = subscriber.awaitSubscription();
         s.request(1);
@@ -78,12 +78,12 @@ public class From2PublisherTest {
     }
 
     @Test
-    public void throwFirst() {
+    void throwFirst() {
         throwInOnNext(1);
     }
 
     @Test
-    public void throwSecond() {
+    void throwSecond() {
         throwInOnNext(2);
     }
 
@@ -107,12 +107,12 @@ public class From2PublisherTest {
     }
 
     @Test
-    public void invalidRequestNZero() {
+    void invalidRequestNZero() {
         invalidRequestN(0);
     }
 
     @Test
-    public void invalidRequestNNeg() {
+    void invalidRequestNNeg() {
         invalidRequestN(-1);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/From3PublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/From3PublisherTest.java
@@ -40,11 +40,11 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class From3PublisherTest {
+class From3PublisherTest {
     private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
 
     @Test
-    public void request3Complete() {
+    void request3Complete() {
         toSource(fromPublisher()).subscribe(subscriber);
         subscriber.awaitSubscription().request(3);
         assertThat(subscriber.takeOnNext(3), contains(1, 2, 3));
@@ -52,7 +52,7 @@ public class From3PublisherTest {
     }
 
     @Test
-    public void request2FirstComplete() {
+    void request2FirstComplete() {
         toSource(fromPublisher()).subscribe(subscriber);
         Subscription s = subscriber.awaitSubscription();
         s.request(2);
@@ -63,7 +63,7 @@ public class From3PublisherTest {
     }
 
     @Test
-    public void request2SecondComplete() {
+    void request2SecondComplete() {
         toSource(fromPublisher()).subscribe(subscriber);
         Subscription s = subscriber.awaitSubscription();
         s.request(1);
@@ -74,7 +74,7 @@ public class From3PublisherTest {
     }
 
     @Test
-    public void request1Complete() {
+    void request1Complete() {
         toSource(fromPublisher()).subscribe(subscriber);
         Subscription s = subscriber.awaitSubscription();
         s.request(1);
@@ -91,7 +91,7 @@ public class From3PublisherTest {
     }
 
     @Test
-    public void request1Cancel() {
+    void request1Cancel() {
         toSource(fromPublisher()).subscribe(subscriber);
         Subscription s = subscriber.awaitSubscription();
         s.request(1);
@@ -104,7 +104,7 @@ public class From3PublisherTest {
     }
 
     @Test
-    public void request2Cancel() {
+    void request2Cancel() {
         toSource(fromPublisher()).subscribe(subscriber);
         Subscription s = subscriber.awaitSubscription();
         s.request(1);
@@ -120,17 +120,17 @@ public class From3PublisherTest {
     }
 
     @Test
-    public void throwFirst() {
+    void throwFirst() {
         throwInOnNext(1);
     }
 
     @Test
-    public void throwSecond() {
+    void throwSecond() {
         throwInOnNext(2);
     }
 
     @Test
-    public void throwThird() {
+    void throwThird() {
         throwInOnNext(3);
     }
 
@@ -154,12 +154,12 @@ public class From3PublisherTest {
     }
 
     @Test
-    public void invalidRequestNZero() {
+    void invalidRequestNZero() {
         invalidRequestN(0);
     }
 
     @Test
-    public void invalidRequestNNeg() {
+    void invalidRequestNNeg() {
         invalidRequestN(-1);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/FromInputStreamPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/FromInputStreamPublisherTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class FromInputStreamPublisherTest {
+class FromInputStreamPublisherTest {
 
     private final TestPublisherSubscriber<byte[]> sub1 = new TestPublisherSubscriber<>();
     private final TestPublisherSubscriber<byte[]> sub2 = new TestPublisherSubscriber<>();
@@ -64,13 +64,13 @@ public class FromInputStreamPublisherTest {
     private Publisher<byte[]> pub;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         inputStream = mock(InputStream.class);
         pub = new FromInputStreamPublisher(inputStream);
     }
 
     @Test
-    public void noDuplicateSubscription() throws Exception {
+    void noDuplicateSubscription() throws Exception {
         initEmptyStream();
 
         toSource(pub).subscribe(sub1);
@@ -83,7 +83,7 @@ public class FromInputStreamPublisherTest {
     }
 
     @Test
-    public void noDuplicateSubscriptionAfterError() throws Exception {
+    void noDuplicateSubscriptionAfterError() throws Exception {
         when(inputStream.available()).thenThrow(IOException.class);
 
         toSource(pub).subscribe(sub1);
@@ -95,7 +95,7 @@ public class FromInputStreamPublisherTest {
     }
 
     @Test
-    public void noDuplicateSubscriptionAfterComplete() throws Exception {
+    void noDuplicateSubscriptionAfterComplete() throws Exception {
         initEmptyStream();
 
         toSource(pub).subscribe(sub1);
@@ -107,14 +107,14 @@ public class FromInputStreamPublisherTest {
     }
 
     @Test
-    public void closeStreamOnCancelByDefault() throws Exception {
+    void closeStreamOnCancelByDefault() throws Exception {
         toSource(pub).subscribe(sub1);
         sub1.awaitSubscription().cancel();
         verify(inputStream).close();
     }
 
     @Test
-    public void streamClosedAndErrorOnInvalidReqN() throws Exception {
+    void streamClosedAndErrorOnInvalidReqN() throws Exception {
         toSource(pub).subscribe(sub1);
         sub1.awaitSubscription().request(-1);
         assertThat(sub1.awaitOnError(), instanceOf(IllegalArgumentException.class));
@@ -123,7 +123,7 @@ public class FromInputStreamPublisherTest {
     }
 
     @Test
-    public void streamClosedAndErrorOnInvalidReqNAndValidReqN() throws Exception {
+    void streamClosedAndErrorOnInvalidReqNAndValidReqN() throws Exception {
         initChunkedStream(smallBuff, of(10, 0), of(10, 0));
 
         toSource(pub).subscribe(sub1);
@@ -135,7 +135,7 @@ public class FromInputStreamPublisherTest {
     }
 
     @Test
-    public void streamClosedAndErrorOnDoubleInvalidReqN() throws Exception {
+    void streamClosedAndErrorOnDoubleInvalidReqN() throws Exception {
         initChunkedStream(smallBuff, of(10, 0), of(10, 0));
 
         toSource(pub).subscribe(sub1);
@@ -147,7 +147,7 @@ public class FromInputStreamPublisherTest {
     }
 
     @Test
-    public void streamClosedAndErrorOnAvailableIOError() throws Exception {
+    void streamClosedAndErrorOnAvailableIOError() throws Exception {
         when(inputStream.available()).thenThrow(IOException.class);
         toSource(pub).subscribe(sub1);
         sub1.awaitSubscription().request(1);
@@ -156,7 +156,7 @@ public class FromInputStreamPublisherTest {
     }
 
     @Test
-    public void streamClosedAndErrorOnReadIOError() throws Exception {
+    void streamClosedAndErrorOnReadIOError() throws Exception {
         when(inputStream.available()).thenReturn(10);
         when(inputStream.read(any(), anyInt(), anyInt())).thenThrow(IOException.class);
 
@@ -168,7 +168,7 @@ public class FromInputStreamPublisherTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void streamClosedAndErrorOnDeliveryError() throws Exception {
+    void streamClosedAndErrorOnDeliveryError() throws Exception {
         initChunkedStream(smallBuff, of(10), of(10));
 
         Subscriber sub = mock(Subscriber.class);
@@ -189,7 +189,7 @@ public class FromInputStreamPublisherTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void streamClosedAndErrorOnDeliveryErrorOnce() throws Exception {
+    void streamClosedAndErrorOnDeliveryErrorOnce() throws Exception {
         initChunkedStream(smallBuff, ofAll(10), ofAll(10));
 
         Subscriber sub = mock(Subscriber.class);
@@ -214,7 +214,7 @@ public class FromInputStreamPublisherTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void streamCanceledShouldCloseOnce() throws Exception {
+    void streamCanceledShouldCloseOnce() throws Exception {
         initChunkedStream(smallBuff, ofAll(10), ofAll(10));
 
         Subscriber sub = mock(Subscriber.class);
@@ -235,7 +235,7 @@ public class FromInputStreamPublisherTest {
     }
 
     @Test
-    public void breakReentrantRequestN() throws Throwable {
+    void breakReentrantRequestN() throws Throwable {
 
         AtomicInteger count = new AtomicInteger();
         AtomicBoolean complete = new AtomicBoolean();
@@ -281,7 +281,7 @@ public class FromInputStreamPublisherTest {
     }
 
     @Test
-    public void consumeSimpleStream() {
+    void consumeSimpleStream() {
         initChunkedStream(smallBuff, of(10, 0), of(10, 0));
         toSource(pub).subscribe(sub1);
         sub1.awaitSubscription().request(1); // smallBuff
@@ -291,7 +291,7 @@ public class FromInputStreamPublisherTest {
     }
 
     @Test
-    public void multiRequests() {
+    void multiRequests() {
         initChunkedStream(smallBuff, of(8, 2, 0), of(8, 2, 0));
         byte[] first = new byte[8];
         arraycopy(smallBuff, 0, first, 0, 8);
@@ -309,7 +309,7 @@ public class FromInputStreamPublisherTest {
     }
 
     @Test
-    public void completeStreamIfEOFObservedDuringReadFromOverEstimatedAvailability() throws Throwable {
+    void completeStreamIfEOFObservedDuringReadFromOverEstimatedAvailability() throws Throwable {
         initChunkedStream(smallBuff, ofAll(100), of(10, 0)); // only has 10 items
 
         byte[][] items = new byte[][]{
@@ -320,7 +320,7 @@ public class FromInputStreamPublisherTest {
     }
 
     @Test
-    public void dontFailOnInputStreamWithBrokenAvailableCall() throws Throwable {
+    void dontFailOnInputStreamWithBrokenAvailableCall() throws Throwable {
         initChunkedStream(bigBuff, of(5, 0, 0, 10, 5, 5, 5, 5, 0),
                                    of(5, 1, 1, 10, 5, 5, 5, 5, 0));
 
@@ -339,7 +339,7 @@ public class FromInputStreamPublisherTest {
     }
 
     @Test
-    public void expandBufferOnIncreasingAvailability() throws Throwable {
+    void expandBufferOnIncreasingAvailability() throws Throwable {
         initChunkedStream(bigBuff, of(3, 2, 15, 15, 10, 0),
                                    of(3, 2, 15, 15, 2, 0));
 
@@ -355,7 +355,7 @@ public class FromInputStreamPublisherTest {
     }
 
     @Test
-    public void keepReadingWhenAvailabilityPermits() throws Throwable {
+    void keepReadingWhenAvailabilityPermits() throws Throwable {
         // constrain publisher to 10 byte chunks with full data availability to enforce inner loops until buffer drained
         initChunkedStream(bigBuff, ofAll(100), ofAll(10));
 
@@ -370,7 +370,7 @@ public class FromInputStreamPublisherTest {
     }
 
     @Test
-    public void repeatedReadingWhenAvailabilityRunsOut() throws Throwable {
+    void repeatedReadingWhenAvailabilityRunsOut() throws Throwable {
         // constrain publisher to 10 byte chunks with only 5 byte availability per chunk to enforce multiple outer loops
         // simulating multiple calls to IS.available()
         initChunkedStream(bigBuff, ofAll(5), ofAll(5)); // 5 byte chunks per available() call
@@ -445,7 +445,7 @@ public class FromInputStreamPublisherTest {
     }
 
     @Test
-    public void assertChunkedUtil() {
+    void assertChunkedUtil() {
         assertThat(new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, equalTo(init0toN(10)));
         assertThat(new byte[][]{
                 new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
@@ -510,7 +510,7 @@ public class FromInputStreamPublisherTest {
     }
 
     @Test
-    public void dontFailWhenInputStreamAvailableExceedsVmArraySizeLimit() throws Throwable {
+    void dontFailWhenInputStreamAvailableExceedsVmArraySizeLimit() throws Throwable {
         when(inputStream.available()).thenReturn(MAX_VALUE);
         when(inputStream.read(any(), anyInt(), anyInt())).thenReturn(-1);
         toSource(pub).subscribe(sub1);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/IterableMergeCompletableDelayErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/IterableMergeCompletableDelayErrorTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class IterableMergeCompletableDelayErrorTest {
+class IterableMergeCompletableDelayErrorTest {
 
     private final CompletableHolder collectionHolder =
             new CompletableHolder() {
@@ -51,14 +51,14 @@ public class IterableMergeCompletableDelayErrorTest {
     };
 
     @Test
-    public void testCollectionCompletion() {
+    void testCollectionCompletion() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         collectionHolder.init(2).listen(subscriber).completeAll();
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void testCollectionCompletionFew() {
+    void testCollectionCompletionFew() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         collectionHolder.init(2).listen(subscriber).complete(1, 2);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -67,7 +67,7 @@ public class IterableMergeCompletableDelayErrorTest {
     }
 
     @Test
-    public void testCollectionFailFirstEvent() {
+    void testCollectionFailFirstEvent() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         collectionHolder.init(2).listen(subscriber).fail(1);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -76,7 +76,7 @@ public class IterableMergeCompletableDelayErrorTest {
     }
 
     @Test
-    public void testCollectionFailLastEvent() {
+    void testCollectionFailLastEvent() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         collectionHolder.init(2).listen(subscriber).complete(0, 2);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -85,7 +85,7 @@ public class IterableMergeCompletableDelayErrorTest {
     }
 
     @Test
-    public void testCollectionFailMiddleEvent() {
+    void testCollectionFailMiddleEvent() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         collectionHolder.init(2).listen(subscriber).complete(0);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -96,21 +96,21 @@ public class IterableMergeCompletableDelayErrorTest {
     }
 
     @Test
-    public void testCollectionMergeWithOne() {
+    void testCollectionMergeWithOne() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         collectionHolder.init(1).listen(subscriber).completeAll();
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void testIterableCompletion() {
+    void testIterableCompletion() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         iterableHolder.init(2).listen(subscriber).completeAll();
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void testIterableCompletionFew() {
+    void testIterableCompletionFew() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         iterableHolder.init(2).listen(subscriber).complete(1, 2);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -119,7 +119,7 @@ public class IterableMergeCompletableDelayErrorTest {
     }
 
     @Test
-    public void testIterableFailFirstEvent() {
+    void testIterableFailFirstEvent() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         iterableHolder.init(2).listen(subscriber).fail(1);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -128,7 +128,7 @@ public class IterableMergeCompletableDelayErrorTest {
     }
 
     @Test
-    public void testIterableFailLastEvent() {
+    void testIterableFailLastEvent() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         iterableHolder.init(2).listen(subscriber).complete(0, 2);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -137,7 +137,7 @@ public class IterableMergeCompletableDelayErrorTest {
     }
 
     @Test
-    public void testIterableFailMiddleEvent() {
+    void testIterableFailMiddleEvent() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         iterableHolder.init(2).listen(subscriber).complete(0);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -148,14 +148,14 @@ public class IterableMergeCompletableDelayErrorTest {
     }
 
     @Test
-    public void testIterableMergeWithOne() {
+    void testIterableMergeWithOne() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         iterableHolder.init(1).listen(subscriber).completeAll();
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void mergedCompletablesTerminateSynchronouslyWithDelayErrorDoesNotTerminateTwice()
+    void mergedCompletablesTerminateSynchronouslyWithDelayErrorDoesNotTerminateTwice()
             throws InterruptedException, ExecutionException {
         ExecutorService executorService = java.util.concurrent.Executors.newCachedThreadPool();
         executorService.submit(() -> { }).get();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/IterableMergeCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/IterableMergeCompletableTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class IterableMergeCompletableTest {
+class IterableMergeCompletableTest {
     private final CompletableHolder collectionHolder = new CompletableHolder() {
         @Override
         protected Completable createCompletable(Completable[] completables) {
@@ -49,14 +49,14 @@ public class IterableMergeCompletableTest {
     };
 
     @Test
-    public void testCollectionCompletion() {
+    void testCollectionCompletion() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         collectionHolder.init(2).listen(subscriber).completeAll();
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void testCollectionCompletionFew() {
+    void testCollectionCompletionFew() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         collectionHolder.init(2).listen(subscriber).complete(1, 2);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -65,7 +65,7 @@ public class IterableMergeCompletableTest {
     }
 
     @Test
-    public void testCollectionFail() {
+    void testCollectionFail() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         collectionHolder.init(2).listen(subscriber).fail(1);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
@@ -73,21 +73,21 @@ public class IterableMergeCompletableTest {
     }
 
     @Test
-    public void testCollectionMergeWithOne() {
+    void testCollectionMergeWithOne() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         collectionHolder.init(1).listen(subscriber).completeAll();
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void testIterableCompletion() {
+    void testIterableCompletion() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         iterableHolder.init(2).listen(subscriber).completeAll();
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void testIterableCompletionFew() {
+    void testIterableCompletionFew() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         iterableHolder.init(2).listen(subscriber).complete(1, 2);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -96,7 +96,7 @@ public class IterableMergeCompletableTest {
     }
 
     @Test
-    public void testIterableFail() {
+    void testIterableFail() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         iterableHolder.init(2).listen(subscriber).fail(1);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
@@ -104,28 +104,28 @@ public class IterableMergeCompletableTest {
     }
 
     @Test
-    public void testIterableMergeWithOne() {
+    void testIterableMergeWithOne() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         iterableHolder.init(1).listen(subscriber).completeAll();
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void arrayMergeMultipleCompleted() {
+    void arrayMergeMultipleCompleted() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         toSource(completed().merge(completed(), completed(), completed())).subscribe(subscriber);
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void collectionMergeMultipleCompleted() {
+    void collectionMergeMultipleCompleted() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         toSource(completed().merge(asList(completed(), completed(), completed()))).subscribe(subscriber);
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void iterableMergeMultipleCompleted() {
+    void iterableMergeMultipleCompleted() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         toSource(completed().merge(() -> asList(completed(), completed(), completed()).iterator()))
                 .subscribe(subscriber);
@@ -133,21 +133,21 @@ public class IterableMergeCompletableTest {
     }
 
     @Test
-    public void mergeEmptyArray() {
+    void mergeEmptyArray() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         toSource(completed().merge(new Completable[0])).subscribe(subscriber);
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void mergeEmptyIterable() {
+    void mergeEmptyIterable() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         toSource(completed().merge(() -> Collections.emptyIterator())).subscribe(subscriber);
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void mergeEmptyCollection() {
+    void mergeEmptyCollection() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         toSource(completed().merge(Collections.emptyList())).subscribe(subscriber);
         subscriber.awaitOnComplete();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MapPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MapPublisherTest.java
@@ -24,14 +24,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 
-public class MapPublisherTest {
+class MapPublisherTest {
 
     private final TestPublisher<Integer> source = new TestPublisher.Builder<Integer>()
             .disableAutoOnSubscribe().build();
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
 
     @Test
-    public void testMapFunctionReturnsNull() {
+    void testMapFunctionReturnsNull() {
         Publisher<String> map = source.map(v -> null);
 
         toSource(map).subscribe(subscriber);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MergeCompletableDelayErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MergeCompletableDelayErrorTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class MergeCompletableDelayErrorTest {
+class MergeCompletableDelayErrorTest {
     private final MergeCompletableTest.CompletableHolder holder = new MergeCompletableTest.CompletableHolder() {
         @Override
         protected Completable createCompletable(Completable[] completables) {
@@ -37,14 +37,14 @@ public class MergeCompletableDelayErrorTest {
     };
 
     @Test
-    public void testCompletion() {
+    void testCompletion() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         holder.init(2).listen(subscriber).completeAll();
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void testCompletionFew() {
+    void testCompletionFew() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         holder.init(2).listen(subscriber).complete(1, 2);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -53,7 +53,7 @@ public class MergeCompletableDelayErrorTest {
     }
 
     @Test
-    public void testFailFirstEvent() {
+    void testFailFirstEvent() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         holder.init(2).listen(subscriber).fail(1);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -62,7 +62,7 @@ public class MergeCompletableDelayErrorTest {
     }
 
     @Test
-    public void testFailLastEvent() {
+    void testFailLastEvent() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         holder.init(2).listen(subscriber).complete(0, 2);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -71,7 +71,7 @@ public class MergeCompletableDelayErrorTest {
     }
 
     @Test
-    public void testFailMiddleEvent() {
+    void testFailMiddleEvent() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         holder.init(2).listen(subscriber).complete(0);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -82,7 +82,7 @@ public class MergeCompletableDelayErrorTest {
     }
 
     @Test
-    public void testMergeWithOne() {
+    void testMergeWithOne() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         holder.init(1).listen(subscriber).completeAll();
         subscriber.awaitOnComplete();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MergeCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MergeCompletableTest.java
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class MergeCompletableTest {
+class MergeCompletableTest {
 
     private final CompletableHolder holder = new CompletableHolder() {
         @Override
@@ -47,21 +47,21 @@ public class MergeCompletableTest {
     };
 
     @Test
-    public void testEmpty() {
+    void testEmpty() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         holder.init(0).listen(subscriber).completeAll();
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void testCompletion() {
+    void testCompletion() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         holder.init(2).listen(subscriber).completeAll();
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void testCompletionFew() {
+    void testCompletionFew() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         holder.init(2).listen(subscriber).complete(1, 2);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -70,7 +70,7 @@ public class MergeCompletableTest {
     }
 
     @Test
-    public void testFail() {
+    void testFail() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         holder.init(2).listen(subscriber).fail(1);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
@@ -78,7 +78,7 @@ public class MergeCompletableTest {
     }
 
     @Test
-    public void testMergeWithOne() {
+    void testMergeWithOne() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         holder.init(1).listen(subscriber).completeAll();
         subscriber.awaitOnComplete();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MulticastPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MulticastPublisherTest.java
@@ -51,13 +51,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @Timeout(60)
-public class MulticastPublisherTest {
+class MulticastPublisherTest {
 
     private TestPublisher<Integer> source = new TestPublisher.Builder<Integer>().disableAutoOnSubscribe().build();
     private TestSubscription subscription = new TestSubscription();
 
     @Test
-    public void emitItemsAndThenError() {
+    void emitItemsAndThenError() {
         Publisher<Integer> multicast = source.multicastToExactly(2);
         TestPublisherSubscriber<Integer> subscriber1 = new TestPublisherSubscriber<>();
         TestPublisherSubscriber<Integer> subscriber2 = new TestPublisherSubscriber<>();
@@ -78,7 +78,7 @@ public class MulticastPublisherTest {
     }
 
     @Test
-    public void duplicateOnSubscribeIsInvalid() {
+    void duplicateOnSubscribeIsInvalid() {
         MulticastPublisher<Integer> source = new MulticastPublisher<>(new Publisher<Integer>(immediate()) {
             @Override
             protected void handleSubscribe(Subscriber<? super Integer> subscriber) {
@@ -101,7 +101,7 @@ public class MulticastPublisherTest {
     }
 
     @Test
-    public void sourceSubscribeAfter() {
+    void sourceSubscribeAfter() {
         Publisher<Integer> multicast = source.multicastToExactly(2);
         TestPublisherSubscriber<Integer> subscriber1 = new TestPublisherSubscriber<>();
         TestPublisherSubscriber<Integer> subscriber2 = new TestPublisherSubscriber<>();
@@ -123,7 +123,7 @@ public class MulticastPublisherTest {
     }
 
     @Test
-    public void sourceSubscribeBefore() {
+    void sourceSubscribeBefore() {
         source = new TestPublisher<>(); // With auto-on-subscribe enabled
         Publisher<Integer> multicast = source.multicastToExactly(2);
         TestPublisherSubscriber<Integer> subscriber1 = new TestPublisherSubscriber<>();
@@ -143,7 +143,7 @@ public class MulticastPublisherTest {
     }
 
     @Test
-    public void concurrentRequestN() throws InterruptedException {
+    void concurrentRequestN() throws InterruptedException {
         final int expectedSubscribers = 50;
         Publisher<Integer> multicast = source.multicastToExactly(expectedSubscribers, expectedSubscribers);
         @SuppressWarnings("unchecked")
@@ -183,7 +183,7 @@ public class MulticastPublisherTest {
     }
 
     @Test
-    public void concurrentRequestNAndOnNext() throws BrokenBarrierException, InterruptedException {
+    void concurrentRequestNAndOnNext() throws BrokenBarrierException, InterruptedException {
         final int expectedSubscribers = 400;
         Publisher<Integer> multicast = source.multicastToExactly(expectedSubscribers, expectedSubscribers);
         @SuppressWarnings("unchecked")
@@ -243,17 +243,17 @@ public class MulticastPublisherTest {
     }
 
     @Test
-    public void reentryFirstSubscriberRequestCountIsCorrect() {
+    void reentryFirstSubscriberRequestCountIsCorrect() {
         reentrySubscriberRequestCountIsCorrect(true);
     }
 
     @Test
-    public void reentrySecondSubscriberRequestCountIsCorrect() {
+    void reentrySecondSubscriberRequestCountIsCorrect() {
         reentrySubscriberRequestCountIsCorrect(false);
     }
 
     @Test
-    public void reentryBothSubscriberRequestCountIsCorrect() {
+    void reentryBothSubscriberRequestCountIsCorrect() {
         Publisher<Integer> multicast = source.multicastToExactly(2);
         TestPublisherSubscriber<Integer> subscriber1 = new TestPublisherSubscriber<>();
         TestPublisherSubscriber<Integer> subscriber2 = new TestPublisherSubscriber<>();
@@ -314,7 +314,7 @@ public class MulticastPublisherTest {
     }
 
     @Test
-    public void reentryAndMultiQueueSupportsNull() {
+    void reentryAndMultiQueueSupportsNull() {
         Publisher<Integer> multicast = source.multicastToExactly(2);
         TestPublisherSubscriber<Integer> subscriber1 = new TestPublisherSubscriber<>();
         TestPublisherSubscriber<Integer> subscriber2 = new TestPublisherSubscriber<>();
@@ -347,7 +347,7 @@ public class MulticastPublisherTest {
     }
 
     @Test
-    public void requestLongMax() {
+    void requestLongMax() {
         final int maxQueueSize = 1000;
         Publisher<Integer> multicast = source.multicastToExactly(2, maxQueueSize);
         TestPublisherSubscriber<Integer> subscriber1 = new TestPublisherSubscriber<>();
@@ -370,7 +370,7 @@ public class MulticastPublisherTest {
     }
 
     @Test
-    public void longMaxForAllSubs() throws Exception {
+    void longMaxForAllSubs() throws Exception {
         Publisher<Integer> original = range(1, 10);
         ArrayList<Integer> items = original.collect((Supplier<ArrayList<Integer>>) ArrayList::new, (list, integer) -> {
             list.add(integer);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MulticastRealizedSourcePublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/MulticastRealizedSourcePublisherTest.java
@@ -44,10 +44,10 @@ import static org.hamcrest.core.Is.is;
  * {@link Subscriber#onSubscribe(Subscription)}.
  */
 
-public class MulticastRealizedSourcePublisherTest {
+class MulticastRealizedSourcePublisherTest {
 
     @Test
-    public void testOnSubscribeErrors() throws InterruptedException {
+    void testOnSubscribeErrors() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(2);
         Publisher<Integer> multicast = new TerminateFromOnSubscribePublisher(error(DELIBERATE_EXCEPTION))
                 .multicastToExactly(2);
@@ -61,7 +61,7 @@ public class MulticastRealizedSourcePublisherTest {
     }
 
     @Test
-    public void testOnSubscribeCompletesNoItems() throws InterruptedException {
+    void testOnSubscribeCompletesNoItems() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(2);
         Publisher<Integer> multicast = new TerminateFromOnSubscribePublisher(complete()).multicastToExactly(2);
         MulticastSubscriber subscriber1 = new MulticastSubscriber(latch);
@@ -74,7 +74,7 @@ public class MulticastRealizedSourcePublisherTest {
     }
 
     @Test
-    public void testOnSubscribeCompletesWithItems() throws InterruptedException {
+    void testOnSubscribeCompletesWithItems() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(2);
         Publisher<Integer> multicast = from(1, 2).multicastToExactly(2);
         MulticastSubscriber subscriber1 = new MulticastSubscriber(latch);
@@ -87,7 +87,7 @@ public class MulticastRealizedSourcePublisherTest {
     }
 
     @Test
-    public void testOnSubscribeCompletesWithSingleItem() throws InterruptedException {
+    void testOnSubscribeCompletesWithSingleItem() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(2);
         Publisher<Integer> multicast = from(1).multicastToExactly(2);
         MulticastSubscriber subscriber1 = new MulticastSubscriber(latch);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/OnErrorCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/OnErrorCompletableTest.java
@@ -28,18 +28,18 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class OnErrorCompletableTest {
+class OnErrorCompletableTest {
     private TestCompletableSubscriber subscriber;
     private TestCompletable first;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         subscriber = new TestCompletableSubscriber();
         first = new TestCompletable();
     }
 
     @Test
-    public void onErrorComplete() {
+    void onErrorComplete() {
         toSource(first.onErrorComplete()).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -47,7 +47,7 @@ public class OnErrorCompletableTest {
     }
 
     @Test
-    public void onErrorCompleteClassMatch() {
+    void onErrorCompleteClassMatch() {
         toSource(first.onErrorComplete(DeliberateException.class)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -55,7 +55,7 @@ public class OnErrorCompletableTest {
     }
 
     @Test
-    public void onErrorCompleteClassNoMatch() {
+    void onErrorCompleteClassNoMatch() {
         toSource(first.onErrorComplete(IllegalArgumentException.class)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -63,7 +63,7 @@ public class OnErrorCompletableTest {
     }
 
     @Test
-    public void onErrorCompletePredicateMatch() {
+    void onErrorCompletePredicateMatch() {
         toSource(first.onErrorComplete(t -> t == DELIBERATE_EXCEPTION)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -71,7 +71,7 @@ public class OnErrorCompletableTest {
     }
 
     @Test
-    public void onErrorCompletePredicateNoMatch() {
+    void onErrorCompletePredicateNoMatch() {
         toSource(first.onErrorComplete(t -> false)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -79,7 +79,7 @@ public class OnErrorCompletableTest {
     }
 
     @Test
-    public void onErrorMapMatch() {
+    void onErrorMapMatch() {
         toSource(first.onErrorMap(t -> DELIBERATE_EXCEPTION)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(new DeliberateException());
@@ -87,7 +87,7 @@ public class OnErrorCompletableTest {
     }
 
     @Test
-    public void onErrorMapMatchThrows() {
+    void onErrorMapMatchThrows() {
         toSource(first.onErrorMap(t -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(subscriber);
@@ -97,7 +97,7 @@ public class OnErrorCompletableTest {
     }
 
     @Test
-    public void onErrorMapClassMatch() {
+    void onErrorMapClassMatch() {
         toSource(first.onErrorMap(DeliberateException.class, t -> DELIBERATE_EXCEPTION)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(new DeliberateException());
@@ -105,7 +105,7 @@ public class OnErrorCompletableTest {
     }
 
     @Test
-    public void onErrorMapClassNoMatch() {
+    void onErrorMapClassNoMatch() {
         toSource(first.onErrorMap(IllegalArgumentException.class, t -> new DeliberateException()))
                 .subscribe(subscriber);
         subscriber.awaitSubscription();
@@ -114,7 +114,7 @@ public class OnErrorCompletableTest {
     }
 
     @Test
-    public void onErrorMapPredicateMatch() {
+    void onErrorMapPredicateMatch() {
         toSource(first.onErrorMap(t -> t instanceof DeliberateException, t -> DELIBERATE_EXCEPTION))
                 .subscribe(subscriber);
         subscriber.awaitSubscription();
@@ -123,7 +123,7 @@ public class OnErrorCompletableTest {
     }
 
     @Test
-    public void onErrorMapPredicateNoMatch() {
+    void onErrorMapPredicateNoMatch() {
         toSource(first.onErrorMap(t -> false, t -> new IllegalStateException())).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -131,7 +131,7 @@ public class OnErrorCompletableTest {
     }
 
     @Test
-    public void onErrorResumeClassMatch() {
+    void onErrorResumeClassMatch() {
         toSource(first.onErrorResume(DeliberateException.class, t -> failed(DELIBERATE_EXCEPTION)))
                 .subscribe(subscriber);
         subscriber.awaitSubscription();
@@ -140,7 +140,7 @@ public class OnErrorCompletableTest {
     }
 
     @Test
-    public void onErrorResumeClassNoMatch() {
+    void onErrorResumeClassNoMatch() {
         toSource(first.onErrorResume(IllegalArgumentException.class, t -> completed())).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -148,7 +148,7 @@ public class OnErrorCompletableTest {
     }
 
     @Test
-    public void onErrorResumePredicateMatch() {
+    void onErrorResumePredicateMatch() {
         toSource(first.onErrorResume(t -> t instanceof DeliberateException,
                 t -> failed(DELIBERATE_EXCEPTION))).subscribe(subscriber);
         subscriber.awaitSubscription();
@@ -157,7 +157,7 @@ public class OnErrorCompletableTest {
     }
 
     @Test
-    public void onErrorResumePredicateNoMatch() {
+    void onErrorResumePredicateNoMatch() {
         toSource(first.onErrorResume(t -> false, t -> completed())).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/OnErrorPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/OnErrorPublisherTest.java
@@ -28,18 +28,18 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class OnErrorPublisherTest {
+class OnErrorPublisherTest {
     private TestPublisherSubscriber<Integer> subscriber;
     private TestPublisher<Integer> first;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         subscriber = new TestPublisherSubscriber<>();
         first = new TestPublisher<>();
     }
 
     @Test
-    public void onErrorComplete() {
+    void onErrorComplete() {
         toSource(first.onErrorComplete()).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -47,7 +47,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorCompleteClassMatch() {
+    void onErrorCompleteClassMatch() {
         toSource(first.onErrorComplete(DeliberateException.class)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -55,7 +55,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorCompleteClassNoMatch() {
+    void onErrorCompleteClassNoMatch() {
         toSource(first.onErrorComplete(IllegalArgumentException.class)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -63,7 +63,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorCompletePredicateMatch() {
+    void onErrorCompletePredicateMatch() {
         toSource(first.onErrorComplete(t -> t == DELIBERATE_EXCEPTION)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -71,7 +71,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorCompletePredicateNoMatch() {
+    void onErrorCompletePredicateNoMatch() {
         toSource(first.onErrorComplete(t -> false)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -79,7 +79,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorReturnMatch() {
+    void onErrorReturnMatch() {
         toSource(first.onErrorReturn(t -> 1)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         first.onError(DELIBERATE_EXCEPTION);
@@ -88,7 +88,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorReturnThrows() {
+    void onErrorReturnThrows() {
         toSource(first.onErrorReturn(t -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(subscriber);
@@ -98,7 +98,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorReturnClassMatch() {
+    void onErrorReturnClassMatch() {
         toSource(first.onErrorReturn(DeliberateException.class, t -> 1)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         first.onError(DELIBERATE_EXCEPTION);
@@ -107,7 +107,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorReturnClassNoMatch() {
+    void onErrorReturnClassNoMatch() {
         toSource(first.onErrorReturn(IllegalArgumentException.class, t -> 1)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         first.onError(DELIBERATE_EXCEPTION);
@@ -115,7 +115,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorReturnPredicateMatch() {
+    void onErrorReturnPredicateMatch() {
         toSource(first.onErrorReturn(t -> t == DELIBERATE_EXCEPTION, t -> 1)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         first.onError(DELIBERATE_EXCEPTION);
@@ -124,7 +124,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorReturnPredicateNoMatch() {
+    void onErrorReturnPredicateNoMatch() {
         toSource(first.onErrorReturn(t -> false, t -> 1)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         first.onError(DELIBERATE_EXCEPTION);
@@ -132,7 +132,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorMapMatch() {
+    void onErrorMapMatch() {
         toSource(first.onErrorMap(t -> DELIBERATE_EXCEPTION)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(new DeliberateException());
@@ -140,7 +140,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorMapMatchThrows() {
+    void onErrorMapMatchThrows() {
         toSource(first.onErrorMap(t -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(subscriber);
@@ -150,7 +150,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorMapClassMatch() {
+    void onErrorMapClassMatch() {
         toSource(first.onErrorMap(DeliberateException.class, t -> DELIBERATE_EXCEPTION)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(new DeliberateException());
@@ -158,7 +158,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorMapClassNoMatch() {
+    void onErrorMapClassNoMatch() {
         toSource(first.onErrorMap(IllegalArgumentException.class, t -> new DeliberateException()))
                 .subscribe(subscriber);
         subscriber.awaitSubscription();
@@ -167,7 +167,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorMapPredicateMatch() {
+    void onErrorMapPredicateMatch() {
         toSource(first.onErrorMap(t -> t instanceof DeliberateException, t -> DELIBERATE_EXCEPTION))
                 .subscribe(subscriber);
         subscriber.awaitSubscription();
@@ -176,7 +176,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorMapPredicateNoMatch() {
+    void onErrorMapPredicateNoMatch() {
         toSource(first.onErrorMap(t -> false, t -> new IllegalStateException())).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -184,7 +184,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorResumeClassMatch() {
+    void onErrorResumeClassMatch() {
         toSource(first.onErrorResume(DeliberateException.class, t -> failed(DELIBERATE_EXCEPTION)))
                 .subscribe(subscriber);
         subscriber.awaitSubscription();
@@ -193,7 +193,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorResumeClassNoMatch() {
+    void onErrorResumeClassNoMatch() {
         toSource(first.onErrorResume(IllegalArgumentException.class, t -> empty())).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -201,7 +201,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorResumePredicateMatch() {
+    void onErrorResumePredicateMatch() {
         toSource(first.onErrorResume(t -> t instanceof DeliberateException,
                 t -> failed(DELIBERATE_EXCEPTION))).subscribe(subscriber);
         subscriber.awaitSubscription();
@@ -210,7 +210,7 @@ public class OnErrorPublisherTest {
     }
 
     @Test
-    public void onErrorResumePredicateNoMatch() {
+    void onErrorResumePredicateNoMatch() {
         toSource(first.onErrorResume(t -> false, t -> empty())).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/OnErrorResumeCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/OnErrorResumeCompletableTest.java
@@ -32,14 +32,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public final class OnErrorResumeCompletableTest {
+final class OnErrorResumeCompletableTest {
 
     private TestCompletableSubscriber subscriber;
     private TestCompletable first;
     private TestCompletable second;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         subscriber = new TestCompletableSubscriber();
         first = new TestCompletable();
         second = new TestCompletable();
@@ -47,13 +47,13 @@ public final class OnErrorResumeCompletableTest {
     }
 
     @Test
-    public void testFirstComplete() {
+    void testFirstComplete() {
         first.onComplete();
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void testFirstErrorSecondComplete() {
+    void testFirstErrorSecondComplete() {
         first.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         second.onComplete();
@@ -61,7 +61,7 @@ public final class OnErrorResumeCompletableTest {
     }
 
     @Test
-    public void testFirstErrorSecondError() {
+    void testFirstErrorSecondError() {
         first.onError(new DeliberateException());
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         second.onError(DELIBERATE_EXCEPTION);
@@ -69,7 +69,7 @@ public final class OnErrorResumeCompletableTest {
     }
 
     @Test
-    public void testCancelFirstActive() {
+    void testCancelFirstActive() {
         subscriber.awaitSubscription().cancel();
         TestCancellable cancellable = new TestCancellable();
         first.onSubscribe(cancellable);
@@ -78,7 +78,7 @@ public final class OnErrorResumeCompletableTest {
     }
 
     @Test
-    public void testCancelSecondActive() {
+    void testCancelSecondActive() {
         first.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
@@ -93,7 +93,7 @@ public final class OnErrorResumeCompletableTest {
     }
 
     @Test
-    public void testErrorSuppressOriginalException() {
+    void testErrorSuppressOriginalException() {
         subscriber = new TestCompletableSubscriber();
         first = new TestCompletable();
         DeliberateException ex = new DeliberateException();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/OnErrorResumePublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/OnErrorResumePublisherTest.java
@@ -32,14 +32,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public final class OnErrorResumePublisherTest {
+final class OnErrorResumePublisherTest {
 
     private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
     private TestPublisher<Integer> first = new TestPublisher<>();
     private TestPublisher<Integer> second = new TestPublisher<>();
 
     @Test
-    public void testFirstComplete() {
+    void testFirstComplete() {
         toSource(first.onErrorResume(throwable -> second)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         first.onNext(1);
@@ -49,7 +49,7 @@ public final class OnErrorResumePublisherTest {
     }
 
     @Test
-    public void testFirstErrorSecondComplete() {
+    void testFirstErrorSecondComplete() {
         toSource(first.onErrorResume(throwable -> second)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         first.onError(DELIBERATE_EXCEPTION);
@@ -62,7 +62,7 @@ public final class OnErrorResumePublisherTest {
     }
 
     @Test
-    public void testFirstErrorSecondError() {
+    void testFirstErrorSecondError() {
         toSource(first.onErrorResume(throwable -> second)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         first.onError(new DeliberateException());
@@ -73,7 +73,7 @@ public final class OnErrorResumePublisherTest {
     }
 
     @Test
-    public void testCancelFirstActive() {
+    void testCancelFirstActive() {
         toSource(first.onErrorResume(throwable -> second)).subscribe(subscriber);
         final TestSubscription subscription = new TestSubscription();
         first.onSubscribe(subscription);
@@ -85,7 +85,7 @@ public final class OnErrorResumePublisherTest {
     }
 
     @Test
-    public void testCancelSecondActive() {
+    void testCancelSecondActive() {
         toSource(first.onErrorResume(throwable -> second)).subscribe(subscriber);
         final TestSubscription subscription = new TestSubscription();
         subscriber.awaitSubscription().request(1);
@@ -99,7 +99,7 @@ public final class OnErrorResumePublisherTest {
     }
 
     @Test
-    public void testDemandAcrossPublishers() {
+    void testDemandAcrossPublishers() {
         toSource(first.onErrorResume(throwable -> second)).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
         first.onNext(1);
@@ -113,7 +113,7 @@ public final class OnErrorResumePublisherTest {
     }
 
     @Test
-    public void testDuplicateOnError() {
+    void testDuplicateOnError() {
         toSource(first.onErrorResume(throwable -> second)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         first.onError(DELIBERATE_EXCEPTION);
@@ -126,7 +126,7 @@ public final class OnErrorResumePublisherTest {
     }
 
     @Test
-    public void exceptionInTerminalCallsOnError() {
+    void exceptionInTerminalCallsOnError() {
         DeliberateException ex = new DeliberateException();
         toSource(first.onErrorResume(throwable -> {
             throw ex;
@@ -139,7 +139,7 @@ public final class OnErrorResumePublisherTest {
     }
 
     @Test
-    public void nullInTerminalCallsOnError() {
+    void nullInTerminalCallsOnError() {
         toSource(first.onErrorResume(throwable -> null)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         first.onError(DELIBERATE_EXCEPTION);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/OnErrorResumeSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/OnErrorResumeSingleTest.java
@@ -33,14 +33,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public final class OnErrorResumeSingleTest {
+final class OnErrorResumeSingleTest {
 
     private TestSingleSubscriber<Integer> subscriber;
     private TestSingle<Integer> first;
     private TestSingle<Integer> second;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         subscriber = new TestSingleSubscriber<>();
         first = new TestSingle<>();
         second = new TestSingle<>();
@@ -48,13 +48,13 @@ public final class OnErrorResumeSingleTest {
     }
 
     @Test
-    public void testFirstComplete() {
+    void testFirstComplete() {
         first.onSuccess(1);
         assertThat(subscriber.awaitOnSuccess(), is(1));
     }
 
     @Test
-    public void testFirstErrorSecondComplete() {
+    void testFirstErrorSecondComplete() {
         first.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         second.onSuccess(1);
@@ -62,7 +62,7 @@ public final class OnErrorResumeSingleTest {
     }
 
     @Test
-    public void testFirstErrorSecondError() {
+    void testFirstErrorSecondError() {
         first.onError(new DeliberateException());
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         second.onError(DELIBERATE_EXCEPTION);
@@ -70,7 +70,7 @@ public final class OnErrorResumeSingleTest {
     }
 
     @Test
-    public void testCancelFirstActive() {
+    void testCancelFirstActive() {
         subscriber.awaitSubscription().cancel();
         TestCancellable cancellable = new TestCancellable();
         first.onSubscribe(cancellable);
@@ -79,7 +79,7 @@ public final class OnErrorResumeSingleTest {
     }
 
     @Test
-    public void testCancelSecondActive() {
+    void testCancelSecondActive() {
         first.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
@@ -92,7 +92,7 @@ public final class OnErrorResumeSingleTest {
     }
 
     @Test
-    public void testErrorSuppressOriginalException() {
+    void testErrorSuppressOriginalException() {
         first = new TestSingle<>();
         subscriber = new TestSingleSubscriber<>();
         DeliberateException ex = new DeliberateException();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/OnErrorSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/OnErrorSingleTest.java
@@ -28,18 +28,18 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class OnErrorSingleTest {
+class OnErrorSingleTest {
     private TestSingleSubscriber<Integer> subscriber;
     private TestSingle<Integer> first;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         subscriber = new TestSingleSubscriber<>();
         first = new TestSingle<>();
     }
 
     @Test
-    public void onErrorReturnMatch() {
+    void onErrorReturnMatch() {
         toSource(first.onErrorReturn(t -> 1)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -47,7 +47,7 @@ public class OnErrorSingleTest {
     }
 
     @Test
-    public void onErrorReturnThrows() {
+    void onErrorReturnThrows() {
         toSource(first.onErrorReturn(t -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(subscriber);
@@ -57,7 +57,7 @@ public class OnErrorSingleTest {
     }
 
     @Test
-    public void onErrorReturnClassMatch() {
+    void onErrorReturnClassMatch() {
         toSource(first.onErrorReturn(DeliberateException.class, t -> 1)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -65,7 +65,7 @@ public class OnErrorSingleTest {
     }
 
     @Test
-    public void onErrorReturnClassNoMatch() {
+    void onErrorReturnClassNoMatch() {
         toSource(first.onErrorReturn(IllegalArgumentException.class, t -> 1)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -73,7 +73,7 @@ public class OnErrorSingleTest {
     }
 
     @Test
-    public void onErrorReturnPredicateMatch() {
+    void onErrorReturnPredicateMatch() {
         toSource(first.onErrorReturn(t -> t == DELIBERATE_EXCEPTION, t -> 1)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -81,7 +81,7 @@ public class OnErrorSingleTest {
     }
 
     @Test
-    public void onErrorReturnPredicateNoMatch() {
+    void onErrorReturnPredicateNoMatch() {
         toSource(first.onErrorReturn(t -> false, t -> 1)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -89,7 +89,7 @@ public class OnErrorSingleTest {
     }
 
     @Test
-    public void onErrorMapMatch() {
+    void onErrorMapMatch() {
         toSource(first.onErrorMap(t -> DELIBERATE_EXCEPTION)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(new DeliberateException());
@@ -97,7 +97,7 @@ public class OnErrorSingleTest {
     }
 
     @Test
-    public void onErrorMapMatchThrows() {
+    void onErrorMapMatchThrows() {
         toSource(first.onErrorMap(t -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(subscriber);
@@ -107,7 +107,7 @@ public class OnErrorSingleTest {
     }
 
     @Test
-    public void onErrorMapClassMatch() {
+    void onErrorMapClassMatch() {
         toSource(first.onErrorMap(DeliberateException.class, t -> DELIBERATE_EXCEPTION)).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(new DeliberateException());
@@ -115,7 +115,7 @@ public class OnErrorSingleTest {
     }
 
     @Test
-    public void onErrorMapClassNoMatch() {
+    void onErrorMapClassNoMatch() {
         toSource(first.onErrorMap(IllegalArgumentException.class, t -> new DeliberateException()))
                 .subscribe(subscriber);
         subscriber.awaitSubscription();
@@ -124,7 +124,7 @@ public class OnErrorSingleTest {
     }
 
     @Test
-    public void onErrorMapPredicateMatch() {
+    void onErrorMapPredicateMatch() {
         toSource(first.onErrorMap(t -> t instanceof DeliberateException, t -> DELIBERATE_EXCEPTION))
                 .subscribe(subscriber);
         subscriber.awaitSubscription();
@@ -133,7 +133,7 @@ public class OnErrorSingleTest {
     }
 
     @Test
-    public void onErrorMapPredicateNoMatch() {
+    void onErrorMapPredicateNoMatch() {
         toSource(first.onErrorMap(t -> false, t -> new IllegalStateException())).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -141,7 +141,7 @@ public class OnErrorSingleTest {
     }
 
     @Test
-    public void onErrorResumeClassMatch() {
+    void onErrorResumeClassMatch() {
         toSource(first.onErrorResume(DeliberateException.class, t -> failed(DELIBERATE_EXCEPTION)))
                 .subscribe(subscriber);
         subscriber.awaitSubscription();
@@ -150,7 +150,7 @@ public class OnErrorSingleTest {
     }
 
     @Test
-    public void onErrorResumeClassNoMatch() {
+    void onErrorResumeClassNoMatch() {
         toSource(first.onErrorResume(IllegalArgumentException.class, t -> succeeded(1))).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
@@ -158,7 +158,7 @@ public class OnErrorSingleTest {
     }
 
     @Test
-    public void onErrorResumePredicateMatch() {
+    void onErrorResumePredicateMatch() {
         toSource(first.onErrorResume(t -> t instanceof DeliberateException, t -> failed(DELIBERATE_EXCEPTION)))
                 .subscribe(subscriber);
         subscriber.awaitSubscription();
@@ -167,7 +167,7 @@ public class OnErrorSingleTest {
     }
 
     @Test
-    public void onErrorResumePredicateNoMatch() {
+    void onErrorResumePredicateNoMatch() {
         toSource(first.onErrorResume(t -> false, t -> succeeded(1))).subscribe(subscriber);
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterableTest.java
@@ -42,12 +42,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public final class PublisherAsBlockingIterableTest {
+final class PublisherAsBlockingIterableTest {
 
     private final TestPublisher<Integer> source = new TestPublisher<>();
 
     @Test
-    public void subscribeDelayedTillIterator() {
+    void subscribeDelayedTillIterator() {
         Iterable<Integer> iterable = source.toIterable();
         assertFalse(source.isSubscribed());
         iterable.iterator();
@@ -55,19 +55,19 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void removeNotSupported() {
+    void removeNotSupported() {
         assertThrows(UnsupportedOperationException.class, () -> source.toIterable().iterator().remove());
     }
 
     @Test
-    public void allItemsAreReturned() {
+    void allItemsAreReturned() {
         Spliterator<Integer> iterator = from(1, 2, 3, 4).toIterable().spliterator();
         List<Integer> result = stream(iterator, false).collect(toList());
         assertThat("Unexpected result.", result, contains(1, 2, 3, 4));
     }
 
     @Test
-    public void errorEmittedIsThrown() {
+    void errorEmittedIsThrown() {
         DeliberateException de = new DeliberateException();
         Iterator<Integer> iterator = Publisher.<Integer>failed(de).toIterable().iterator();
         assertThat("Item expected but not found.", iterator.hasNext(), is(true));
@@ -75,7 +75,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void doubleHashNextWithError() {
+    void doubleHashNextWithError() {
         DeliberateException de = new DeliberateException();
         Iterator<Integer> iterator = Publisher.<Integer>failed(de).toIterable().iterator();
         assertThat("Item expected but not found.", iterator.hasNext(), is(true));
@@ -84,20 +84,20 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void hasNextWithEmpty() {
+    void hasNextWithEmpty() {
         Iterator<Integer> iterator = Publisher.<Integer>empty().toIterable().iterator();
         assertThat("Item not expected but found.", iterator.hasNext(), is(false));
     }
 
     @Test
-    public void nextWithEmpty() {
+    void nextWithEmpty() {
         Iterator<Integer> iterator = Publisher.<Integer>empty().toIterable().iterator();
         assertThat("Item not expected but found.", iterator.hasNext(), is(false));
         assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Test
-    public void hasNextWithTimeout() throws Exception {
+    void hasNextWithTimeout() throws Exception {
         BlockingIterator<Integer> iterator = source.toIterable().iterator();
         assertTrue(source.isSubscribed());
         TestSubscription subscription = new TestSubscription();
@@ -113,7 +113,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void nextWithTimeout() throws Exception {
+    void nextWithTimeout() throws Exception {
         BlockingIterator<Integer> iterator = source.toIterable().iterator();
         assertTrue(source.isSubscribed());
         TestSubscription subscription = new TestSubscription();
@@ -130,7 +130,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void cancelShouldTerminatePostDrain() throws Exception {
+    void cancelShouldTerminatePostDrain() throws Exception {
         BlockingIterator<Integer> iterator = source.toIterable().iterator();
         assertTrue(source.isSubscribed());
         source.onNext(1, 2);
@@ -141,7 +141,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void cancelShouldTerminatePostDrainAndRejectSubsequentItems() throws Exception {
+    void cancelShouldTerminatePostDrainAndRejectSubsequentItems() throws Exception {
         BlockingIterator<Integer> iterator = source.toIterable().iterator();
         assertTrue(source.isSubscribed());
         source.onNext(1, 2);
@@ -153,7 +153,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void nextWithoutHasNext() {
+    void nextWithoutHasNext() {
         Iterator<Integer> iterator = source.toIterable().iterator();
         assertTrue(source.isSubscribed());
         source.onNext(1);
@@ -165,7 +165,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void nextWithoutHasNextAndTerminal() {
+    void nextWithoutHasNextAndTerminal() {
         Iterator<Integer> iterator = source.toIterable().iterator();
         assertTrue(source.isSubscribed());
         source.onNext(1);
@@ -177,7 +177,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void nextWithTimeoutWithoutHasNextAndTerminal() {
+    void nextWithTimeoutWithoutHasNextAndTerminal() {
         BlockingIterator<Integer> iterator = source.toIterable().iterator();
         assertTrue(source.isSubscribed());
         source.onNext(1);
@@ -189,7 +189,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void errorEmittedIsThrownAfterEmittingAllItems() {
+    void errorEmittedIsThrownAfterEmittingAllItems() {
         DeliberateException de = new DeliberateException();
         Iterator<Integer> iterator = from(1, 2, 3, 4)
                 .concat(Publisher.failed(de)).toIterable().iterator();
@@ -206,7 +206,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void delayOnNextThenComplete() {
+    void delayOnNextThenComplete() {
         Iterator<Integer> iterator = source.toIterable(2).iterator();
         TestSubscription subscription = new TestSubscription();
         source.onSubscribe(subscription);
@@ -221,7 +221,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void delayOnNextThenError() {
+    void delayOnNextThenError() {
         Iterator<Integer> iterator = source.toIterable(2).iterator();
         TestSubscription subscription = new TestSubscription();
         source.onSubscribe(subscription);
@@ -239,7 +239,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void verifyRequestedReplenishedCapacityAs1() {
+    void verifyRequestedReplenishedCapacityAs1() {
         Iterator<Integer> iterator = source.toIterable(1).iterator();
         TestSubscription subscription = new TestSubscription();
         source.onSubscribe(subscription);
@@ -253,7 +253,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void verifyRequestedReplenishedOddQueueCapacity() {
+    void verifyRequestedReplenishedOddQueueCapacity() {
         Iterator<Integer> iterator = source.toIterable(5).iterator();
         TestSubscription subscription = new TestSubscription();
         source.onSubscribe(subscription);
@@ -268,7 +268,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void verifyRequestedReplenishedEvenQueueCapacity() {
+    void verifyRequestedReplenishedEvenQueueCapacity() {
         Iterator<Integer> iterator = source.toIterable(4).iterator();
         TestSubscription subscription = new TestSubscription();
         source.onSubscribe(subscription);
@@ -283,7 +283,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void verifyFullRequestedSatisfiedAndRequestMore() {
+    void verifyFullRequestedSatisfiedAndRequestMore() {
         Iterator<Integer> iterator = source.toIterable(2).iterator();
         TestSubscription subscription = new TestSubscription();
         source.onSubscribe(subscription);
@@ -299,7 +299,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void queueFullButAccommodatesOnError() {
+    void queueFullButAccommodatesOnError() {
         Iterator<Integer> iterator = source.toIterable(1).iterator();
         TestSubscription subscription = new TestSubscription();
         source.onSubscribe(subscription);
@@ -315,7 +315,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void queueFullButAccommodatesOnComplete() {
+    void queueFullButAccommodatesOnComplete() {
         Iterator<Integer> iterator = source.toIterable(1).iterator();
         TestSubscription subscription = new TestSubscription();
         source.onSubscribe(subscription);
@@ -328,7 +328,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void queueFullButAccommodatesCancel() throws Exception {
+    void queueFullButAccommodatesCancel() throws Exception {
         BlockingIterator<Integer> iterator = source.toIterable(1).iterator();
         TestSubscription subscription = new TestSubscription();
         source.onSubscribe(subscription);
@@ -341,7 +341,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void replenishingRequestedShouldHonourQueueContents() {
+    void replenishingRequestedShouldHonourQueueContents() {
         Iterator<Integer> iterator = source.toIterable(2).iterator();
         TestSubscription subscription = new TestSubscription();
         source.onSubscribe(subscription);
@@ -367,7 +367,7 @@ public final class PublisherAsBlockingIterableTest {
     }
 
     @Test
-    public void nullShouldBeEmitted() {
+    void nullShouldBeEmitted() {
         Iterator<Void> iterator = Publisher.from((Void) null).toIterable().iterator();
         assertThat("Item expected but not found.", iterator.hasNext(), is(true));
         assertThat("Unexpected item found.", iterator.next(), is(nullValue()));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferConcurrencyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferConcurrencyTest.java
@@ -41,7 +41,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class PublisherBufferConcurrencyTest {
+class PublisherBufferConcurrencyTest {
     private static final String THREAD_NAME_PREFIX = "buffer-concurrency-test";
     private static final Key<Integer> CTX_KEY = Key.newKey("foo");
 
@@ -49,12 +49,12 @@ public class PublisherBufferConcurrencyTest {
     final ExecutorExtension<Executor> executorExtension = withCachedExecutor(THREAD_NAME_PREFIX);
 
     @Test
-    public void largeRun() throws Exception {
+    void largeRun() throws Exception {
         runTest(identity(), identity());
     }
 
     @Test
-    public void executorIsPreserved() throws Exception {
+    void executorIsPreserved() throws Exception {
         final Executor executor = executorExtension.executor();
         runTest(beforeBuffer -> beforeBuffer.publishOn(executor),
                 afterBuffer -> afterBuffer.beforeOnNext(__ ->
@@ -67,7 +67,7 @@ public class PublisherBufferConcurrencyTest {
     }
 
     @Test
-    public void contextIsPreserved() throws Exception {
+    void contextIsPreserved() throws Exception {
         AsyncContext.put(CTX_KEY, 0);
         runTest(beforeBuffer -> beforeBuffer.beforeOnSubscribe(__ -> AsyncContext.put(CTX_KEY, 1)),
                 afterBuffer -> afterBuffer.beforeOnNext(__ ->
@@ -79,7 +79,7 @@ public class PublisherBufferConcurrencyTest {
     }
 
     @Test
-    public void addingAndBoundaryEmission() throws Exception {
+    void addingAndBoundaryEmission() throws Exception {
         TestPublisher<Integer> original = new TestPublisher<>();
         TestPublisher<Accumulator<Integer, Integer>> boundaries = new TestPublisher<>();
         TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferTest.java
@@ -34,14 +34,14 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class PublisherBufferTest {
+class PublisherBufferTest {
     private static final int EMPTY_ACCUMULATOR_VAL = -1;
-    public static final int BUFFER_SIZE_HINT = 8;
+    static final int BUFFER_SIZE_HINT = 8;
     private final TestPublisher<Integer> original = new TestPublisher<>();
     private final TestPublisher<SumAccumulator> boundaries = new TestPublisher<>();
     private final TestPublisherSubscriber<Integer> bufferSubscriber = new TestPublisherSubscriber<>();
 
-    public PublisherBufferTest() {
+    PublisherBufferTest() {
         toSource(original.buffer(new BufferStrategy<Integer, SumAccumulator, Integer>() {
             @Override
             public Publisher<SumAccumulator> boundaries() {
@@ -59,7 +59,7 @@ public class PublisherBufferTest {
     }
 
     @Test
-    public void invalidBufferSizeHint() {
+    void invalidBufferSizeHint() {
         TestPublisherSubscriber<Integer> bufferSubscriber = new TestPublisherSubscriber<>();
         toSource(Publisher.<Integer>empty()
                 .buffer(new BufferStrategy<Integer, Accumulator<Integer, Integer>, Integer>() {
@@ -78,7 +78,7 @@ public class PublisherBufferTest {
     }
 
     @Test
-    public void emptyBuffer() {
+    void emptyBuffer() {
         bufferSubscriber.awaitSubscription().request(1);
         verifyNoBuffersNoTerminal();
 
@@ -88,7 +88,7 @@ public class PublisherBufferTest {
     }
 
     @Test
-    public void originalCompleteBeforeBufferRequested() {
+    void originalCompleteBeforeBufferRequested() {
         verifyNoBuffersNoTerminal();
 
         original.onComplete();
@@ -100,7 +100,7 @@ public class PublisherBufferTest {
     }
 
     @Test
-    public void originalFailedBeforeBufferRequested() {
+    void originalFailedBeforeBufferRequested() {
         verifyNoBuffersNoTerminal();
 
         original.onError(DELIBERATE_EXCEPTION);
@@ -112,7 +112,7 @@ public class PublisherBufferTest {
     }
 
     @Test
-    public void bufferContainsItemsBeforeBoundaryClose() {
+    void bufferContainsItemsBeforeBoundaryClose() {
         verifyNoBuffersNoTerminal();
 
         original.onNext(1, 2, 3, 4);
@@ -123,7 +123,7 @@ public class PublisherBufferTest {
     }
 
     @Test
-    public void itemCompletionCancelsBoundaries() {
+    void itemCompletionCancelsBoundaries() {
         verifyNoBuffersNoTerminal();
         original.onComplete();
         emitBoundary();
@@ -133,7 +133,7 @@ public class PublisherBufferTest {
     }
 
     @Test
-    public void itemFailureCancelsBoundaries() {
+    void itemFailureCancelsBoundaries() {
         verifyNoBuffersNoTerminal();
         original.onError(DELIBERATE_EXCEPTION);
         emitBoundary();
@@ -143,7 +143,7 @@ public class PublisherBufferTest {
     }
 
     @Test
-    public void multipleBoundaries() {
+    void multipleBoundaries() {
         verifyNoBuffersNoTerminal();
         bufferSubscriber.awaitSubscription().request(2);
 
@@ -159,14 +159,14 @@ public class PublisherBufferTest {
     }
 
     @Test
-    public void bufferSubCancel() {
+    void bufferSubCancel() {
         bufferSubscriber.awaitSubscription().cancel();
         verifyCancelled(original);
         verifyCancelled(boundaries);
     }
 
     @Test
-    public void itemsBufferedTillBoundariesRequested() {
+    void itemsBufferedTillBoundariesRequested() {
         verifyNoBuffersNoTerminal();
 
         original.onNext(1, 2, 3, 4);
@@ -176,7 +176,7 @@ public class PublisherBufferTest {
     }
 
     @Test
-    public void itemsAndCompletionBufferedTillBoundariesRequested() {
+    void itemsAndCompletionBufferedTillBoundariesRequested() {
         verifyNoBuffersNoTerminal();
 
         original.onNext(1, 2, 3, 4);
@@ -189,7 +189,7 @@ public class PublisherBufferTest {
     }
 
     @Test
-    public void itemsAndFailureBufferedTillBoundariesRequested() {
+    void itemsAndFailureBufferedTillBoundariesRequested() {
         verifyNoBuffersNoTerminal();
 
         original.onNext(1, 2, 3, 4);
@@ -202,7 +202,7 @@ public class PublisherBufferTest {
     }
 
     @Test
-    public void boundariesCompletion() {
+    void boundariesCompletion() {
         verifyNoBuffersNoTerminal();
 
         original.onNext(1, 2, 3, 4);
@@ -213,7 +213,7 @@ public class PublisherBufferTest {
     }
 
     @Test
-    public void boundariesFailure() {
+    void boundariesFailure() {
         verifyNoBuffersNoTerminal();
 
         original.onNext(1, 2, 3, 4);
@@ -224,7 +224,7 @@ public class PublisherBufferTest {
 
     @Disabled("Accumulator will not emit boundary ATM")
     @Test
-    public void accumulateEmitsBoundary() {
+    void accumulateEmitsBoundary() {
         bufferSubscriber.awaitSubscription().request(1);
         boundaries.onNext(new SumAccumulator(boundaries, true));
         verifyEmptyBufferReceived();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherConcatMapIterableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherConcatMapIterableTest.java
@@ -59,7 +59,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
-public class PublisherConcatMapIterableTest {
+class PublisherConcatMapIterableTest {
     @RegisterExtension
     static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
 
@@ -69,7 +69,7 @@ public class PublisherConcatMapIterableTest {
     private final TestSubscription subscription = new TestSubscription();
 
     @Test
-    public void upstreamRecoverWithMakesProgress() throws Exception {
+    void upstreamRecoverWithMakesProgress() throws Exception {
         @SuppressWarnings("unchecked")
         Subscriber<String> mockSubscriber = mock(Subscriber.class);
         CountDownLatch latchOnSubscribe = new CountDownLatch(1);
@@ -112,7 +112,7 @@ public class PublisherConcatMapIterableTest {
     }
 
     @Test
-    public void cancellableIterableIsCancelled() {
+    void cancellableIterableIsCancelled() {
         toSource(cancellablePublisher.flatMapConcatIterable(identity())).subscribe(subscriber);
         cancellablePublisher.onSubscribe(subscription);
         subscriber.awaitSubscription().request(1);
@@ -127,7 +127,7 @@ public class PublisherConcatMapIterableTest {
     }
 
     @Test
-    public void justComplete() {
+    void justComplete() {
         toSource(publisher.flatMapConcatIterable(identity())).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         subscriber.awaitSubscription();
@@ -135,7 +135,7 @@ public class PublisherConcatMapIterableTest {
     }
 
     @Test
-    public void justFail() {
+    void justFail() {
         toSource(publisher.flatMapConcatIterable(identity())).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         subscriber.awaitSubscription();
@@ -143,12 +143,12 @@ public class PublisherConcatMapIterableTest {
     }
 
     @Test
-    public void singleElementSingleValueThenSuccess() {
+    void singleElementSingleValueThenSuccess() {
         singleElementSingleValue(true);
     }
 
     @Test
-    public void singleElementSingleValueThenFail() {
+    void singleElementSingleValueThenFail() {
         singleElementSingleValue(false);
     }
 
@@ -165,12 +165,12 @@ public class PublisherConcatMapIterableTest {
     }
 
     @Test
-    public void singleElementMultipleValuesDelayedRequestThenSuccess() {
+    void singleElementMultipleValuesDelayedRequestThenSuccess() {
         singleElementMultipleValuesDelayedRequest(true);
     }
 
     @Test
-    public void singleElementMultipleValuesDelayedRequestThenFail() {
+    void singleElementMultipleValuesDelayedRequestThenFail() {
         singleElementMultipleValuesDelayedRequest(false);
     }
 
@@ -199,12 +199,12 @@ public class PublisherConcatMapIterableTest {
     }
 
     @Test
-    public void multipleElementsSingleValueThenSuccess() {
+    void multipleElementsSingleValueThenSuccess() {
         multipleElementsSingleValue(true);
     }
 
     @Test
-    public void multipleElementsSingleValueThenFail() {
+    void multipleElementsSingleValueThenFail() {
         multipleElementsSingleValue(false);
     }
 
@@ -223,12 +223,12 @@ public class PublisherConcatMapIterableTest {
     }
 
     @Test
-    public void multipleElementsMultipleValuesThenSuccess() {
+    void multipleElementsMultipleValuesThenSuccess() {
         multipleElementsMultipleValues(true);
     }
 
     @Test
-    public void multipleElementsMultipleValuesThenFail() {
+    void multipleElementsMultipleValuesThenFail() {
         multipleElementsMultipleValues(false);
     }
 
@@ -253,7 +253,7 @@ public class PublisherConcatMapIterableTest {
     }
 
     @Test
-    public void cancelIsPropagated() {
+    void cancelIsPropagated() {
         toSource(publisher.flatMapConcatIterable(identity())).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         subscriber.awaitSubscription().request(1);
@@ -264,12 +264,12 @@ public class PublisherConcatMapIterableTest {
     }
 
     @Test
-    public void requestWithEmptyIterableThenSuccess() {
+    void requestWithEmptyIterableThenSuccess() {
         requestWithEmptyIterable(true);
     }
 
     @Test
-    public void requestWithEmptyIterableThenFail() {
+    void requestWithEmptyIterableThenFail() {
         requestWithEmptyIterable(false);
     }
 
@@ -291,7 +291,7 @@ public class PublisherConcatMapIterableTest {
     }
 
     @Test
-    public void exceptionFromOnErrorIsPropagated() {
+    void exceptionFromOnErrorIsPropagated() {
         toSource(publisher.flatMapConcatIterable(identity())
                 .afterOnError(t -> {
                     throw DELIBERATE_EXCEPTION;
@@ -303,7 +303,7 @@ public class PublisherConcatMapIterableTest {
     }
 
     @Test
-    public void testExceptionFromBufferedOnNextThenTerminalIsPropagated() {
+    void testExceptionFromBufferedOnNextThenTerminalIsPropagated() {
         final DeliberateException ex2 = new DeliberateException();
         final AtomicBoolean errored = new AtomicBoolean();
         toSource(publisher.flatMapConcatIterable(identity())
@@ -319,7 +319,7 @@ public class PublisherConcatMapIterableTest {
     }
 
     @Test
-    public void exceptionFromOnCompleteIsPropagated() {
+    void exceptionFromOnCompleteIsPropagated() {
         toSource(publisher.flatMapConcatIterable(identity())
                 .afterOnComplete(() -> {
                     throw DELIBERATE_EXCEPTION;
@@ -331,7 +331,7 @@ public class PublisherConcatMapIterableTest {
     }
 
     @Test
-    public void exceptionInsideOnNextWhenOnCompleteRacesRequestNIsPropagated() throws Exception {
+    void exceptionInsideOnNextWhenOnCompleteRacesRequestNIsPropagated() throws Exception {
         CyclicBarrier barrier = new CyclicBarrier(2);
         toSource(publisher.flatMapConcatIterable(identity())
                 .map(new Function<String, String>() {
@@ -364,7 +364,7 @@ public class PublisherConcatMapIterableTest {
     }
 
     @Test
-    public void exceptionFromOnNextIsPropagated() {
+    void exceptionFromOnNextIsPropagated() {
         toSource(publisher.flatMapConcatIterable(identity())
                 .map((Function<String, String>) s -> {
                     throw DELIBERATE_EXCEPTION;
@@ -375,7 +375,7 @@ public class PublisherConcatMapIterableTest {
     }
 
     @Test
-    public void exceptionFromOnNextIsPropagatedAndDoesNotCancel() {
+    void exceptionFromOnNextIsPropagatedAndDoesNotCancel() {
         TestPublisher<List<String>> localPublisher = new TestPublisher.Builder<List<String>>().disableAutoOnSubscribe()
                 .build(subscriber1 -> {
                     subscriber1.onSubscribe(subscription);
@@ -393,7 +393,7 @@ public class PublisherConcatMapIterableTest {
     }
 
     @Test
-    public void exceptionFromSubscriptionRequestNIsPropagated() {
+    void exceptionFromSubscriptionRequestNIsPropagated() {
         toSource(publisher.flatMapConcatIterable(identity())
                 .map((Function<String, String>) s -> {
                     throw DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherExecutorPreservationTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherExecutorPreservationTest.java
@@ -21,34 +21,34 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public class PublisherExecutorPreservationTest {
+class PublisherExecutorPreservationTest {
     @RegisterExtension
     static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor("test");
 
     private Publisher<String> publisher;
 
     @BeforeEach
-    public void setupPublisher() {
+    void setupPublisher() {
         publisher = Publisher.<String>empty().publishAndSubscribeOnOverride(EXEC.executor());
     }
 
     @Test
-    public void testPubToSingle() {
+    void testPubToSingle() {
         assertSame(EXEC.executor(), publisher.firstOrElse(() -> null).executor());
     }
 
     @Test
-    public void testPubToSingleOrError() {
+    void testPubToSingleOrError() {
         assertSame(EXEC.executor(), publisher.firstOrError().executor());
     }
 
     @Test
-    public void testPubToCompletable() {
+    void testPubToCompletable() {
         assertSame(EXEC.executor(), publisher.ignoreElements().executor());
     }
 
     @Test
-    public void testReduceSingle() {
+    void testReduceSingle() {
         assertSame(EXEC.executor(), publisher.collect(() -> 0, (n, s) -> n += s.length()).executor());
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
@@ -76,7 +76,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class PublisherFlatMapMergeTest {
+class PublisherFlatMapMergeTest {
     private static final long TERMINAL_POLL_MS = 10;
     @Nullable
     private static ExecutorService executorService;
@@ -87,13 +87,13 @@ public class PublisherFlatMapMergeTest {
     private TestPublisher<Integer> publisher = new TestPublisher<>();
 
     @BeforeAll
-    public static void beforeClass() {
+    static void beforeClass() {
         executorService = java.util.concurrent.Executors.newFixedThreadPool(10);
         executor = io.servicetalk.concurrent.api.Executors.from(executorService);
     }
 
     @AfterAll
-    public static void afterClass() throws Exception {
+    static void afterClass() throws Exception {
         if (executor != null) {
             executor.closeAsync().toFuture().get();
         }
@@ -103,7 +103,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void mappedRecoverMakesProgress() throws Exception {
+    void mappedRecoverMakesProgress() throws Exception {
         @SuppressWarnings("unchecked")
         Subscriber<Integer> mockSubscriber = mock(Subscriber.class);
         CountDownLatch latchOnSubscribe = new CountDownLatch(1);
@@ -142,22 +142,22 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void singleConcurrencyComplete() {
+    void singleConcurrencyComplete() {
         singleConcurrencyComplete(publisher.flatMapMerge(i -> from(i + 1), 1));
     }
 
     @Test
-    public void defaultConcurrencyComplete() {
+    void defaultConcurrencyComplete() {
         singleConcurrencyComplete(publisher.flatMapMerge(i -> from(i + 1)));
     }
 
     @Test
-    public void singleConcurrencyDelayErrorComplete() {
+    void singleConcurrencyDelayErrorComplete() {
         singleConcurrencyComplete(publisher.flatMapMergeDelayError(i -> from(i + 1), 1));
     }
 
     @Test
-    public void defaultConcurrencyDelayErrorComplete() {
+    void defaultConcurrencyDelayErrorComplete() {
         singleConcurrencyComplete(publisher.flatMapMergeDelayError(i -> from(i + 1)));
     }
 
@@ -173,7 +173,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void singleConcurrencyNullComplete() {
+    void singleConcurrencyNullComplete() {
         toSource(publisher.flatMapMerge(i -> from((Integer) null), 1)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         publisher.onNext(1);
@@ -184,7 +184,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void singleItemSourceCompleteFirst() {
+    void singleItemSourceCompleteFirst() {
         TestPublisher<Integer> mappedPublisher = new TestPublisher<>();
         toSource(publisher.flatMapMerge(i -> mappedPublisher, 1)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
@@ -203,7 +203,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void singleItemMappedCompleteFirst() {
+    void singleItemMappedCompleteFirst() {
         TestPublisher<Integer> mappedPublisher = new TestPublisher<>();
         toSource(publisher.flatMapMerge(i -> mappedPublisher, 1)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
@@ -222,7 +222,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void singleItemMappedError() {
+    void singleItemMappedError() {
         toSource(publisher.flatMapMerge(i -> Publisher.<Integer>failed(DELIBERATE_EXCEPTION), 1))
                 .subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
@@ -231,7 +231,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void singleItemMappedErrorPostSourceComplete() {
+    void singleItemMappedErrorPostSourceComplete() {
         TestPublisher<Integer> mappedPublisher = new TestPublisher<>();
         toSource(publisher.flatMapMerge(i -> mappedPublisher, 1)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
@@ -248,7 +248,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void testDuplicateTerminal() {
+    void testDuplicateTerminal() {
         PublisherSource<Integer> mappedPublisher = subscriber -> {
             subscriber.onSubscribe(EMPTY_SUBSCRIPTION);
             subscriber.onComplete();
@@ -265,7 +265,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void cancelPropagatedBeforeErrorButOriginalErrorPreserved() {
+    void cancelPropagatedBeforeErrorButOriginalErrorPreserved() {
         CountDownLatch cancelledLatch = new CountDownLatch(1);
         publisher = new TestPublisher.Builder<Integer>().disableAutoOnSubscribe().build(subscriber1 -> {
             subscriber1.onSubscribe(new Subscription() {
@@ -301,7 +301,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void sourceEmitsErrorNoOnNext() {
+    void sourceEmitsErrorNoOnNext() {
         toSource(publisher.flatMapMerge(i -> from(i + 1), 1)).subscribe(subscriber);
         subscriber.awaitSubscription();
         publisher.onError(DELIBERATE_EXCEPTION);
@@ -309,7 +309,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void sourceEmitsErrorPostOnNexts() {
+    void sourceEmitsErrorPostOnNexts() {
         toSource(publisher.flatMapMerge(i -> from(i + 1), 1)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         publisher.onNext(1);
@@ -322,7 +322,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void sourceEmitsErrorPostOnNextsMappedNotCompleted() {
+    void sourceEmitsErrorPostOnNextsMappedNotCompleted() {
         TestSubscription mappedSubscription = new TestSubscription();
         TestPublisher<Integer> mappedPublisher = new TestPublisher.Builder<Integer>()
                 .disableAutoOnSubscribe().build();
@@ -337,7 +337,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void sourceCancelAlsoCancelMapped() {
+    void sourceCancelAlsoCancelMapped() {
         TestSubscription mappedSubscription = new TestSubscription();
         TestPublisher<Integer> mappedPublisher = new TestPublisher.Builder<Integer>()
                 .disableAutoOnSubscribe().build();
@@ -352,12 +352,12 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void mappedCompletePostCancel() {
+    void mappedCompletePostCancel() {
         mappedTerminalPostCancel(false);
     }
 
     @Test
-    public void mappedErrorPostCancel() {
+    void mappedErrorPostCancel() {
         mappedTerminalPostCancel(true);
     }
 
@@ -387,7 +387,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void errorDeliveredWithoutDrainingOptimisticDemand() throws InterruptedException {
+    void errorDeliveredWithoutDrainingOptimisticDemand() throws InterruptedException {
         TestSubscription upstreamSubscription = new TestSubscription();
         publisher = new TestPublisher.Builder<Integer>()
                 .disableAutoOnSubscribe().build(subscriber1 -> {
@@ -408,7 +408,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void errorFromMappedSubscriberIsSequencedWithOnNextSignals() throws InterruptedException {
+    void errorFromMappedSubscriberIsSequencedWithOnNextSignals() throws InterruptedException {
         List<TestSubscriptionPublisherPair<Integer>> mappedPublishers = new ArrayList<>();
         TestSubscription upstreamSubscription = new TestSubscription();
         publisher = new TestPublisher.Builder<Integer>()
@@ -452,7 +452,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void mapperThrows() {
+    void mapperThrows() {
         TestSubscription upstreamSubscription = new TestSubscription();
         publisher = new TestPublisher.Builder<Integer>()
                 .disableAutoOnSubscribe().build(subscriber1 -> {
@@ -470,7 +470,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void mixedOrderMappedEmission() throws InterruptedException {
+    void mixedOrderMappedEmission() throws InterruptedException {
         List<TestSubscriptionPublisherPair<Integer>> mappedPublishers = new ArrayList<>();
         TestSubscription upstreamSubscription = new TestSubscription();
         publisher = new TestPublisher.Builder<Integer>()
@@ -532,7 +532,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void requestLongMaxMultipleTimes() throws InterruptedException {
+    void requestLongMaxMultipleTimes() throws InterruptedException {
         TestSubscription upstreamSubscription = new TestSubscription();
         publisher = new TestPublisher.Builder<Integer>()
                 .disableAutoOnSubscribe().build(subscriber1 -> {
@@ -555,12 +555,12 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void accumulateToLongMax() throws InterruptedException {
+    void accumulateToLongMax() throws InterruptedException {
         accumulateToMax(Long.MAX_VALUE);
     }
 
     @Test
-    public void accumulateToIntMax() throws InterruptedException {
+    void accumulateToIntMax() throws InterruptedException {
         accumulateToMax(Integer.MAX_VALUE);
     }
 
@@ -583,7 +583,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void requestAfterMappedError() throws InterruptedException {
+    void requestAfterMappedError() throws InterruptedException {
         TestSubscription upstreamSubscription = new TestSubscription();
         publisher = new TestPublisher.Builder<Integer>()
                 .disableAutoOnSubscribe().build(subscriber1 -> {
@@ -601,7 +601,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void requestMultipleTimes() throws InterruptedException {
+    void requestMultipleTimes() throws InterruptedException {
         TestSubscription upstreamSubscription = new TestSubscription();
         publisher = new TestPublisher.Builder<Integer>()
                 .disableAutoOnSubscribe().build(subscriber1 -> {
@@ -629,7 +629,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void requestMultipleTimesBreachMaxConcurrency() throws InterruptedException {
+    void requestMultipleTimesBreachMaxConcurrency() throws InterruptedException {
         TestSubscription upstreamSubscription = new TestSubscription();
         publisher = new TestPublisher.Builder<Integer>()
                 .disableAutoOnSubscribe().build(subscriber1 -> {
@@ -653,7 +653,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void multipleMappedErrors() {
+    void multipleMappedErrors() {
         Queue<DeliberateException> errors = new ArrayDeque<>();
         toSource(publisher.<Integer>flatMapMergeDelayError(i -> {
             DeliberateException de = new DeliberateException();
@@ -672,7 +672,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void subscriptionReentry() throws InterruptedException {
+    void subscriptionReentry() throws InterruptedException {
         Queue<Integer> resultsQueue = new ConcurrentLinkedQueue<>();
         AtomicReference<Throwable> causeRef = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
@@ -717,7 +717,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void emitFromExecutor() throws InterruptedException, ExecutionException {
+    void emitFromExecutor() throws InterruptedException, ExecutionException {
         List<TestSubscriptionPublisherPair<Integer>> mappedPublishers = new ArrayList<>();
         TestSubscription upstreamSubscription = new TestSubscription();
         publisher = new TestPublisher.Builder<Integer>()
@@ -764,7 +764,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void requestAndEmitConcurrency() throws Exception {
+    void requestAndEmitConcurrency() throws Exception {
         int totalToRequest = 1000;
         List<Integer> received = new ArrayList<>(totalToRequest);
         CountDownLatch requestingStarting = new CountDownLatch(1);
@@ -798,7 +798,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void concurrentMappedAndPublisherTermination() throws Exception {
+    void concurrentMappedAndPublisherTermination() throws Exception {
         assert executor != null;
         Single<List<Integer>> single = range(0, 1000)
                 .flatMapMerge(i -> executor.submit(() -> i).toPublisher(), 1024)
@@ -813,7 +813,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void concurrentMappedDeliveryOrderPreserved() {
+    void concurrentMappedDeliveryOrderPreserved() {
         assert executor != null;
         final int upstreamItems = 10000;
         final int mappedItems = 5;
@@ -843,7 +843,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void concurrentSkipQueueDoesNotDeadlock() throws Throwable {
+    void concurrentSkipQueueDoesNotDeadlock() throws Throwable {
         assert executorService != null;
         List<TestSubscriptionPublisherPair<Integer>> mappedPublishers = new ArrayList<>();
         CountDownLatch onNextLatch = new CountDownLatch(1);
@@ -942,7 +942,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void concurrentMappedErrorAndPublisherTermination() throws Exception {
+    void concurrentMappedErrorAndPublisherTermination() throws Exception {
         assert executor != null;
         AtomicReference<Throwable> error = new AtomicReference<>();
         Single<List<Integer>> single = range(0, 1000)
@@ -971,7 +971,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void mappedQuotaIsRenewedAfterSingleMappedPublisherCompletes() throws InterruptedException {
+    void mappedQuotaIsRenewedAfterSingleMappedPublisherCompletes() throws InterruptedException {
         List<TestSubscriptionPublisherPair<Integer>> mappedPublishers = new ArrayList<>();
         TestSubscription upstreamSubscription = new TestSubscription();
         publisher = new TestPublisher.Builder<Integer>()
@@ -1019,7 +1019,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void mappedQuotaIsRenewedAfterExhausted() throws InterruptedException {
+    void mappedQuotaIsRenewedAfterExhausted() throws InterruptedException {
         List<TestSubscriptionPublisherPair<Integer>> mappedPublishers = new ArrayList<>();
         TestSubscription upstreamSubscription = new TestSubscription();
         publisher = new TestPublisher.Builder<Integer>()
@@ -1061,7 +1061,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void lastActiveMappedPublisherCanDeliverData() throws Throwable {
+    void lastActiveMappedPublisherCanDeliverData() throws Throwable {
         final int mappedRangeBegin = 5;
         final int mappedRangeEnd = 10;
         CountDownLatch latch = new CountDownLatch(mappedRangeEnd - mappedRangeBegin);
@@ -1111,7 +1111,7 @@ public class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void internalQueueSizeIsBoundedByDownstreamDemand() throws Throwable {
+    void internalQueueSizeIsBoundedByDownstreamDemand() throws Throwable {
         // We only expect 1 signal, and if we get 2 then the test has failed. The goal is to only request 1 onNext and
         // verify the operator bounds the amount of memory behind the scenes.
         final AtomicReference<Throwable> throwableRef = new AtomicReference<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
@@ -67,7 +67,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class PublisherFlatMapSingleTest {
+class PublisherFlatMapSingleTest {
     private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
     private TestPublisher<Integer> source = new TestPublisher<>();
     private final TestSubscription subscription = new TestSubscription();
@@ -75,18 +75,18 @@ public class PublisherFlatMapSingleTest {
     private static Executor executor;
 
     @BeforeAll
-    public static void beforeClass() {
+    static void beforeClass() {
         executorService = Executors.newFixedThreadPool(10);
         executor = io.servicetalk.concurrent.api.Executors.from(executorService);
     }
 
     @AfterAll
-    public static void afterClass() throws Exception {
+    static void afterClass() throws Exception {
         executor.closeAsync().toFuture().get();
     }
 
     @Test
-    public void concurrentSingleAndPublisherTermination() throws Exception {
+    void concurrentSingleAndPublisherTermination() throws Exception {
         final List<String> elements = range(0, 1000).mapToObj(Integer::toString).collect(toList());
         final Publisher<String> publisher = fromIterable(elements);
         final Single<List<String>> single = publisher.flatMapMergeSingle(x -> executor.submit(() -> x), 1024)
@@ -101,7 +101,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void concurrentSingleErrorAndPublisherTermination() throws Exception {
+    void concurrentSingleErrorAndPublisherTermination() throws Exception {
         final Publisher<Integer> publisher = fromIterable(() -> range(0, 1000).iterator());
         AtomicReference<Throwable> error = new AtomicReference<>();
         final Single<List<Integer>> single = publisher.flatMapMergeSingleDelayError(x -> executor.submit(() -> {
@@ -128,7 +128,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testSingleItemSyncSingle() {
+    void testSingleItemSyncSingle() {
         toSource(source.flatMapMergeSingle(integer1 -> succeeded(2), 2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         source.onNext(1);
@@ -138,7 +138,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testSingleItemCompletesWithNull() {
+    void testSingleItemCompletesWithNull() {
         toSource(source.<Integer>flatMapMergeSingle(integer1 -> succeeded(null), 2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         source.onNext(1);
@@ -148,7 +148,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testSingleItemSourceCompleteFirst() {
+    void testSingleItemSourceCompleteFirst() {
         LegacyTestSingle<Integer> single = new LegacyTestSingle<>();
         toSource(source.flatMapMergeSingle(integer1 -> single, 2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
@@ -160,7 +160,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testSingleItemSingleCompleteFirst() {
+    void testSingleItemSingleCompleteFirst() {
         LegacyTestSingle<Integer> single = new LegacyTestSingle<>();
         toSource(source.flatMapMergeSingle(integer1 -> single, 2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
@@ -172,7 +172,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testSingleItemSingleError() {
+    void testSingleItemSingleError() {
         toSource(source.<Integer>flatMapMergeSingle(integer1 -> failed(DELIBERATE_EXCEPTION), 2))
                 .subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
@@ -181,7 +181,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testSingleErrorPostSourceComplete() {
+    void testSingleErrorPostSourceComplete() {
         LegacyTestSingle<Integer> single = new LegacyTestSingle<>();
         toSource(source.flatMapMergeSingle(integer1 -> single, 2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
@@ -192,7 +192,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testDuplicateTerminal() {
+    void testDuplicateTerminal() {
         SingleSource<Integer> single = subscriber -> {
             subscriber.onSubscribe(IGNORE_CANCEL);
             subscriber.onSuccess(2);
@@ -209,7 +209,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void cancelPropagatedBeforeErrorButOriginalErrorPreserved() {
+    void cancelPropagatedBeforeErrorButOriginalErrorPreserved() {
         CountDownLatch cancelledLatch = new CountDownLatch(1);
         source = new TestPublisher.Builder<Integer>().disableAutoOnSubscribe().build(subscriber1 -> {
             subscriber1.onSubscribe(new Subscription() {
@@ -244,7 +244,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testSourceEmitsErrorNoOnNexts() {
+    void testSourceEmitsErrorNoOnNexts() {
         toSource(source.flatMapMergeSingle(integer1 -> succeeded(2), 2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         source.onError(DELIBERATE_EXCEPTION);
@@ -252,7 +252,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testSourceEmitsErrorPostOnNexts() {
+    void testSourceEmitsErrorPostOnNexts() {
         toSource(source.flatMapMergeSingle(integer1 -> succeeded(2), 2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         source.onNext(1);
@@ -262,7 +262,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testSourceEmitsErrorPostOnNextsSingleNotCompleted() {
+    void testSourceEmitsErrorPostOnNextsSingleNotCompleted() {
         LegacyTestSingle<Integer> single = new LegacyTestSingle<>(true);
         toSource(source.flatMapMergeSingle(integer1 -> single, 2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
@@ -274,7 +274,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testSubscriberCancel() {
+    void testSubscriberCancel() {
         LegacyTestSingle<Integer> single = new LegacyTestSingle<>();
         toSource(source.flatMapMergeSingle(integer1 -> single, 2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
@@ -286,7 +286,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testSingleCompletePostCancel() {
+    void testSingleCompletePostCancel() {
         final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
         LegacyTestSingle<Integer> single = new LegacyTestSingle<>(true);
         toSource(source.flatMapMergeSingle(integer1 -> single, 2)).subscribe(subscriber);
@@ -303,7 +303,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testSingleErrorPostCancel() {
+    void testSingleErrorPostCancel() {
         LegacyTestSingle<Integer> single = new LegacyTestSingle<>(true);
         toSource(source.flatMapMergeSingle(integer1 -> single, 2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
@@ -317,7 +317,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testMaxConcurrency() {
+    void testMaxConcurrency() {
         List<LegacyTestSingle<Integer>> emittedSingles = new ArrayList<>();
         toSource(source.flatMapMergeSingle(integer -> {
             LegacyTestSingle<Integer> s = new LegacyTestSingle<>();
@@ -351,7 +351,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testMapperThrows() {
+    void testMapperThrows() {
         toSource(source.<Integer>flatMapMergeSingle(integer1 -> {
             throw DELIBERATE_EXCEPTION;
         }, 2)).subscribe(subscriber);
@@ -364,7 +364,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testNoFlowControl() {
+    void testNoFlowControl() {
         List<LegacyTestSingle<Integer>> emittedSingles = new ArrayList<>();
         toSource(source.flatMapMergeSingle(integer1 -> {
             LegacyTestSingle<Integer> s1 = new LegacyTestSingle<>();
@@ -401,7 +401,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testRequestPostSingleError() {
+    void testRequestPostSingleError() {
         toSource(source.<Integer>flatMapMergeSingleDelayError(integer1 -> failed(DELIBERATE_EXCEPTION), 2))
                 .subscribe(subscriber);
         source.onSubscribe(subscription);
@@ -419,7 +419,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testRequestMultipleTimes() {
+    void testRequestMultipleTimes() {
         toSource(source.flatMapMergeSingle(integer1 -> succeeded(2), 10)).subscribe(subscriber);
         source.onSubscribe(subscription);
         subscriber.awaitSubscription().request(2);
@@ -432,7 +432,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testRequestMultipleTimesBreachMaxConcurrency() {
+    void testRequestMultipleTimesBreachMaxConcurrency() {
         toSource(source.flatMapMergeSingle(integer -> succeeded(2), 2)).subscribe(subscriber);
         source.onSubscribe(subscription);
         subscriber.awaitSubscription().request(2);
@@ -446,7 +446,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testMultipleSingleErrors() {
+    void testMultipleSingleErrors() {
         Queue<DeliberateException> errors = new ArrayDeque<>();
         toSource(source.flatMapMergeSingleDelayError(integer -> {
             DeliberateException de = new DeliberateException();
@@ -464,7 +464,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testRequestLongMaxValue() {
+    void testRequestLongMaxValue() {
         int maxConcurrency = 2;
         toSource(source.flatMapMergeSingle(integer1 -> succeeded(2), maxConcurrency)).subscribe(subscriber);
         source.onSubscribe(subscription);
@@ -477,7 +477,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testAccumulateToLongMaxValue() {
+    void testAccumulateToLongMaxValue() {
         int maxConcurrency = 2;
         toSource(source.flatMapMergeSingle(integer1 -> succeeded(2), maxConcurrency)).subscribe(subscriber);
         source.onSubscribe(subscription);
@@ -490,7 +490,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testAccumulateToIntMaxValue() {
+    void testAccumulateToIntMaxValue() {
         int maxConcurrency = 2;
         toSource(source.flatMapMergeSingle(integer1 -> succeeded(2), maxConcurrency)).subscribe(subscriber);
         source.onSubscribe(subscription);
@@ -503,7 +503,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testReentry() throws InterruptedException {
+    void testReentry() throws InterruptedException {
         Queue<String> resultsQueue = new ConcurrentLinkedQueue<>();
         AtomicReference<Throwable> causeRef = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
@@ -551,7 +551,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testEmitFromQueue() {
+    void testEmitFromQueue() {
         List<TestSingle<Integer>> emittedSingles = new ArrayList<>();
         io.servicetalk.concurrent.test.internal.TestPublisherSubscriber<Integer> subscriber =
                 new io.servicetalk.concurrent.test.internal.TestPublisherSubscriber<>();
@@ -590,7 +590,7 @@ public class PublisherFlatMapSingleTest {
     }
 
     @Test
-    public void testRequestAndEmitConcurrency() throws Exception {
+    void testRequestAndEmitConcurrency() throws Exception {
         int totalToRequest = 1000;
         Set<Integer> received = new LinkedHashSet<>(totalToRequest);
         toSource(source.flatMapMergeSingle(Single::succeeded, 2).beforeOnNext(received::add)).subscribe(subscriber);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherGroupByConcurrencyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherGroupByConcurrencyTest.java
@@ -49,7 +49,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Timeout(30)
-public final class PublisherGroupByConcurrencyTest {
+final class PublisherGroupByConcurrencyTest {
     private final TestPublisherSubscriber<Integer> groupsSubscriber = new TestPublisherSubscriber<>();
     private ConcurrentLinkedQueue<Integer> allItemsReceivedOnAllGroups;
     private TestPublisher<Integer> source;
@@ -57,7 +57,7 @@ public final class PublisherGroupByConcurrencyTest {
     private AtomicBoolean allWorkDone;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         source = new TestPublisher<>();
         allItemsReceivedOnAllGroups = new ConcurrentLinkedQueue<>();
         executor = newCachedThreadPool();
@@ -65,13 +65,13 @@ public final class PublisherGroupByConcurrencyTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         executor.shutdown();
         allItemsReceivedOnAllGroups.clear();
     }
 
     @Test
-    public void testConcurrentEmissionAndGroupCancel() throws Exception {
+    void testConcurrentEmissionAndGroupCancel() throws Exception {
         int itemCount = 1000;
         Queue<GroupSubscriber> subs = subscribeToAll(itemCount, true);
         Task cancels = drainGroupSubscribers(subs, GroupSubscriber::cancel).awaitStart();
@@ -81,7 +81,7 @@ public final class PublisherGroupByConcurrencyTest {
     }
 
     @Test
-    public void testConcurrentEmissionAndGroupRequestN() throws Exception {
+    void testConcurrentEmissionAndGroupRequestN() throws Exception {
         int itemCount = 1000;
         Queue<GroupSubscriber> subs = subscribeToAll(itemCount, false);
         Task requestNs = requestAndDrainGroupSubscribers(subs).awaitStart();
@@ -91,7 +91,7 @@ public final class PublisherGroupByConcurrencyTest {
     }
 
     @Test
-    public void testConcurrentGroupsCancel() throws Exception {
+    void testConcurrentGroupsCancel() throws Exception {
         int itemCount = 1000;
         Queue<GroupSubscriber> subs = subscribeToAll(itemCount, false);
         final TestSubscription subscription = new TestSubscription();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherGroupByTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherGroupByTest.java
@@ -55,59 +55,59 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class PublisherGroupByTest {
+class PublisherGroupByTest {
     private TestPublisher<Integer> source;
     private TestPublisherSubscriber<Boolean> subscriber;
     private TestSubscription subscription = new TestSubscription();
     private List<TestPublisherSubscriber<Integer>> groupSubs = new ArrayList<>();
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         source = new TestPublisher<>();
         subscriber = new TestPublisherSubscriber<>();
     }
 
     @Test
-    public void testGroupOnNextAndCompleteWithGroupQueue() {
+    void testGroupOnNextAndCompleteWithGroupQueue() {
         toSource(subscribeToAllGroups(10)).subscribe(subscriber);
         testGroupOnNextAndComplete(groupSubs);
     }
 
     @Test
-    public void testGroupOnNextAndErrorWithGroupQueue() {
+    void testGroupOnNextAndErrorWithGroupQueue() {
         toSource(subscribeToAllGroups(10)).subscribe(subscriber);
         testGroupOnNextAndError(groupSubs);
     }
 
     @Test
-    public void testGroupOnNextAndCompleteNoQueue() {
+    void testGroupOnNextAndCompleteNoQueue() {
         toSource(subscribeToAllGroups(10, s -> s)).subscribe(subscriber);
         testGroupOnNextAndComplete(groupSubs);
     }
 
     @Test
-    public void testGroupOnNextAndErrorNoQueue() {
+    void testGroupOnNextAndErrorNoQueue() {
         toSource(subscribeToAllGroups(10, s -> s)).subscribe(subscriber);
         testGroupOnNextAndError(groupSubs);
     }
 
     @Test
-    public void testGroupOnNextThrowsNoQueue() {
+    void testGroupOnNextThrowsNoQueue() {
         testGroupOnNextThrows(1);
     }
 
     @Test
-    public void testGroupOnNextThrowsWithQueue() {
+    void testGroupOnNextThrowsWithQueue() {
         testGroupOnNextThrows(0);
     }
 
     @Test
-    public void testGroupSubscriberCancelNoQueue() {
+    void testGroupSubscriberCancelNoQueue() {
         testGroupSubscriberCancel(1);
     }
 
     @Test
-    public void testHighDemandWithQueue() {
+    void testHighDemandWithQueue() {
         toSource(subscribeToAllGroups(10)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         source.onNext(1);
@@ -126,7 +126,7 @@ public class PublisherGroupByTest {
     }
 
     @Test
-    public void testIndividualGroupSubscriptionRequestQueuesGroups() {
+    void testIndividualGroupSubscriptionRequestQueuesGroups() {
         toSource(subscribeToAllGroups(10)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         source.onNext(1);
@@ -148,7 +148,7 @@ public class PublisherGroupByTest {
     }
 
     @Test
-    public void groupEnqueueOnComplete() {
+    void groupEnqueueOnComplete() {
         toSource(subscribeToAllGroups(10)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         source.onNext(1);
@@ -178,7 +178,7 @@ public class PublisherGroupByTest {
     }
 
     @Test
-    public void groupEnqueueOnError() {
+    void groupEnqueueOnError() {
         toSource(subscribeToAllGroups(10)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         source.onNext(1);
@@ -207,7 +207,7 @@ public class PublisherGroupByTest {
     }
 
     @Test
-    public void testOnNextThrows() {
+    void testOnNextThrows() {
         toSource(subscribeToAllGroups(10, s -> s).afterOnNext(i -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(subscriber);
@@ -224,7 +224,7 @@ public class PublisherGroupByTest {
     }
 
     @Test
-    public void testIndividualGroupOnNextThrows() {
+    void testIndividualGroupOnNextThrows() {
         AtomicInteger subscriberCount = new AtomicInteger();
         AtomicBoolean failOnNext = new AtomicBoolean();
         toSource(subscribeToAllGroups(10, s -> {
@@ -265,7 +265,7 @@ public class PublisherGroupByTest {
     }
 
     @Test
-    public void testConcurrentDrain() throws Exception {
+    void testConcurrentDrain() throws Exception {
         ExecutorService executorService = Executors.newFixedThreadPool(1);
         try {
             final int totalData = 10000;
@@ -342,7 +342,7 @@ public class PublisherGroupByTest {
     }
 
     @Test
-    public void testGroupsSubscriberCancelled() {
+    void testGroupsSubscriberCancelled() {
         toSource(subscribeToAllGroups(10)).subscribe(subscriber);
         subscriber.awaitSubscription().request(5);
         source.onNext(1, 3, 5, 7, 9);
@@ -356,7 +356,7 @@ public class PublisherGroupByTest {
     }
 
     @Test
-    public void testDelaySubscriptionToGroup() {
+    void testDelaySubscriptionToGroup() {
         List<GroupedPublisher<Boolean, Integer>> groups = subscribe(8);
         subscriber.awaitSubscription().request(1);
         source.onNext(1);
@@ -373,7 +373,7 @@ public class PublisherGroupByTest {
     }
 
     @Test
-    public void testGroupLevelQueueBreachWhenNotSubscribed() {
+    void testGroupLevelQueueBreachWhenNotSubscribed() {
         List<GroupedPublisher<Boolean, Integer>> groups = subscribe(16);
         source.onSubscribe(subscription);
         subscriber.awaitSubscription().request(1);
@@ -393,7 +393,7 @@ public class PublisherGroupByTest {
     }
 
     @Test
-    public void testGroupLevelQueueBreachWhenNotRequested() {
+    void testGroupLevelQueueBreachWhenNotRequested() {
         toSource(subscribeToAllGroups(integer -> Boolean.TRUE, 16, s -> s)).subscribe(subscriber);
         source.onSubscribe(subscription);
         subscriber.awaitSubscription().request(1);
@@ -411,7 +411,7 @@ public class PublisherGroupByTest {
     }
 
     @Test
-    public void testKeySelectorThrowsWithQueue() {
+    void testKeySelectorThrowsWithQueue() {
         toSource(subscribeToAllGroups(integer -> {
             if (integer % 2 == 0) {
                 throw DELIBERATE_EXCEPTION;
@@ -431,7 +431,7 @@ public class PublisherGroupByTest {
     }
 
     @Test
-    public void testKeySelectorThrowsNoQueue() {
+    void testKeySelectorThrowsNoQueue() {
         toSource(subscribeToAllGroups(integer -> {
             if (integer % 2 == 0) {
                 throw DELIBERATE_EXCEPTION;
@@ -451,7 +451,7 @@ public class PublisherGroupByTest {
     }
 
     @Test
-    public void testPendingGroupsQueueBreach() {
+    void testPendingGroupsQueueBreach() {
         @SuppressWarnings("unchecked")
         Subscriber<GroupedPublisher<Integer, Integer>> subscriber = mock(Subscriber.class);
         toSource(source.groupBy(integer -> integer, 16)).subscribe(subscriber);
@@ -466,7 +466,7 @@ public class PublisherGroupByTest {
     }
 
     @Test
-    public void testMaxBufferRequestNAndThenRequestMore() {
+    void testMaxBufferRequestNAndThenRequestMore() {
         toSource(subscribeToAllGroups(2)).subscribe(subscriber);
         source.onSubscribe(subscription);
         subscriber.awaitSubscription().request(1);
@@ -485,7 +485,7 @@ public class PublisherGroupByTest {
     }
 
     @Test
-    public void nullValueIsSupported() {
+    void nullValueIsSupported() {
         toSource(subscribeToAllGroups(2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         source.onNext(1, null);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherProcessorConcurrencyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherProcessorConcurrencyTest.java
@@ -35,17 +35,17 @@ import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 
-public class PublisherProcessorConcurrencyTest {
+class PublisherProcessorConcurrencyTest {
 
     private final ExecutorService executorService = newCachedThreadPool();
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         executorService.shutdownNow();
     }
 
     @Test
-    public void concurrentEmissionAndConsumption() throws Exception {
+    void concurrentEmissionAndConsumption() throws Exception {
         final int items = 10_000;
         final Collection<Integer> expected = Publisher.range(0, items).toFuture().get();
         final CountDownLatch done = new CountDownLatch(1);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherProcessorSignalsHolderTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherProcessorSignalsHolderTest.java
@@ -31,13 +31,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
-public class PublisherProcessorSignalsHolderTest {
+class PublisherProcessorSignalsHolderTest {
     private final List<Object> pastBufferSizeSignals;
     private final AbstractPublisherProcessorSignalsHolder<Integer, Queue<Object>> buffer;
     @SuppressWarnings("unchecked")
     private final ProcessorSignalsConsumer<Integer> consumer = mock(ProcessorSignalsConsumer.class);
 
-    public PublisherProcessorSignalsHolderTest() {
+    PublisherProcessorSignalsHolderTest() {
         pastBufferSizeSignals = new ArrayList<>();
         buffer = new AbstractPublisherProcessorSignalsHolder<Integer, Queue<Object>>(1, new ConcurrentLinkedQueue<>()) {
             @Override
@@ -48,7 +48,7 @@ public class PublisherProcessorSignalsHolderTest {
     }
 
     @Test
-    public void bufferOverflow() {
+    void bufferOverflow() {
         buffer.add(1);
         assertThat("Unexpected items overflow.", pastBufferSizeSignals, hasSize(0));
         buffer.add(2); // overflow
@@ -57,7 +57,7 @@ public class PublisherProcessorSignalsHolderTest {
     }
 
     @Test
-    public void consumeItem() {
+    void consumeItem() {
         buffer.add(1);
         assertThat("Item not consumed.", buffer.tryConsume(consumer), is(true));
         verify(consumer).consumeItem(1);
@@ -65,7 +65,7 @@ public class PublisherProcessorSignalsHolderTest {
     }
 
     @Test
-    public void addAfterOverflowAndConsume() {
+    void addAfterOverflowAndConsume() {
         buffer.add(1);
         assertThat("Unexpected items overflow.", pastBufferSizeSignals, hasSize(0));
         buffer.add(2); // overflow
@@ -84,13 +84,13 @@ public class PublisherProcessorSignalsHolderTest {
     }
 
     @Test
-    public void tryConsumeEmpty() {
+    void tryConsumeEmpty() {
         assertThat("Item consumed when empty.", buffer.tryConsume(consumer), is(false));
         verifyZeroInteractions(consumer);
     }
 
     @Test
-    public void consumeTerminal() {
+    void consumeTerminal() {
         buffer.add(1);
         buffer.terminate();
         assertThat("Item not consumed.", buffer.tryConsume(consumer), is(true));
@@ -101,7 +101,7 @@ public class PublisherProcessorSignalsHolderTest {
     }
 
     @Test
-    public void consumeTerminalError() {
+    void consumeTerminalError() {
         buffer.add(1);
         buffer.terminate(DELIBERATE_EXCEPTION);
         assertThat("Item not consumed.", buffer.tryConsume(consumer), is(true));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherProcessorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherProcessorTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class PublisherProcessorTest {
+class PublisherProcessorTest {
     private final BlockingQueue<Integer> bufferQueue = new LinkedBlockingQueue<>();
     private final PublisherProcessor<Integer> processor;
     private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
@@ -48,7 +48,7 @@ public class PublisherProcessorTest {
     @Nullable
     private volatile TerminalNotification terminalNotification;
 
-    public PublisherProcessorTest() {
+    PublisherProcessorTest() {
         @SuppressWarnings("unchecked")
         final PublisherProcessorSignalsHolder<Integer> buffer = mock(PublisherProcessorSignalsHolder.class);
         doAnswer(invocation -> {
@@ -99,7 +99,7 @@ public class PublisherProcessorTest {
     }
 
     @Test
-    public void itemBeforeSubscriber() {
+    void itemBeforeSubscriber() {
         processor.onNext(1);
         toSource(processor).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
@@ -109,7 +109,7 @@ public class PublisherProcessorTest {
     }
 
     @Test
-    public void itemBeforeRequest() {
+    void itemBeforeRequest() {
         toSource(processor).subscribe(subscriber);
         processor.onNext(1);
         subscriber.awaitSubscription().request(1);
@@ -119,21 +119,21 @@ public class PublisherProcessorTest {
     }
 
     @Test
-    public void terminalBeforeSubscriber() {
+    void terminalBeforeSubscriber() {
         processor.onComplete();
         toSource(processor).subscribe(subscriber);
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void terminalAfterSubscriber() {
+    void terminalAfterSubscriber() {
         toSource(processor).subscribe(subscriber);
         processor.onComplete();
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void terminalErrorBeforeSubscriber() {
+    void terminalErrorBeforeSubscriber() {
         processor.onError(DELIBERATE_EXCEPTION);
         toSource(processor).subscribe(subscriber);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
@@ -141,14 +141,14 @@ public class PublisherProcessorTest {
     }
 
     @Test
-    public void terminalErrorAfterSubscriber() {
+    void terminalErrorAfterSubscriber() {
         toSource(processor).subscribe(subscriber);
         processor.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void completeDeliveredAfterBuffer() {
+    void completeDeliveredAfterBuffer() {
         toSource(processor).subscribe(subscriber);
         processor.onNext(1);
         processor.onComplete();
@@ -159,7 +159,7 @@ public class PublisherProcessorTest {
     }
 
     @Test
-    public void completeNotDeliveredWithoutRequestWhenAfterBuffer() {
+    void completeNotDeliveredWithoutRequestWhenAfterBuffer() {
         toSource(processor).subscribe(subscriber);
         processor.onNext(1);
         processor.onComplete();
@@ -172,7 +172,7 @@ public class PublisherProcessorTest {
     }
 
     @Test
-    public void errorDeliveredAfterBuffer() {
+    void errorDeliveredAfterBuffer() {
         toSource(processor).subscribe(subscriber);
         processor.onNext(1);
         processor.onError(DELIBERATE_EXCEPTION);
@@ -183,7 +183,7 @@ public class PublisherProcessorTest {
     }
 
     @Test
-    public void errorNotDeliveredWithoutRequestWhenAfterBuffer() {
+    void errorNotDeliveredWithoutRequestWhenAfterBuffer() {
         toSource(processor).subscribe(subscriber);
         processor.onNext(1);
         processor.onError(DELIBERATE_EXCEPTION);
@@ -196,7 +196,7 @@ public class PublisherProcessorTest {
     }
 
     @Test
-    public void duplicateSubscriber() {
+    void duplicateSubscriber() {
         toSource(processor).subscribe(subscriber);
         TestPublisherSubscriber<Integer> subscriber2 = new TestPublisherSubscriber<>();
         toSource(processor).subscribe(subscriber2);
@@ -205,7 +205,7 @@ public class PublisherProcessorTest {
     }
 
     @Test
-    public void duplicateSubscriberPostCancel() {
+    void duplicateSubscriberPostCancel() {
         toSource(processor).subscribe(subscriber);
         subscriber.awaitSubscription().cancel();
         TestPublisherSubscriber<Integer> subscriber2 = new TestPublisherSubscriber<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RedoStrategiesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RedoStrategiesTest.java
@@ -33,13 +33,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class RedoStrategiesTest {
+class RedoStrategiesTest {
 
     protected LinkedBlockingQueue<LegacyTestCompletable> timers;
     protected Executor timerExecutor;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         timers = new LinkedBlockingQueue<>();
         timerExecutor = mock(Executor.class);
         when(timerExecutor.timer(anyLong(), any(TimeUnit.class))).thenAnswer(invocation -> {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RepeatStrategiesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RepeatStrategiesTest.java
@@ -35,10 +35,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class RepeatStrategiesTest extends RedoStrategiesTest {
+class RepeatStrategiesTest extends RedoStrategiesTest {
 
     @Test
-    public void testBackoff() throws Exception {
+    void testBackoff() throws Exception {
         Duration backoff = ofSeconds(1);
         RepeatStrategy strategy = new RepeatStrategy(repeatWithConstantBackoffDeltaJitter(2, backoff, ofNanos(1),
                 timerExecutor));
@@ -50,13 +50,13 @@ public class RepeatStrategiesTest extends RedoStrategiesTest {
     }
 
     @Test
-    public void testBackoffMaxRepeats() throws Exception {
+    void testBackoffMaxRepeats() throws Exception {
         Duration backoff = ofSeconds(1);
         testMaxRepeats(repeatWithConstantBackoffFullJitter(1, backoff, timerExecutor), backoff);
     }
 
     @Test
-    public void testExpBackoff() throws Exception {
+    void testExpBackoff() throws Exception {
         Duration initialDelay = ofSeconds(1);
         RepeatStrategy strategy = new RepeatStrategy(repeatWithConstantBackoffFullJitter(2, initialDelay,
                 timerExecutor));
@@ -74,33 +74,33 @@ public class RepeatStrategiesTest extends RedoStrategiesTest {
     }
 
     @Test
-    public void testExpBackoffMaxRepeats() throws Exception {
+    void testExpBackoffMaxRepeats() throws Exception {
         Duration backoff = ofSeconds(1);
         testMaxRepeats(repeatWithConstantBackoffFullJitter(1, backoff, timerExecutor), backoff);
     }
 
     @Test
-    public void testExpBackoffWithJitterLargeMaxDelayAndMaxRetries() throws Exception {
+    void testExpBackoffWithJitterLargeMaxDelayAndMaxRetries() throws Exception {
         testExpBackoffWithJitter(2, ofSeconds(1), duration -> duration.plus(ofDays(10)));
     }
 
     @Test
-    public void testExpBackoffWithJitterLargeMaxDelayAndNoMaxRetries() throws Exception {
+    void testExpBackoffWithJitterLargeMaxDelayAndNoMaxRetries() throws Exception {
         testExpBackoffWithJitter(MAX_VALUE, ofSeconds(1), duration -> duration.plus(ofDays(10)));
     }
 
     @Test
-    public void testExpBackoffWithJitterSmallMaxDelayAndMaxRetries() throws Exception {
+    void testExpBackoffWithJitterSmallMaxDelayAndMaxRetries() throws Exception {
         testExpBackoffWithJitter(2, ofSeconds(1), duration -> duration.plus(ofMillis(10)));
     }
 
     @Test
-    public void testExpBackoffWithJitterSmallMaxDelayAndNoMaxRetries() throws Exception {
+    void testExpBackoffWithJitterSmallMaxDelayAndNoMaxRetries() throws Exception {
         testExpBackoffWithJitter(MAX_VALUE, ofSeconds(1), duration -> duration.plus(ofMillis(10)));
     }
 
     @Test
-    public void testExpBackoffWithJitterMaxRepeats() throws Exception {
+    void testExpBackoffWithJitterMaxRepeats() throws Exception {
         Duration backoff = ofSeconds(1);
         Duration jitter = ofMillis(500);
         testMaxRepeats(repeatWithExponentialBackoffDeltaJitter(1, backoff, jitter, ofDays(10), timerExecutor),

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RetryStrategiesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RetryStrategiesTest.java
@@ -36,10 +36,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class RetryStrategiesTest extends RedoStrategiesTest {
+class RetryStrategiesTest extends RedoStrategiesTest {
 
     @Test
-    public void testBackoff() throws Exception {
+    void testBackoff() throws Exception {
         Duration backoff = ofSeconds(1);
         RetryStrategy strategy = new RetryStrategy(retryWithConstantBackoffDeltaJitter(2, cause -> true, backoff,
                 ofNanos(1), timerExecutor));
@@ -52,7 +52,7 @@ public class RetryStrategiesTest extends RedoStrategiesTest {
     }
 
     @Test
-    public void testBackoffWithJitter() throws Exception {
+    void testBackoffWithJitter() throws Exception {
         Duration backoff = ofSeconds(1);
         Duration jitter = ofMillis(10);
         RetryStrategy strategy = new RetryStrategy(retryWithConstantBackoffDeltaJitter(2, cause -> true,
@@ -66,20 +66,20 @@ public class RetryStrategiesTest extends RedoStrategiesTest {
     }
 
     @Test
-    public void testBackoffMaxRetries() throws Exception {
+    void testBackoffMaxRetries() throws Exception {
         Duration backoff = ofSeconds(1);
         testMaxRetries(retryWithExponentialBackoffFullJitter(1, cause -> true, backoff, ofDays(10), timerExecutor),
                 backoff);
     }
 
     @Test
-    public void testBackoffCauseFilter() {
+    void testBackoffCauseFilter() {
         testCauseFilter(retryWithExponentialBackoffFullJitter(1, cause -> cause instanceof IllegalStateException,
                 ofSeconds(1), ofDays(10), timerExecutor));
     }
 
     @Test
-    public void testExpBackoff() throws Exception {
+    void testExpBackoff() throws Exception {
         Duration initialDelay = ofSeconds(1);
         RetryStrategy strategy = new RetryStrategy(retryWithExponentialBackoffFullJitter(2, cause -> true, initialDelay,
                 ofDays(10), timerExecutor));
@@ -98,40 +98,40 @@ public class RetryStrategiesTest extends RedoStrategiesTest {
     }
 
     @Test
-    public void testExpBackoffMaxRetries() throws Exception {
+    void testExpBackoffMaxRetries() throws Exception {
         Duration backoff = ofSeconds(1);
         testMaxRetries(retryWithExponentialBackoffFullJitter(1, cause -> true, backoff, ofDays(10), timerExecutor),
                 backoff);
     }
 
     @Test
-    public void testExpBackoffCauseFilter() {
+    void testExpBackoffCauseFilter() {
         testCauseFilter(retryWithExponentialBackoffFullJitter(1, cause -> cause instanceof IllegalStateException,
                 ofSeconds(1), ofDays(10), timerExecutor));
     }
 
     @Test
-    public void testExpBackoffWithJitterLargeMaxDelayAndMaxRetries() throws Exception {
+    void testExpBackoffWithJitterLargeMaxDelayAndMaxRetries() throws Exception {
         testExpBackoffWithJitter(2, ofSeconds(1), duration -> duration.plus(ofDays(10)));
     }
 
     @Test
-    public void testExpBackoffWithJitterLargeMaxDelayAndNoMaxRetries() throws Exception {
+    void testExpBackoffWithJitterLargeMaxDelayAndNoMaxRetries() throws Exception {
         testExpBackoffWithJitter(MAX_VALUE, ofSeconds(1), duration -> duration.plus(ofDays(10)));
     }
 
     @Test
-    public void testExpBackoffWithJitterSmallMaxDelayAndMaxRetries() throws Exception {
+    void testExpBackoffWithJitterSmallMaxDelayAndMaxRetries() throws Exception {
         testExpBackoffWithJitter(2, ofSeconds(1), duration -> duration.plus(ofMillis(10)));
     }
 
     @Test
-    public void testExpBackoffWithJitterSmallMaxDelayAndNoMaxRetries() throws Exception {
+    void testExpBackoffWithJitterSmallMaxDelayAndNoMaxRetries() throws Exception {
         testExpBackoffWithJitter(MAX_VALUE, ofSeconds(1), duration -> duration.plus(ofMillis(10)));
     }
 
     @Test
-    public void testExpBackoffWithJitterMaxRetries() throws Exception {
+    void testExpBackoffWithJitterMaxRetries() throws Exception {
         Duration backoff = ofSeconds(1);
         Duration jitter = ofMillis(10);
         testMaxRetries(retryWithExponentialBackoffDeltaJitter(1, cause -> true, backoff, jitter, ofDays(10),
@@ -139,7 +139,7 @@ public class RetryStrategiesTest extends RedoStrategiesTest {
     }
 
     @Test
-    public void testExpBackoffWithJitterCauseFilter() {
+    void testExpBackoffWithJitterCauseFilter() {
         testCauseFilter(retryWithExponentialBackoffDeltaJitter(1, cause -> cause instanceof IllegalStateException,
                 ofSeconds(1), ofMillis(10), ofDays(10), timerExecutor));
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ScanWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ScanWithPublisherTest.java
@@ -46,15 +46,15 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class ScanWithPublisherTest {
+class ScanWithPublisherTest {
 
     @Test
-    public void scanWithComplete() {
+    void scanWithComplete() {
         scanWithNoTerminalMapper(true);
     }
 
     @Test
-    public void scanWithError() {
+    void scanWithError() {
         scanWithNoTerminalMapper(false);
     }
 
@@ -80,7 +80,7 @@ public class ScanWithPublisherTest {
     }
 
     @Test
-    public void scanWithLifetimeSignalReentry() throws InterruptedException {
+    void scanWithLifetimeSignalReentry() throws InterruptedException {
         AtomicInteger finalizations = new AtomicInteger();
         CountDownLatch completed = new CountDownLatch(1);
         PublisherSource<Integer> syncNoReentryProtectionSource =
@@ -159,25 +159,25 @@ public class ScanWithPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @ValueSource(booleans = {true, false})
-    public void scanOnNextOnCompleteNoConcat(boolean withLifetime) {
+    void scanOnNextOnCompleteNoConcat(boolean withLifetime) {
         scanOnNextTerminalNoConcat(true, true, withLifetime);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @ValueSource(booleans = {true, false})
-    public void scanOnNextOnErrorNoConcat(boolean withLifetime) {
+    void scanOnNextOnErrorNoConcat(boolean withLifetime) {
         scanOnNextTerminalNoConcat(true, false, withLifetime);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @ValueSource(booleans = {true, false})
-    public void scanOnCompleteNoConcat(boolean withLifetime) {
+    void scanOnCompleteNoConcat(boolean withLifetime) {
         scanOnNextTerminalNoConcat(false, true, withLifetime);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @ValueSource(booleans = {true, false})
-    public void scanOnErrorNoConcat(boolean withLifetime) {
+    void scanOnErrorNoConcat(boolean withLifetime) {
         scanOnNextTerminalNoConcat(false, false, withLifetime);
     }
 
@@ -235,25 +235,25 @@ public class ScanWithPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @ValueSource(booleans = {true, false})
-    public void onCompleteConcatUpfrontDemand(boolean withLifetime) {
+    void onCompleteConcatUpfrontDemand(boolean withLifetime) {
         terminalConcatWithDemand(true, true, withLifetime);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @ValueSource(booleans = {true, false})
-    public void onErrorConcatWithUpfrontDemand(boolean withLifetime) {
+    void onErrorConcatWithUpfrontDemand(boolean withLifetime) {
         terminalConcatWithDemand(true, false, withLifetime);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @ValueSource(booleans = {true, false})
-    public void onCompleteConcatDelayedDemand(boolean withLifetime) {
+    void onCompleteConcatDelayedDemand(boolean withLifetime) {
         terminalConcatWithDemand(false, true, withLifetime);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @ValueSource(booleans = {true, false})
-    public void onErrorConcatDelayedDemand(boolean withLifetime) {
+    void onErrorConcatDelayedDemand(boolean withLifetime) {
         terminalConcatWithDemand(false, false, withLifetime);
     }
 
@@ -317,7 +317,7 @@ public class ScanWithPublisherTest {
     }
 
     @Test
-    public void scanWithFinalizationOnCancel() {
+    void scanWithFinalizationOnCancel() {
         final AtomicInteger finalizations = new AtomicInteger(0);
         PublisherSource.Processor<Integer, Integer> processor = newPublisherProcessor();
         TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
@@ -359,7 +359,7 @@ public class ScanWithPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @ValueSource(booleans = {true, false})
-    public void scanWithFinalizationOnCancelDifferentThreads(final boolean interleaveCancellation) {
+    void scanWithFinalizationOnCancelDifferentThreads(final boolean interleaveCancellation) {
         ExecutorService executorService = Executors.newFixedThreadPool(1);
         try {
             final AtomicInteger finalizations = new AtomicInteger(0);
@@ -453,13 +453,13 @@ public class ScanWithPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @ValueSource(booleans = {true, false})
-    public void onCompleteThrowsHandled(boolean withLifetime) {
+    void onCompleteThrowsHandled(boolean withLifetime) {
         terminalThrowsHandled(true, withLifetime);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @ValueSource(booleans = {true, false})
-    public void onErrorThrowsHandled(boolean withLifetime) {
+    void onErrorThrowsHandled(boolean withLifetime) {
         terminalThrowsHandled(false, withLifetime);
     }
 
@@ -511,13 +511,13 @@ public class ScanWithPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @ValueSource(booleans = {true, false})
-    public void mapOnCompleteThrows(boolean withLifetime) {
+    void mapOnCompleteThrows(boolean withLifetime) {
         mapTerminalSignalThrows(true, withLifetime);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @ValueSource(booleans = {true, false})
-    public void mapOnErrorThrows(boolean withLifetime) {
+    void mapOnErrorThrows(boolean withLifetime) {
         mapTerminalSignalThrows(false, withLifetime);
     }
 
@@ -569,7 +569,7 @@ public class ScanWithPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @ValueSource(booleans = {true, false})
-    public void invalidDemandAllowsError(boolean withLifetime) {
+    void invalidDemandAllowsError(boolean withLifetime) {
         final AtomicInteger finalizations = new AtomicInteger(0);
         PublisherSource.Processor<Integer, Integer> processor = newPublisherProcessor();
         TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
@@ -585,7 +585,7 @@ public class ScanWithPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @ValueSource(booleans = {true, false})
-    public void invalidDemandWithOnNextAllowsError(boolean withLifetime) throws InterruptedException {
+    void invalidDemandWithOnNextAllowsError(boolean withLifetime) throws InterruptedException {
         final AtomicInteger finalizations = new AtomicInteger(0);
         TestSubscription upstreamSubscription = new TestSubscription();
         TestPublisher<Integer> publisher = new TestPublisher.Builder<Integer>().disableAutoOnSubscribe()
@@ -613,7 +613,7 @@ public class ScanWithPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @MethodSource("cancelStillAllowsMapsParams")
-    public void cancelStillAllowsMaps(boolean onError, boolean cancelBefore, boolean withLifetime) {
+    void cancelStillAllowsMaps(boolean onError, boolean cancelBefore, boolean withLifetime) {
         final AtomicInteger finalizations = new AtomicInteger(0);
         TestPublisher<Integer> publisher = new TestPublisher<>();
         TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SchedulerOffloadTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SchedulerOffloadTest.java
@@ -26,24 +26,24 @@ import static io.servicetalk.concurrent.api.Executors.from;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 
-public class SchedulerOffloadTest {
+class SchedulerOffloadTest {
 
-    public static final String EXPECTED_THREAD_PREFIX = "jdk-executor";
+    static final String EXPECTED_THREAD_PREFIX = "jdk-executor";
     @Nullable
     private Executor executor;
 
-    public SchedulerOffloadTest() {
+    SchedulerOffloadTest() {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         if (executor != null) {
             executor.closeAsync().toFuture().get();
         }
     }
 
     @Test
-    public void userSchedulerInvokesUserCode() throws InterruptedException {
+    void userSchedulerInvokesUserCode() throws InterruptedException {
         verifyInvokerThread(
                 from(java.util.concurrent.Executors.newCachedThreadPool(new DefaultThreadFactory("foo")),
                         java.util.concurrent.Executors.newScheduledThreadPool(1,
@@ -51,7 +51,7 @@ public class SchedulerOffloadTest {
     }
 
     @Test
-    public void globalSchedulerDoesNotInvokeUserCode() throws InterruptedException {
+    void globalSchedulerDoesNotInvokeUserCode() throws InterruptedException {
         verifyInvokerThread(from(java.util.concurrent.Executors.newFixedThreadPool(1,
                 new DefaultThreadFactory(EXPECTED_THREAD_PREFIX))));
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SequentialSubscriptionTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SequentialSubscriptionTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public final class SequentialSubscriptionTest {
+final class SequentialSubscriptionTest {
     private static final int ITERATIONS_FOR_CONCURRENT_TESTS = 500;
     private SequentialSubscription s;
     private Subscription s1;
@@ -62,7 +62,7 @@ public final class SequentialSubscriptionTest {
     private ExecutorService executor;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         s1 = mock(Subscription.class);
         s = new SequentialSubscription(s1);
         s2 = mock(Subscription.class);
@@ -70,31 +70,31 @@ public final class SequentialSubscriptionTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         executor.shutdownNow();
         executor.awaitTermination(DEFAULT_TIMEOUT_SECONDS, SECONDS);
     }
 
     @Test
-    public void testInvalidRequestNNegative1() {
+    void testInvalidRequestNNegative1() {
         s.request(-1);
         verify(s1).request(-1);
     }
 
     @Test
-    public void testInvalidRequestNZero() {
+    void testInvalidRequestNZero() {
         s.request(0);
         verify(s1).request(leq(0L));
     }
 
     @Test
-    public void testInvalidRequestNLongMin() {
+    void testInvalidRequestNLongMin() {
         s.request(MIN_VALUE);
         verify(s1).request(leq(0L));
     }
 
     @Test
-    public void testInvalidRequestNDefaultConstructorPropagatedAfterSwitch() {
+    void testInvalidRequestNDefaultConstructorPropagatedAfterSwitch() {
         s = new SequentialSubscription();
         s.request(-1);
         s.switchTo(s1);
@@ -104,7 +104,7 @@ public final class SequentialSubscriptionTest {
     }
 
     @Test
-    public void testRequestNIncremental() {
+    void testRequestNIncremental() {
         s.request(1);
         verify(s1).request(1);
         verifyNoMoreInteractions(s1);
@@ -114,7 +114,7 @@ public final class SequentialSubscriptionTest {
     }
 
     @Test
-    public void testCancel() {
+    void testCancel() {
         s.cancel();
 
         verify(s1).cancel();
@@ -126,7 +126,7 @@ public final class SequentialSubscriptionTest {
     }
 
     @Test
-    public void testPendingRequest() {
+    void testPendingRequest() {
         s.request(5);
         verify(s1).request(5);
         verifyNoMoreInteractions(s1);
@@ -139,18 +139,18 @@ public final class SequentialSubscriptionTest {
     }
 
     @Test
-    public void testOldSubscriptionIsNotCancelled() {
+    void testOldSubscriptionIsNotCancelled() {
         s.switchTo(s2);
         verifyNoMoreInteractions(s1);
     }
 
     @Test
-    public void testSwitchToNull() {
+    void testSwitchToNull() {
         assertThrows(NullPointerException.class, () -> s.switchTo(null));
     }
 
     @Test
-    public void testCancelAfterRequest() {
+    void testCancelAfterRequest() {
         s.cancel();
         verify(s1).cancel();
         s.request(1);
@@ -158,7 +158,7 @@ public final class SequentialSubscriptionTest {
     }
 
     @Test
-    public void testSubscriptionRequestThrows() {
+    void testSubscriptionRequestThrows() {
         doThrow(DELIBERATE_EXCEPTION).when(s1).request(anyLong());
         try {
             s.request(1);
@@ -178,43 +178,43 @@ public final class SequentialSubscriptionTest {
     }
 
     @Test
-    public void testConcurrentNoSwitch() throws Exception {
+    void testConcurrentNoSwitch() throws Exception {
         testConcurrentRequestEmitAndSwitch(1000, 1000);
     }
 
     @Test
-    public void testConcurrentWithSwitch() throws Exception {
+    void testConcurrentWithSwitch() throws Exception {
         testConcurrentRequestEmitAndSwitch(1000, 5);
     }
 
     @Test
-    public void testConcurrentLargeRequestedWithSwitch() throws Exception {
+    void testConcurrentLargeRequestedWithSwitch() throws Exception {
         testConcurrentRequestEmitAndSwitch(1_000_000, 10_000);
     }
 
     @Test
-    public void testRequestNAlwaysDirectedTowardSwitchedSubscription() throws Exception {
+    void testRequestNAlwaysDirectedTowardSwitchedSubscription() throws Exception {
         for (int i = 0; i < ITERATIONS_FOR_CONCURRENT_TESTS; ++i) {
             requestNAlwaysDirectedTowardSwitchedSubscription();
         }
     }
 
     @Test
-    public void requestNNegative1AlwaysDirectedTowardSwitchedSubscription() throws Exception {
+    void requestNNegative1AlwaysDirectedTowardSwitchedSubscription() throws Exception {
         for (int i = 0; i < ITERATIONS_FOR_CONCURRENT_TESTS; ++i) {
             invalidRequestNAlwaysDirectedTowardSwitchedSubscription(-1, matchValueOrCancelled(is(-1L)));
         }
     }
 
     @Test
-    public void requestNZeroAlwaysDirectedTowardSwitchedSubscription() throws Exception {
+    void requestNZeroAlwaysDirectedTowardSwitchedSubscription() throws Exception {
         for (int i = 0; i < ITERATIONS_FOR_CONCURRENT_TESTS; ++i) {
             invalidRequestNAlwaysDirectedTowardSwitchedSubscription(0, matchValueOrCancelled(lessThanOrEqualTo(0L)));
         }
     }
 
     @Test
-    public void requestNLongMinAlwaysDirectedTowardSwitchedSubscription() throws Exception {
+    void requestNLongMinAlwaysDirectedTowardSwitchedSubscription() throws Exception {
         for (int i = 0; i < ITERATIONS_FOR_CONCURRENT_TESTS; ++i) {
             invalidRequestNAlwaysDirectedTowardSwitchedSubscription(MIN_VALUE, matchValueOrCancelled(is(MIN_VALUE)));
         }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbSubscribeThrowsTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbSubscribeThrowsTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class SingleAmbSubscribeThrowsTest {
+class SingleAmbSubscribeThrowsTest {
 
     private volatile boolean throwFromFirst;
     private volatile boolean throwFromSecond;
@@ -80,7 +80,7 @@ public class SingleAmbSubscribeThrowsTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void firstSubscribeThrows(final AmbParam ambParam) {
+    void firstSubscribeThrows(final AmbParam ambParam) {
         init(ambParam);
         throwFromFirst = true;
         subscribeToAmbAndVerifyFail();
@@ -92,7 +92,7 @@ public class SingleAmbSubscribeThrowsTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void secondSubscribeThrows(final AmbParam ambParam) {
+    void secondSubscribeThrows(final AmbParam ambParam) {
         init(ambParam);
         throwFromSecond = true;
         subscribeToAmbAndVerifyFail();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class SingleAmbTest {
+class SingleAmbTest {
 
     private final TestSingle<Integer> first = new TestSingle<>();
     private final TestSingle<Integer> second = new TestSingle<>();
@@ -69,7 +69,7 @@ public class SingleAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void successFirst(final AmbParam ambParam) {
+    void successFirst(final AmbParam ambParam) {
         init(ambParam);
         sendSuccessToAndVerify(first);
         verifyCancelled(second);
@@ -77,7 +77,7 @@ public class SingleAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void successSecond(final AmbParam ambParam) {
+    void successSecond(final AmbParam ambParam) {
         init(ambParam);
         sendSuccessToAndVerify(second);
         verifyCancelled(first);
@@ -85,7 +85,7 @@ public class SingleAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void failFirst(final AmbParam ambParam) {
+    void failFirst(final AmbParam ambParam) {
         init(ambParam);
         sendErrorToAndVerify(first);
         verifyCancelled(second);
@@ -93,7 +93,7 @@ public class SingleAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void failSecond(final AmbParam ambParam) {
+    void failSecond(final AmbParam ambParam) {
         init(ambParam);
         sendErrorToAndVerify(second);
         verifyCancelled(first);
@@ -101,7 +101,7 @@ public class SingleAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void successFirstThenSecond(final AmbParam ambParam) {
+    void successFirstThenSecond(final AmbParam ambParam) {
         init(ambParam);
         sendSuccessToAndVerify(first);
         verifyCancelled(second);
@@ -110,7 +110,7 @@ public class SingleAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void successSecondThenFirst(final AmbParam ambParam) {
+    void successSecondThenFirst(final AmbParam ambParam) {
         init(ambParam);
         sendSuccessToAndVerify(second);
         verifyCancelled(first);
@@ -119,7 +119,7 @@ public class SingleAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void failFirstThenSecond(final AmbParam ambParam) {
+    void failFirstThenSecond(final AmbParam ambParam) {
         init(ambParam);
         sendErrorToAndVerify(first);
         verifyCancelled(second);
@@ -128,7 +128,7 @@ public class SingleAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void failSecondThenFirst(final AmbParam ambParam) {
+    void failSecondThenFirst(final AmbParam ambParam) {
         init(ambParam);
         sendErrorToAndVerify(second);
         verifyCancelled(first);
@@ -137,7 +137,7 @@ public class SingleAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void successFirstThenSecondFail(final AmbParam ambParam) {
+    void successFirstThenSecondFail(final AmbParam ambParam) {
         init(ambParam);
         sendSuccessToAndVerify(first);
         verifyCancelled(second);
@@ -146,7 +146,7 @@ public class SingleAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void successSecondThenFirstFail(final AmbParam ambParam) {
+    void successSecondThenFirstFail(final AmbParam ambParam) {
         init(ambParam);
         sendSuccessToAndVerify(second);
         verifyCancelled(first);
@@ -155,7 +155,7 @@ public class SingleAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void failFirstThenSecondSuccess(final AmbParam ambParam) {
+    void failFirstThenSecondSuccess(final AmbParam ambParam) {
         init(ambParam);
         sendErrorToAndVerify(first);
         verifyCancelled(second);
@@ -164,7 +164,7 @@ public class SingleAmbTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(AmbParam.class)
-    public void failSecondThenFirstSuccess(final AmbParam ambParam) {
+    void failSecondThenFirstSuccess(final AmbParam ambParam) {
         init(ambParam);
         sendErrorToAndVerify(second);
         verifyCancelled(first);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbWithAsyncTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbWithAsyncTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class SingleAmbWithAsyncTest {
+class SingleAmbWithAsyncTest {
     private static final String FIRST_EXECUTOR_THREAD_NAME_PREFIX = "first";
     private static final String SECOND_EXECUTOR_THREAD_NAME_PREFIX = "second";
 
@@ -49,7 +49,7 @@ public class SingleAmbWithAsyncTest {
     final ExecutorExtension<Executor> secondExec = withCachedExecutor(SECOND_EXECUTOR_THREAD_NAME_PREFIX);
 
     @Test
-    public void offloadSuccessFromFirst() throws Exception {
+    void offloadSuccessFromFirst() throws Exception {
         assertThat("Unexpected result.", testOffloadSecond(succeeded(1), never()), is(1));
     }
 
@@ -59,104 +59,104 @@ public class SingleAmbWithAsyncTest {
     }
 
     @Test
-    public void offloadErrorFromFirst() {
+    void offloadErrorFromFirst() {
         assertThrowsWithDeliberateExceptionAsCause(() -> testOffloadSecond(never(), failed(DELIBERATE_EXCEPTION)));
     }
 
     @Test
-    public void offloadSuccessFromSecond() throws Exception {
+    void offloadSuccessFromSecond() throws Exception {
         assertThat("Unexpected result.", testOffloadSecond(never(), succeeded(2)), is(2));
     }
 
     @Test
-    public void offloadErrorFromSecond() {
+    void offloadErrorFromSecond() {
         assertThrowsWithDeliberateExceptionAsCause(() -> testOffloadSecond(never(), failed(DELIBERATE_EXCEPTION)));
     }
 
     @Test
-    public void contextFromSubscribeFirstSuccess() throws Exception {
+    void contextFromSubscribeFirstSuccess() throws Exception {
         assertThat("Unexpected result.", testContextFromSubscribe(succeeded(1), never()), is(1));
     }
 
     @Test
-    public void contextFromSubscribeFirstError() {
+    void contextFromSubscribeFirstError() {
         assertThrowsWithDeliberateExceptionAsCause(
                 () -> testContextFromSubscribe(failed(DELIBERATE_EXCEPTION), never()));
     }
 
     @Test
-    public void contextFromSubscribeSecondSuccess() throws Exception {
+    void contextFromSubscribeSecondSuccess() throws Exception {
         assertThat("Unexpected result.", testContextFromSubscribe(never(), succeeded(2)), is(2));
     }
 
     @Test
-    public void contextFromSubscribeSecondError() {
+    void contextFromSubscribeSecondError() {
         assertThrowsWithDeliberateExceptionAsCause(
                 () -> testContextFromSubscribe(never(), failed(DELIBERATE_EXCEPTION)));
     }
 
     @Test
-    public void contextFromSecondSubscribeFirstSuccess() throws Exception {
+    void contextFromSecondSubscribeFirstSuccess() throws Exception {
         assertThat("Unexpected result.", testContextFromSecondSubscribe(succeeded(1), never()), is(1));
     }
 
     @Test
-    public void contextFromSecondSubscribeFirstError() {
+    void contextFromSecondSubscribeFirstError() {
         assertThrowsWithDeliberateExceptionAsCause(() ->
                 testContextFromSecondSubscribe(failed(DELIBERATE_EXCEPTION), never()));
     }
 
     @Test
-    public void contextFromSecondSubscribeSecondSuccess() throws Exception {
+    void contextFromSecondSubscribeSecondSuccess() throws Exception {
         assertThat("Unexpected result.", testContextFromSecondSubscribe(never(), succeeded(2)), is(2));
     }
 
     @Test
-    public void contextFromSecondSubscribeSecondError() {
+    void contextFromSecondSubscribeSecondError() {
         assertThrowsWithDeliberateExceptionAsCause(() ->
                 testContextFromSecondSubscribe(never(), failed(DELIBERATE_EXCEPTION)));
     }
 
     @Test
-    public void contextFromOnSubscribeFirstSuccess() throws Exception {
+    void contextFromOnSubscribeFirstSuccess() throws Exception {
         assertThat("Unexpected result.", testContextFromOnSubscribe(succeeded(1), never()), is(1));
     }
 
     @Test
-    public void contextFromOnSubscribeFirstError() {
+    void contextFromOnSubscribeFirstError() {
         assertThrowsWithDeliberateExceptionAsCause(
                 () -> testContextFromOnSubscribe(failed(DELIBERATE_EXCEPTION), never()));
     }
 
     @Test
-    public void contextFromOnSubscribeSecondSuccess() throws Exception {
+    void contextFromOnSubscribeSecondSuccess() throws Exception {
         assertThat("Unexpected result.", testContextFromOnSubscribe(never(), succeeded(2)), is(2));
     }
 
     @Test
-    public void contextFromOnSubscribeSecondError() {
+    void contextFromOnSubscribeSecondError() {
         assertThrowsWithDeliberateExceptionAsCause(
                 () -> testContextFromOnSubscribe(never(), failed(DELIBERATE_EXCEPTION)));
     }
 
     @Test
-    public void contextFromSecondOnSubscribeFirstSuccess() throws Exception {
+    void contextFromSecondOnSubscribeFirstSuccess() throws Exception {
         assertThat("Unexpected result.", testContextFromSecondOnSubscribe(succeeded(1), never()), is(1));
     }
 
     @Test
-    public void contextFromSecondOnSubscribeFirstError() {
+    void contextFromSecondOnSubscribeFirstError() {
         assertThrowsWithDeliberateExceptionAsCause(() ->
                 testContextFromSecondOnSubscribe(failed(DELIBERATE_EXCEPTION), never()));
     }
 
     @Test
-    public void contextFromSecondOnSubscribeSecondSuccess() throws Exception {
+    void contextFromSecondOnSubscribeSecondSuccess() throws Exception {
         assertThat("Unexpected result.", testContextFromSecondOnSubscribe(never(), succeeded(2)), is(2));
     }
 
     @Test
-    public void contextFromSecondOnSubscribeSecondError() {
+    void contextFromSecondOnSubscribeSecondError() {
         assertThrowsWithDeliberateExceptionAsCause(() ->
                 testContextFromSecondOnSubscribe(never(), failed(DELIBERATE_EXCEPTION)));
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleExecutorPreservationTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleExecutorPreservationTest.java
@@ -23,25 +23,25 @@ import static java.time.Duration.ofMillis;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public class SingleExecutorPreservationTest {
+class SingleExecutorPreservationTest {
     @RegisterExtension
     static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor("test");
 
     private Single<String> single;
 
     @BeforeEach
-    public void setupSingle() {
+    void setupSingle() {
         single = Single.<String>never().publishAndSubscribeOnOverride(EXEC.executor());
     }
 
     @Test
-    public void testTimeoutSingle() {
+    void testTimeoutSingle() {
         assertSame(EXEC.executor(), single.timeout(1, MILLISECONDS).executor());
         assertSame(EXEC.executor(), single.timeout(ofMillis(1)).executor());
     }
 
     @Test
-    public void testAfterFinallySingle() {
+    void testAfterFinallySingle() {
         assertSame(EXEC.executor(), single.afterFinally(() -> { /* NOOP */ }).executor());
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleProcessorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleProcessorTest.java
@@ -41,21 +41,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class SingleProcessorTest {
+class SingleProcessorTest {
     @RegisterExtension
     static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
     @Test
-    public void testSuccessBeforeListen() {
+    void testSuccessBeforeListen() {
         testSuccessBeforeListen("foo");
     }
 
     @Test
-    public void testSuccessThrowableBeforeListen() {
+    void testSuccessThrowableBeforeListen() {
         testSuccessBeforeListen(DELIBERATE_EXCEPTION);
     }
 
     @Test
-    public void testSuccessNullBeforeListen() {
+    void testSuccessNullBeforeListen() {
         testSuccessBeforeListen(null);
     }
 
@@ -68,7 +68,7 @@ public class SingleProcessorTest {
     }
 
     @Test
-    public void testErrorBeforeListen() {
+    void testErrorBeforeListen() {
         SingleProcessor<String> processor = new SingleProcessor<>();
         processor.onError(DELIBERATE_EXCEPTION);
         TestSingleSubscriber<String> subscriber = new TestSingleSubscriber<>();
@@ -77,17 +77,17 @@ public class SingleProcessorTest {
     }
 
     @Test
-    public void testSuccessAfterListen() {
+    void testSuccessAfterListen() {
         testSuccessAfterListen("foo");
     }
 
     @Test
-    public void testSuccessNullAfterListen() {
+    void testSuccessNullAfterListen() {
         testSuccessAfterListen(null);
     }
 
     @Test
-    public void testSuccessThrowableAfterListen() {
+    void testSuccessThrowableAfterListen() {
         testSuccessAfterListen(DELIBERATE_EXCEPTION);
     }
 
@@ -101,7 +101,7 @@ public class SingleProcessorTest {
     }
 
     @Test
-    public void testErrorAfterListen() {
+    void testErrorAfterListen() {
         SingleProcessor<String> processor = new SingleProcessor<>();
         TestSingleSubscriber<String> subscriber = new TestSingleSubscriber<>();
         processor.subscribe(subscriber);
@@ -111,17 +111,17 @@ public class SingleProcessorTest {
     }
 
     @Test
-    public void testSuccessThenError() {
+    void testSuccessThenError() {
         testSuccessThenError("foo");
     }
 
     @Test
-    public void testSuccessThrowableThenError() {
+    void testSuccessThrowableThenError() {
         testSuccessThenError(DELIBERATE_EXCEPTION);
     }
 
     @Test
-    public void testSuccessNullThenError() {
+    void testSuccessNullThenError() {
         testSuccessThenError(null);
     }
 
@@ -135,17 +135,17 @@ public class SingleProcessorTest {
     }
 
     @Test
-    public void testErrorThenSuccess() {
+    void testErrorThenSuccess() {
         testErrorThenSuccess("foo");
     }
 
     @Test
-    public void testErrorThenSuccessThrowable() {
+    void testErrorThenSuccessThrowable() {
         testErrorThenSuccess(DELIBERATE_EXCEPTION);
     }
 
     @Test
-    public void testErrorThenSuccessNull() {
+    void testErrorThenSuccessNull() {
         testErrorThenSuccess(null);
     }
 
@@ -159,17 +159,17 @@ public class SingleProcessorTest {
     }
 
     @Test
-    public void cancelRemovesListenerAndStillAllowsOtherListenersToBeNotified() {
+    void cancelRemovesListenerAndStillAllowsOtherListenersToBeNotified() {
         cancelRemovesListenerAndStillAllowsOtherListenersToBeNotified("foo");
     }
 
     @Test
-    public void cancelRemovesListenerAndStillAllowsOtherListenersToBeNotifiedWithNull() {
+    void cancelRemovesListenerAndStillAllowsOtherListenersToBeNotifiedWithNull() {
         cancelRemovesListenerAndStillAllowsOtherListenersToBeNotified(null);
     }
 
     @Test
-    public void cancelRemovesListenerAndStillAllowsOtherListenersToBeNotifiedWithThrowable() {
+    void cancelRemovesListenerAndStillAllowsOtherListenersToBeNotifiedWithThrowable() {
         cancelRemovesListenerAndStillAllowsOtherListenersToBeNotified(DELIBERATE_EXCEPTION);
     }
 
@@ -188,7 +188,7 @@ public class SingleProcessorTest {
     }
 
     @Test
-    public void synchronousCancelStillAllowsForGC() throws InterruptedException {
+    void synchronousCancelStillAllowsForGC() throws InterruptedException {
         SingleProcessor<Integer> processor = new SingleProcessor<>();
         ReferenceQueue<Subscriber<Integer>> queue = new ReferenceQueue<>();
         WeakReference<Subscriber<Integer>> subscriberRef =
@@ -219,17 +219,17 @@ public class SingleProcessorTest {
     }
 
     @Test
-    public void multiThreadedAddAlwaysTerminatesError() throws Exception {
+    void multiThreadedAddAlwaysTerminatesError() throws Exception {
         multiThreadedAddAlwaysTerminates(null, DELIBERATE_EXCEPTION);
     }
 
     @Test
-    public void multiThreadedAddAlwaysTerminatesSuccess() throws Exception {
+    void multiThreadedAddAlwaysTerminatesSuccess() throws Exception {
         multiThreadedAddAlwaysTerminates("foo", null);
     }
 
     @Test
-    public void multiThreadedAddAlwaysTerminatesSuccessNull() throws Exception {
+    void multiThreadedAddAlwaysTerminatesSuccessNull() throws Exception {
         multiThreadedAddAlwaysTerminates(null, null);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleToCompletableFutureToCompletionStageWrappingTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleToCompletableFutureToCompletionStageWrappingTest.java
@@ -25,16 +25,16 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class SingleToCompletableFutureToCompletionStageWrappingTest {
+class SingleToCompletableFutureToCompletionStageWrappingTest {
     @Test
-    public void wrappedTerminationTerminates() throws Exception {
+    void wrappedTerminationTerminates() throws Exception {
         CompletableFuture<String> composed = completedFuture("Hello")
                 .thenCompose(s -> succeeded("Hello-Nested").toCompletionStage().toCompletableFuture());
         assertThat("Unexpected result.", composed.get(), is("Hello-Nested"));
     }
 
     @Test
-    public void deferredWrappedTerminationTerminates() throws Exception {
+    void deferredWrappedTerminationTerminates() throws Exception {
         CompletableFuture<String> cf = new CompletableFuture<>();
         CompletableFuture<String> composed = completedFuture("Hello")
                 .thenCompose(s -> fromStage(cf).toCompletionStage().toCompletableFuture());
@@ -44,7 +44,7 @@ public class SingleToCompletableFutureToCompletionStageWrappingTest {
     }
 
     @Test
-    public void wrappedAndApplyTerminationTerminates() throws Exception {
+    void wrappedAndApplyTerminationTerminates() throws Exception {
         CompletableFuture<String> composed = completedFuture("Hello")
                 .thenCompose(s -> succeeded("Hello-Nested").toCompletionStage().toCompletableFuture()
                         .thenApply(s1 -> s1));
@@ -52,7 +52,7 @@ public class SingleToCompletableFutureToCompletionStageWrappingTest {
     }
 
     @Test
-    public void deferredWrappedAndApplyTerminationTerminates() throws Exception {
+    void deferredWrappedAndApplyTerminationTerminates() throws Exception {
         CompletableFuture<String> cf = new CompletableFuture<>();
         CompletableFuture<String> composed = completedFuture("Hello")
                 .thenCompose(s -> fromStage(cf).toCompletionStage().toCompletableFuture().thenApply(str -> str));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleZip3Test.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleZip3Test.java
@@ -33,14 +33,14 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class SingleZip3Test {
+class SingleZip3Test {
     private TestSingle<Integer> first;
     private TestSingle<Double> second;
     private TestSingle<Short> third;
     private TestSingleSubscriber<String> subscriber;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         first = new TestSingle<>();
         second = new TestSingle<>();
         third = new TestSingle<>();
@@ -48,12 +48,12 @@ public class SingleZip3Test {
     }
 
     @Test
-    public void completeInOrder() {
+    void completeInOrder() {
         allComplete(true);
     }
 
     @Test
-    public void completeOutOfOrder() {
+    void completeOutOfOrder() {
         allComplete(false);
     }
 
@@ -76,17 +76,17 @@ public class SingleZip3Test {
     }
 
     @Test
-    public void justErrorFirst() {
+    void justErrorFirst() {
         justError(1);
     }
 
     @Test
-    public void justErrorSecond() {
+    void justErrorSecond() {
         justError(2);
     }
 
     @Test
-    public void justErrorThird() {
+    void justErrorThird() {
         justError(3);
     }
 
@@ -104,12 +104,12 @@ public class SingleZip3Test {
     }
 
     @Test
-    public void errorAfterCompleteInOrder() {
+    void errorAfterCompleteInOrder() {
         errorAfterComplete(true);
     }
 
     @Test
-    public void errorAfterCompleteOutOfOrder() {
+    void errorAfterCompleteOutOfOrder() {
         errorAfterComplete(false);
     }
 
@@ -129,7 +129,7 @@ public class SingleZip3Test {
     }
 
     @Test
-    public void justCancel() throws InterruptedException {
+    void justCancel() throws InterruptedException {
         TestCancellable cancellable1 = new TestCancellable();
         TestSingle<Integer> first = new TestSingle.Builder<Integer>().disableAutoOnSubscribe().build(subscriber1 -> {
             subscriber1.onSubscribe(cancellable1);
@@ -153,7 +153,7 @@ public class SingleZip3Test {
     }
 
     @Test
-    public void cancelAfterCompleteOutOfOrder() throws InterruptedException {
+    void cancelAfterCompleteOutOfOrder() throws InterruptedException {
         TestCancellable cancellable1 = new TestCancellable();
         TestSingle<Integer> first = new TestSingle.Builder<Integer>().disableAutoOnSubscribe().build(subscriber1 -> {
             subscriber1.onSubscribe(cancellable1);
@@ -173,7 +173,7 @@ public class SingleZip3Test {
     }
 
     @Test
-    public void delayErrorOneFail() {
+    void delayErrorOneFail() {
         toSource(zipDelayError(first, second, third, SingleZip3Test::combine)).subscribe(subscriber);
         subscriber.awaitSubscription();
         DeliberateException e1 = new DeliberateException();
@@ -185,7 +185,7 @@ public class SingleZip3Test {
     }
 
     @Test
-    public void delayErrorAllFail() {
+    void delayErrorAllFail() {
         toSource(zipDelayError(first, second, third, SingleZip3Test::combine)).subscribe(subscriber);
         subscriber.awaitSubscription();
         DeliberateException e1 = new DeliberateException();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleZip4Test.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleZip4Test.java
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class SingleZip4Test {
+class SingleZip4Test {
     private TestSingle<Integer> first;
     private TestSingle<Double> second;
     private TestSingle<Short> third;
@@ -41,7 +41,7 @@ public class SingleZip4Test {
     private TestSingleSubscriber<String> subscriber;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         first = new TestSingle<>();
         second = new TestSingle<>();
         third = new TestSingle<>();
@@ -50,12 +50,12 @@ public class SingleZip4Test {
     }
 
     @Test
-    public void completeInOrder() {
+    void completeInOrder() {
         allComplete(true);
     }
 
     @Test
-    public void completeOutOfOrder() {
+    void completeOutOfOrder() {
         allComplete(false);
     }
 
@@ -81,22 +81,22 @@ public class SingleZip4Test {
     }
 
     @Test
-    public void justErrorFirst() {
+    void justErrorFirst() {
         justError(1);
     }
 
     @Test
-    public void justErrorSecond() {
+    void justErrorSecond() {
         justError(2);
     }
 
     @Test
-    public void justErrorThird() {
+    void justErrorThird() {
         justError(3);
     }
 
     @Test
-    public void justErrorForth() {
+    void justErrorForth() {
         justError(4);
     }
 
@@ -116,12 +116,12 @@ public class SingleZip4Test {
     }
 
     @Test
-    public void errorAfterCompleteInOrder() {
+    void errorAfterCompleteInOrder() {
         errorAfterComplete(true);
     }
 
     @Test
-    public void errorAfterCompleteOutOfOrder() {
+    void errorAfterCompleteOutOfOrder() {
         errorAfterComplete(false);
     }
 
@@ -143,7 +143,7 @@ public class SingleZip4Test {
     }
 
     @Test
-    public void justCancel() throws InterruptedException {
+    void justCancel() throws InterruptedException {
         TestCancellable cancellable1 = new TestCancellable();
         TestSingle<Integer> first = new TestSingle.Builder<Integer>().disableAutoOnSubscribe().build(subscriber1 -> {
             subscriber1.onSubscribe(cancellable1);
@@ -173,7 +173,7 @@ public class SingleZip4Test {
     }
 
     @Test
-    public void cancelAfterCompleteOutOfOrder() throws InterruptedException {
+    void cancelAfterCompleteOutOfOrder() throws InterruptedException {
         TestCancellable cancellable1 = new TestCancellable();
         TestSingle<Integer> first = new TestSingle.Builder<Integer>().disableAutoOnSubscribe().build(subscriber1 -> {
             subscriber1.onSubscribe(cancellable1);
@@ -199,7 +199,7 @@ public class SingleZip4Test {
     }
 
     @Test
-    public void delayErrorOneFail() {
+    void delayErrorOneFail() {
         toSource(zipDelayError(first, second, third, fourth, SingleZip4Test::combine)).subscribe(subscriber);
         subscriber.awaitSubscription();
         DeliberateException e1 = new DeliberateException();
@@ -212,7 +212,7 @@ public class SingleZip4Test {
     }
 
     @Test
-    public void delayErrorAllFail() {
+    void delayErrorAllFail() {
         toSource(zipDelayError(first, second, third, fourth, SingleZip4Test::combine)).subscribe(subscriber);
         subscriber.awaitSubscription();
         DeliberateException e1 = new DeliberateException();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleZip5Test.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleZip5Test.java
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class SingleZip5Test {
+class SingleZip5Test {
     private TestSingle<Integer> first;
     private TestSingle<Double> second;
     private TestSingle<Short> third;
@@ -44,7 +44,7 @@ public class SingleZip5Test {
     private TestSingleSubscriber<String> subscriber;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         first = new TestSingle<>();
         second = new TestSingle<>();
         third = new TestSingle<>();
@@ -54,12 +54,12 @@ public class SingleZip5Test {
     }
 
     @Test
-    public void completeInOrder() {
+    void completeInOrder() {
         allComplete(true);
     }
 
     @Test
-    public void completeOutOfOrder() {
+    void completeOutOfOrder() {
         allComplete(false);
     }
 
@@ -88,27 +88,27 @@ public class SingleZip5Test {
     }
 
     @Test
-    public void justErrorFirst() {
+    void justErrorFirst() {
         justError(1);
     }
 
     @Test
-    public void justErrorSecond() {
+    void justErrorSecond() {
         justError(2);
     }
 
     @Test
-    public void justErrorThird() {
+    void justErrorThird() {
         justError(3);
     }
 
     @Test
-    public void justErrorForth() {
+    void justErrorForth() {
         justError(4);
     }
 
     @Test
-    public void justErrorFifth() {
+    void justErrorFifth() {
         justError(5);
     }
 
@@ -130,12 +130,12 @@ public class SingleZip5Test {
     }
 
     @Test
-    public void errorAfterCompleteInOrder() {
+    void errorAfterCompleteInOrder() {
         errorAfterComplete(true);
     }
 
     @Test
-    public void errorAfterCompleteOutOfOrder() {
+    void errorAfterCompleteOutOfOrder() {
         errorAfterComplete(false);
     }
 
@@ -159,7 +159,7 @@ public class SingleZip5Test {
     }
 
     @Test
-    public void justCancel() throws InterruptedException {
+    void justCancel() throws InterruptedException {
         TestCancellable cancellable1 = new TestCancellable();
         TestSingle<Integer> first = new TestSingle.Builder<Integer>().disableAutoOnSubscribe().build(subscriber1 -> {
             subscriber1.onSubscribe(cancellable1);
@@ -195,7 +195,7 @@ public class SingleZip5Test {
     }
 
     @Test
-    public void cancelAfterCompleteOutOfOrder() throws InterruptedException {
+    void cancelAfterCompleteOutOfOrder() throws InterruptedException {
         TestCancellable cancellable1 = new TestCancellable();
         TestSingle<Integer> first = new TestSingle.Builder<Integer>().disableAutoOnSubscribe().build(subscriber1 -> {
             subscriber1.onSubscribe(cancellable1);
@@ -227,7 +227,7 @@ public class SingleZip5Test {
     }
 
     @Test
-    public void delayErrorOneFail() {
+    void delayErrorOneFail() {
         toSource(zipDelayError(combineFunc(), first, second, third, fourth, fifth)).subscribe(subscriber);
         subscriber.awaitSubscription();
         DeliberateException e1 = new DeliberateException();
@@ -241,7 +241,7 @@ public class SingleZip5Test {
     }
 
     @Test
-    public void delayErrorAllFail() {
+    void delayErrorAllFail() {
         toSource(zipDelayError(combineFunc(), first, second, third, fourth, fifth)).subscribe(subscriber);
         subscriber.awaitSubscription();
         DeliberateException e1 = new DeliberateException();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleZipWithTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleZipWithTest.java
@@ -31,25 +31,25 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class SingleZipWithTest {
+class SingleZipWithTest {
     private TestSingle<Integer> first;
     private TestSingle<Double> second;
     private TestSingleSubscriber<String> subscriber;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         first = new TestSingle<>();
         second = new TestSingle<>();
         subscriber = new TestSingleSubscriber<>();
     }
 
     @Test
-    public void bothCompleteInOrder() {
+    void bothCompleteInOrder() {
         bothComplete(true);
     }
 
     @Test
-    public void bothCompleteOutOfOrder() {
+    void bothCompleteOutOfOrder() {
         bothComplete(false);
     }
 
@@ -69,12 +69,12 @@ public class SingleZipWithTest {
     }
 
     @Test
-    public void justErrorFirst() {
+    void justErrorFirst() {
         justError(true);
     }
 
     @Test
-    public void justErrorSecond() {
+    void justErrorSecond() {
         justError(false);
     }
 
@@ -90,12 +90,12 @@ public class SingleZipWithTest {
     }
 
     @Test
-    public void errorAfterCompleteInOrder() {
+    void errorAfterCompleteInOrder() {
         errorAfterComplete(true);
     }
 
     @Test
-    public void errorAfterCompleteOutOfOrder() {
+    void errorAfterCompleteOutOfOrder() {
         errorAfterComplete(false);
     }
 
@@ -113,7 +113,7 @@ public class SingleZipWithTest {
     }
 
     @Test
-    public void justCancel() throws InterruptedException {
+    void justCancel() throws InterruptedException {
         TestCancellable cancellable1 = new TestCancellable();
         TestSingle<Integer> first = new TestSingle.Builder<Integer>().disableAutoOnSubscribe().build(subscriber1 -> {
             subscriber1.onSubscribe(cancellable1);
@@ -131,7 +131,7 @@ public class SingleZipWithTest {
     }
 
     @Test
-    public void cancelAfterCompleteOutOfOrder() throws InterruptedException {
+    void cancelAfterCompleteOutOfOrder() throws InterruptedException {
         TestCancellable cancellable = new TestCancellable();
         TestSingle<Integer> first = new TestSingle.Builder<Integer>().disableAutoOnSubscribe().build(subscriber1 -> {
             subscriber1.onSubscribe(cancellable);
@@ -145,7 +145,7 @@ public class SingleZipWithTest {
     }
 
     @Test
-    public void delayErrorOneFail() {
+    void delayErrorOneFail() {
         toSource(first.zipWithDelayError(second, SingleZipWithTest::combine)).subscribe(subscriber);
         subscriber.awaitSubscription();
         DeliberateException e1 = new DeliberateException();
@@ -156,7 +156,7 @@ public class SingleZipWithTest {
     }
 
     @Test
-    public void delayErrorAllFail() {
+    void delayErrorAllFail() {
         toSource(first.zipWithDelayError(second, SingleZipWithTest::combine)).subscribe(subscriber);
         subscriber.awaitSubscription();
         DeliberateException e1 = new DeliberateException();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SourceAdaptersTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SourceAdaptersTest.java
@@ -46,10 +46,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class SourceAdaptersTest {
+class SourceAdaptersTest {
 
     @Test
-    public void publisherToSourceSuccess() {
+    void publisherToSourceSuccess() {
         PublisherSource.Subscriber<Integer> subscriber = toSourceAndSubscribe(from(1));
         verify(subscriber).onNext(1);
         verify(subscriber).onComplete();
@@ -57,14 +57,14 @@ public class SourceAdaptersTest {
     }
 
     @Test
-    public void publisherToSourceError() {
+    void publisherToSourceError() {
         PublisherSource.Subscriber<Integer> subscriber = toSourceAndSubscribe(Publisher.failed(DELIBERATE_EXCEPTION));
         verify(subscriber).onError(DELIBERATE_EXCEPTION);
         verifyNoMoreInteractions(subscriber);
     }
 
     @Test
-    public void publisherToSourceCancel() {
+    void publisherToSourceCancel() {
         TestPublisher<Integer> stPublisher = new TestPublisher<>();
         PublisherSource.Subscriber<Integer> subscriber = toSourceAndSubscribe(stPublisher);
         TestSubscription subscription = new TestSubscription();
@@ -77,21 +77,21 @@ public class SourceAdaptersTest {
     }
 
     @Test
-    public void singleToSourceSuccess() {
+    void singleToSourceSuccess() {
         SingleSource.Subscriber<Integer> subscriber = toSourceAndSubscribe(succeeded(1));
         verify(subscriber).onSuccess(1);
         verifyNoMoreInteractions(subscriber);
     }
 
     @Test
-    public void singleToSourceError() {
+    void singleToSourceError() {
         SingleSource.Subscriber<Integer> subscriber = toSourceAndSubscribe(Single.failed(DELIBERATE_EXCEPTION));
         verify(subscriber).onError(DELIBERATE_EXCEPTION);
         verifyNoMoreInteractions(subscriber);
     }
 
     @Test
-    public void singleToSourceCancel() {
+    void singleToSourceCancel() {
         LegacyTestSingle<Integer> stSingle = new LegacyTestSingle<>();
         SingleSource.Subscriber<Integer> subscriber = toSourceAndSubscribe(stSingle);
         stSingle.verifyListenCalled();
@@ -102,21 +102,21 @@ public class SourceAdaptersTest {
     }
 
     @Test
-    public void completableToSourceSuccess() {
+    void completableToSourceSuccess() {
         CompletableSource.Subscriber subscriber = toSourceAndSubscribe(completed());
         verify(subscriber).onComplete();
         verifyNoMoreInteractions(subscriber);
     }
 
     @Test
-    public void completableToSourceError() {
+    void completableToSourceError() {
         CompletableSource.Subscriber subscriber = toSourceAndSubscribe(Completable.failed(DELIBERATE_EXCEPTION));
         verify(subscriber).onError(DELIBERATE_EXCEPTION);
         verifyNoMoreInteractions(subscriber);
     }
 
     @Test
-    public void completableToSourceCancel() {
+    void completableToSourceCancel() {
         LegacyTestCompletable stCompletable = new LegacyTestCompletable();
         CompletableSource.Subscriber subscriber = toSourceAndSubscribe(stCompletable);
         stCompletable.verifyListenCalled();
@@ -127,14 +127,14 @@ public class SourceAdaptersTest {
     }
 
     @Test
-    public void publisherFromSourceSuccess() throws Exception {
+    void publisherFromSourceSuccess() throws Exception {
         PublisherSource<Integer> src = s -> s.onSubscribe(new ScalarValueSubscription<>(1, s));
         Integer result = fromSource(src).firstOrElse(() -> null).toFuture().get();
         assertThat("Unexpected result.", result, is(1));
     }
 
     @Test
-    public void publisherFromSourceError() {
+    void publisherFromSourceError() {
         PublisherSource<Integer> src = s -> {
             s.onSubscribe(EMPTY_SUBSCRIPTION);
             s.onError(DELIBERATE_EXCEPTION);
@@ -146,7 +146,7 @@ public class SourceAdaptersTest {
     }
 
     @Test
-    public void publisherFromSourceCancel() {
+    void publisherFromSourceCancel() {
         PublisherSource.Subscription srcSubscription = mock(PublisherSource.Subscription.class);
         PublisherSource<Integer> source = s -> s.onSubscribe(srcSubscription);
 
@@ -155,7 +155,7 @@ public class SourceAdaptersTest {
     }
 
     @Test
-    public void singleFromSourceSuccess() throws Exception {
+    void singleFromSourceSuccess() throws Exception {
         SingleSource<Integer> src = s -> {
             s.onSubscribe(IGNORE_CANCEL);
             s.onSuccess(1);
@@ -165,7 +165,7 @@ public class SourceAdaptersTest {
     }
 
     @Test
-    public void singleFromSourceError() {
+    void singleFromSourceError() {
         SingleSource<Integer> src = s -> {
             s.onSubscribe(IGNORE_CANCEL);
             s.onError(DELIBERATE_EXCEPTION);
@@ -177,7 +177,7 @@ public class SourceAdaptersTest {
     }
 
     @Test
-    public void singleFromSourceCancel() {
+    void singleFromSourceCancel() {
         Cancellable srcCancellable = mock(Cancellable.class);
         SingleSource<Integer> source = s -> s.onSubscribe(srcCancellable);
 
@@ -186,7 +186,7 @@ public class SourceAdaptersTest {
     }
 
     @Test
-    public void completableFromSourceSuccess() throws Exception {
+    void completableFromSourceSuccess() throws Exception {
         CompletableSource src = s -> {
             s.onSubscribe(IGNORE_CANCEL);
             s.onComplete();
@@ -195,7 +195,7 @@ public class SourceAdaptersTest {
     }
 
     @Test
-    public void completableFromSourceError() {
+    void completableFromSourceError() {
         CompletableSource src = s -> {
             s.onSubscribe(IGNORE_CANCEL);
             s.onError(DELIBERATE_EXCEPTION);
@@ -207,7 +207,7 @@ public class SourceAdaptersTest {
     }
 
     @Test
-    public void completableFromSourceCancel() {
+    void completableFromSourceCancel() {
         Cancellable srcCancellable = mock(Cancellable.class);
         CompletableSource source = s -> s.onSubscribe(srcCancellable);
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SubscribeThrowsTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SubscribeThrowsTest.java
@@ -32,10 +32,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class SubscribeThrowsTest {
+class SubscribeThrowsTest {
 
     @Test
-    public void publisherSubscriberThrows() {
+    void publisherSubscriberThrows() {
         Publisher<String> p = new Publisher<String>() {
             @Override
             protected void handleSubscribe(final Subscriber<? super String> subscriber) {
@@ -47,7 +47,7 @@ public class SubscribeThrowsTest {
     }
 
     @Test
-    public void publisherSubscriberWithOffloaderThrows() {
+    void publisherSubscriberWithOffloaderThrows() {
         SignalOffloader offloader = ((AbstractOffloaderAwareExecutor) immediate()).newSignalOffloader(immediate());
         @SuppressWarnings("unchecked")
         Subscriber<String> subscriber = (Subscriber<String>) mock(Subscriber.class);
@@ -63,7 +63,7 @@ public class SubscribeThrowsTest {
     }
 
     @Test
-    public void singleSubscriberThrows() {
+    void singleSubscriberThrows() {
         Single<String> s = new Single<String>() {
             @Override
             protected void handleSubscribe(final SingleSource.Subscriber subscriber) {
@@ -75,7 +75,7 @@ public class SubscribeThrowsTest {
     }
 
     @Test
-    public void singleSubscriberWithOffloaderThrows() {
+    void singleSubscriberWithOffloaderThrows() {
         SignalOffloader offloader = ((AbstractOffloaderAwareExecutor) immediate()).newSignalOffloader(immediate());
         @SuppressWarnings("unchecked")
         SingleSource.Subscriber<String> subscriber =
@@ -92,7 +92,7 @@ public class SubscribeThrowsTest {
     }
 
     @Test
-    public void completableSubscriberThrows() {
+    void completableSubscriberThrows() {
         Completable c = new Completable() {
             @Override
             protected void handleSubscribe(final CompletableSource.Subscriber subscriber) {
@@ -104,7 +104,7 @@ public class SubscribeThrowsTest {
     }
 
     @Test
-    public void completableSubscriberWithOffloaderThrows() {
+    void completableSubscriberWithOffloaderThrows() {
         SignalOffloader offloader = ((AbstractOffloaderAwareExecutor) immediate()).newSignalOffloader(immediate());
         CompletableSource.Subscriber subscriber = mock(CompletableSource.Subscriber.class);
         Completable c = new Completable() {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TakePublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TakePublisherTest.java
@@ -27,14 +27,14 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TakePublisherTest {
+class TakePublisherTest {
 
     private final TestPublisher<String> publisher = new TestPublisher<>();
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
     private final TestSubscription subscription = new TestSubscription();
 
     @Test
-    public void testEnoughRequests() {
+    void testEnoughRequests() {
         Publisher<String> p = publisher.takeAtMost(2);
         toSource(p).subscribe(subscriber);
         publisher.onSubscribe(subscription);
@@ -46,7 +46,7 @@ public class TakePublisherTest {
     }
 
     @Test
-    public void testTakeError() {
+    void testTakeError() {
         Publisher<String> p = publisher.takeAtMost(2);
         toSource(p).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
@@ -57,7 +57,7 @@ public class TakePublisherTest {
     }
 
     @Test
-    public void testTakeComplete() {
+    void testTakeComplete() {
         Publisher<String> p = publisher.takeAtMost(2);
         toSource(p).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
@@ -67,7 +67,7 @@ public class TakePublisherTest {
     }
 
     @Test
-    public void testSubCancelled() {
+    void testSubCancelled() {
         Publisher<String> p = publisher.takeAtMost(3);
         toSource(p).subscribe(subscriber);
         publisher.onSubscribe(subscription);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TakeUntilPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TakeUntilPublisherTest.java
@@ -27,14 +27,14 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TakeUntilPublisherTest {
+class TakeUntilPublisherTest {
 
     private final TestPublisher<String> publisher = new TestPublisher<>();
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
     private final TestSubscription subscription = new TestSubscription();
 
     @Test
-    public void testUntilComplete() {
+    void testUntilComplete() {
         LegacyTestCompletable completable = new LegacyTestCompletable();
         Publisher<String> p = publisher.takeUntil(completable);
         toSource(p).subscribe(subscriber);
@@ -48,7 +48,7 @@ public class TakeUntilPublisherTest {
     }
 
     @Test
-    public void testUntilError() {
+    void testUntilError() {
         LegacyTestCompletable completable = new LegacyTestCompletable();
         Publisher<String> p = publisher.takeUntil(completable);
         toSource(p).subscribe(subscriber);
@@ -62,7 +62,7 @@ public class TakeUntilPublisherTest {
     }
 
     @Test
-    public void testEmitsError() {
+    void testEmitsError() {
         LegacyTestCompletable completable = new LegacyTestCompletable();
         Publisher<String> p = publisher.takeUntil(completable);
         toSource(p).subscribe(subscriber);
@@ -74,7 +74,7 @@ public class TakeUntilPublisherTest {
     }
 
     @Test
-    public void testEmitsComplete() {
+    void testEmitsComplete() {
         LegacyTestCompletable completable = new LegacyTestCompletable();
         Publisher<String> p = publisher.takeUntil(completable);
         toSource(p).subscribe(subscriber);
@@ -85,7 +85,7 @@ public class TakeUntilPublisherTest {
     }
 
     @Test
-    public void testSubCancelled() {
+    void testSubCancelled() {
         LegacyTestCompletable completable = new LegacyTestCompletable();
         Publisher<String> p = publisher.takeUntil(completable);
         toSource(p).subscribe(subscriber);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TakeWhilePublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TakeWhilePublisherTest.java
@@ -27,14 +27,14 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TakeWhilePublisherTest {
+class TakeWhilePublisherTest {
 
     private final TestPublisher<String> publisher = new TestPublisher<>();
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
     private final TestSubscription subscription = new TestSubscription();
 
     @Test
-    public void testWhile() {
+    void testWhile() {
         Publisher<String> p = publisher.takeWhile(s -> !s.equals("Hello3"));
         toSource(p).subscribe(subscriber);
         publisher.onSubscribe(subscription);
@@ -46,7 +46,7 @@ public class TakeWhilePublisherTest {
     }
 
     @Test
-    public void testWhileError() {
+    void testWhileError() {
         Publisher<String> p = publisher.takeWhile(s -> !s.equals("Hello3"));
         toSource(p).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
@@ -57,7 +57,7 @@ public class TakeWhilePublisherTest {
     }
 
     @Test
-    public void testWhileComplete() {
+    void testWhileComplete() {
         Publisher<String> p = publisher.takeWhile(s -> !s.equals("Hello3"));
         toSource(p).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
@@ -67,7 +67,7 @@ public class TakeWhilePublisherTest {
     }
 
     @Test
-    public void testSubCancelled() {
+    void testSubCancelled() {
         Publisher<String> p = publisher.takeWhile(s -> !s.equals("Hello3"));
         toSource(p).subscribe(subscriber);
         publisher.onSubscribe(subscription);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestCompletableTest.java
@@ -30,13 +30,13 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class TestCompletableTest {
+class TestCompletableTest {
 
     private final TestCompletableSubscriber subscriber1 = new TestCompletableSubscriber();
     private final TestCompletableSubscriber subscriber2 = new TestCompletableSubscriber();
 
     @Test
-    public void testNonResubscribeableCompletable() {
+    void testNonResubscribeableCompletable() {
         TestCompletable source = new TestCompletable.Builder()
                 .singleSubscriber()
                 .build();
@@ -56,7 +56,7 @@ public class TestCompletableTest {
     }
 
     @Test
-    public void testSequentialSubscribeCompletable() {
+    void testSequentialSubscribeCompletable() {
         TestCompletable source = new TestCompletable.Builder()
                 .build();
 
@@ -71,7 +71,7 @@ public class TestCompletableTest {
     }
 
     @Test
-    public void testConcurrentSubscribeCompletable() {
+    void testConcurrentSubscribeCompletable() {
         TestCompletable source = new TestCompletable.Builder()
                 .concurrentSubscribers()
                 .build();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestExecutorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestExecutorTest.java
@@ -28,10 +28,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TestExecutorTest {
+class TestExecutorTest {
 
     @Test
-    public void testAdvanceTimeByNoExecuteTasks() {
+    void testAdvanceTimeByNoExecuteTasks() {
         TestExecutor fixture = new TestExecutor();
 
         long initialTime = fixture.currentNanos();
@@ -43,7 +43,7 @@ public class TestExecutorTest {
     }
 
     @Test
-    public void testExecute() {
+    void testExecute() {
         TestExecutor fixture = new TestExecutor();
 
         AtomicInteger i = new AtomicInteger();
@@ -58,7 +58,7 @@ public class TestExecutorTest {
     }
 
     @Test
-    public void testExecuteSameTaskMultipleTimes() {
+    void testExecuteSameTaskMultipleTimes() {
         TestExecutor fixture = new TestExecutor();
 
         AtomicInteger i = new AtomicInteger();
@@ -74,7 +74,7 @@ public class TestExecutorTest {
     }
 
     @Test
-    public void testSchedule() {
+    void testSchedule() {
         TestExecutor fixture = new TestExecutor();
 
         AtomicInteger i = new AtomicInteger();
@@ -99,7 +99,7 @@ public class TestExecutorTest {
     }
 
     @Test
-    public void testScheduleAtSameTime() {
+    void testScheduleAtSameTime() {
         TestExecutor fixture = new TestExecutor();
 
         AtomicInteger i = new AtomicInteger();
@@ -125,7 +125,7 @@ public class TestExecutorTest {
     }
 
     @Test
-    public void testScheduleAtSameTimeFromDifferentNow() {
+    void testScheduleAtSameTimeFromDifferentNow() {
         TestExecutor fixture = new TestExecutor();
 
         AtomicInteger i = new AtomicInteger();
@@ -152,7 +152,7 @@ public class TestExecutorTest {
     }
 
     @Test
-    public void testScheduleAtDifferentTimes() {
+    void testScheduleAtDifferentTimes() {
         TestExecutor fixture = new TestExecutor();
 
         AtomicInteger i = new AtomicInteger();
@@ -186,7 +186,7 @@ public class TestExecutorTest {
     }
 
     @Test
-    public void testExecuteNextTask() {
+    void testExecuteNextTask() {
         TestExecutor fixture = new TestExecutor();
 
         AtomicInteger i = new AtomicInteger();
@@ -204,12 +204,12 @@ public class TestExecutorTest {
     }
 
     @Test
-    public void testExecuteNextScheduledTask() {
+    void testExecuteNextScheduledTask() {
         testExecuteNextScheduledTask(new TestExecutor());
     }
 
     @Test
-    public void testScheduleDoesNotOverflow() {
+    void testScheduleDoesNotOverflow() {
         testExecuteNextScheduledTask(new TestExecutor(Long.MAX_VALUE - 1));
     }
 
@@ -231,7 +231,7 @@ public class TestExecutorTest {
     }
 
     @Test
-    public void testCloseAsync() throws Exception {
+    void testCloseAsync() throws Exception {
         TestExecutor fixture = new TestExecutor();
         Future<Void> closeFuture = fixture.closeAsync().toFuture();
         Future<Void> onCloseFuture = fixture.onClose().toFuture();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestPublisherTest.java
@@ -40,13 +40,13 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class TestPublisherTest {
+class TestPublisherTest {
 
     private final TestPublisherSubscriber<String> subscriber1 = new TestPublisherSubscriber<>();
     private final TestPublisherSubscriber<String> subscriber2 = new TestPublisherSubscriber<>();
 
     @Test
-    public void testNonResubscribeablePublisher() {
+    void testNonResubscribeablePublisher() {
         TestPublisher<String> source = new TestPublisher.Builder<String>()
                 .singleSubscriber()
                 .build();
@@ -67,7 +67,7 @@ public class TestPublisherTest {
     }
 
     @Test
-    public void testSequentialSubscribePublisher() {
+    void testSequentialSubscribePublisher() {
         TestPublisher<String> source = new TestPublisher.Builder<String>()
                 .build();
 
@@ -81,7 +81,7 @@ public class TestPublisherTest {
     }
 
     @Test
-    public void testConcurrentSubscribePublisher() {
+    void testConcurrentSubscribePublisher() {
         TestPublisher<String> source = new TestPublisher.Builder<String>()
                 .concurrentSubscribers()
                 .build();
@@ -96,7 +96,7 @@ public class TestPublisherTest {
     }
 
     @Test
-    public void testFanOut() {
+    void testFanOut() {
         final ConcurrentPublisherSubscriberFunction<Integer> concurrentPublisherSubscriberFunction =
                 new ConcurrentPublisherSubscriberFunction<>();
         TestPublisher<Integer> source = new TestPublisher.Builder<Integer>()
@@ -127,7 +127,7 @@ public class TestPublisherTest {
     }
 
     @Test
-    public void testFanOut2() {
+    void testFanOut2() {
         ConcurrentPublisherSubscriberFunction<Integer> concurrentPublisherSubscriberFunction =
                 new ConcurrentPublisherSubscriberFunction<>();
         TestPublisher<Integer> source = new TestPublisher.Builder<Integer>()
@@ -159,7 +159,7 @@ public class TestPublisherTest {
     }
 
     @Test
-    public void testFanOut3() {
+    void testFanOut3() {
         ConcurrentPublisherSubscriberFunction<Integer> concurrentPublisherSubscriberFunction =
                 new ConcurrentPublisherSubscriberFunction<>();
         TestPublisher<Integer> source = new TestPublisher.Builder<Integer>().build(
@@ -191,7 +191,7 @@ public class TestPublisherTest {
     }
 
     @Test
-    public void testDemandNoRequest() {
+    void testDemandNoRequest() {
         TestPublisher<String> source = new TestPublisher<>();
         source.subscribe(subscriber1);
 
@@ -200,7 +200,7 @@ public class TestPublisherTest {
     }
 
     @Test
-    public void testDemandPostCancel() {
+    void testDemandPostCancel() {
         TestPublisher<String> source = new TestPublisher<>();
         source.subscribe(subscriber1);
 
@@ -210,7 +210,7 @@ public class TestPublisherTest {
     }
 
     @Test
-    public void testInsufficientDemand() {
+    void testInsufficientDemand() {
         TestPublisher<String> source = new TestPublisher.Builder<String>().build();
         source.subscribe(subscriber1);
 
@@ -224,7 +224,7 @@ public class TestPublisherTest {
     }
 
     @Test
-    public void testRequestMaxMultiple() {
+    void testRequestMaxMultiple() {
         TestPublisher<String> source = new TestPublisher.Builder<String>()
                 .build();
         source.subscribe(subscriber1);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TestSingleTest.java
@@ -28,13 +28,13 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class TestSingleTest {
+class TestSingleTest {
 
     private final TestSingleSubscriber<String> subscriber1 = new TestSingleSubscriber<>();
     private final TestSingleSubscriber<String> subscriber2 = new TestSingleSubscriber<>();
 
     @Test
-    public void testNonResubscribeableSingle() {
+    void testNonResubscribeableSingle() {
         TestSingle<String> source = new TestSingle.Builder<String>()
                 .singleSubscriber()
                 .build();
@@ -55,7 +55,7 @@ public class TestSingleTest {
     }
 
     @Test
-    public void testSequentialSubscribeSingle() {
+    void testSequentialSubscribeSingle() {
         TestSingle<String> source = new TestSingle.Builder<String>()
                 .build();
 
@@ -69,7 +69,7 @@ public class TestSingleTest {
     }
 
     @Test
-    public void testConcurrentSubscribeSingle() {
+    void testConcurrentSubscribeSingle() {
         TestSingle<String> source = new TestSingle.Builder<String>()
                 .concurrentSubscribers()
                 .build();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenCancelTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenCancelTest.java
@@ -35,7 +35,7 @@ public abstract class AbstractWhenCancelTest {
     final TestCompletableSubscriber listener = new TestCompletableSubscriber();
 
     @Test
-    public void testCancelNoEmissions() {
+    void testCancelNoEmissions() {
         Runnable onCancel = Mockito.mock(Runnable.class);
         LegacyTestCompletable completable = new LegacyTestCompletable();
         toSource(doCancel(completable, onCancel)).subscribe(listener);
@@ -45,7 +45,7 @@ public abstract class AbstractWhenCancelTest {
     }
 
     @Test
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         LegacyTestCompletable completable = new LegacyTestCompletable();
         DeliberateException e = assertThrows(DeliberateException.class, () -> {
             try {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenFinallyTest.java
@@ -39,7 +39,7 @@ abstract class AbstractWhenFinallyTest {
     private final TerminalSignalConsumer doFinally = mock(TerminalSignalConsumer.class);
 
     @Test
-    public void testForCancel() {
+    void testForCancel() {
         toSource(doFinally(Completable.never(), doFinally)).subscribe(listener);
         listener.awaitSubscription().cancel();
         verify(doFinally).cancel();
@@ -47,7 +47,7 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public void testForCancelPostSuccess() {
+    void testForCancelPostSuccess() {
         toSource(doFinally(Completable.completed(), doFinally)).subscribe(listener);
         listener.awaitSubscription().cancel();
         verify(doFinally).onComplete();
@@ -55,7 +55,7 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public void testForCancelPostError() {
+    void testForCancelPostError() {
         toSource(doFinally(Completable.failed(DELIBERATE_EXCEPTION), doFinally)).subscribe(listener);
         listener.awaitSubscription().cancel();
         verify(doFinally).onError(DELIBERATE_EXCEPTION);
@@ -63,7 +63,7 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public void testForSuccess() {
+    void testForSuccess() {
         toSource(doFinally(Completable.completed(), doFinally)).subscribe(listener);
         listener.awaitOnComplete();
         listener.awaitSubscription().cancel();
@@ -72,7 +72,7 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public void testForError() {
+    void testForError() {
         toSource(doFinally(Completable.failed(DELIBERATE_EXCEPTION), doFinally)).subscribe(listener);
         assertThat(listener.awaitOnError(), is(DELIBERATE_EXCEPTION));
         verify(doFinally).onError(DELIBERATE_EXCEPTION);
@@ -80,7 +80,7 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public void testCallbackThrowsErrorWhenCancel() {
+    void testCallbackThrowsErrorWhenCancel() {
         TerminalSignalConsumer mock = throwableMock(DELIBERATE_EXCEPTION);
         LegacyTestCompletable completable = new LegacyTestCompletable();
         try {
@@ -95,10 +95,10 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public abstract void testCallbackThrowsErrorOnComplete();
+    abstract void testCallbackThrowsErrorOnComplete();
 
     @Test
-    public abstract void testCallbackThrowsErrorOnError();
+    abstract void testCallbackThrowsErrorOnError();
 
     protected abstract Completable doFinally(Completable completable, TerminalSignalConsumer doFinally);
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenOnCompleteTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenOnCompleteTest.java
@@ -28,14 +28,14 @@ public abstract class AbstractWhenOnCompleteTest {
     final TestCompletableSubscriber listener = new TestCompletableSubscriber();
 
     @Test
-    public void testComplete() {
+    void testComplete() {
         Runnable onComplete = mock(Runnable.class);
         toSource(doComplete(Completable.completed(), onComplete)).subscribe(listener);
         verify(onComplete).run();
     }
 
     @Test
-    public abstract void testCallbackThrowsError();
+    abstract void testCallbackThrowsError();
 
     protected abstract Completable doComplete(Completable completable, Runnable runnable);
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenOnErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenOnErrorTest.java
@@ -31,7 +31,7 @@ public abstract class AbstractWhenOnErrorTest {
     final TestCompletableSubscriber listener = new TestCompletableSubscriber();
 
     @Test
-    public void testError() {
+    void testError() {
         @SuppressWarnings("unchecked")
         Consumer<Throwable> onError = Mockito.mock(Consumer.class);
         toSource(doError(Completable.failed(DELIBERATE_EXCEPTION), onError)).subscribe(listener);
@@ -39,7 +39,7 @@ public abstract class AbstractWhenOnErrorTest {
     }
 
     @Test
-    public abstract void testCallbackThrowsError();
+    abstract void testCallbackThrowsError();
 
     protected abstract Completable doError(Completable completable, Consumer<Throwable> consumer);
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenOnSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenOnSubscribeTest.java
@@ -35,12 +35,12 @@ public abstract class AbstractWhenOnSubscribeTest {
 
     @SuppressWarnings("unchecked")
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         doOnListen = mock(Consumer.class);
     }
 
     @Test
-    public void testOnSubscribe() {
+    void testOnSubscribe() {
         toSource(doSubscribe(Completable.completed(), doOnListen)).subscribe(listener);
         listener.awaitOnComplete();
         verify(doOnListen).accept(any(Cancellable.class));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AbstractWhenSubscriberTest.java
@@ -38,12 +38,12 @@ public abstract class AbstractWhenSubscriberTest {
     private CompletableSource.Subscriber subscriber;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         subscriber = mock(CompletableSource.Subscriber.class);
     }
 
     @Test
-    public void testOnWithOnComplete() {
+    void testOnWithOnComplete() {
         toSource(doSubscriber(Completable.completed(), () -> subscriber)).subscribe(listener);
         listener.awaitOnComplete();
         verify(subscriber).onSubscribe(any());
@@ -51,7 +51,7 @@ public abstract class AbstractWhenSubscriberTest {
     }
 
     @Test
-    public void testOnWithOnError() {
+    void testOnWithOnError() {
         toSource(doSubscriber(Completable.failed(DELIBERATE_EXCEPTION), () -> subscriber)).subscribe(listener);
         assertThat(listener.awaitOnError(), is(DELIBERATE_EXCEPTION));
         verify(subscriber).onSubscribe(any());

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterCancelTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterCancelTest.java
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api.completable;
 
 import io.servicetalk.concurrent.api.Completable;
 
-public class AfterCancelTest extends AbstractWhenCancelTest {
+class AfterCancelTest extends AbstractWhenCancelTest {
     @Override
     protected Completable doCancel(Completable completable, Runnable runnable) {
         return completable.afterCancel(runnable);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterCompleteTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterCompleteTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 
-public class AfterCompleteTest extends AbstractWhenOnCompleteTest {
+class AfterCompleteTest extends AbstractWhenOnCompleteTest {
 
     @Override
     protected Completable doComplete(Completable completable, Runnable runnable) {
@@ -30,7 +30,7 @@ public class AfterCompleteTest extends AbstractWhenOnCompleteTest {
     }
 
     @Test
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         toSource(doComplete(Completable.completed(), () -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(listener);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterErrorTest.java
@@ -27,7 +27,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class AfterErrorTest extends AbstractWhenOnErrorTest {
+class AfterErrorTest extends AbstractWhenOnErrorTest {
 
     @Override
     protected Completable doError(Completable completable, Consumer<Throwable> consumer) {
@@ -36,7 +36,7 @@ public class AfterErrorTest extends AbstractWhenOnErrorTest {
 
     @Test
     @Override
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         DeliberateException srcEx = new DeliberateException();
         toSource(doError(Completable.failed(srcEx), __ -> {
             throw DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterFinallyTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class AfterFinallyTest extends AbstractWhenFinallyTest {
+class AfterFinallyTest extends AbstractWhenFinallyTest {
     @Override
     protected Completable doFinally(Completable completable, TerminalSignalConsumer doFinally) {
         return completable.afterFinally(doFinally);
@@ -36,7 +36,7 @@ public class AfterFinallyTest extends AbstractWhenFinallyTest {
 
     @Test
     @Override
-    public void testCallbackThrowsErrorOnComplete() {
+    void testCallbackThrowsErrorOnComplete() {
         TerminalSignalConsumer mock = throwableMock(DELIBERATE_EXCEPTION);
         toSource(doFinally(Completable.completed(), mock)).subscribe(listener);
         listener.awaitOnComplete();
@@ -46,7 +46,7 @@ public class AfterFinallyTest extends AbstractWhenFinallyTest {
 
     @Test
     @Override
-    public void testCallbackThrowsErrorOnError() {
+    void testCallbackThrowsErrorOnError() {
         TerminalSignalConsumer mock = throwableMock(new DeliberateException());
         toSource(doFinally(Completable.failed(DELIBERATE_EXCEPTION), mock)).subscribe(listener);
         assertThat(listener.awaitOnError(), is(DELIBERATE_EXCEPTION));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterSubscribeTest.java
@@ -27,10 +27,10 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class AfterSubscribeTest extends AbstractWhenOnSubscribeTest {
+class AfterSubscribeTest extends AbstractWhenOnSubscribeTest {
 
     @Test
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         toSource(doSubscribe(Completable.completed(), __ -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(listener);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/AfterSubscriberTest.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.api.Completable;
 
 import java.util.function.Supplier;
 
-public class AfterSubscriberTest extends AbstractWhenSubscriberTest {
+class AfterSubscriberTest extends AbstractWhenSubscriberTest {
     @Override
     protected Completable doSubscriber(Completable completable,
                                        Supplier<CompletableSource.Subscriber> subscriberSupplier) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeCancelTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeCancelTest.java
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api.completable;
 
 import io.servicetalk.concurrent.api.Completable;
 
-public class BeforeCancelTest extends AbstractWhenCancelTest {
+class BeforeCancelTest extends AbstractWhenCancelTest {
     @Override
     protected Completable doCancel(Completable completable, Runnable runnable) {
         return completable.beforeCancel(runnable);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeCompleteTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeCompleteTest.java
@@ -24,14 +24,14 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class BeforeCompleteTest extends AbstractWhenOnCompleteTest {
+class BeforeCompleteTest extends AbstractWhenOnCompleteTest {
     @Override
     protected Completable doComplete(Completable completable, Runnable runnable) {
         return completable.beforeOnComplete(runnable);
     }
 
     @Test
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         toSource(doComplete(Completable.completed(), () -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(listener);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeErrorTest.java
@@ -27,7 +27,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class BeforeErrorTest extends AbstractWhenOnErrorTest {
+class BeforeErrorTest extends AbstractWhenOnErrorTest {
     @Override
     protected Completable doError(Completable completable, Consumer<Throwable> consumer) {
         return completable.beforeOnError(consumer);
@@ -35,7 +35,7 @@ public class BeforeErrorTest extends AbstractWhenOnErrorTest {
 
     @Test
     @Override
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         DeliberateException srcEx = new DeliberateException();
         toSource(doError(Completable.failed(srcEx), t -> {
             throw DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeFinallyTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class BeforeFinallyTest extends AbstractWhenFinallyTest {
+class BeforeFinallyTest extends AbstractWhenFinallyTest {
     @Override
     protected Completable doFinally(Completable completable, TerminalSignalConsumer doFinally) {
         return completable.beforeFinally(doFinally);
@@ -36,7 +36,7 @@ public class BeforeFinallyTest extends AbstractWhenFinallyTest {
 
     @Test
     @Override
-    public void testCallbackThrowsErrorOnComplete() {
+    void testCallbackThrowsErrorOnComplete() {
         TerminalSignalConsumer mock = throwableMock(DELIBERATE_EXCEPTION);
         toSource(doFinally(Completable.completed(), mock)).subscribe(listener);
         assertThat(listener.awaitOnError(), is(DELIBERATE_EXCEPTION));
@@ -46,7 +46,7 @@ public class BeforeFinallyTest extends AbstractWhenFinallyTest {
 
     @Test
     @Override
-    public void testCallbackThrowsErrorOnError() {
+    void testCallbackThrowsErrorOnError() {
         DeliberateException exception = new DeliberateException();
         TerminalSignalConsumer mock = throwableMock(exception);
         toSource(doFinally(Completable.failed(DELIBERATE_EXCEPTION), mock)).subscribe(listener);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeSubscribeTest.java
@@ -30,10 +30,10 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 
-public class BeforeSubscribeTest extends AbstractWhenOnSubscribeTest {
+class BeforeSubscribeTest extends AbstractWhenOnSubscribeTest {
 
     @Test
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         List<Throwable> failures = new ArrayList<>();
         toSource(doSubscribe(Completable.completed(), s -> {
             throw DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/BeforeSubscriberTest.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.api.Completable;
 
 import java.util.function.Supplier;
 
-public class BeforeSubscriberTest extends AbstractWhenSubscriberTest {
+class BeforeSubscriberTest extends AbstractWhenSubscriberTest {
     @Override
     protected Completable doSubscriber(Completable completable,
                                        Supplier<CompletableSource.Subscriber> subscriberSupplier) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CollectTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CollectTest.java
@@ -31,21 +31,21 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class CollectTest {
+class CollectTest {
 
     @Test
-    public void collectVarArgSuccess() throws Exception {
+    void collectVarArgSuccess() throws Exception {
         mergeAll(completed(), completed()).toFuture().get();
     }
 
     @Test
-    public void collectVarArgMaxConcurrencySuccess() throws Exception {
+    void collectVarArgMaxConcurrencySuccess() throws Exception {
         // Just testing that the method works. As it uses existing operators, we don't require elaborate tests
         mergeAll(1, completed(), completed()).toFuture().get();
     }
 
     @Test
-    public void collectVarArgFailure() throws Exception {
+    void collectVarArgFailure() throws Exception {
         Future<Void> future = mergeAll(failed(DELIBERATE_EXCEPTION), completed()).toFuture();
         try {
             future.get();
@@ -56,7 +56,7 @@ public class CollectTest {
     }
 
     @Test
-    public void collectVarArgDelayError() throws Exception {
+    void collectVarArgDelayError() throws Exception {
         AtomicBoolean secondSubscribed = new AtomicBoolean();
         Future<Void> future = mergeAllDelayError(failed(DELIBERATE_EXCEPTION),
                 completed().beforeOnSubscribe(__ -> secondSubscribed.set(true))).toFuture();
@@ -70,7 +70,7 @@ public class CollectTest {
     }
 
     @Test
-    public void collectVarArgDelayErrorMaxConcurrency() throws Exception {
+    void collectVarArgDelayErrorMaxConcurrency() throws Exception {
         AtomicBoolean secondSubscribed = new AtomicBoolean();
         Future<Void> future = mergeAllDelayError(1, failed(DELIBERATE_EXCEPTION),
                 completed().beforeOnSubscribe(__ -> secondSubscribed.set(true))).toFuture();
@@ -84,18 +84,18 @@ public class CollectTest {
     }
 
     @Test
-    public void collectIterableSuccess() throws Exception {
+    void collectIterableSuccess() throws Exception {
         mergeAll(asList(completed(), completed())).toFuture().get();
     }
 
     @Test
-    public void collectIterableMaxConcurrencySuccess() throws Exception {
+    void collectIterableMaxConcurrencySuccess() throws Exception {
         // Just testing that the method works. As it uses existing operators, we don't require elaborate tests
         mergeAll(asList(completed(), completed()), 1).toFuture().get();
     }
 
     @Test
-    public void collectIterableFailure() throws Exception {
+    void collectIterableFailure() throws Exception {
         Future<Void> future = mergeAll(asList(failed(DELIBERATE_EXCEPTION), completed())).toFuture();
         try {
             future.get();
@@ -106,7 +106,7 @@ public class CollectTest {
     }
 
     @Test
-    public void collectIterableDelayError() throws Exception {
+    void collectIterableDelayError() throws Exception {
         AtomicBoolean secondSubscribed = new AtomicBoolean();
         Future<Void> future = mergeAllDelayError(asList(failed(DELIBERATE_EXCEPTION),
                 completed().beforeOnSubscribe(__ -> secondSubscribed.set(true)))).toFuture();
@@ -120,7 +120,7 @@ public class CollectTest {
     }
 
     @Test
-    public void collectIterableDelayErrorMaxConcurrency() throws Exception {
+    void collectIterableDelayErrorMaxConcurrency() throws Exception {
         AtomicBoolean secondSubscribed = new AtomicBoolean();
         Future<Void> future = mergeAllDelayError(asList(failed(DELIBERATE_EXCEPTION),
                 completed().beforeOnSubscribe(__ -> secondSubscribed.set(true))), 1).toFuture();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithCompletableTest.java
@@ -31,21 +31,21 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CompletableConcatWithCompletableTest {
+class CompletableConcatWithCompletableTest {
 
     private TestCompletableSubscriber subscriber;
     private TestCompletable source;
     private TestCompletable next;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         subscriber = new TestCompletableSubscriber();
         source = new TestCompletable();
         next = new TestCompletable();
     }
 
     @Test
-    public void testSourceSuccessNextSuccess() {
+    void testSourceSuccessNextSuccess() {
         toSource(source.concat(next)).subscribe(subscriber);
         source.onComplete();
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -54,7 +54,7 @@ public class CompletableConcatWithCompletableTest {
     }
 
     @Test
-    public void testSourceSuccessNextError() {
+    void testSourceSuccessNextError() {
         toSource(source.concat(next)).subscribe(subscriber);
         source.onComplete();
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -63,7 +63,7 @@ public class CompletableConcatWithCompletableTest {
     }
 
     @Test
-    public void testSourceError() {
+    void testSourceError() {
         toSource(source.concat(next)).subscribe(subscriber);
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
@@ -71,7 +71,7 @@ public class CompletableConcatWithCompletableTest {
     }
 
     @Test
-    public void testCancelSource() {
+    void testCancelSource() {
         toSource(source.concat(next)).subscribe(subscriber);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
@@ -82,7 +82,7 @@ public class CompletableConcatWithCompletableTest {
     }
 
     @Test
-    public void testCancelNext() {
+    void testCancelNext() {
         toSource(source.concat(next)).subscribe(subscriber);
         source.onComplete();
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithPublisherTest.java
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CompletableConcatWithPublisherTest {
+class CompletableConcatWithPublisherTest {
     private TestPublisherSubscriber<Integer> subscriber;
     private TestCompletable source;
     private TestPublisher<Integer> next;
@@ -42,7 +42,7 @@ public class CompletableConcatWithPublisherTest {
     private TestCancellable cancellable;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         subscriber = new TestPublisherSubscriber<>();
         cancellable = new TestCancellable();
         source = new TestCompletable.Builder().disableAutoOnSubscribe().build();
@@ -54,7 +54,7 @@ public class CompletableConcatWithPublisherTest {
     }
 
     @Test
-    public void bothCompletion() {
+    void bothCompletion() {
         triggerNextSubscribe();
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(1);
@@ -66,7 +66,7 @@ public class CompletableConcatWithPublisherTest {
     }
 
     @Test
-    public void sourceCompletionNextError() {
+    void sourceCompletionNextError() {
         triggerNextSubscribe();
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         next.onError(DELIBERATE_EXCEPTION);
@@ -74,7 +74,7 @@ public class CompletableConcatWithPublisherTest {
     }
 
     @Test
-    public void invalidRequestBeforeNextSubscribe() {
+    void invalidRequestBeforeNextSubscribe() {
         subscriber.awaitSubscription().request(-1);
         triggerNextSubscribe();
         assertThat("Invalid request-n not propagated " + subscription, subscription.requestedEquals(-1),
@@ -82,7 +82,7 @@ public class CompletableConcatWithPublisherTest {
     }
 
     @Test
-    public void invalidRequestAfterNextSubscribe() {
+    void invalidRequestAfterNextSubscribe() {
         triggerNextSubscribe();
         subscriber.awaitSubscription().request(-1);
         assertThat("Invalid request-n not propagated " + subscription, subscription.requestedEquals(-1),
@@ -90,7 +90,7 @@ public class CompletableConcatWithPublisherTest {
     }
 
     @Test
-    public void multipleInvalidRequest() {
+    void multipleInvalidRequest() {
         subscriber.awaitSubscription().request(-1);
         triggerNextSubscribe();
         subscriber.awaitSubscription().request(-10);
@@ -99,7 +99,7 @@ public class CompletableConcatWithPublisherTest {
     }
 
     @Test
-    public void invalidThenValidRequest() {
+    void invalidThenValidRequest() {
         subscriber.awaitSubscription().request(-1);
         subscriber.awaitSubscription().request(10);
         triggerNextSubscribe();
@@ -108,7 +108,7 @@ public class CompletableConcatWithPublisherTest {
     }
 
     @Test
-    public void request0Propagated() {
+    void request0Propagated() {
         subscriber.awaitSubscription().request(0);
         triggerNextSubscribe();
         assertThat("Invalid request-n not propagated " + subscription, subscription.requestedEquals(0),
@@ -116,7 +116,7 @@ public class CompletableConcatWithPublisherTest {
     }
 
     @Test
-    public void request0PropagatedAfterComplete() {
+    void request0PropagatedAfterComplete() {
         source.onComplete();
         subscriber.awaitSubscription().request(0);
         next.onSubscribe(subscription);
@@ -125,7 +125,7 @@ public class CompletableConcatWithPublisherTest {
     }
 
     @Test
-    public void invalidThenValidRequestAcrossNext() {
+    void invalidThenValidRequestAcrossNext() {
         subscriber.awaitSubscription().request(-1);
         triggerNextSubscribe();
         subscriber.awaitSubscription().request(10);
@@ -134,14 +134,14 @@ public class CompletableConcatWithPublisherTest {
     }
 
     @Test
-    public void sourceError() {
+    void sourceError() {
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
         assertFalse(next.isSubscribed(), "Next source subscribed unexpectedly.");
     }
 
     @Test
-    public void cancelSource() {
+    void cancelSource() {
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         assertTrue(cancellable.isCancelled(), "Original completable not cancelled.");
@@ -151,7 +151,7 @@ public class CompletableConcatWithPublisherTest {
     }
 
     @Test
-    public void cancelSourcePostRequest() {
+    void cancelSourcePostRequest() {
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(1);
         subscriber.awaitSubscription().cancel();
@@ -160,7 +160,7 @@ public class CompletableConcatWithPublisherTest {
     }
 
     @Test
-    public void cancelNext() {
+    void cancelNext() {
         triggerNextSubscribe();
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithSingleTest.java
@@ -33,14 +33,14 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CompletableConcatWithSingleTest {
+class CompletableConcatWithSingleTest {
 
     private TestSingleSubscriber<Integer> subscriber;
     private TestCompletable source;
     private TestSingle<Integer> next;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         subscriber = new TestSingleSubscriber<>();
         source = new TestCompletable();
         next = new TestSingle<>();
@@ -48,7 +48,7 @@ public class CompletableConcatWithSingleTest {
     }
 
     @Test
-    public void testSourceSuccessNextSuccess() {
+    void testSourceSuccessNextSuccess() {
         source.onComplete();
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         next.onSuccess(1);
@@ -56,7 +56,7 @@ public class CompletableConcatWithSingleTest {
     }
 
     @Test
-    public void testSourceSuccessNextError() {
+    void testSourceSuccessNextError() {
         source.onComplete();
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         next.onError(DELIBERATE_EXCEPTION);
@@ -64,14 +64,14 @@ public class CompletableConcatWithSingleTest {
     }
 
     @Test
-    public void testSourceError() {
+    void testSourceError() {
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
         assertFalse(next.isSubscribed());
     }
 
     @Test
-    public void testCancelSource() {
+    void testCancelSource() {
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         TestCancellable cancellable = new TestCancellable();
@@ -81,7 +81,7 @@ public class CompletableConcatWithSingleTest {
     }
 
     @Test
-    public void testCancelNext() {
+    void testCancelNext() {
         source.onComplete();
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableDeferTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableDeferTest.java
@@ -32,12 +32,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class CompletableDeferTest {
+class CompletableDeferTest {
 
     private Supplier<Completable> factory;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         @SuppressWarnings("unchecked")
         Supplier<Completable> mock = mock(Supplier.class);
         when(mock.get()).thenReturn(completed());
@@ -45,7 +45,7 @@ public class CompletableDeferTest {
     }
 
     @Test
-    public void testEverySubscribeCreatesNew() {
+    void testEverySubscribeCreatesNew() {
         Completable source = Completable.defer(factory);
         listenAndVerify(source);
         listenAndVerify(source);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToCompletionStageTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToCompletionStageTest.java
@@ -35,35 +35,35 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class CompletableToCompletionStageTest {
+class CompletableToCompletionStageTest {
     private static ExecutorService jdkExecutor;
 
     private LegacyTestCompletable source;
 
     @BeforeAll
-    public static void beforeClass() {
+    static void beforeClass() {
         jdkExecutor = java.util.concurrent.Executors.newCachedThreadPool();
     }
 
     @AfterAll
-    public static void afterClass() {
+    static void afterClass() {
         if (jdkExecutor != null) {
             jdkExecutor.shutdown();
         }
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         source = new LegacyTestCompletable();
     }
 
     @Test
-    public void listenBeforeComplete() throws InterruptedException {
+    void listenBeforeComplete() throws InterruptedException {
         verifyComplete(false);
     }
 
     @Test
-    public void completeBeforeListen() throws InterruptedException {
+    void completeBeforeListen() throws InterruptedException {
         verifyComplete(true);
     }
 
@@ -81,12 +81,12 @@ public class CompletableToCompletionStageTest {
     }
 
     @Test
-    public void listenBeforeError() throws InterruptedException {
+    void listenBeforeError() throws InterruptedException {
         verifyError(false);
     }
 
     @Test
-    public void errorBeforeListen() throws InterruptedException {
+    void errorBeforeListen() throws InterruptedException {
         verifyError(true);
     }
 
@@ -114,14 +114,14 @@ public class CompletableToCompletionStageTest {
     }
 
     @Test
-    public void futureComplete() throws Exception {
+    void futureComplete() throws Exception {
         Future<Void> f = source.toFuture();
         jdkExecutor.execute(source::onComplete);
         f.get();
     }
 
     @Test
-    public void futureFail() {
+    void futureFail() {
         Future<Void> f = source.toFuture();
         jdkExecutor.execute(() -> source.onError(DELIBERATE_EXCEPTION));
         Exception e = assertThrows(ExecutionException.class, () -> f.get());

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToFutureTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToFutureTest.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.api.TestCompletable;
 
 import java.util.concurrent.Future;
 
-public class CompletableToFutureTest extends AbstractToFutureTest<Void> {
+class CompletableToFutureTest extends AbstractToFutureTest<Void> {
 
     private final TestCompletable source = new TestCompletable.Builder().build(subscriber -> {
         subscriber.onSubscribe(mockCancellable);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToPublisherTest.java
@@ -37,14 +37,14 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class CompletableToPublisherTest {
+class CompletableToPublisherTest {
     @RegisterExtension
     final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
 
     private TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
 
     @Test
-    public void invalidRequestNCancelsCompletable() {
+    void invalidRequestNCancelsCompletable() {
         TestCompletable completable = new TestCompletable.Builder().disableAutoOnSubscribe().build();
         toSource(completable.<String>toPublisher()).subscribe(subscriber);
         TestCancellable cancellable = new TestCancellable();
@@ -55,14 +55,14 @@ public class CompletableToPublisherTest {
     }
 
     @Test
-    public void noTerminalSucceeds() {
+    void noTerminalSucceeds() {
         toSource(Completable.completed().<String>toPublisher()).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void subscribeOnOriginalIsPreserved() throws Exception {
+    void subscribeOnOriginalIsPreserved() throws Exception {
         final Thread testThread = currentThread();
         final CountDownLatch analyzed = new CountDownLatch(1);
         ConcurrentLinkedQueue<AssertionError> errors = new ConcurrentLinkedQueue<>();
@@ -88,7 +88,7 @@ public class CompletableToPublisherTest {
     }
 
     @Test
-    public void publishOnOriginalIsPreservedOnComplete() throws Exception {
+    void publishOnOriginalIsPreservedOnComplete() throws Exception {
         ConcurrentLinkedQueue<AssertionError> errors = new ConcurrentLinkedQueue<>();
         TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
         TestCompletable completable = new TestCompletable();
@@ -100,7 +100,7 @@ public class CompletableToPublisherTest {
     }
 
     @Test
-    public void publishOnOriginalIsPreservedOnError() throws Exception {
+    void publishOnOriginalIsPreservedOnError() throws Exception {
         ConcurrentLinkedQueue<AssertionError> errors = new ConcurrentLinkedQueue<>();
         TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
         TestCompletable completable = new TestCompletable();
@@ -113,7 +113,7 @@ public class CompletableToPublisherTest {
     }
 
     @Test
-    public void publishOnOriginalIsPreservedOnInvalidRequestN() throws Exception {
+    void publishOnOriginalIsPreservedOnInvalidRequestN() throws Exception {
         ConcurrentLinkedQueue<AssertionError> errors = new ConcurrentLinkedQueue<>();
         TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
         TestCompletable completable = new TestCompletable();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToSingleTest.java
@@ -32,20 +32,20 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
 
-public class CompletableToSingleTest {
+class CompletableToSingleTest {
     @RegisterExtension
     final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
 
     private TestSingleSubscriber<Void> subscriber = new TestSingleSubscriber<>();
 
     @Test
-    public void noTerminalSucceeds() {
+    void noTerminalSucceeds() {
         toSource(Completable.completed().toSingle()).subscribe(subscriber);
         assertThat(subscriber.awaitOnSuccess(), nullValue());
     }
 
     @Test
-    public void subscribeOnOriginalIsPreserved() throws InterruptedException {
+    void subscribeOnOriginalIsPreserved() throws InterruptedException {
         final Thread testThread = currentThread();
         final CountDownLatch analyzed = new CountDownLatch(1);
         ConcurrentLinkedQueue<AssertionError> errors = new ConcurrentLinkedQueue<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/RepeatTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/RepeatTest.java
@@ -26,10 +26,10 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 
-public class RepeatTest {
+class RepeatTest {
 
     @Test
-    public void repeatValueSupplier() throws Exception {
+    void repeatValueSupplier() throws Exception {
         Collection<Integer> repeats = completed().repeat(count -> count < 2).map(new Function<Object, Integer>() {
             private int count;
 
@@ -42,7 +42,7 @@ public class RepeatTest {
     }
 
     @Test
-    public void repeatWhenValueSupplier() throws Exception {
+    void repeatWhenValueSupplier() throws Exception {
         Collection<Integer> repeats = completed().repeatWhen(count ->
                         count < 2 ? completed() : failed(DELIBERATE_EXCEPTION)).map(
             new Function<Object, Integer>() {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/RunnableCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/RunnableCompletableTest.java
@@ -33,18 +33,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class RunnableCompletableTest {
+class RunnableCompletableTest {
     private static final RuntimeException DELIBERATE_EXCEPTION = new IllegalArgumentException();
 
     private Runnable factory;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         factory = mock(Runnable.class);
     }
 
     @Test
-    public void testEverySubscribeRuns() {
+    void testEverySubscribeRuns() {
         Completable source = Completable.fromRunnable(factory);
         listenAndVerify(source);
         listenAndVerify(source);
@@ -60,7 +60,7 @@ public class RunnableCompletableTest {
     }
 
     @Test
-    public void testOnError() {
+    void testOnError() {
         doThrow(IllegalArgumentException.class).when(factory).run();
         Completable source = Completable.fromRunnable(factory);
         listenAndVerifyError(source);
@@ -76,7 +76,7 @@ public class RunnableCompletableTest {
     }
 
     @Test
-    public void cancelInterrupts() throws Exception {
+    void cancelInterrupts() throws Exception {
         final Completable source = Completable.fromRunnable(factory);
         final CountDownLatch latch = new CountDownLatch(1);
 
@@ -111,7 +111,7 @@ public class RunnableCompletableTest {
     }
 
     @Test
-    public void onSubscribeThrows() {
+    void onSubscribeThrows() {
         final Completable source = Completable.fromRunnable(factory);
 
         final CompletableSource.Subscriber subscriber = mock(CompletableSource.Subscriber.class);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/SimpleSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/SimpleSubscribeTest.java
@@ -27,17 +27,17 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
-public class SimpleSubscribeTest {
+class SimpleSubscribeTest {
 
     @Test
-    public void noRunnable() throws Exception {
+    void noRunnable() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         completed().afterFinally(latch::countDown).subscribe();
         latch.await();
     }
 
     @Test
-    public void runnableThrows() throws Exception {
+    void runnableThrows() throws Exception {
         Runnable onComplete = Mockito.mock(Runnable.class);
         doThrow(DELIBERATE_EXCEPTION).when(onComplete).run();
         CountDownLatch latch = new CountDownLatch(1);
@@ -47,7 +47,7 @@ public class SimpleSubscribeTest {
     }
 
     @Test
-    public void runnableIsInvokedOnComplete() throws Exception {
+    void runnableIsInvokedOnComplete() throws Exception {
         Runnable onComplete = Mockito.mock(Runnable.class);
         CountDownLatch latch = new CountDownLatch(1);
         completed().afterFinally(latch::countDown).subscribe(onComplete);
@@ -56,7 +56,7 @@ public class SimpleSubscribeTest {
     }
 
     @Test
-    public void runnableIsNotInvokedOnError() throws Exception {
+    void runnableIsNotInvokedOnError() throws Exception {
         Runnable onComplete = Mockito.mock(Runnable.class);
         CountDownLatch latch = new CountDownLatch(1);
         failed(DELIBERATE_EXCEPTION).afterFinally(latch::countDown).subscribe(onComplete);
@@ -65,7 +65,7 @@ public class SimpleSubscribeTest {
     }
 
     @Test
-    public void runnableIsNotInvokedWhenCancelled() throws Exception {
+    void runnableIsNotInvokedWhenCancelled() throws Exception {
         Runnable onComplete = Mockito.mock(Runnable.class);
         CountDownLatch latch = new CountDownLatch(1);
         failed(DELIBERATE_EXCEPTION).afterFinally(latch::countDown).subscribe(onComplete).cancel();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/SubscribeShareContextTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/SubscribeShareContextTest.java
@@ -30,19 +30,19 @@ import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class SubscribeShareContextTest {
+class SubscribeShareContextTest {
 
-    public static final AsyncContextMap.Key<String> KEY = AsyncContextMap.Key.newKey("share-context-key");
+    static final AsyncContextMap.Key<String> KEY = AsyncContextMap.Key.newKey("share-context-key");
 
     @Test
-    public void contextIsShared() throws Exception {
+    void contextIsShared() throws Exception {
         AsyncContext.put(KEY, "v1");
         awaitTermination(completed().beforeOnComplete(() -> AsyncContext.put(KEY, "v2")).subscribeShareContext());
         assertThat("Unexpected value found in the context.", AsyncContext.get(KEY), is("v2"));
     }
 
     @Test
-    public void contextIsNotSharedIfNotLastOperator() throws Exception {
+    void contextIsNotSharedIfNotLastOperator() throws Exception {
         // When we support this feature, then we can change this test
         AsyncContext.put(KEY, "v1");
         awaitTermination(completed().beforeOnComplete(() -> AsyncContext.put(KEY, "v2")).subscribeShareContext()

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/SubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/SubscribeTest.java
@@ -21,19 +21,19 @@ import io.servicetalk.concurrent.api.LegacyTestCompletable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public final class SubscribeTest {
+final class SubscribeTest {
 
     private LegacyTestCompletable source;
     private Cancellable cancellable;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         source = new LegacyTestCompletable();
         cancellable = source.subscribe();
     }
 
     @Test
-    public void testCancel() {
+    void testCancel() {
         source.verifyNotCancelled();
         cancellable.cancel();
         source.verifyCancelled();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/TimeoutCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/TimeoutCompletableTest.java
@@ -48,20 +48,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class TimeoutCompletableTest {
+class TimeoutCompletableTest {
     @RegisterExtension
-    public final ExecutorExtension<TestExecutor> executorExtension = ExecutorExtension.withTestExecutor();
+    final ExecutorExtension<TestExecutor> executorExtension = ExecutorExtension.withTestExecutor();
     private final TestCompletableSubscriber listener = new TestCompletableSubscriber();
     private final TestSingle<Integer> source = new TestSingle<>();
     private TestExecutor testExecutor;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         testExecutor = executorExtension.executor();
     }
 
     @Test
-    public void executorScheduleThrows() {
+    void executorScheduleThrows() {
         toSource(source.ignoreElement().timeout(1, NANOSECONDS, new DelegatingExecutor(testExecutor) {
             @Override
             public Cancellable schedule(final Runnable task, final long delay, final TimeUnit unit) {
@@ -76,7 +76,7 @@ public class TimeoutCompletableTest {
     }
 
     @Test
-    public void noDataOnCompletionNoTimeout() {
+    void noDataOnCompletionNoTimeout() {
         init();
 
         source.onSuccess(1);
@@ -87,7 +87,7 @@ public class TimeoutCompletableTest {
     }
 
     @Test
-    public void noDataOnErrorNoTimeout() {
+    void noDataOnErrorNoTimeout() {
         init();
 
         source.onError(DELIBERATE_EXCEPTION);
@@ -98,7 +98,7 @@ public class TimeoutCompletableTest {
     }
 
     @Test
-    public void subscriptionCancelAlsoCancelsTimer() {
+    void subscriptionCancelAlsoCancelsTimer() {
         init();
 
         listener.awaitSubscription().cancel();
@@ -108,7 +108,7 @@ public class TimeoutCompletableTest {
     }
 
     @Test
-    public void noDataAndTimeout() {
+    void noDataAndTimeout() {
         init();
 
         testExecutor.advanceTimeBy(1, NANOSECONDS);
@@ -119,7 +119,7 @@ public class TimeoutCompletableTest {
     }
 
     @Test
-    public void justSubscribeTimeout() {
+    void justSubscribeTimeout() {
         DelayedOnSubscribeCompletable delayedCompletable = new DelayedOnSubscribeCompletable();
 
         init(delayedCompletable, false);
@@ -137,7 +137,7 @@ public class TimeoutCompletableTest {
     }
 
     @Test
-    public void cancelDoesOnError() throws Exception {
+    void cancelDoesOnError() throws Exception {
         DelayedOnSubscribeCompletable delayedCompletable = new DelayedOnSubscribeCompletable();
         init(delayedCompletable, false);
         CountDownLatch cancelLatch = new CountDownLatch(1);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenCancelTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenCancelTest.java
@@ -40,7 +40,7 @@ public abstract class AbstractWhenCancelTest {
     private TestSubscription subscription = new TestSubscription();
 
     @Test
-    public void testCancelAfterEmissions() {
+    void testCancelAfterEmissions() {
         Runnable onCancel = mock(Runnable.class);
         doCancel(publisher, onCancel).subscribe(subscriber);
         publisher.onSubscribe(subscription);
@@ -53,7 +53,7 @@ public abstract class AbstractWhenCancelTest {
     }
 
     @Test
-    public void testCancelNoEmissions() {
+    void testCancelNoEmissions() {
         Runnable onCancel = mock(Runnable.class);
         doCancel(publisher, onCancel).subscribe(subscriber);
         publisher.onSubscribe(subscription);
@@ -63,7 +63,7 @@ public abstract class AbstractWhenCancelTest {
     }
 
     @Test
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         Exception e = assertThrows(DeliberateException.class, () -> {
 
             try {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenFinallyTest.java
@@ -46,7 +46,7 @@ abstract class AbstractWhenFinallyTest {
     private final TerminalSignalConsumer doFinally = mock(TerminalSignalConsumer.class);
 
     @Test
-    public void testForCancelPostEmissions() {
+    void testForCancelPostEmissions() {
         doFinally(publisher, doFinally).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         subscriber.awaitSubscription().request(1);
@@ -59,7 +59,7 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public void testForCancelNoEmissions() {
+    void testForCancelNoEmissions() {
         doFinally(publisher, doFinally).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         subscriber.awaitSubscription().cancel();
@@ -69,7 +69,7 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public void testForCancelPostError() {
+    void testForCancelPostError() {
         doFinally(publisher, doFinally).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         publisher.onError(DELIBERATE_EXCEPTION);
@@ -80,7 +80,7 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public void testForCancelPostComplete() {
+    void testForCancelPostComplete() {
         doFinally(publisher, doFinally).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         assertFalse(subscription.isCancelled());
@@ -92,7 +92,7 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public void testForCompletePostEmissions() {
+    void testForCompletePostEmissions() {
         doFinally(publisher, doFinally).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         subscriber.awaitSubscription().request(1);
@@ -107,7 +107,7 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public void testForCompleteNoEmissions() {
+    void testForCompleteNoEmissions() {
         doFinally(publisher, doFinally).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         subscriber.awaitSubscription().request(1);
@@ -120,7 +120,7 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public void testForErrorPostEmissions() {
+    void testForErrorPostEmissions() {
         doFinally(publisher, doFinally).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         subscriber.awaitSubscription().request(1);
@@ -134,7 +134,7 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public void testForErrorNoEmissions() {
+    void testForErrorNoEmissions() {
         doFinally(publisher, doFinally).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         subscriber.awaitSubscription().request(1);
@@ -146,7 +146,7 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public void testCallbackThrowsErrorOnCancel() {
+    void testCallbackThrowsErrorOnCancel() {
         TerminalSignalConsumer mock = throwableMock(DELIBERATE_EXCEPTION);
         try {
             doFinally(publisher, mock).subscribe(subscriber);
@@ -161,10 +161,10 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public abstract void testCallbackThrowsErrorOnComplete();
+    abstract void testCallbackThrowsErrorOnComplete();
 
     @Test
-    public abstract void testCallbackThrowsErrorOnError();
+    abstract void testCallbackThrowsErrorOnError();
 
     protected abstract <T> PublisherSource<T> doFinally(Publisher<T> publisher, TerminalSignalConsumer signalConsumer);
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenOnCompleteTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenOnCompleteTest.java
@@ -35,7 +35,7 @@ public abstract class AbstractWhenOnCompleteTest {
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
 
     @Test
-    public void testComplete() {
+    void testComplete() {
         Runnable onComplete = mock(Runnable.class);
         toSource(doComplete(publisher, onComplete)).subscribe(subscriber);
         publisher.onComplete();
@@ -44,7 +44,7 @@ public abstract class AbstractWhenOnCompleteTest {
     }
 
     @Test
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         DeliberateException srcEx = new DeliberateException();
         Publisher<String> src = doComplete(Publisher.failed(srcEx), () -> {
             throw DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenOnErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenOnErrorTest.java
@@ -36,7 +36,7 @@ public abstract class AbstractWhenOnErrorTest {
     final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
 
     @Test
-    public void testError() {
+    void testError() {
         @SuppressWarnings("unchecked")
         Consumer<Throwable> onError = mock(Consumer.class);
         doError(publisher, onError).subscribe(subscriber);
@@ -47,7 +47,7 @@ public abstract class AbstractWhenOnErrorTest {
     }
 
     @Test
-    public abstract void testCallbackThrowsError();
+    abstract void testCallbackThrowsError();
 
     protected abstract <T> PublisherSource<T> doError(Publisher<T> publisher, Consumer<Throwable> consumer);
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenOnNextTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenOnNextTest.java
@@ -34,7 +34,7 @@ public abstract class AbstractWhenOnNextTest {
     final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
 
     @Test
-    public void testSingleItem() {
+    void testSingleItem() {
         @SuppressWarnings("unchecked")
         Consumer<String> onNext = mock(Consumer.class);
         toSource(doNext(Publisher.from("Hello"), onNext)).subscribe(subscriber);
@@ -45,7 +45,7 @@ public abstract class AbstractWhenOnNextTest {
     }
 
     @Test
-    public void testMultipleItems() {
+    void testMultipleItems() {
         @SuppressWarnings("unchecked")
         Consumer<String> onNext = mock(Consumer.class);
         toSource(doNext(Publisher.from("Hello", "Hello1"), onNext)).subscribe(subscriber);
@@ -57,7 +57,7 @@ public abstract class AbstractWhenOnNextTest {
     }
 
     @Test
-    public abstract void testCallbackThrowsError();
+    abstract void testCallbackThrowsError();
 
     protected abstract <T> Publisher<T> doNext(Publisher<T> publisher, Consumer<T> consumer);
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenOnSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenOnSubscribeTest.java
@@ -39,12 +39,12 @@ public abstract class AbstractWhenOnSubscribeTest {
 
     @SuppressWarnings("unchecked")
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         doOnSubscribe = mock(Consumer.class);
     }
 
     @Test
-    public void testOnSubscribe() {
+    void testOnSubscribe() {
         toSource(doSubscribe(from("Hello"), doOnSubscribe)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         assertThat(subscriber.takeOnNext(), is("Hello"));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenRequestTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenRequestTest.java
@@ -42,7 +42,7 @@ public abstract class AbstractWhenRequestTest {
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
 
     @Test
-    public void testSingleRequest() {
+    void testSingleRequest() {
         LongConsumer onRequest = mock(LongConsumer.class);
 
         doRequest(publisher, onRequest).subscribe(subscriber);
@@ -54,7 +54,7 @@ public abstract class AbstractWhenRequestTest {
     }
 
     @Test
-    public void testMultiRequest() {
+    void testMultiRequest() {
         LongConsumer onRequest = mock(LongConsumer.class);
 
         doRequest(publisher, onRequest).subscribe(subscriber);
@@ -68,7 +68,7 @@ public abstract class AbstractWhenRequestTest {
     }
 
     @Test
-    public void testRequestNoEmissions() {
+    void testRequestNoEmissions() {
         LongConsumer onRequest = mock(LongConsumer.class);
 
         doRequest(publisher, onRequest).subscribe(subscriber);
@@ -79,7 +79,7 @@ public abstract class AbstractWhenRequestTest {
     }
 
     @Test
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         doRequest(Publisher.from("Hello"), n -> {
             throw DELIBERATE_EXCEPTION;
         }).subscribe(subscriber);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractWhenSubscriberTest.java
@@ -40,7 +40,7 @@ public abstract class AbstractWhenSubscriberTest {
     private final TestPublisherSubscriber<String> finalSubscriber = new TestPublisherSubscriber<>();
 
     @Test
-    public void testOnWithOnComplete() {
+    void testOnWithOnComplete() {
         toSource(doSubscriber(from("Hello"), () -> subscriber)).subscribe(finalSubscriber);
         finalSubscriber.awaitSubscription().request(1);
         assertThat(finalSubscriber.takeOnNext(), is("Hello"));
@@ -50,7 +50,7 @@ public abstract class AbstractWhenSubscriberTest {
     }
 
     @Test
-    public void testOnWithOnError() {
+    void testOnWithOnError() {
         toSource(doSubscriber(Publisher.failed(DeliberateException.DELIBERATE_EXCEPTION), () -> subscriber))
                 .subscribe(finalSubscriber);
         assertThat(finalSubscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterCancelTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterCancelTest.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.api.Publisher;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 
-public class AfterCancelTest extends AbstractWhenCancelTest {
+class AfterCancelTest extends AbstractWhenCancelTest {
     @Override
     protected <T> PublisherSource<T> doCancel(Publisher<T> publisher, Runnable runnable) {
         return toSource(publisher.afterCancel(runnable));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterCompleteTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterCompleteTest.java
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api.publisher;
 
 import io.servicetalk.concurrent.api.Publisher;
 
-public class AfterCompleteTest extends AbstractWhenOnCompleteTest {
+class AfterCompleteTest extends AbstractWhenOnCompleteTest {
 
     @Override
     protected <T> Publisher<T> doComplete(Publisher<T> publisher, Runnable runnable) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterErrorTest.java
@@ -28,7 +28,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class AfterErrorTest extends AbstractWhenOnErrorTest {
+class AfterErrorTest extends AbstractWhenOnErrorTest {
 
     @Override
     protected <T> PublisherSource<T> doError(Publisher<T> publisher, Consumer<Throwable> consumer) {
@@ -37,7 +37,7 @@ public class AfterErrorTest extends AbstractWhenOnErrorTest {
 
     @Override
     @Test
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         DeliberateException srcEx = new DeliberateException();
         doError(Publisher.<String>failed(srcEx), t -> {
             throw DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterFinallyTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class AfterFinallyTest extends AbstractWhenFinallyTest {
+class AfterFinallyTest extends AbstractWhenFinallyTest {
     @Override
     protected <T> PublisherSource<T> doFinally(Publisher<T> publisher, TerminalSignalConsumer signalConsumer) {
         return toSource(publisher.afterFinally(signalConsumer));
@@ -40,7 +40,7 @@ public class AfterFinallyTest extends AbstractWhenFinallyTest {
 
     @Override
     @Test
-    public void testCallbackThrowsErrorOnComplete() {
+    void testCallbackThrowsErrorOnComplete() {
         TerminalSignalConsumer mock = throwableMock(DELIBERATE_EXCEPTION);
         try {
             doFinally(publisher, mock).subscribe(subscriber);
@@ -57,7 +57,7 @@ public class AfterFinallyTest extends AbstractWhenFinallyTest {
 
     @Override
     @Test
-    public void testCallbackThrowsErrorOnError() {
+    void testCallbackThrowsErrorOnError() {
         DeliberateException exception = new DeliberateException();
         TerminalSignalConsumer mock = throwableMock(exception);
         try {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterNextTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterNextTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class AfterNextTest extends AbstractWhenOnNextTest {
+class AfterNextTest extends AbstractWhenOnNextTest {
     @Override
     protected <T> Publisher<T> doNext(Publisher<T> publisher, Consumer<T> consumer) {
         return publisher.afterOnNext(consumer);
@@ -35,7 +35,7 @@ public class AfterNextTest extends AbstractWhenOnNextTest {
 
     @Override
     @Test
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         toSource(doNext(Publisher.from("Hello"), s1 -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(subscriber);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterRequestTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterRequestTest.java
@@ -22,7 +22,7 @@ import java.util.function.LongConsumer;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 
-public class AfterRequestTest extends AbstractWhenRequestTest {
+class AfterRequestTest extends AbstractWhenRequestTest {
     @Override
     protected <T> PublisherSource<T> doRequest(Publisher<T> publisher, LongConsumer consumer) {
         return toSource(publisher.afterRequest(consumer));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterSubscribeTest.java
@@ -28,10 +28,10 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class AfterSubscribeTest extends AbstractWhenOnSubscribeTest {
+class AfterSubscribeTest extends AbstractWhenOnSubscribeTest {
 
     @Test
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         Publisher<String> src = doSubscribe(from("Hello"), s -> {
             throw DELIBERATE_EXCEPTION;
         });

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/AfterSubscriberTest.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.api.Publisher;
 
 import java.util.function.Supplier;
 
-public class AfterSubscriberTest extends AbstractWhenSubscriberTest {
+class AfterSubscriberTest extends AbstractWhenSubscriberTest {
     @Override
     protected <T> Publisher<T> doSubscriber(Publisher<T> publisher,
                                             Supplier<Subscriber<? super T>> subscriberSupplier) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeCancelTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeCancelTest.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.api.Publisher;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 
-public class BeforeCancelTest extends AbstractWhenCancelTest {
+class BeforeCancelTest extends AbstractWhenCancelTest {
     @Override
     protected <T> PublisherSource<T> doCancel(Publisher<T> publisher, Runnable runnable) {
         return toSource(publisher.beforeCancel(runnable));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeCompleteTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeCompleteTest.java
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api.publisher;
 
 import io.servicetalk.concurrent.api.Publisher;
 
-public class BeforeCompleteTest extends AbstractWhenOnCompleteTest {
+class BeforeCompleteTest extends AbstractWhenOnCompleteTest {
 
     @Override
     protected <T> Publisher<T> doComplete(Publisher<T> publisher, Runnable runnable) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeErrorTest.java
@@ -29,7 +29,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class BeforeErrorTest extends AbstractWhenOnErrorTest {
+class BeforeErrorTest extends AbstractWhenOnErrorTest {
 
     @Override
     protected <T> PublisherSource<T> doError(Publisher<T> publisher, Consumer<Throwable> consumer) {
@@ -38,7 +38,7 @@ public class BeforeErrorTest extends AbstractWhenOnErrorTest {
 
     @Override
     @Test
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         DeliberateException srcEx = new DeliberateException();
         this.<String>doError(Publisher.failed(srcEx), t1 -> {
             throw DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeFinallyTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class BeforeFinallyTest extends AbstractWhenFinallyTest {
+class BeforeFinallyTest extends AbstractWhenFinallyTest {
     @Override
     protected <T> PublisherSource<T> doFinally(Publisher<T> publisher, TerminalSignalConsumer signalConsumer) {
         return toSource(publisher.beforeFinally(signalConsumer));
@@ -40,7 +40,7 @@ public class BeforeFinallyTest extends AbstractWhenFinallyTest {
 
     @Override
     @Test
-    public void testCallbackThrowsErrorOnComplete() {
+    void testCallbackThrowsErrorOnComplete() {
         TerminalSignalConsumer mock = throwableMock(DELIBERATE_EXCEPTION);
         doFinally(publisher, mock).subscribe(subscriber);
         assertFalse(subscription.isCancelled());
@@ -55,7 +55,7 @@ public class BeforeFinallyTest extends AbstractWhenFinallyTest {
 
     @Override
     @Test
-    public void testCallbackThrowsErrorOnError() {
+    void testCallbackThrowsErrorOnError() {
         DeliberateException exception = new DeliberateException();
         TerminalSignalConsumer mock = throwableMock(exception);
         doFinally(publisher, mock).subscribe(subscriber);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeNextTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeNextTest.java
@@ -26,7 +26,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class BeforeNextTest extends AbstractWhenOnNextTest {
+class BeforeNextTest extends AbstractWhenOnNextTest {
     @Override
     protected <T> Publisher<T> doNext(Publisher<T> publisher, Consumer<T> consumer) {
         return publisher.beforeOnNext(consumer);
@@ -34,7 +34,7 @@ public class BeforeNextTest extends AbstractWhenOnNextTest {
 
     @Override
     @Test
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         try {
             toSource(doNext(Publisher.from("Hello"), s1 -> {
                 throw DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeRequestTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeRequestTest.java
@@ -22,7 +22,7 @@ import java.util.function.LongConsumer;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 
-public class BeforeRequestTest extends AbstractWhenRequestTest {
+class BeforeRequestTest extends AbstractWhenRequestTest {
     @Override
     protected <T> PublisherSource<T> doRequest(Publisher<T> publisher, LongConsumer consumer) {
         return toSource(publisher.beforeRequest(consumer));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeSubscribeTest.java
@@ -31,10 +31,10 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 
-public class BeforeSubscribeTest extends AbstractWhenOnSubscribeTest {
+class BeforeSubscribeTest extends AbstractWhenOnSubscribeTest {
 
     @Test
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         List<Throwable> failures = new ArrayList<>();
         toSource(doSubscribe(from("Hello"), s -> {
             throw DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/BeforeSubscriberTest.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.api.Publisher;
 
 import java.util.function.Supplier;
 
-public class BeforeSubscriberTest extends AbstractWhenSubscriberTest {
+class BeforeSubscriberTest extends AbstractWhenSubscriberTest {
     @Override
     protected <T> Publisher<T> doSubscriber(Publisher<T> publisher,
                                             Supplier<Subscriber<? super T>> subscriberSupplier) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/ForEachTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/ForEachTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public final class ForEachTest {
+final class ForEachTest {
 
     private TestPublisher<Integer> source;
     private Consumer<Integer> forEach;
@@ -39,7 +39,7 @@ public final class ForEachTest {
 
     @SuppressWarnings("unchecked")
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         source = new TestPublisher.Builder<Integer>().disableAutoOnSubscribe().build();
         forEach = (Consumer<Integer>) mock(Consumer.class);
         cancellable = source.forEach(forEach);
@@ -47,7 +47,7 @@ public final class ForEachTest {
     }
 
     @Test
-    public void testRequestedMax() {
+    void testRequestedMax() {
         source.onNext(1, 2, 3); // Not requested explicitly
         verify(forEach).accept(1);
         verify(forEach).accept(2);
@@ -56,7 +56,7 @@ public final class ForEachTest {
     }
 
     @Test
-    public void testCancel() {
+    void testCancel() {
         assertFalse(subscription.isCancelled());
         cancellable.cancel();
         assertTrue(subscription.isCancelled());

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromArrayPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromArrayPublisherTest.java
@@ -24,7 +24,7 @@ import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class FromArrayPublisherTest extends FromInMemoryPublisherAbstractTest {
+final class FromArrayPublisherTest extends FromInMemoryPublisherAbstractTest {
     @Override
     protected InMemorySource newPublisher(final Executor executor, final String[] values) {
         return new InMemorySource(values) {
@@ -37,7 +37,7 @@ public final class FromArrayPublisherTest extends FromInMemoryPublisherAbstractT
     }
 
     @Test
-    public void testEmptyInvalidRequestAfterCompleteDoesNotDeliverOnError() {
+    void testEmptyInvalidRequestAfterCompleteDoesNotDeliverOnError() {
         InMemorySource source = newSource(0);
         toSource(source.publisher()).subscribe(subscriber);
         subscriber.awaitOnComplete();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromBlockingIterableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromBlockingIterableTest.java
@@ -35,7 +35,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class FromBlockingIterableTest extends FromInMemoryPublisherAbstractTest {
+class FromBlockingIterableTest extends FromInMemoryPublisherAbstractTest {
     @Override
     protected InMemorySource newPublisher(final Executor executor, final String[] values) {
         return newPublisher(executor, values, (timeout, unit) -> { }, (timeout, unit) -> { }, () -> { });
@@ -67,7 +67,7 @@ public class FromBlockingIterableTest extends FromInMemoryPublisherAbstractTest 
     }
 
     @Test
-    public void requestNTimeoutIsCaught() {
+    void requestNTimeoutIsCaught() {
         BiConsumer<Long, TimeUnit> hashNextConsumer = (timeout, unit) -> {
             throw DELIBERATE_EXCEPTION;
         };
@@ -83,7 +83,7 @@ public class FromBlockingIterableTest extends FromInMemoryPublisherAbstractTest 
     }
 
     @Test
-    public void nextWithTimeoutIsCalled() {
+    void nextWithTimeoutIsCalled() {
         BiConsumer<Long, TimeUnit> hashNextConsumer = (timeout, unit) -> {
         };
         BiConsumer<Long, TimeUnit> nextConsumer = (timeout, unit) -> {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromInMemoryPublisherAbstractTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromInMemoryPublisherAbstractTest.java
@@ -51,7 +51,7 @@ public abstract class FromInMemoryPublisherAbstractTest {
     protected abstract InMemorySource newPublisher(Executor executor, String[] values);
 
     @Test
-    public void testRequestAllValues() {
+    void testRequestAllValues() {
         InMemorySource source = newSource(5);
         toSource(source.publisher()).subscribe(subscriber);
         subscriber.awaitSubscription().request(source.values().length);
@@ -60,7 +60,7 @@ public abstract class FromInMemoryPublisherAbstractTest {
     }
 
     @Test
-    public void testRequestInChunks() {
+    void testRequestInChunks() {
         InMemorySource source = newSource(10);
         toSource(source.publisher()).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
@@ -70,7 +70,7 @@ public abstract class FromInMemoryPublisherAbstractTest {
     }
 
     @Test
-    public void testNullAsValue() {
+    void testNullAsValue() {
         String[] values = {"Hello", null};
         InMemorySource source = newPublisher(immediate(), values);
         toSource(source.publisher()).subscribe(subscriber);
@@ -80,7 +80,7 @@ public abstract class FromInMemoryPublisherAbstractTest {
     }
 
     @Test
-    public void testRequestPostComplete() {
+    void testRequestPostComplete() {
         // Due to race between on* and request-n, request-n may arrive after onComplete/onError.
         InMemorySource source = newSource(5);
         toSource(source.publisher()).subscribe(subscriber);
@@ -91,7 +91,7 @@ public abstract class FromInMemoryPublisherAbstractTest {
     }
 
     @Test
-    public void testRequestPostError() {
+    void testRequestPostError() {
         String[] values = {"Hello", null};
         InMemorySource source = newPublisher(immediate(), values);
         toSource(source.publisher().afterOnNext(n -> {
@@ -107,7 +107,7 @@ public abstract class FromInMemoryPublisherAbstractTest {
     }
 
     @Test
-    public void testReentrant() {
+    void testReentrant() {
         InMemorySource source = newSource(6);
         Publisher<String> p = source.publisher().beforeOnNext(s -> subscriber.awaitSubscription().request(5));
         toSource(p).subscribe(subscriber);
@@ -116,7 +116,7 @@ public abstract class FromInMemoryPublisherAbstractTest {
     }
 
     @Test
-    public void testReactiveStreams2_13() {
+    void testReactiveStreams2_13() {
         InMemorySource source = newSource(6);
         Publisher<String> p = source.publisher().beforeOnNext(s -> {
             throw DELIBERATE_EXCEPTION;
@@ -127,13 +127,13 @@ public abstract class FromInMemoryPublisherAbstractTest {
     }
 
     @Test
-    public void testIncompleteRequest() {
+    void testIncompleteRequest() {
         InMemorySource source = newSource(6);
         requestItemsAndVerifyEmissions(source);
     }
 
     @Test
-    public void testCancel() {
+    void testCancel() {
         InMemorySource source = newSource(6);
         requestItemsAndVerifyEmissions(source);
         subscriber.awaitSubscription().cancel();
@@ -145,7 +145,7 @@ public abstract class FromInMemoryPublisherAbstractTest {
     }
 
     @Test
-    public void testCancelFromInOnNext() {
+    void testCancelFromInOnNext() {
         InMemorySource source = newSource(2);
         toSource(source.publisher().afterOnNext(n -> {
             subscriber.awaitSubscription().cancel();
@@ -158,7 +158,7 @@ public abstract class FromInMemoryPublisherAbstractTest {
     }
 
     @Test
-    public void testReentrantInvalidRequestN() throws InterruptedException {
+    void testReentrantInvalidRequestN() throws InterruptedException {
         InMemorySource source = newSource(2);
         CountDownLatch latch = new CountDownLatch(1);
         AtomicReference<Throwable> throwableRef = new AtomicReference<>();
@@ -206,7 +206,7 @@ public abstract class FromInMemoryPublisherAbstractTest {
     }
 
     @Test
-    public void testInvalidRequestNZeroLengthArrayNoMultipleTerminal() {
+    void testInvalidRequestNZeroLengthArrayNoMultipleTerminal() {
         InMemorySource source = newSource(1);
         toSource(source.publisher()).subscribe(subscriber);
         subscriber.awaitSubscription().request(-1);
@@ -215,7 +215,7 @@ public abstract class FromInMemoryPublisherAbstractTest {
     }
 
     @Test
-    public void testInvalidRequestAfterCompleteDoesNotDeliverOnError() {
+    void testInvalidRequestAfterCompleteDoesNotDeliverOnError() {
         InMemorySource source = newSource(1);
         toSource(source.publisher()).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
@@ -225,7 +225,7 @@ public abstract class FromInMemoryPublisherAbstractTest {
     }
 
     @Test
-    public void testOnNextThrows() {
+    void testOnNextThrows() {
         final AtomicReference<AssertionError> assertErrorRef = new AtomicReference<>();
         final AtomicBoolean onErrorCalled = new AtomicBoolean();
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromIterablePublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromIterablePublisherTest.java
@@ -21,7 +21,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import static io.servicetalk.concurrent.api.Publisher.fromIterable;
 import static java.util.Arrays.asList;
 
-public class FromIterablePublisherTest extends FromInMemoryPublisherAbstractTest {
+class FromIterablePublisherTest extends FromInMemoryPublisherAbstractTest {
     @Override
     protected InMemorySource newPublisher(final Executor executor, final String[] values) {
         return new InMemorySource(values) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromSingleItemPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/FromSingleItemPublisherTest.java
@@ -28,12 +28,12 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class FromSingleItemPublisherTest {
+class FromSingleItemPublisherTest {
 
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
 
     @Test
-    public void exceptionInTerminalCallsOnError() {
+    void exceptionInTerminalCallsOnError() {
         toSource(from("foo").afterOnNext(n -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(subscriber);
@@ -43,7 +43,7 @@ public class FromSingleItemPublisherTest {
     }
 
     @Test
-    public void nullInTerminalSucceeds() {
+    void nullInTerminalSucceeds() {
         toSource(Publisher.from((String) null)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         assertThat(subscriber.takeOnNext(), is(nullValue()));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubCompletableOrErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubCompletableOrErrorTest.java
@@ -30,29 +30,29 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class PubCompletableOrErrorTest {
+class PubCompletableOrErrorTest {
     private final TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
 
     @Test
-    public void noElementsCompleted() {
+    void noElementsCompleted() {
         toSource(empty().completableOrError()).subscribe(subscriber);
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void noElementsError() {
+    void noElementsError() {
         toSource(failed(DELIBERATE_EXCEPTION).completableOrError()).subscribe(subscriber);
         assertSame(DELIBERATE_EXCEPTION, subscriber.awaitOnError());
     }
 
     @Test
-    public void oneElementsAlwaysFails() {
+    void oneElementsAlwaysFails() {
         toSource(from("foo").completableOrError()).subscribe(subscriber);
         assertThat(subscriber.awaitOnError(), instanceOf(IllegalArgumentException.class));
     }
 
     @Test
-    public void twoElementsAlwaysFails() {
+    void twoElementsAlwaysFails() {
         // Use TestPublisher to force deliver two items, and verify the operator doesn't duplicate terminate.
         TestPublisher<String> publisher = new TestPublisher<>();
         toSource(publisher.completableOrError()).subscribe(subscriber);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubFirstOrErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubFirstOrErrorTest.java
@@ -34,26 +34,26 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class PubFirstOrErrorTest {
+class PubFirstOrErrorTest {
     @RegisterExtension
     final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
     private final TestSingleSubscriber<String> listenerRule = new TestSingleSubscriber<>();
     private final TestPublisher<String> publisher = new TestPublisher<>();
 
     @Test
-    public void syncSingleItemCompleted() {
+    void syncSingleItemCompleted() {
         toSource(from("hello").firstOrError()).subscribe(listenerRule);
         assertThat(listenerRule.awaitOnSuccess(), is("hello"));
     }
 
     @Test
-    public void syncMultipleItemCompleted() {
+    void syncMultipleItemCompleted() {
         toSource(from("foo", "bar").firstOrError()).subscribe(listenerRule);
         assertThat(listenerRule.awaitOnError(), instanceOf(IllegalArgumentException.class));
     }
 
     @Test
-    public void asyncSingleItemCompleted() throws Exception {
+    void asyncSingleItemCompleted() throws Exception {
         toSource(publisher.firstOrError()).subscribe(listenerRule);
         executorExtension.executor().submit(() -> {
             publisher.onNext("hello");
@@ -63,7 +63,7 @@ public class PubFirstOrErrorTest {
     }
 
     @Test
-    public void asyncMultipleItemCompleted() throws Exception {
+    void asyncMultipleItemCompleted() throws Exception {
         toSource(publisher.firstOrError()).subscribe(listenerRule);
         executorExtension.executor().submit(() -> {
             publisher.onNext("foo", "bar");
@@ -73,14 +73,14 @@ public class PubFirstOrErrorTest {
     }
 
     @Test
-    public void singleItemNoComplete() {
+    void singleItemNoComplete() {
         toSource(publisher.firstOrError()).subscribe(listenerRule);
         publisher.onNext("hello");
         assertThat(listenerRule.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
     @Test
-    public void singleItemErrorPropagates() {
+    void singleItemErrorPropagates() {
         toSource(publisher.firstOrError()).subscribe(listenerRule);
         publisher.onNext("hello");
         publisher.onError(DELIBERATE_EXCEPTION);
@@ -88,21 +88,21 @@ public class PubFirstOrErrorTest {
     }
 
     @Test
-    public void noItemsFails() {
+    void noItemsFails() {
         toSource(publisher.firstOrError()).subscribe(listenerRule);
         publisher.onComplete();
         assertThat(listenerRule.awaitOnError(), instanceOf(NoSuchElementException.class));
     }
 
     @Test
-    public void noItemErrorPropagates() {
+    void noItemErrorPropagates() {
         toSource(publisher.firstOrError()).subscribe(listenerRule);
         publisher.onError(DELIBERATE_EXCEPTION);
         assertThat(listenerRule.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void multipleItemsFails() {
+    void multipleItemsFails() {
         toSource(publisher.firstOrError()).subscribe(listenerRule);
         publisher.onNext("foo", "bar");
         publisher.onComplete();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToCompletableIgnoreTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToCompletableIgnoreTest.java
@@ -38,31 +38,31 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-public class PubToCompletableIgnoreTest {
+class PubToCompletableIgnoreTest {
     @RegisterExtension
     final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
     private final TestCompletableSubscriber listenerRule = new TestCompletableSubscriber();
 
     @Test
-    public void testSuccess() {
+    void testSuccess() {
         listen(from("Hello"));
         listenerRule.awaitOnComplete();
     }
 
     @Test
-    public void testError() {
+    void testError() {
         listen(Publisher.failed(DELIBERATE_EXCEPTION));
         assertThat(listenerRule.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void testEmpty() {
+    void testEmpty() {
         listen(Publisher.empty());
         listenerRule.awaitOnComplete();
     }
 
     @Test
-    public void testEmptyFromRequestN() {
+    void testEmptyFromRequestN() {
         listen(new Publisher<String>() {
             @Override
             protected void handleSubscribe(final Subscriber<? super String> subscriber) {
@@ -73,7 +73,7 @@ public class PubToCompletableIgnoreTest {
     }
 
     @Test
-    public void testErrorFromRequestN() {
+    void testErrorFromRequestN() {
         listen(new Publisher<String>() {
             @Override
             protected void handleSubscribe(final Subscriber<? super String> subscriber) {
@@ -85,7 +85,7 @@ public class PubToCompletableIgnoreTest {
     }
 
     @Test
-    public void subscribeOnOriginalIsPreserved() throws Exception {
+    void subscribeOnOriginalIsPreserved() throws Exception {
         final Thread testThread = currentThread();
         final CountDownLatch analyzed = new CountDownLatch(1);
         ConcurrentLinkedQueue<AssertionError> errors = new ConcurrentLinkedQueue<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToSingleFirstOrElseTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToSingleFirstOrElseTest.java
@@ -43,7 +43,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class PubToSingleFirstOrElseTest {
+class PubToSingleFirstOrElseTest {
     @RegisterExtension
     final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
     private final TestSingleSubscriber<String> listenerRule = new TestSingleSubscriber<>();
@@ -51,25 +51,25 @@ public class PubToSingleFirstOrElseTest {
     private final TestSubscription subscription = new TestSubscription();
 
     @Test
-    public void testSuccess() {
+    void testSuccess() {
         listen(from("Hello"));
         assertThat(listenerRule.awaitOnSuccess(), is("Hello"));
     }
 
     @Test
-    public void testError() {
+    void testError() {
         listen(Publisher.failed(DELIBERATE_EXCEPTION));
         assertThat(listenerRule.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void testEmpty() {
+    void testEmpty() {
         listen(Publisher.empty());
         assertThat(listenerRule.awaitOnError(), instanceOf(NoSuchElementException.class));
     }
 
     @Test
-    public void testCancelled() {
+    void testCancelled() {
         listen(publisher);
         publisher.onSubscribe(subscription);
         publisher.onNext("Hello");
@@ -78,7 +78,7 @@ public class PubToSingleFirstOrElseTest {
     }
 
     @Test
-    public void testErrorPostEmit() {
+    void testErrorPostEmit() {
         listen(publisher);
         publisher.onSubscribe(subscription);
         publisher.onNext("Hello");
@@ -87,7 +87,7 @@ public class PubToSingleFirstOrElseTest {
     }
 
     @Test
-    public void testCompletePostEmit() {
+    void testCompletePostEmit() {
         listen(publisher);
         publisher.onNext("Hello");
         assertThat(listenerRule.awaitOnSuccess(), is("Hello"));
@@ -95,7 +95,7 @@ public class PubToSingleFirstOrElseTest {
     }
 
     @Test
-    public void testEmptyFromRequestN() {
+    void testEmptyFromRequestN() {
         listen(new Publisher<String>() {
             @Override
             protected void handleSubscribe(final Subscriber<? super String> subscriber) {
@@ -106,7 +106,7 @@ public class PubToSingleFirstOrElseTest {
     }
 
     @Test
-    public void testErrorFromRequestN() {
+    void testErrorFromRequestN() {
         listen(new Publisher<String>() {
             @Override
             protected void handleSubscribe(final Subscriber<? super String> subscriber) {
@@ -118,7 +118,7 @@ public class PubToSingleFirstOrElseTest {
     }
 
     @Test
-    public void subscribeOnOriginalIsPreserved() throws Exception {
+    void subscribeOnOriginalIsPreserved() throws Exception {
         final Thread testThread = currentThread();
         final CountDownLatch analyzed = new CountDownLatch(1);
         ConcurrentLinkedQueue<AssertionError> errors = new ConcurrentLinkedQueue<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherAsInputStreamTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherAsInputStreamTest.java
@@ -35,12 +35,12 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class PublisherAsInputStreamTest {
+final class PublisherAsInputStreamTest {
 
     private final TestPublisher<String> publisher = new TestPublisher<>();
 
     @Test
-    public void streamEmitsAllDataInSingleRead() throws IOException {
+    void streamEmitsAllDataInSingleRead() throws IOException {
         Character[] src = {'1', '2', '3', '4'};
         InputStream stream = from(src).toInputStream(c -> new byte[]{(byte) c.charValue()});
         byte[] data = new byte[4];
@@ -51,7 +51,7 @@ public final class PublisherAsInputStreamTest {
     }
 
     @Test
-    public void streamEmitsAllDataInMultipleReads() throws IOException {
+    void streamEmitsAllDataInMultipleReads() throws IOException {
         Character[] src = {'1', '2', '3', '4'};
         InputStream stream = from(src).toInputStream(c -> new byte[]{(byte) c.charValue()});
         byte[] data = new byte[2];
@@ -69,7 +69,7 @@ public final class PublisherAsInputStreamTest {
     }
 
     @Test
-    public void incrementallyFillAnArray() throws IOException {
+    void incrementallyFillAnArray() throws IOException {
         Character[] src = {'1', '2', '3', '4'};
         InputStream stream = from(src).toInputStream(c -> new byte[]{(byte) c.charValue()});
         byte[] data = new byte[4];
@@ -86,7 +86,7 @@ public final class PublisherAsInputStreamTest {
     }
 
     @Test
-    public void readRequestMoreThanDataBuffer() throws IOException {
+    void readRequestMoreThanDataBuffer() throws IOException {
         Character[] src = {'1', '2', '3', '4'};
         InputStream stream = from(src).toInputStream(c -> new byte[]{(byte) c.charValue()});
         byte[] data = new byte[16];
@@ -97,7 +97,7 @@ public final class PublisherAsInputStreamTest {
     }
 
     @Test
-    public void readRequestLessThanDataBuffer() throws IOException {
+    void readRequestLessThanDataBuffer() throws IOException {
         String src = "1234";
         InputStream stream = from(src).toInputStream(str -> str.getBytes(US_ASCII));
         byte[] data = new byte[2];
@@ -107,7 +107,7 @@ public final class PublisherAsInputStreamTest {
     }
 
     @Test
-    public void largerSizeItems() throws IOException {
+    void largerSizeItems() throws IOException {
         InputStream stream = from("123", "45678")
                 .toInputStream(str -> str.getBytes(US_ASCII));
         byte[] data = new byte[4];
@@ -118,7 +118,7 @@ public final class PublisherAsInputStreamTest {
     }
 
     @Test
-    public void streamErrorShouldBeEmittedPostData() throws IOException {
+    void streamErrorShouldBeEmittedPostData() throws IOException {
         DeliberateException de = new DeliberateException();
         Character[] src = {'1', '2', '3', '4'};
         InputStream stream = from(src).concat(Completable.failed(de))
@@ -134,7 +134,7 @@ public final class PublisherAsInputStreamTest {
     }
 
     @Test
-    public void closeThenReadShouldBeInvalid() throws IOException {
+    void closeThenReadShouldBeInvalid() throws IOException {
         Character[] src = {'1', '2', '3', '4'};
         InputStream stream = from(src).toInputStream(c -> new byte[]{(byte) c.charValue()});
         stream.close();
@@ -142,7 +142,7 @@ public final class PublisherAsInputStreamTest {
     }
 
     @Test
-    public void singleByteRead() throws IOException {
+    void singleByteRead() throws IOException {
         Character[] src = {'1'};
         InputStream stream = from(src).toInputStream(c -> new byte[]{(byte) c.charValue()});
         int read = stream.read();
@@ -151,7 +151,7 @@ public final class PublisherAsInputStreamTest {
     }
 
     @Test
-    public void singleByteReadWithEmptyIterable() throws IOException {
+    void singleByteReadWithEmptyIterable() throws IOException {
         Character[] src = {'1'};
         InputStream stream = from(src).toInputStream(c -> new byte[0]);
         assertThat("Unexpected bytes read.", stream.read(), is(-1));
@@ -161,7 +161,7 @@ public final class PublisherAsInputStreamTest {
     }
 
     @Test
-    public void readWithEmptyIterable() throws IOException {
+    void readWithEmptyIterable() throws IOException {
         Character[] src = {'1'};
         InputStream stream = from(src).toInputStream(c -> new byte[0]);
         byte[] r = new byte[1];
@@ -172,7 +172,7 @@ public final class PublisherAsInputStreamTest {
     }
 
     @Test
-    public void zeroLengthReadShouldBeValid() throws IOException {
+    void zeroLengthReadShouldBeValid() throws IOException {
         Character[] src = {'1'};
         InputStream stream = from(src).toInputStream(c -> new byte[]{(byte) c.charValue()});
         byte[] data = new byte[0];
@@ -182,7 +182,7 @@ public final class PublisherAsInputStreamTest {
     }
 
     @Test
-    public void checkAvailableReturnsCorrectlyWithPrefetch() throws IOException {
+    void checkAvailableReturnsCorrectlyWithPrefetch() throws IOException {
         TestPublisher<String> testPublisher = new TestPublisher<>();
         InputStream stream = testPublisher.toInputStream(str -> str.getBytes(US_ASCII));
         assertThat("Unexpected available return type.", stream.available(), is(0));
@@ -196,7 +196,7 @@ public final class PublisherAsInputStreamTest {
     }
 
     @Test
-    public void completionAndEmptyReadShouldIndicateEOF() throws IOException {
+    void completionAndEmptyReadShouldIndicateEOF() throws IOException {
         InputStream stream = from(Publisher.empty()).toInputStream(obj -> new byte[0]);
         byte[] data = new byte[32];
         int read = stream.read(data, 0, 32);
@@ -204,12 +204,12 @@ public final class PublisherAsInputStreamTest {
     }
 
     @Test
-    public void testEmptyIteratorValue() throws IOException {
+    void testEmptyIteratorValue() throws IOException {
         testNullAndEmptyIteratorValue(new byte[0]);
     }
 
     @Test
-    public void testNullIteratorValue() throws IOException {
+    void testNullIteratorValue() throws IOException {
         testNullAndEmptyIteratorValue(null);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherConcatWithCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherConcatWithCompletableTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class PublisherConcatWithCompletableTest {
+class PublisherConcatWithCompletableTest {
 
     private final TestSubscription subscription = new TestSubscription();
     private final TestCancellable cancellable = new TestCancellable();
@@ -38,7 +38,7 @@ public class PublisherConcatWithCompletableTest {
     private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
     private final TestCompletable completable = new TestCompletable();
 
-    public PublisherConcatWithCompletableTest() {
+    PublisherConcatWithCompletableTest() {
         toSource(source.concat(completable)).subscribe(subscriber);
         source.onSubscribe(subscription);
         assertThat("Unexpected termination.", subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -46,7 +46,7 @@ public class PublisherConcatWithCompletableTest {
     }
 
     @Test
-    public void bothComplete() {
+    void bothComplete() {
         subscriber.awaitSubscription().request(1);
         source.onNext(1);
         source.onComplete();
@@ -58,7 +58,7 @@ public class PublisherConcatWithCompletableTest {
     }
 
     @Test
-    public void sourceError() {
+    void sourceError() {
         subscriber.awaitSubscription().request(1);
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
@@ -67,7 +67,7 @@ public class PublisherConcatWithCompletableTest {
     }
 
     @Test
-    public void nextError() {
+    void nextError() {
         subscriber.awaitSubscription().request(1);
         source.onNext(1);
         source.onComplete();
@@ -79,7 +79,7 @@ public class PublisherConcatWithCompletableTest {
     }
 
     @Test
-    public void sourceCancel() {
+    void sourceCancel() {
         subscriber.awaitSubscription().cancel();
         assertThat("Source subscription not cancelled.", subscription.isCancelled(), is(true));
         assertThat("Next source subscribed on cancellation.", completable.isSubscribed(), is(false));
@@ -90,7 +90,7 @@ public class PublisherConcatWithCompletableTest {
     }
 
     @Test
-    public void nextCancel() {
+    void nextCancel() {
         source.onComplete();
         assertThat("Next source not subscribed.", completable.isSubscribed(), is(true));
         subscriber.awaitSubscription().cancel();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherConcatWithSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherConcatWithSingleTest.java
@@ -33,14 +33,14 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class PublisherConcatWithSingleTest {
+class PublisherConcatWithSingleTest {
     private TestSubscription subscription;
     private TestCancellable cancellable;
     private TestPublisher<Long> source;
     private TestPublisherSubscriber<Long> subscriber;
     private TestSingle<Long> single;
 
-    public PublisherConcatWithSingleTest() {
+    PublisherConcatWithSingleTest() {
         initState();
         toSource(source.concat(single)).subscribe(subscriber);
         source.onSubscribe(subscription);
@@ -66,7 +66,7 @@ public class PublisherConcatWithSingleTest {
     }
 
     @Test
-    public void subscriberDemandThenOnNextThrowsSendsOnError() {
+    void subscriberDemandThenOnNextThrowsSendsOnError() {
         initStateOnNextThrows();
         source.onSubscribe(subscription);
         subscriber.awaitSubscription().request(1);
@@ -77,7 +77,7 @@ public class PublisherConcatWithSingleTest {
     }
 
     @Test
-    public void subscriberOnNextThenDemandThrowsSendsOnError() {
+    void subscriberOnNextThenDemandThrowsSendsOnError() {
         initStateOnNextThrows();
         source.onSubscribe(subscription);
         source.onComplete();
@@ -87,12 +87,12 @@ public class PublisherConcatWithSingleTest {
     }
 
     @Test
-    public void bothComplete() {
+    void bothComplete() {
         testBothComplete(2L);
     }
 
     @Test
-    public void publisherEmpty() {
+    void publisherEmpty() {
         completeSource();
         subscriber.awaitSubscription().request(1);
         single.onSuccess(1L);
@@ -100,12 +100,12 @@ public class PublisherConcatWithSingleTest {
     }
 
     @Test
-    public void nextEmitsNull() {
+    void nextEmitsNull() {
         testBothComplete(null);
     }
 
     @Test
-    public void sourceError() {
+    void sourceError() {
         subscriber.awaitSubscription().request(1);
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
@@ -114,7 +114,7 @@ public class PublisherConcatWithSingleTest {
     }
 
     @Test
-    public void nextError() {
+    void nextError() {
         subscriber.awaitSubscription().request(1);
         source.onNext(1L);
         source.onComplete();
@@ -126,7 +126,7 @@ public class PublisherConcatWithSingleTest {
     }
 
     @Test
-    public void sourceCancel() {
+    void sourceCancel() {
         subscriber.awaitSubscription().cancel();
         assertThat("Source subscription not cancelled.", subscription.isCancelled(), is(true));
         assertThat("Next source subscribed on cancellation.", single.isSubscribed(), is(false));
@@ -137,7 +137,7 @@ public class PublisherConcatWithSingleTest {
     }
 
     @Test
-    public void nextCancel() {
+    void nextCancel() {
         source.onComplete();
         assertThat("Next source not subscribed.", single.isSubscribed(), is(true));
         subscriber.awaitSubscription().cancel();
@@ -146,72 +146,72 @@ public class PublisherConcatWithSingleTest {
     }
 
     @Test
-    public void onSuccessBeforeRequest() {
+    void onSuccessBeforeRequest() {
         testOnSuccessBeforeRequest(1L);
     }
 
     @Test
-    public void onSuccessWithNullBeforeRequest() {
+    void onSuccessWithNullBeforeRequest() {
         testOnSuccessBeforeRequest(null);
     }
 
     @Test
-    public void invalidRequestNNegative1BeforeProcessingSingle() {
+    void invalidRequestNNegative1BeforeProcessingSingle() {
         invalidRequestNWhenProcessingSingle(-1, true);
     }
 
     @Test
-    public void invalidRequestNNegative1AfterProcessingSingle() {
+    void invalidRequestNNegative1AfterProcessingSingle() {
         invalidRequestNWhenProcessingSingle(-1, false);
     }
 
     @Test
-    public void invalidRequestNZeroBeforeProcessingSingle() {
+    void invalidRequestNZeroBeforeProcessingSingle() {
         invalidRequestNWhenProcessingSingle(0, true);
     }
 
     @Test
-    public void invalidRequestNZeroAfterProcessingSingle() {
+    void invalidRequestNZeroAfterProcessingSingle() {
         invalidRequestNWhenProcessingSingle(0, false);
     }
 
     @Test
-    public void invalidRequestNLongMinBeforeProcessingSingle() {
+    void invalidRequestNLongMinBeforeProcessingSingle() {
         invalidRequestNWhenProcessingSingle(Long.MIN_VALUE, true);
     }
 
     @Test
-    public void invalidRequestNLongMinAfterProcessingSingle() {
+    void invalidRequestNLongMinAfterProcessingSingle() {
         invalidRequestNWhenProcessingSingle(Long.MIN_VALUE, false);
     }
 
     @Test
-    public void validRequestNAfterInvalidRequestNNegative1AfterProcessingSingle() {
+    void validRequestNAfterInvalidRequestNNegative1AfterProcessingSingle() {
         validRequestNAfterInvalidRequestNWhenProcessingSingle(-1, false);
     }
 
     @Test
-    public void validRequestNAfterInvalidRequestNNegative1BeforeProcessingSingle() {
+    void validRequestNAfterInvalidRequestNNegative1BeforeProcessingSingle() {
         validRequestNAfterInvalidRequestNWhenProcessingSingle(-1, true);
     }
 
     @Test
-    public void validRequestNAfterInvalidRequestNZeroBeforeProcessingSingle() {
+    void validRequestNAfterInvalidRequestNZeroBeforeProcessingSingle() {
         validRequestNAfterInvalidRequestNWhenProcessingSingle(0, true);
     }
 
     @Test
-    public void validRequestNAfterInvalidRequestNZeroAfterProcessingSingle() {
+    void validRequestNAfterInvalidRequestNZeroAfterProcessingSingle() {
         validRequestNAfterInvalidRequestNWhenProcessingSingle(0, false);
     }
 
     @Test
-    public void validRequestNAfterInvalidRequestNLongMinBeforeProcessingSingle() {
+    void validRequestNAfterInvalidRequestNLongMinBeforeProcessingSingle() {
         validRequestNAfterInvalidRequestNWhenProcessingSingle(Long.MIN_VALUE, true);
     }
 
     @Test
-    public void validRequestNAfterInvalidRequestNLongMinAfterProcessingSingle() {
+    void validRequestNAfterInvalidRequestNLongMinAfterProcessingSingle() {
         validRequestNAfterInvalidRequestNWhenProcessingSingle(Long.MIN_VALUE, false);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherDeferTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherDeferTest.java
@@ -32,19 +32,19 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class PublisherDeferTest {
+class PublisherDeferTest {
 
     private Supplier<Publisher<Integer>> factory;
 
     @SuppressWarnings("unchecked")
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         factory = mock(Supplier.class);
         when(factory.get()).thenReturn(empty());
     }
 
     @Test
-    public void testEverySubscribeCreatesNew() {
+    void testEverySubscribeCreatesNew() {
         Publisher<Integer> source = Publisher.defer(factory);
         subscribeAndVerify(source);
         subscribeAndVerify(source);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherToCompletionStageTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PublisherToCompletionStageTest.java
@@ -36,31 +36,31 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class PublisherToCompletionStageTest {
+class PublisherToCompletionStageTest {
 
     private final TestPublisher<String> publisher = new TestPublisher<>();
     private static ExecutorService jdkExecutor;
 
     @BeforeAll
-    public static void beforeClass() {
+    static void beforeClass() {
         jdkExecutor = java.util.concurrent.Executors.newCachedThreadPool();
     }
 
     @AfterAll
-    public static void afterClass() {
+    static void afterClass() {
         if (jdkExecutor != null) {
             jdkExecutor.shutdown();
         }
     }
 
     @Test
-    public void listenBeforeComplete() throws InterruptedException {
+    void listenBeforeComplete() throws InterruptedException {
         verifyComplete(false, false);
         verifyComplete(false, true);
     }
 
     @Test
-    public void completeBeforeListen() throws InterruptedException {
+    void completeBeforeListen() throws InterruptedException {
         verifyComplete(true, false);
         verifyComplete(true, true);
     }
@@ -97,13 +97,13 @@ public class PublisherToCompletionStageTest {
     }
 
     @Test
-    public void listenBeforeError() throws InterruptedException {
+    void listenBeforeError() throws InterruptedException {
         verifyError(false, true);
         verifyError(false, false);
     }
 
     @Test
-    public void errorBeforeListen() throws InterruptedException {
+    void errorBeforeListen() throws InterruptedException {
         verifyError(true, true);
         verifyError(true, false);
     }
@@ -138,14 +138,14 @@ public class PublisherToCompletionStageTest {
     }
 
     @Test
-    public void futureEmptyComplete() throws Exception {
+    void futureEmptyComplete() throws Exception {
         Future<? extends Collection<String>> f = publisher.toFuture();
         jdkExecutor.execute(publisher::onComplete);
         assertThat(f.get(), is(empty()));
     }
 
     @Test
-    public void futureComplete() throws Exception {
+    void futureComplete() throws Exception {
         Future<? extends Collection<String>> f = publisher.toFuture();
         jdkExecutor.execute(() -> {
             publisher.onNext("Hello", "World");
@@ -155,7 +155,7 @@ public class PublisherToCompletionStageTest {
     }
 
     @Test
-    public void futureReduceComplete() throws Exception {
+    void futureReduceComplete() throws Exception {
         Future<StringBuilder> f = publisher.toFuture(StringBuilder::new, (sb, next) -> {
             sb.append(next);
             return sb;
@@ -168,7 +168,7 @@ public class PublisherToCompletionStageTest {
     }
 
     @Test
-    public void futureFail() {
+    void futureFail() {
         Future<? extends Collection<String>> f = publisher.toFuture();
         jdkExecutor.execute(() -> {
             publisher.onNext("Hello", "World");

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RangeIntPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RangeIntPublisherTest.java
@@ -29,25 +29,25 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class RangeIntPublisherTest {
+class RangeIntPublisherTest {
     final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
 
     @Test
-    public void zeroElements() {
+    void zeroElements() {
         toSource(range(Integer.MAX_VALUE, Integer.MAX_VALUE)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void zeroElementsStride() {
+    void zeroElementsStride() {
         toSource(range(-1, -1, 2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void singleElement() {
+    void singleElement() {
         toSource(range(-1, 0)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         assertThat(subscriber.takeOnNext(), is(-1));
@@ -55,7 +55,7 @@ public class RangeIntPublisherTest {
     }
 
     @Test
-    public void singleElementStride() {
+    void singleElementStride() {
         toSource(range(0, 1, 2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         assertThat(subscriber.takeOnNext(), is(0));
@@ -63,7 +63,7 @@ public class RangeIntPublisherTest {
     }
 
     @Test
-    public void multipleElements() {
+    void multipleElements() {
         toSource(range(0, 5)).subscribe(subscriber);
         subscriber.awaitSubscription().request(5);
         assertThat(subscriber.takeOnNext(5), contains(0, 1, 2, 3, 4));
@@ -71,7 +71,7 @@ public class RangeIntPublisherTest {
     }
 
     @Test
-    public void multipleElementsStride() {
+    void multipleElementsStride() {
         toSource(range(0, 10, 3)).subscribe(subscriber);
         subscriber.awaitSubscription().request(4);
         assertThat(subscriber.takeOnNext(4), contains(0, 3, 6, 9));
@@ -79,7 +79,7 @@ public class RangeIntPublisherTest {
     }
 
     @Test
-    public void overflowStride() {
+    void overflowStride() {
         int begin = Integer.MAX_VALUE - 1;
         toSource(range(begin, Integer.MAX_VALUE, 10)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
@@ -88,7 +88,7 @@ public class RangeIntPublisherTest {
     }
 
     @Test
-    public void negativeToPositive() {
+    void negativeToPositive() {
         toSource(range(-2, 3)).subscribe(subscriber);
         subscriber.awaitSubscription().request(5);
         assertThat(subscriber.takeOnNext(5), contains(-2, -1, 0, 1, 2));
@@ -96,7 +96,7 @@ public class RangeIntPublisherTest {
     }
 
     @Test
-    public void negativeToPositiveStride() {
+    void negativeToPositiveStride() {
         toSource(range(-1, Integer.MAX_VALUE, Integer.MAX_VALUE)).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
         assertThat(subscriber.takeOnNext(2), contains(-1, Integer.MAX_VALUE - 1));
@@ -104,7 +104,7 @@ public class RangeIntPublisherTest {
     }
 
     @Test
-    public void allNegative() {
+    void allNegative() {
         toSource(range(-10, -5)).subscribe(subscriber);
         subscriber.awaitSubscription().request(5);
         assertThat(subscriber.takeOnNext(5), contains(-10, -9, -8, -7, -6));
@@ -112,7 +112,7 @@ public class RangeIntPublisherTest {
     }
 
     @Test
-    public void allNegativeStride() {
+    void allNegativeStride() {
         toSource(range(-20, -10, 2)).subscribe(subscriber);
         subscriber.awaitSubscription().request(5);
         assertThat(subscriber.takeOnNext(5), contains(-20, -18, -16, -14, -12));
@@ -120,12 +120,12 @@ public class RangeIntPublisherTest {
     }
 
     @Test
-    public void thrownExceptionTerminatesOnError() {
+    void thrownExceptionTerminatesOnError() {
         thrownExceptionTerminatesOnError(false);
     }
 
     @Test
-    public void thrownExceptionTerminatesOnErrorStride() {
+    void thrownExceptionTerminatesOnErrorStride() {
         thrownExceptionTerminatesOnError(true);
     }
 
@@ -138,7 +138,7 @@ public class RangeIntPublisherTest {
     }
 
     @Test
-    public void reentrantDeliversInOrder() {
+    void reentrantDeliversInOrder() {
         toSource(range(0, 5).whenOnNext(n -> subscriber.awaitSubscription().request(1))).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         assertThat(subscriber.takeOnNext(5), contains(0, 1, 2, 3, 4));
@@ -146,7 +146,7 @@ public class RangeIntPublisherTest {
     }
 
     @Test
-    public void reentrantDeliversInOrderStride() {
+    void reentrantDeliversInOrderStride() {
         toSource(range(5, 15, 4).whenOnNext(n -> subscriber.awaitSubscription().request(1))).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         assertThat(subscriber.takeOnNext(3), contains(5, 9, 13));
@@ -154,12 +154,12 @@ public class RangeIntPublisherTest {
     }
 
     @Test
-    public void reentrantCancelStopsDelivery() {
+    void reentrantCancelStopsDelivery() {
         reentrantCancelStopsDelivery(true);
     }
 
     @Test
-    public void reentrantCancelStopsDeliveryStride() {
+    void reentrantCancelStopsDeliveryStride() {
         reentrantCancelStopsDelivery(false);
     }
 
@@ -175,12 +175,12 @@ public class RangeIntPublisherTest {
     }
 
     @Test
-    public void requestNAfterCancelIsNoop() {
+    void requestNAfterCancelIsNoop() {
         requestNAfterCancelIsNoop(false);
     }
 
     @Test
-    public void requestNAfterCancelIsNoopStride() {
+    void requestNAfterCancelIsNoopStride() {
         requestNAfterCancelIsNoop(true);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class RepeatTest {
+class RepeatTest {
 
     private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
     private final TestPublisher<Integer> source = new TestPublisher<>();
@@ -48,13 +48,13 @@ public class RepeatTest {
     private boolean shouldRepeatValue;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         when(shouldRepeat.test(anyInt())).thenAnswer(invocation -> shouldRepeatValue);
         toSource(source.repeat(shouldRepeat)).subscribe(subscriber);
     }
 
     @Test
-    public void testError() {
+    void testError() {
         subscriber.awaitSubscription().request(2);
         source.onNext(1, 2);
         source.onError(DELIBERATE_EXCEPTION);
@@ -64,7 +64,7 @@ public class RepeatTest {
     }
 
     @Test
-    public void testRepeatCount() {
+    void testRepeatCount() {
         subscriber.awaitSubscription().request(2);
         source.onNext(1, 2);
         source.onComplete();
@@ -75,7 +75,7 @@ public class RepeatTest {
     }
 
     @Test
-    public void testRequestAcrossRepeat() {
+    void testRequestAcrossRepeat() {
         shouldRepeatValue = true;
         subscriber.awaitSubscription().request(3);
         source.onNext(1, 2);
@@ -89,7 +89,7 @@ public class RepeatTest {
     }
 
     @Test
-    public void testTwoCompletes() {
+    void testTwoCompletes() {
         shouldRepeatValue = true;
         subscriber.awaitSubscription().request(3);
         source.onNext(1, 2);
@@ -107,7 +107,7 @@ public class RepeatTest {
     }
 
     @Test
-    public void testMaxRepeats() {
+    void testMaxRepeats() {
         shouldRepeatValue = true;
         subscriber.awaitSubscription().request(3);
         source.onNext(1, 2);
@@ -121,7 +121,7 @@ public class RepeatTest {
     }
 
     @Test
-    public void testCancel() {
+    void testCancel() {
         final TestSubscription subscription = new TestSubscription();
         source.onSubscribe(subscription);
         subscriber.awaitSubscription().request(2);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatWhenTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatWhenTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class RepeatWhenTest {
+class RepeatWhenTest {
 
     private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
     private TestPublisher<Integer> source;
@@ -58,14 +58,14 @@ public class RepeatWhenTest {
     private Executor executor;
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         if (executor != null) {
             executor.closeAsync().toFuture().get();
         }
     }
 
     @Test
-    public void publishOnWithRepeat() throws Exception {
+    void publishOnWithRepeat() throws Exception {
         // This is an indication of whether we are using the same offloader across different subscribes. If this works,
         // then it does not really matter if we reuse offloaders or not. eg: if tomorrow we do not hold up a thread for
         // the lifetime of the Subscriber, we can reuse the offloader.
@@ -78,7 +78,7 @@ public class RepeatWhenTest {
     }
 
     @Test
-    public void testError() {
+    void testError() {
         init();
         subscriber.awaitSubscription().request(2);
         source.onNext(1, 2);
@@ -89,7 +89,7 @@ public class RepeatWhenTest {
     }
 
     @Test
-    public void testRepeatCount() {
+    void testRepeatCount() {
         init();
         subscriber.awaitSubscription().request(2);
         source.onNext(1, 2);
@@ -101,7 +101,7 @@ public class RepeatWhenTest {
     }
 
     @Test
-    public void testRequestAcrossRepeat() {
+    void testRequestAcrossRepeat() {
         init();
         subscriber.awaitSubscription().request(3);
         source.onNext(1, 2);
@@ -116,7 +116,7 @@ public class RepeatWhenTest {
     }
 
     @Test
-    public void testTwoCompletes() {
+    void testTwoCompletes() {
         init();
         subscriber.awaitSubscription().request(3);
         source.onNext(1, 2);
@@ -136,7 +136,7 @@ public class RepeatWhenTest {
     }
 
     @Test
-    public void testMaxRepeats() {
+    void testMaxRepeats() {
         init();
         subscriber.awaitSubscription().request(3);
         source.onNext(1, 2);
@@ -152,7 +152,7 @@ public class RepeatWhenTest {
     }
 
     @Test
-    public void testCancelPostCompleteButBeforeRetryStart() {
+    void testCancelPostCompleteButBeforeRetryStart() {
         SequentialPublisherSubscriberFunction<Integer> sequentialPublisherSubscriberFunction =
                 new SequentialPublisherSubscriberFunction<>();
         init(new TestPublisher.Builder<Integer>()
@@ -170,7 +170,7 @@ public class RepeatWhenTest {
     }
 
     @Test
-    public void testCancelBeforeRetry() {
+    void testCancelBeforeRetry() {
         init();
         final TestSubscription subscription = new TestSubscription();
         source.onSubscribe(subscription);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RetryTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RetryTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class RetryTest {
+class RetryTest {
 
     private TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
     private TestPublisher<Integer> source;
@@ -52,7 +52,7 @@ public class RetryTest {
 
     @SuppressWarnings("unchecked")
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         source = new TestPublisher<>();
         shouldRetry = (BiIntPredicate<Throwable>) mock(BiIntPredicate.class);
         when(shouldRetry.test(anyInt(), any())).thenAnswer(invocation -> shouldRetryValue);
@@ -60,7 +60,7 @@ public class RetryTest {
     }
 
     @Test
-    public void testComplete() {
+    void testComplete() {
         subscriber.awaitSubscription().request(2);
         source.onNext(1, 2);
         source.onComplete();
@@ -70,7 +70,7 @@ public class RetryTest {
     }
 
     @Test
-    public void testRetryCount() {
+    void testRetryCount() {
         subscriber.awaitSubscription().request(2);
         source.onNext(1, 2);
         source.onError(DELIBERATE_EXCEPTION);
@@ -81,7 +81,7 @@ public class RetryTest {
     }
 
     @Test
-    public void testRequestAcrossRetry() {
+    void testRequestAcrossRetry() {
         shouldRetryValue = true;
         subscriber.awaitSubscription().request(3);
         source.onNext(1, 2);
@@ -95,7 +95,7 @@ public class RetryTest {
     }
 
     @Test
-    public void testTwoFailures() {
+    void testTwoFailures() {
         shouldRetryValue = true;
         subscriber.awaitSubscription().request(3);
         source.onNext(1, 2);
@@ -113,7 +113,7 @@ public class RetryTest {
     }
 
     @Test
-    public void testMaxRetries() {
+    void testMaxRetries() {
         shouldRetryValue = true;
         subscriber.awaitSubscription().request(3);
         source.onNext(1, 2);
@@ -128,7 +128,7 @@ public class RetryTest {
     }
 
     @Test
-    public void testCancel() {
+    void testCancel() {
         final TestSubscription subscription = new TestSubscription();
         source.onSubscribe(subscription);
         subscriber.awaitSubscription().request(2);
@@ -140,7 +140,7 @@ public class RetryTest {
     }
 
     @Test
-    public void exceptionInTerminalCallsOnError() {
+    void exceptionInTerminalCallsOnError() {
         DeliberateException ex = new DeliberateException();
         subscriber = new TestPublisherSubscriber<>();
         source = new TestPublisher<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RetryWhenTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RetryWhenTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class RetryWhenTest {
+class RetryWhenTest {
 
     private TestPublisher<Integer> source = new TestPublisher<>();
     private TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
@@ -64,7 +64,7 @@ public class RetryWhenTest {
 
     @BeforeEach
     @SuppressWarnings("unchecked")
-    public void setUp() {
+    void setUp() {
         shouldRetry = (BiIntFunction<Throwable, Completable>) mock(BiIntFunction.class);
         retrySignal = new LegacyTestCompletable();
         when(shouldRetry.apply(anyInt(), any())).thenAnswer(invocation -> {
@@ -75,14 +75,14 @@ public class RetryWhenTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         if (executor != null) {
             executor.closeAsync().toFuture().get();
         }
     }
 
     @Test
-    public void publishOnWithRetry() {
+    void publishOnWithRetry() {
         // This is an indication of whether we are using the same offloader across different subscribes. If this works,
         // then it does not really matter if we reuse offloaders or not. eg: if tomorrow we do not hold up a thread for
         // the lifetime of the Subscriber, we can reuse the offloader.
@@ -101,7 +101,7 @@ public class RetryWhenTest {
     }
 
     @Test
-    public void testComplete() {
+    void testComplete() {
         subscriber.awaitSubscription().request(2);
         source.onNext(1, 2);
         source.onComplete();
@@ -111,7 +111,7 @@ public class RetryWhenTest {
     }
 
     @Test
-    public void testRetryCount() {
+    void testRetryCount() {
         subscriber.awaitSubscription().request(2);
         source.onNext(1, 2);
         source.onError(DELIBERATE_EXCEPTION);
@@ -124,7 +124,7 @@ public class RetryWhenTest {
     }
 
     @Test
-    public void testRequestAcrossRepeat() {
+    void testRequestAcrossRepeat() {
         subscriber.awaitSubscription().request(3);
         source.onNext(1, 2);
         source.onError(DELIBERATE_EXCEPTION);
@@ -138,7 +138,7 @@ public class RetryWhenTest {
     }
 
     @Test
-    public void testTwoError() {
+    void testTwoError() {
         subscriber.awaitSubscription().request(3);
         source.onNext(1, 2);
         source.onError(DELIBERATE_EXCEPTION);
@@ -157,7 +157,7 @@ public class RetryWhenTest {
     }
 
     @Test
-    public void testMaxRetries() {
+    void testMaxRetries() {
         subscriber.awaitSubscription().request(3);
         source.onNext(1, 2);
         source.onError(DELIBERATE_EXCEPTION);
@@ -173,7 +173,7 @@ public class RetryWhenTest {
     }
 
     @Test
-    public void testCancelPostErrorButBeforeRetryStart() {
+    void testCancelPostErrorButBeforeRetryStart() {
         subscriber.awaitSubscription().request(2);
         source.onNext(1, 2);
         source.onError(DELIBERATE_EXCEPTION);
@@ -185,7 +185,7 @@ public class RetryWhenTest {
     }
 
     @Test
-    public void testCancelBeforeRetry() {
+    void testCancelBeforeRetry() {
         final TestSubscription subscription = new TestSubscription();
         source.onSubscribe(subscription);
         subscriber.awaitSubscription().request(2);
@@ -197,7 +197,7 @@ public class RetryWhenTest {
     }
 
     @Test
-    public void exceptionInTerminalCallsOnError() {
+    void exceptionInTerminalCallsOnError() {
         DeliberateException ex = new DeliberateException();
         subscriber = new TestPublisherSubscriber<>();
         source = new TestPublisher<>();
@@ -212,7 +212,7 @@ public class RetryWhenTest {
     }
 
     @Test
-    public void nullInTerminalCallsOnError() {
+    void nullInTerminalCallsOnError() {
         source = new TestPublisher.Builder<Integer>().disableAutoOnSubscribe().build();
         toSource(source.retryWhen((times1, cause1) -> null)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/ScalarResultPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/ScalarResultPublisherTest.java
@@ -29,12 +29,12 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class ScalarResultPublisherTest {
+class ScalarResultPublisherTest {
 
     private TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
 
     @Test
-    public void testJust() {
+    void testJust() {
         toSource(from("Hello")).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         assertThat(subscriber.takeOnNext(), is("Hello"));
@@ -42,19 +42,19 @@ public class ScalarResultPublisherTest {
     }
 
     @Test
-    public void testError() {
+    void testError() {
         toSource(Publisher.<String>failed(DELIBERATE_EXCEPTION)).subscribe(subscriber);
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void testEmpty() {
+    void testEmpty() {
         toSource(Publisher.<String>empty()).subscribe(subscriber);
         subscriber.awaitOnComplete();
     }
 
     @Test
-    public void testNever() {
+    void testNever() {
         toSource(Publisher.<String>never()).subscribe(subscriber);
         subscriber.awaitSubscription();
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/SubscribeShareContextTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/SubscribeShareContextTest.java
@@ -30,12 +30,12 @@ import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class SubscribeShareContextTest {
+class SubscribeShareContextTest {
 
-    public static final AsyncContextMap.Key<String> KEY = AsyncContextMap.Key.newKey("share-context-key");
+    static final AsyncContextMap.Key<String> KEY = AsyncContextMap.Key.newKey("share-context-key");
 
     @Test
-    public void contextIsShared() throws Exception {
+    void contextIsShared() throws Exception {
         AsyncContext.put(KEY, "v1");
         // publisher.toFuture() will use the toSingle() conversion and share context operator will not be effective
         // since it isn't the last operator. So we directly subscribe to the publisher.
@@ -44,7 +44,7 @@ public class SubscribeShareContextTest {
     }
 
     @Test
-    public void contextIsNotSharedIfNotLastOperator() throws Exception {
+    void contextIsNotSharedIfNotLastOperator() throws Exception {
         // When we support this feature, then we can change this test
         AsyncContext.put(KEY, "v1");
         // publisher.toFuture() will use the toSingle() conversion and share context operator will not be effective

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/TimeoutPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/TimeoutPublisherTest.java
@@ -62,7 +62,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class TimeoutPublisherTest {
+class TimeoutPublisherTest {
 
     private enum TimerBehaviorParam {
         IDLE_TIMER { // timeout : idle
@@ -83,7 +83,7 @@ public class TimeoutPublisherTest {
     }
 
     @RegisterExtension
-    public final ExecutorExtension<TestExecutor> executorExtension = ExecutorExtension.withTestExecutor();
+    final ExecutorExtension<TestExecutor> executorExtension = ExecutorExtension.withTestExecutor();
 
     private final TestPublisher<Integer> publisher = new TestPublisher<>();
     private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
@@ -91,12 +91,12 @@ public class TimeoutPublisherTest {
     private TestExecutor testExecutor;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         testExecutor = executorExtension.executor();
     }
 
     @Test
-    public void executorScheduleThrowsTerminalTimeout() {
+    void executorScheduleThrowsTerminalTimeout() {
         toSource(publisher.timeoutTerminal(1, NANOSECONDS, new DelegatingExecutor(testExecutor) {
             @Override
             public Cancellable schedule(final Runnable task, final long delay, final TimeUnit unit) {
@@ -110,7 +110,7 @@ public class TimeoutPublisherTest {
     }
 
     @Test
-    public void executorScheduleThrowsIdleTimeout() {
+    void executorScheduleThrowsIdleTimeout() {
         toSource(publisher.timeout(1, NANOSECONDS, new DelegatingExecutor(testExecutor) {
             @Override
             public Cancellable schedule(final Runnable task, final long delay, final TimeUnit unit) {
@@ -125,7 +125,7 @@ public class TimeoutPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(TimerBehaviorParam.class)
-    public void noDataOnCompletionNoTimeout(TimerBehaviorParam params) {
+    void noDataOnCompletionNoTimeout(TimerBehaviorParam params) {
         init(params);
 
         subscriber.awaitSubscription().request(10);
@@ -140,7 +140,7 @@ public class TimeoutPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(TimerBehaviorParam.class)
-    public void dataOnCompletionNoTimeout(TimerBehaviorParam params) {
+    void dataOnCompletionNoTimeout(TimerBehaviorParam params) {
         init(params);
 
         subscriber.awaitSubscription().request(10);
@@ -157,7 +157,7 @@ public class TimeoutPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(TimerBehaviorParam.class)
-    public void noDataOnErrorNoTimeout(TimerBehaviorParam params) {
+    void noDataOnErrorNoTimeout(TimerBehaviorParam params) {
         init(params);
 
         subscriber.awaitSubscription().request(10);
@@ -172,7 +172,7 @@ public class TimeoutPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(TimerBehaviorParam.class)
-    public void dataOnErrorNoTimeout(TimerBehaviorParam params) {
+    void dataOnErrorNoTimeout(TimerBehaviorParam params) {
         init(params);
 
         subscriber.awaitSubscription().request(10);
@@ -189,7 +189,7 @@ public class TimeoutPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(TimerBehaviorParam.class)
-    public void subscriptionCancelAlsoCancelsTimer(TimerBehaviorParam params) {
+    void subscriptionCancelAlsoCancelsTimer(TimerBehaviorParam params) {
         init(params);
 
         subscriber.awaitSubscription().cancel();
@@ -200,7 +200,7 @@ public class TimeoutPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(TimerBehaviorParam.class)
-    public void noDataAndTimeout(TimerBehaviorParam params) {
+    void noDataAndTimeout(TimerBehaviorParam params) {
         init(params);
 
         testExecutor.advanceTimeBy(1, NANOSECONDS);
@@ -212,7 +212,7 @@ public class TimeoutPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(TimerBehaviorParam.class)
-    public void dataAndTimeout(TimerBehaviorParam params) throws Exception {
+    void dataAndTimeout(TimerBehaviorParam params) throws Exception {
         final long millisMultiplier = 100;
         init(params, Duration.ofMillis(2 * millisMultiplier));
 
@@ -257,7 +257,7 @@ public class TimeoutPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(TimerBehaviorParam.class)
-    public void justSubscribeTimeout(TimerBehaviorParam params) {
+    void justSubscribeTimeout(TimerBehaviorParam params) {
         DelayedOnSubscribePublisher<Integer> delayedPublisher = new DelayedOnSubscribePublisher<>();
 
         init(delayedPublisher, params, Duration.ofNanos(1), false);
@@ -275,7 +275,7 @@ public class TimeoutPublisherTest {
     }
 
     @Test
-    public void concurrentTimeoutInvocation() throws InterruptedException {
+    void concurrentTimeoutInvocation() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(2);
         AtomicReference<Throwable> causeRef = new AtomicReference<>();
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractFutureToSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractFutureToSingleTest.java
@@ -22,6 +22,7 @@ import io.servicetalk.concurrent.api.Single;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -42,16 +43,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public abstract class AbstractFutureToSingleTest {
-    static ExecutorService jdkExecutor;
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractFutureToSingleTest {
+    protected ExecutorService jdkExecutor;
 
     @BeforeAll
-    public static void beforeClass() {
+    void beforeClass() {
         jdkExecutor = Executors.newCachedThreadPool();
     }
 
     @AfterAll
-    public static void afterClass() {
+    void afterClass() {
         if (jdkExecutor != null) {
             jdkExecutor.shutdown();
         }
@@ -60,7 +62,7 @@ public abstract class AbstractFutureToSingleTest {
     abstract Single<String> from(CompletableFuture<String> future);
 
     @Test
-    public void completion() throws Exception {
+    void completion() throws Exception {
         CompletableFuture<String> future = new CompletableFuture<>();
         Single<String> single = from(future);
         jdkExecutor.execute(() -> future.complete("foo"));
@@ -68,7 +70,7 @@ public abstract class AbstractFutureToSingleTest {
     }
 
     @Test
-    public void timeout() {
+    void timeout() {
         CompletableFuture<String> future = new CompletableFuture<>();
         Single<String> single = from(future).timeout(1, MILLISECONDS);
         Exception e = assertThrows(ExecutionException.class, () -> single.toFuture().get());
@@ -77,7 +79,7 @@ public abstract class AbstractFutureToSingleTest {
     }
 
     @Test
-    public void cancellation() throws InterruptedException {
+    void cancellation() throws InterruptedException {
         CompletableFuture<String> future = new CompletableFuture<>();
         Single<String> single = from(future);
         toSource(single).subscribe(new SingleSource.Subscriber<String>() {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenCancelTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenCancelTest.java
@@ -35,7 +35,7 @@ public abstract class AbstractWhenCancelTest {
     private final TestSingleSubscriber<String> listener = new TestSingleSubscriber<>();
 
     @Test
-    public void testCancelAfterSuccess() {
+    void testCancelAfterSuccess() {
         Runnable onCancel = Mockito.mock(Runnable.class);
         toSource(doCancel(Single.succeeded("Hello"), onCancel)).subscribe(listener);
         listener.awaitSubscription().cancel();
@@ -43,7 +43,7 @@ public abstract class AbstractWhenCancelTest {
     }
 
     @Test
-    public void testCancelNoEmissions() {
+    void testCancelNoEmissions() {
         Runnable onCancel = Mockito.mock(Runnable.class);
         toSource(doCancel(Single.<String>never(), onCancel)).subscribe(listener);
         listener.awaitSubscription().cancel();
@@ -51,7 +51,7 @@ public abstract class AbstractWhenCancelTest {
     }
 
     @Test
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         LegacyTestSingle<String> single = new LegacyTestSingle<>();
 
         Exception e = assertThrows(DeliberateException.class, () -> {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenFinallyTest.java
@@ -43,7 +43,7 @@ abstract class AbstractWhenFinallyTest {
     private final SingleTerminalSignalConsumer<String> doFinally = mock(SingleTerminalSignalConsumer.class);
 
     @Test
-    public void testForCancel() {
+    void testForCancel() {
         toSource(Single.<String>never().afterFinally(doFinally)).subscribe(listener);
         listener.awaitSubscription().cancel();
         verify(doFinally).cancel();
@@ -51,7 +51,7 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public void testForCancelPostSuccess() {
+    void testForCancelPostSuccess() {
         String result = "Hello";
         toSource(doFinally(Single.succeeded(result), doFinally)).subscribe(listener);
         listener.awaitSubscription().cancel();
@@ -60,7 +60,7 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public void testForCancelPostError() {
+    void testForCancelPostError() {
         toSource(doFinally(Single.failed(DELIBERATE_EXCEPTION), doFinally)).subscribe(listener);
         listener.awaitSubscription().cancel();
         verify(doFinally).onError(DELIBERATE_EXCEPTION);
@@ -68,7 +68,7 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public void testForSuccess() {
+    void testForSuccess() {
         String result = "Hello";
         toSource(doFinally(Single.succeeded(result), doFinally)).subscribe(listener);
         assertThat(listener.awaitOnSuccess(), is(result));
@@ -78,7 +78,7 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public void testForError() {
+    void testForError() {
         toSource(doFinally(Single.failed(DELIBERATE_EXCEPTION), doFinally)).subscribe(listener);
         assertThat(listener.awaitOnError(), is(DELIBERATE_EXCEPTION));
         verify(doFinally).onError(DELIBERATE_EXCEPTION);
@@ -86,7 +86,7 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public void testCallbackThrowsErrorOnCancel() {
+    void testCallbackThrowsErrorOnCancel() {
         SingleTerminalSignalConsumer<String> mock = throwableMock(DELIBERATE_EXCEPTION);
         LegacyTestSingle<String> single = new LegacyTestSingle<>();
         try {
@@ -101,10 +101,10 @@ abstract class AbstractWhenFinallyTest {
     }
 
     @Test
-    public abstract void testCallbackThrowsErrorOnSuccess();
+    abstract void testCallbackThrowsErrorOnSuccess();
 
     @Test
-    public abstract void testCallbackThrowsErrorOnError();
+    abstract void testCallbackThrowsErrorOnError();
 
     protected abstract <T> Single<T> doFinally(Single<T> single, SingleTerminalSignalConsumer<T> signalConsumer);
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenOnErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenOnErrorTest.java
@@ -34,7 +34,7 @@ public abstract class AbstractWhenOnErrorTest {
     private final TestSingleSubscriber<String> listener = new TestSingleSubscriber<>();
 
     @Test
-    public void testError() {
+    void testError() {
         @SuppressWarnings("unchecked")
         Consumer<Throwable> onError = Mockito.mock(Consumer.class);
         toSource(doError(Single.<String>failed(DELIBERATE_EXCEPTION), onError)).subscribe(listener);
@@ -43,7 +43,7 @@ public abstract class AbstractWhenOnErrorTest {
     }
 
     @Test
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         DeliberateException srcEx = new DeliberateException();
         toSource(doError(Single.<String>failed(srcEx), t -> {
             throw DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenOnSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenOnSubscribeTest.java
@@ -38,12 +38,12 @@ public abstract class AbstractWhenOnSubscribeTest {
 
     @SuppressWarnings("unchecked")
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         doOnListen = mock(Consumer.class);
     }
 
     @Test
-    public void testSubscribe() {
+    void testSubscribe() {
         toSource(doSubscribe(Single.succeeded("Hello"), doOnListen)).subscribe(listener);
         assertThat(listener.awaitOnSuccess(), is("Hello"));
         verify(doOnListen).accept(any(Cancellable.class));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenOnSuccessTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenOnSuccessTest.java
@@ -32,7 +32,7 @@ public abstract class AbstractWhenOnSuccessTest {
     final TestSingleSubscriber<String> listener = new TestSingleSubscriber<>();
 
     @Test
-    public void testSuccess() {
+    void testSuccess() {
         @SuppressWarnings("unchecked")
         Consumer<String> onSuccess = Mockito.mock(Consumer.class);
         toSource(doSuccess(Single.succeeded("Hello"), onSuccess)).subscribe(listener);
@@ -41,7 +41,7 @@ public abstract class AbstractWhenOnSuccessTest {
     }
 
     @Test
-    public abstract void testCallbackThrowsError();
+    abstract void testCallbackThrowsError();
 
     protected abstract <T> Single<T> doSuccess(Single<T> single, Consumer<T> consumer);
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AbstractWhenSubscriberTest.java
@@ -40,12 +40,12 @@ public abstract class AbstractWhenSubscriberTest {
 
     @SuppressWarnings("unchecked")
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         subscriber = mock(SingleSource.Subscriber.class);
     }
 
     @Test
-    public void testOnWithOnSuccess() {
+    void testOnWithOnSuccess() {
         toSource(doSubscriber(Single.succeeded("Hello"), () -> subscriber)).subscribe(listener);
         assertThat(listener.awaitOnSuccess(), is("Hello"));
         verify(subscriber).onSubscribe(any());
@@ -53,7 +53,7 @@ public abstract class AbstractWhenSubscriberTest {
     }
 
     @Test
-    public void testOnWithOnError() {
+    void testOnWithOnError() {
         toSource(doSubscriber(Single.failed(DELIBERATE_EXCEPTION), () -> subscriber)).subscribe(listener);
         assertThat(listener.awaitOnError(), is(DELIBERATE_EXCEPTION));
         verify(subscriber).onSubscribe(any());

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterCancelTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterCancelTest.java
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api.single;
 
 import io.servicetalk.concurrent.api.Single;
 
-public class AfterCancelTest extends AbstractWhenCancelTest {
+class AfterCancelTest extends AbstractWhenCancelTest {
     @Override
     protected <T> Single<T> doCancel(Single<T> single, Runnable runnable) {
         return single.afterCancel(runnable);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterErrorTest.java
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.api.Single;
 
 import java.util.function.Consumer;
 
-public class AfterErrorTest extends AbstractWhenOnErrorTest {
+class AfterErrorTest extends AbstractWhenOnErrorTest {
     @Override
     protected <T> Single<T> doError(Single<T> single, Consumer<Throwable> consumer) {
         return single.afterOnError(consumer);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterFinallyTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class AfterFinallyTest extends AbstractWhenFinallyTest {
+class AfterFinallyTest extends AbstractWhenFinallyTest {
     @Override
     protected <T> Single<T> doFinally(Single<T> single, SingleTerminalSignalConsumer<T> doFinally) {
         return single.afterFinally(doFinally);
@@ -36,7 +36,7 @@ public class AfterFinallyTest extends AbstractWhenFinallyTest {
 
     @Test
     @Override
-    public void testCallbackThrowsErrorOnSuccess() {
+    void testCallbackThrowsErrorOnSuccess() {
         SingleTerminalSignalConsumer<String> mock = throwableMock(DELIBERATE_EXCEPTION);
         String result = "Hello";
         toSource(doFinally(Single.succeeded(result), mock)).subscribe(listener);
@@ -47,7 +47,7 @@ public class AfterFinallyTest extends AbstractWhenFinallyTest {
 
     @Test
     @Override
-    public void testCallbackThrowsErrorOnError() {
+    void testCallbackThrowsErrorOnError() {
         SingleTerminalSignalConsumer<String> mock = throwableMock(new DeliberateException());
         toSource(doFinally(Single.failed(DELIBERATE_EXCEPTION), mock)).subscribe(listener);
         assertThat(listener.awaitOnError(), is(DELIBERATE_EXCEPTION));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterSubscribeTest.java
@@ -27,10 +27,10 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class AfterSubscribeTest extends AbstractWhenOnSubscribeTest {
+class AfterSubscribeTest extends AbstractWhenOnSubscribeTest {
 
     @Test
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         toSource(doSubscribe(Single.succeeded("Hello"), __ -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(listener);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterSubscriberTest.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.api.Single;
 
 import java.util.function.Supplier;
 
-public class AfterSubscriberTest extends AbstractWhenSubscriberTest {
+class AfterSubscriberTest extends AbstractWhenSubscriberTest {
 
     @Override
     protected <T> Single<T> doSubscriber(Single<T> single,

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterSuccessTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/AfterSuccessTest.java
@@ -26,7 +26,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class AfterSuccessTest extends AbstractWhenOnSuccessTest {
+class AfterSuccessTest extends AbstractWhenOnSuccessTest {
     @Override
     protected <T> Single<T> doSuccess(Single<T> single, Consumer<T> consumer) {
         return single.afterOnSuccess(consumer);
@@ -34,7 +34,7 @@ public class AfterSuccessTest extends AbstractWhenOnSuccessTest {
 
     @Test
     @Override
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         toSource(doSuccess(Single.succeeded("Hello"), t -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(listener);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeCancelTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeCancelTest.java
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api.single;
 
 import io.servicetalk.concurrent.api.Single;
 
-public class BeforeCancelTest extends AbstractWhenCancelTest {
+class BeforeCancelTest extends AbstractWhenCancelTest {
 
     @Override
     protected <T> Single<T> doCancel(Single<T> single, Runnable runnable) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeErrorTest.java
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.api.Single;
 
 import java.util.function.Consumer;
 
-public class BeforeErrorTest extends AbstractWhenOnErrorTest {
+class BeforeErrorTest extends AbstractWhenOnErrorTest {
     @Override
     protected <T> Single<T> doError(Single<T> single, Consumer<Throwable> consumer) {
         return single.beforeOnError(consumer);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeFinallyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeFinallyTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class BeforeFinallyTest extends AbstractWhenFinallyTest {
+class BeforeFinallyTest extends AbstractWhenFinallyTest {
     @Override
     protected <T> Single<T> doFinally(Single<T> single, SingleTerminalSignalConsumer<T> doFinally) {
         return single.beforeFinally(doFinally);
@@ -36,7 +36,7 @@ public class BeforeFinallyTest extends AbstractWhenFinallyTest {
 
     @Test
     @Override
-    public void testCallbackThrowsErrorOnSuccess() {
+    void testCallbackThrowsErrorOnSuccess() {
         SingleTerminalSignalConsumer<String> mock = throwableMock(DELIBERATE_EXCEPTION);
         String result = "Hello";
         toSource(doFinally(Single.succeeded(result), mock)).subscribe(listener);
@@ -47,7 +47,7 @@ public class BeforeFinallyTest extends AbstractWhenFinallyTest {
 
     @Test
     @Override
-    public void testCallbackThrowsErrorOnError() {
+    void testCallbackThrowsErrorOnError() {
         DeliberateException exception = new DeliberateException();
         SingleTerminalSignalConsumer<String> mock = throwableMock(exception);
         toSource(doFinally(Single.failed(DELIBERATE_EXCEPTION), mock)).subscribe(listener);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeSubscribeTest.java
@@ -31,9 +31,9 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 
-public class BeforeSubscribeTest extends AbstractWhenOnSubscribeTest {
+class BeforeSubscribeTest extends AbstractWhenOnSubscribeTest {
     @Test
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         List<Throwable> failures = new ArrayList<>();
         toSource(doSubscribe(Single.succeeded("Hello"), s -> {
             throw DELIBERATE_EXCEPTION;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeSubscriberTest.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.api.Single;
 
 import java.util.function.Supplier;
 
-public class BeforeSubscriberTest extends AbstractWhenSubscriberTest {
+class BeforeSubscriberTest extends AbstractWhenSubscriberTest {
 
     @Override
     protected <T> Single<T> doSubscriber(Single<T> single,

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeSuccessTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/BeforeSuccessTest.java
@@ -26,7 +26,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class BeforeSuccessTest extends AbstractWhenOnSuccessTest {
+class BeforeSuccessTest extends AbstractWhenOnSuccessTest {
     @Override
     protected <T> Single<T> doSuccess(Single<T> single, Consumer<T> consumer) {
         return single.beforeOnSuccess(consumer);
@@ -34,7 +34,7 @@ public class BeforeSuccessTest extends AbstractWhenOnSuccessTest {
 
     @Test
     @Override
-    public void testCallbackThrowsError() {
+    void testCallbackThrowsError() {
         toSource(doSuccess(Single.succeeded("Hello"), t -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(listener);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CallableSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CallableSingleTest.java
@@ -35,19 +35,19 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class CallableSingleTest {
+class CallableSingleTest {
     private static final RuntimeException DELIBERATE_EXCEPTION = new IllegalArgumentException();
 
     private Callable<Integer> factory;
 
     @SuppressWarnings("unchecked")
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         factory = mock(Callable.class);
     }
 
     @Test
-    public void testEverySubscribeCalls() throws Exception {
+    void testEverySubscribeCalls() throws Exception {
         when(factory.call()).thenReturn(1);
 
         final Single<Integer> source = Single.fromCallable(factory);
@@ -67,7 +67,7 @@ public class CallableSingleTest {
     }
 
     @Test
-    public void testOnError() throws Exception {
+    void testOnError() throws Exception {
         when(factory.call()).thenThrow(IllegalArgumentException.class);
 
         final Single<Integer> source = Single.fromCallable(factory);
@@ -85,7 +85,7 @@ public class CallableSingleTest {
     }
 
     @Test
-    public void cancelInterrupts() throws Exception {
+    void cancelInterrupts() throws Exception {
         final Single<Integer> source = Single.fromCallable(factory);
         final CountDownLatch latch = new CountDownLatch(1);
 
@@ -120,7 +120,7 @@ public class CallableSingleTest {
     }
 
     @Test
-    public void onSubscribeThrows() {
+    void onSubscribeThrows() {
         final Single<Integer> source = Single.fromCallable(factory);
 
         @SuppressWarnings("unchecked")

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CollectTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CollectTest.java
@@ -33,23 +33,23 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class CollectTest {
+class CollectTest {
 
     @Test
-    public void collectVarArgSuccess() throws Exception {
+    void collectVarArgSuccess() throws Exception {
         Collection<Integer> integers = collectUnordered(succeeded(1), succeeded(2)).toFuture().get();
         assertThat("Unexpected result.", integers, containsInAnyOrder(1, 2));
     }
 
     @Test
-    public void collectVarArgMaxConcurrencySuccess() throws Exception {
+    void collectVarArgMaxConcurrencySuccess() throws Exception {
         // Just testing that the method works. As it uses existing operators, we don't require elaborate tests
         Collection<Integer> integers = collectUnordered(1, succeeded(1), succeeded(2)).toFuture().get();
         assertThat("Unexpected result.", integers, containsInAnyOrder(1, 2));
     }
 
     @Test
-    public void collectVarArgFailure() throws Exception {
+    void collectVarArgFailure() throws Exception {
         Future<? extends Collection<Integer>> future =
                 collectUnordered(failed(DELIBERATE_EXCEPTION), succeeded(2)).toFuture();
         try {
@@ -61,7 +61,7 @@ public class CollectTest {
     }
 
     @Test
-    public void collectVarArgDelayError() throws Exception {
+    void collectVarArgDelayError() throws Exception {
         AtomicBoolean secondSubscribed = new AtomicBoolean();
         Future<? extends Collection<Integer>> future = collectUnorderedDelayError(failed(DELIBERATE_EXCEPTION),
                 succeeded(2).beforeOnSubscribe(__ -> secondSubscribed.set(true))).toFuture();
@@ -75,7 +75,7 @@ public class CollectTest {
     }
 
     @Test
-    public void collectVarArgDelayErrorMaxConcurrency() throws Exception {
+    void collectVarArgDelayErrorMaxConcurrency() throws Exception {
         AtomicBoolean secondSubscribed = new AtomicBoolean();
         Future<? extends Collection<Integer>> future = collectUnorderedDelayError(1, failed(DELIBERATE_EXCEPTION),
                 succeeded(2).beforeOnSubscribe(__ -> secondSubscribed.set(true))).toFuture();
@@ -89,20 +89,20 @@ public class CollectTest {
     }
 
     @Test
-    public void collectIterableSuccess() throws Exception {
+    void collectIterableSuccess() throws Exception {
         Collection<Integer> integers = collectUnordered(asList(succeeded(1), succeeded(2))).toFuture().get();
         assertThat("Unexpected result.", integers, containsInAnyOrder(1, 2));
     }
 
     @Test
-    public void collectIterableMaxConcurrencySuccess() throws Exception {
+    void collectIterableMaxConcurrencySuccess() throws Exception {
         // Just testing that the method works. As it uses existing operators, we don't require elaborate tests
         Collection<Integer> integers = collectUnordered(asList(succeeded(1), succeeded(2)), 1).toFuture().get();
         assertThat("Unexpected result.", integers, containsInAnyOrder(1, 2));
     }
 
     @Test
-    public void collectIterableFailure() throws Exception {
+    void collectIterableFailure() throws Exception {
         Future<? extends Collection<Integer>> future =
                 collectUnordered(asList(failed(DELIBERATE_EXCEPTION), succeeded(2))).toFuture();
         try {
@@ -114,7 +114,7 @@ public class CollectTest {
     }
 
     @Test
-    public void collectIterableDelayError() throws Exception {
+    void collectIterableDelayError() throws Exception {
         AtomicBoolean secondSubscribed = new AtomicBoolean();
         Future<? extends Collection<Integer>> future = collectUnorderedDelayError(asList(failed(DELIBERATE_EXCEPTION),
                 succeeded(2).beforeOnSubscribe(__ -> secondSubscribed.set(true)))).toFuture();
@@ -128,7 +128,7 @@ public class CollectTest {
     }
 
     @Test
-    public void collectIterableDelayErrorMaxConcurrency() throws Exception {
+    void collectIterableDelayErrorMaxConcurrency() throws Exception {
         AtomicBoolean secondSubscribed = new AtomicBoolean();
         Future<? extends Collection<Integer>> future = collectUnorderedDelayError(asList(failed(DELIBERATE_EXCEPTION),
                 succeeded(2).beforeOnSubscribe(__ -> secondSubscribed.set(true))), 1).toFuture();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CompletionStageAsyncContextTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CompletionStageAsyncContextTest.java
@@ -39,7 +39,7 @@ import static io.servicetalk.concurrent.api.Single.fromStage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CompletionStageAsyncContextTest {
+class CompletionStageAsyncContextTest {
     private static final Key<Integer> K1 = newKey("k1");
     @RegisterExtension
     final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor(ST_THREAD_PREFIX_NAME);
@@ -50,26 +50,26 @@ public class CompletionStageAsyncContextTest {
     private LegacyTestSingle<String> source;
 
     @BeforeAll
-    public static void beforeClass() {
+    static void beforeClass() {
         jdkExecutor = java.util.concurrent.Executors.newCachedThreadPool(
                 r -> new Thread(r, JDK_THREAD_NAME_PREFIX + '-' + threadCount.incrementAndGet()));
     }
 
     @AfterAll
-    public static void afterClass() {
+    static void afterClass() {
         if (jdkExecutor != null) {
             jdkExecutor.shutdown();
         }
     }
 
     @BeforeEach
-    public void beforeTest() {
+    void beforeTest() {
         AsyncContext.clear();
         source = new LegacyTestSingle<>(executorExtension.executor(), true, true);
     }
 
     @Test
-    public void fromStagePreservesContext() throws InterruptedException {
+    void fromStagePreservesContext() throws InterruptedException {
         CompletableFuture<String> future = new CompletableFuture<>();
         int expectedK1Value = ThreadLocalRandom.current().nextInt();
         jdkExecutor.execute(() -> future.complete("foo"));
@@ -87,7 +87,7 @@ public class CompletionStageAsyncContextTest {
     }
 
     @Test
-    public void singleToCompletionStageHandle() throws InterruptedException {
+    void singleToCompletionStageHandle() throws InterruptedException {
         int expectedK1Value = ThreadLocalRandom.current().nextInt();
         AsyncContext.put(K1, expectedK1Value);
         AtomicReference<Integer> actualK1Value = new AtomicReference<>();
@@ -103,7 +103,7 @@ public class CompletionStageAsyncContextTest {
     }
 
     @Test
-    public void singleToCompletionToCompletableFuture() throws InterruptedException {
+    void singleToCompletionToCompletableFuture() throws InterruptedException {
         int expectedK1Value = ThreadLocalRandom.current().nextInt();
         AtomicReference<Integer> actualK1Value = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
@@ -119,7 +119,7 @@ public class CompletionStageAsyncContextTest {
     }
 
     @Test
-    public void singleOperatorAndMultipleCompletionListeners() throws InterruptedException {
+    void singleOperatorAndMultipleCompletionListeners() throws InterruptedException {
         int expectedK1Value = ThreadLocalRandom.current().nextInt();
         AsyncContext.put(K1, expectedK1Value);
         AtomicReference<Integer> actualK1Value1 = new AtomicReference<>();
@@ -149,7 +149,7 @@ public class CompletionStageAsyncContextTest {
     }
 
     @Test
-    public void directToCompletableFuture() throws InterruptedException {
+    void directToCompletableFuture() throws InterruptedException {
         int expectedK1Value = ThreadLocalRandom.current().nextInt();
         AtomicReference<Integer> actualK1Value = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CompletionStageToSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CompletionStageToSingleTest.java
@@ -28,14 +28,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class CompletionStageToSingleTest extends AbstractFutureToSingleTest {
+class CompletionStageToSingleTest extends AbstractFutureToSingleTest {
     @Override
     Single<String> from(final CompletableFuture<String> future) {
         return fromStage(future);
     }
 
     @Test
-    public void failure() {
+    void failure() {
         CompletableFuture<String> future = new CompletableFuture<>();
         Single<String> single = from(future);
         jdkExecutor.execute(() -> future.completeExceptionally(DELIBERATE_EXCEPTION));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/ConcatWithCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/ConcatWithCompletableTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class ConcatWithCompletableTest {
+class ConcatWithCompletableTest {
     @RegisterExtension
     final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
     private final TestSingleSubscriber<String> listener = new TestSingleSubscriber<>();
@@ -39,7 +39,7 @@ public class ConcatWithCompletableTest {
     private LegacyTestCompletable completable = new LegacyTestCompletable();
 
     @Test
-    public void concatWaitsForCompletableSuccess() {
+    void concatWaitsForCompletableSuccess() {
         toSource(single.concat(completable)).subscribe(listener);
         single.onSuccess("foo");
         assertThat(listener.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -48,7 +48,7 @@ public class ConcatWithCompletableTest {
     }
 
     @Test
-    public void concatPropagatesCompletableFailure() {
+    void concatPropagatesCompletableFailure() {
         toSource(single.concat(completable)).subscribe(listener);
         single.onSuccess("foo");
         assertThat(listener.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -57,7 +57,7 @@ public class ConcatWithCompletableTest {
     }
 
     @Test
-    public void concatPropagatesSingleFailure() {
+    void concatPropagatesSingleFailure() {
         toSource(single.concat(completable)).subscribe(listener);
         single.onError(DELIBERATE_EXCEPTION);
         assertThat(listener.awaitOnError(), is(DELIBERATE_EXCEPTION));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/FutureToSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/FutureToSingleTest.java
@@ -29,14 +29,14 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class FutureToSingleTest extends AbstractFutureToSingleTest {
+class FutureToSingleTest extends AbstractFutureToSingleTest {
     @Override
     Single<String> from(final CompletableFuture<String> future) {
         return fromFuture(future);
     }
 
     @Test
-    public void failure() throws Exception {
+    void failure() throws Exception {
         CompletableFuture<String> future = new CompletableFuture<>();
         Single<String> single = from(future);
         jdkExecutor.execute(() -> future.completeExceptionally(DELIBERATE_EXCEPTION));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/MapSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/MapSingleTest.java
@@ -26,11 +26,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class MapSingleTest {
+class MapSingleTest {
     private final TestSingleSubscriber<String> listener = new TestSingleSubscriber<>();
 
     @Test
-    public void exceptionInTerminalCallsOnError() {
+    void exceptionInTerminalCallsOnError() {
         SourceAdapters.<String>toSource(Single.succeeded("foo").map(v -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(listener);
@@ -38,7 +38,7 @@ public class MapSingleTest {
     }
 
     @Test
-    public void nullInTerminalSucceeds() {
+    void nullInTerminalSucceeds() {
         SourceAdapters.<String>toSource(Single.succeeded("foo").map(v -> null)).subscribe(listener);
         assertThat(listener.awaitOnSuccess(), is(nullValue()));
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/ReduceSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/ReduceSingleTest.java
@@ -39,7 +39,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-public class ReduceSingleTest {
+class ReduceSingleTest {
     @RegisterExtension
     final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
 
@@ -48,7 +48,7 @@ public class ReduceSingleTest {
     private final TestSubscription subscription = new TestSubscription();
 
     @Test
-    public void testSingleItem() {
+    void testSingleItem() {
         listen(publisher, listenerRule);
         publisher.onNext("Hello");
         publisher.onComplete();
@@ -56,14 +56,14 @@ public class ReduceSingleTest {
     }
 
     @Test
-    public void testEmpty() {
+    void testEmpty() {
         listen(publisher, listenerRule);
         publisher.onComplete();
         assertThat(listenerRule.awaitOnSuccess(), is("")); // Empty string as exactly one item is required.
     }
 
     @Test
-    public void testMultipleItems() {
+    void testMultipleItems() {
         listen(publisher, listenerRule);
         publisher.onNext("Hello1", "Hello2", "Hello3");
         publisher.onComplete();
@@ -71,14 +71,14 @@ public class ReduceSingleTest {
     }
 
     @Test
-    public void testError() {
+    void testError() {
         listen(publisher, listenerRule);
         publisher.onError(DELIBERATE_EXCEPTION);
         assertThat(listenerRule.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void testFactoryReturnsNull() {
+    void testFactoryReturnsNull() {
         toSource(publisher.<String>collect(() -> null, (o, s) -> o)).subscribe(listenerRule);
         publisher.onNext("foo");
         publisher.onComplete();
@@ -86,7 +86,7 @@ public class ReduceSingleTest {
     }
 
     @Test
-    public void testAggregatorReturnsNull() {
+    void testAggregatorReturnsNull() {
         toSource(publisher.collect(() -> "", (o, s) -> null)).subscribe(listenerRule);
         publisher.onNext("foo");
         publisher.onComplete();
@@ -94,7 +94,7 @@ public class ReduceSingleTest {
     }
 
     @Test
-    public void testReducerExceptionCleanup() {
+    void testReducerExceptionCleanup() {
         final RuntimeException testException = new RuntimeException("fake exception");
         toSource(publisher.collect(() -> "", new BiFunction<String, String, String>() {
             private int callNumber;
@@ -115,7 +115,7 @@ public class ReduceSingleTest {
     }
 
     @Test
-    public void subscribeOnOriginalIsPreserved() throws Exception {
+    void subscribeOnOriginalIsPreserved() throws Exception {
         final Thread testThread = currentThread();
         final CountDownLatch analyzed = new CountDownLatch(1);
         ConcurrentLinkedQueue<AssertionError> errors = new ConcurrentLinkedQueue<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/RetryTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/RetryTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class RetryTest {
+class RetryTest {
 
     private final TestSingleSubscriber<Integer> subscriber = new TestSingleSubscriber<>();
 
@@ -49,7 +49,7 @@ public class RetryTest {
 
     @SuppressWarnings("unchecked")
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         setUp(subscriber);
     }
 
@@ -61,14 +61,14 @@ public class RetryTest {
     }
 
     @Test
-    public void testComplete() {
+    void testComplete() {
         source.onSuccess(1);
         assertThat(subscriber.awaitOnSuccess(), is(1));
         verifyZeroInteractions(shouldRetry);
     }
 
     @Test
-    public void testRetryCount() {
+    void testRetryCount() {
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
         verify(shouldRetry).test(1, DELIBERATE_EXCEPTION);
@@ -76,7 +76,7 @@ public class RetryTest {
     }
 
     @Test
-    public void testTwoFailures() {
+    void testTwoFailures() {
         shouldRetryValue = true;
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -88,7 +88,7 @@ public class RetryTest {
     }
 
     @Test
-    public void testMaxRetries() {
+    void testMaxRetries() {
         shouldRetryValue = true;
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -100,14 +100,14 @@ public class RetryTest {
     }
 
     @Test
-    public void testCancel() {
+    void testCancel() {
         subscriber.awaitSubscription().cancel();
         source.onError(DELIBERATE_EXCEPTION);
         verifyZeroInteractions(shouldRetry);
     }
 
     @Test
-    public void exceptionInTerminalCallsOnError() {
+    void exceptionInTerminalCallsOnError() {
         DeliberateException ex = new DeliberateException();
         TestSingleSubscriber<Integer> subscriberRule = new TestSingleSubscriber<>();
         source = new LegacyTestSingle<>(false, false);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/RetryWhenTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/RetryWhenTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class RetryWhenTest {
+class RetryWhenTest {
     private final TestSingleSubscriber<Integer> subscriberRule = new TestSingleSubscriber<>();
 
     private LegacyTestSingle<Integer> source;
@@ -60,7 +60,7 @@ public class RetryWhenTest {
 
     @SuppressWarnings("unchecked")
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         source = new LegacyTestSingle<>(false, false);
         shouldRetry = (BiIntFunction<Throwable, Completable>) mock(BiIntFunction.class);
         retrySignal = new LegacyTestCompletable();
@@ -72,14 +72,14 @@ public class RetryWhenTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         if (executor != null) {
             executor.closeAsync().toFuture().get();
         }
     }
 
     @Test
-    public void publishOnWithRetry() throws Exception {
+    void publishOnWithRetry() throws Exception {
         // This is an indication of whether we are using the same offloader across different subscribes. If this works,
         // then it does not really matter if we reuse offloaders or not. eg: if tomorrow we do not hold up a thread for
         // the lifetime of the Subscriber, we can reuse the offloader.
@@ -97,14 +97,14 @@ public class RetryWhenTest {
     }
 
     @Test
-    public void testComplete() {
+    void testComplete() {
         source.onSuccess(1);
         assertThat(subscriberRule.awaitOnSuccess(), is(1));
         verifyZeroInteractions(shouldRetry);
     }
 
     @Test
-    public void testRetryCount() {
+    void testRetryCount() {
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriberRule.pollTerminal(10, MILLISECONDS), is(nullValue()));
         DeliberateException fatal = new DeliberateException();
@@ -115,7 +115,7 @@ public class RetryWhenTest {
     }
 
     @Test
-    public void testTwoError() {
+    void testTwoError() {
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriberRule.pollTerminal(10, MILLISECONDS), is(nullValue()));
         verify(shouldRetry).apply(1, DELIBERATE_EXCEPTION);
@@ -129,7 +129,7 @@ public class RetryWhenTest {
     }
 
     @Test
-    public void testMaxRetries() {
+    void testMaxRetries() {
         source.onError(DELIBERATE_EXCEPTION);
         retrySignal.onComplete(); // trigger retry
         assertThat(subscriberRule.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -141,7 +141,7 @@ public class RetryWhenTest {
     }
 
     @Test
-    public void testCancelPostErrorButBeforeRetryStart() {
+    void testCancelPostErrorButBeforeRetryStart() {
         source.onError(DELIBERATE_EXCEPTION);
         retrySignal.verifyListenCalled();
         subscriberRule.awaitSubscription().cancel();
@@ -152,14 +152,14 @@ public class RetryWhenTest {
     }
 
     @Test
-    public void testCancelBeforeRetry() {
+    void testCancelBeforeRetry() {
         subscriberRule.awaitSubscription().cancel();
         source.onSuccess(1);
         verifyZeroInteractions(shouldRetry);
     }
 
     @Test
-    public void exceptionInTerminalCallsOnError() {
+    void exceptionInTerminalCallsOnError() {
         DeliberateException ex = new DeliberateException();
 
         TestSingleSubscriber<Integer> subscriberRule = new TestSingleSubscriber<>();
@@ -174,7 +174,7 @@ public class RetryWhenTest {
     }
 
     @Test
-    public void nullInTerminalCallsOnError() {
+    void nullInTerminalCallsOnError() {
         TestSingleSubscriber<Integer> subscriberRule = new TestSingleSubscriber<>();
         source = new LegacyTestSingle<>(false, false);
         toSource(source.retryWhen((times, cause) -> null)).subscribe(subscriberRule);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithCompletableTest.java
@@ -33,14 +33,14 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SingleConcatWithCompletableTest {
+class SingleConcatWithCompletableTest {
 
     private TestSingleSubscriber<Integer> subscriber;
     private TestSingle<Integer> source;
     private TestCompletable next;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         subscriber = new TestSingleSubscriber<>();
         source = new TestSingle<>();
         next = new TestCompletable();
@@ -48,7 +48,7 @@ public class SingleConcatWithCompletableTest {
     }
 
     @Test
-    public void testSourceSuccessNextComplete() {
+    void testSourceSuccessNextComplete() {
         source.onSuccess(1);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         next.onComplete();
@@ -56,7 +56,7 @@ public class SingleConcatWithCompletableTest {
     }
 
     @Test
-    public void testSourceSuccessNextError() {
+    void testSourceSuccessNextError() {
         source.onSuccess(1);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         next.onError(DELIBERATE_EXCEPTION);
@@ -64,14 +64,14 @@ public class SingleConcatWithCompletableTest {
     }
 
     @Test
-    public void testSourceError() {
+    void testSourceError() {
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
         assertFalse(next.isSubscribed());
     }
 
     @Test
-    public void testCancelSource() {
+    void testCancelSource() {
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         TestCancellable cancellable = new TestCancellable();
@@ -81,7 +81,7 @@ public class SingleConcatWithCompletableTest {
     }
 
     @Test
-    public void testCancelNext() {
+    void testCancelNext() {
         source.onSuccess(1);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
@@ -37,7 +37,7 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class SingleConcatWithPublisherTest {
+class SingleConcatWithPublisherTest {
     private TestPublisherSubscriber<Integer> subscriber;
     private TestSingle<Integer> source;
     private TestPublisher<Integer> next;
@@ -45,7 +45,7 @@ public class SingleConcatWithPublisherTest {
     private TestCancellable cancellable;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         subscriber = new TestPublisherSubscriber<>();
         cancellable = new TestCancellable();
         source = new TestSingle.Builder<Integer>().disableAutoOnSubscribe().build();
@@ -57,7 +57,7 @@ public class SingleConcatWithPublisherTest {
     }
 
     @Test
-    public void bothCompletion() {
+    void bothCompletion() {
         triggerNextSubscribe();
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(2);
@@ -69,7 +69,7 @@ public class SingleConcatWithPublisherTest {
     }
 
     @Test
-    public void sourceCompletionNextError() {
+    void sourceCompletionNextError() {
         triggerNextSubscribe();
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         next.onError(DELIBERATE_EXCEPTION);
@@ -78,12 +78,12 @@ public class SingleConcatWithPublisherTest {
     }
 
     @Test
-    public void invalidRequestBeforeNextSubscribeNegative1() {
+    void invalidRequestBeforeNextSubscribeNegative1() {
         invalidRequestBeforeNextSubscribe(-1);
     }
 
     @Test
-    public void invalidRequestBeforeNextSubscribeZero() {
+    void invalidRequestBeforeNextSubscribeZero() {
         invalidRequestBeforeNextSubscribe(0);
     }
 
@@ -94,7 +94,7 @@ public class SingleConcatWithPublisherTest {
     }
 
     @Test
-    public void invalidRequestNWithInlineSourceCompletion() {
+    void invalidRequestNWithInlineSourceCompletion() {
         TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
         toSource(Single.succeeded(1).concat(empty())).subscribe(subscriber);
         subscriber.awaitSubscription().request(-1);
@@ -102,26 +102,26 @@ public class SingleConcatWithPublisherTest {
     }
 
     @Test
-    public void invalidRequestAfterNextSubscribe() {
+    void invalidRequestAfterNextSubscribe() {
         triggerNextSubscribe();
         subscriber.awaitSubscription().request(-1);
         assertThat("Invalid request-n not propagated.", subscription.requested(), is(lessThan(0L)));
     }
 
     @Test
-    public void multipleInvalidRequest() {
+    void multipleInvalidRequest() {
         subscriber.awaitSubscription().request(-1);
         subscriber.awaitSubscription().request(-10);
         assertThat(subscriber.awaitOnError(), instanceOf(IllegalArgumentException.class));
     }
 
     @Test
-    public void invalidThenValidRequestNegative1() {
+    void invalidThenValidRequestNegative1() {
         invalidThenValidRequest(-1);
     }
 
     @Test
-    public void invalidThenValidRequestZero() {
+    void invalidThenValidRequestZero() {
         invalidThenValidRequest(0);
     }
 
@@ -133,7 +133,7 @@ public class SingleConcatWithPublisherTest {
     }
 
     @Test
-    public void request0PropagatedAfterSuccess() {
+    void request0PropagatedAfterSuccess() {
         source.onSuccess(1);
         subscriber.awaitSubscription().request(1); // get the success from the Single
         subscriber.awaitSubscription().request(0);
@@ -143,14 +143,14 @@ public class SingleConcatWithPublisherTest {
     }
 
     @Test
-    public void sourceError() {
+    void sourceError() {
         source.onError(DELIBERATE_EXCEPTION);
         assertThat("Unexpected subscriber termination.", subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
         assertThat("Next source subscribed unexpectedly.", next.isSubscribed(), is(false));
     }
 
     @Test
-    public void cancelSource() {
+    void cancelSource() {
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         assertThat("Original single not cancelled.", cancellable.isCancelled(), is(true));
@@ -158,7 +158,7 @@ public class SingleConcatWithPublisherTest {
     }
 
     @Test
-    public void cancelSourcePostRequest() {
+    void cancelSourcePostRequest() {
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(1);
         subscriber.awaitSubscription().cancel();
@@ -167,7 +167,7 @@ public class SingleConcatWithPublisherTest {
     }
 
     @Test
-    public void cancelNext() {
+    void cancelNext() {
         triggerNextSubscribe();
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
@@ -176,7 +176,7 @@ public class SingleConcatWithPublisherTest {
     }
 
     @Test
-    public void zeroIsNotRequestedOnTransitionToSubscription() {
+    void zeroIsNotRequestedOnTransitionToSubscription() {
         subscriber.awaitSubscription().request(1);
         source.onSuccess(1);
         next.onSubscribe(subscription);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleDeferTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleDeferTest.java
@@ -32,19 +32,19 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class SingleDeferTest {
+class SingleDeferTest {
 
     private Supplier<Single<Integer>> factory;
 
     @SuppressWarnings("unchecked")
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         factory = mock(Supplier.class);
         when(factory.get()).thenReturn(succeeded(1));
     }
 
     @Test
-    public void testEverySubscribeCreatesNew() {
+    void testEverySubscribeCreatesNew() {
         Single<Integer> source = Single.defer(factory);
         listenAndVerify(source);
         listenAndVerify(source);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleFlatMapCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleFlatMapCompletableTest.java
@@ -32,45 +32,45 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
-public final class SingleFlatMapCompletableTest {
+final class SingleFlatMapCompletableTest {
     private final TestCompletableSubscriber listener = new TestCompletableSubscriber();
 
     private LegacyTestSingle<String> single;
     private LegacyTestCompletable completable;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         single = new LegacyTestSingle<>();
         completable = new LegacyTestCompletable();
     }
 
     @Test
-    public void testSuccess() {
+    void testSuccess() {
         toSource(succeeded(1).flatMapCompletable(s -> completed())).subscribe(listener);
         listener.awaitOnComplete();
     }
 
     @Test
-    public void testFirstEmitsError() {
+    void testFirstEmitsError() {
         toSource(Single.failed(DELIBERATE_EXCEPTION).flatMapCompletable(s -> completable)).subscribe(listener);
         assertThat(listener.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void testSecondEmitsError() {
+    void testSecondEmitsError() {
         toSource(succeeded(1).flatMapCompletable(s -> failed(DELIBERATE_EXCEPTION))).subscribe(listener);
         assertThat(listener.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void testCancelBeforeFirst() {
+    void testCancelBeforeFirst() {
         toSource(single.flatMapCompletable(s -> completable)).subscribe(listener);
         listener.awaitSubscription().cancel();
         single.verifyCancelled();
     }
 
     @Test
-    public void testCancelBeforeSecond() {
+    void testCancelBeforeSecond() {
         toSource(single.flatMapCompletable(s -> completable)).subscribe(listener);
         single.onSuccess("Hello");
         listener.awaitSubscription().cancel();
@@ -79,7 +79,7 @@ public final class SingleFlatMapCompletableTest {
     }
 
     @Test
-    public void exceptionInTerminalCallsOnError() {
+    void exceptionInTerminalCallsOnError() {
         toSource(single.flatMapCompletable(s -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(listener);
@@ -88,7 +88,7 @@ public final class SingleFlatMapCompletableTest {
     }
 
     @Test
-    public void nullInTerminalCallsOnError() {
+    void nullInTerminalCallsOnError() {
         toSource(single.flatMapCompletable(s -> null)).subscribe(listener);
         single.onSuccess("Hello");
         assertThat(listener.awaitOnError(), instanceOf(NullPointerException.class));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleFlatMapPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleFlatMapPublisherTest.java
@@ -47,7 +47,7 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public final class SingleFlatMapPublisherTest {
+final class SingleFlatMapPublisherTest {
     @RegisterExtension
     final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
 
@@ -58,7 +58,7 @@ public final class SingleFlatMapPublisherTest {
     private final TestSubscription subscription = new TestSubscription();
 
     @Test
-    public void testFirstAndSecondPropagate() {
+    void testFirstAndSecondPropagate() {
         toSource(succeeded(1).flatMapPublisher(s1 -> from(new String[]{"Hello1", "Hello2"}).map(str1 -> str1 + s1)))
                 .subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
@@ -67,7 +67,7 @@ public final class SingleFlatMapPublisherTest {
     }
 
     @Test
-    public void testSuccess() {
+    void testSuccess() {
         toSource(succeeded(1).flatMapPublisher(s1 -> publisher)).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
         publisher.onNext("Hello1", "Hello2");
@@ -77,7 +77,7 @@ public final class SingleFlatMapPublisherTest {
     }
 
     @Test
-    public void testPublisherEmitsError() {
+    void testPublisherEmitsError() {
         toSource(succeeded(1).flatMapPublisher(s1 -> publisher)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         publisher.onError(DELIBERATE_EXCEPTION);
@@ -85,7 +85,7 @@ public final class SingleFlatMapPublisherTest {
     }
 
     @Test
-    public void testSingleEmitsError() {
+    void testSingleEmitsError() {
         toSource(failed(DELIBERATE_EXCEPTION).flatMapPublisher(s1 -> publisher)).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         assertFalse(publisher.isSubscribed());
@@ -93,7 +93,7 @@ public final class SingleFlatMapPublisherTest {
     }
 
     @Test
-    public void testCancelBeforeNextPublisher() {
+    void testCancelBeforeNextPublisher() {
         toSource(single.flatMapPublisher(s1 -> publisher)).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
         subscriber.awaitSubscription().cancel();
@@ -101,7 +101,7 @@ public final class SingleFlatMapPublisherTest {
     }
 
     @Test
-    public void testCancelNoRequest() {
+    void testCancelNoRequest() {
         toSource(single.flatMapPublisher(s -> publisher)).subscribe(subscriber);
         subscriber.awaitSubscription().cancel();
         subscriber.awaitSubscription().request(1);
@@ -109,7 +109,7 @@ public final class SingleFlatMapPublisherTest {
     }
 
     @Test
-    public void testCancelBeforeOnSubscribe() {
+    void testCancelBeforeOnSubscribe() {
         toSource(single.flatMapPublisher(s1 -> publisher)).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
         single.onSuccess("Hello");
@@ -122,7 +122,7 @@ public final class SingleFlatMapPublisherTest {
     }
 
     @Test
-    public void testCancelPostOnSubscribe() {
+    void testCancelPostOnSubscribe() {
         toSource(succeeded(1).flatMapPublisher(s1 -> publisher)).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
         publisher.onSubscribe(subscription);
@@ -131,7 +131,7 @@ public final class SingleFlatMapPublisherTest {
     }
 
     @Test
-    public void exceptionInTerminalCallsOnError() {
+    void exceptionInTerminalCallsOnError() {
         toSource(succeeded(1).<String>flatMapPublisher(s1 -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(subscriber);
@@ -141,7 +141,7 @@ public final class SingleFlatMapPublisherTest {
     }
 
     @Test
-    public void nullInTerminalCallsOnError() {
+    void nullInTerminalCallsOnError() {
         toSource(succeeded(1).<String>flatMapPublisher(s1 -> null)).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
         single.onSuccess("Hello");
@@ -149,7 +149,7 @@ public final class SingleFlatMapPublisherTest {
     }
 
     @Test
-    public void subscribeOnOriginalIsPreserved() throws Exception {
+    void subscribeOnOriginalIsPreserved() throws Exception {
         final Thread testThread = currentThread();
         final CountDownLatch analyzed = new CountDownLatch(1);
         ConcurrentLinkedQueue<AssertionError> errors = new ConcurrentLinkedQueue<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleFlatMapSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleFlatMapSingleTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
-public final class SingleFlatMapSingleTest {
+final class SingleFlatMapSingleTest {
 
     private final TestSingleSubscriber<String> listener = new TestSingleSubscriber<>();
 
@@ -38,44 +38,44 @@ public final class SingleFlatMapSingleTest {
     private LegacyTestSingle<String> second;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         first = new LegacyTestSingle<>();
         second = new LegacyTestSingle<>();
     }
 
     @Test
-    public void testFirstAndSecondPropagate() {
+    void testFirstAndSecondPropagate() {
         toSource(succeeded(1).flatMap(s -> succeeded("Hello" + s))).subscribe(listener);
         assertThat(listener.awaitOnSuccess(), is("Hello1"));
     }
 
     @Test
-    public void testSuccess() {
+    void testSuccess() {
         toSource(succeeded(1).flatMap(s -> succeeded("Hello"))).subscribe(listener);
         assertThat(listener.awaitOnSuccess(), is("Hello"));
     }
 
     @Test
-    public void testFirstEmitsError() {
+    void testFirstEmitsError() {
         toSource(failed(DELIBERATE_EXCEPTION).flatMap(s -> succeeded("Hello"))).subscribe(listener);
         assertThat(listener.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void testSecondEmitsError() {
+    void testSecondEmitsError() {
         SourceAdapters.<String>toSource(succeeded(1).flatMap(s -> failed(DELIBERATE_EXCEPTION))).subscribe(listener);
         assertThat(listener.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void testCancelBeforeFirst() {
+    void testCancelBeforeFirst() {
         toSource(first.flatMap(s -> second)).subscribe(listener);
         listener.awaitSubscription().cancel();
         first.verifyCancelled();
     }
 
     @Test
-    public void testCancelBeforeSecond() {
+    void testCancelBeforeSecond() {
         toSource(first.flatMap(s -> second)).subscribe(listener);
         first.onSuccess("Hello");
         listener.awaitSubscription().cancel();
@@ -84,7 +84,7 @@ public final class SingleFlatMapSingleTest {
     }
 
     @Test
-    public void exceptionInTerminalCallsOnError() {
+    void exceptionInTerminalCallsOnError() {
         SourceAdapters.<String>toSource(first.flatMap(s -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(listener);
@@ -93,7 +93,7 @@ public final class SingleFlatMapSingleTest {
     }
 
     @Test
-    public void nullInTerminalCallsOnError() {
+    void nullInTerminalCallsOnError() {
         SourceAdapters.<String>toSource(first.flatMap(s -> null)).subscribe(listener);
         first.onSuccess("Hello");
         assertThat(listener.awaitOnError(), instanceOf(NullPointerException.class));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletableTest.java
@@ -29,12 +29,12 @@ import static java.lang.Thread.currentThread;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 
-public class SingleToCompletableTest {
+class SingleToCompletableTest {
     @RegisterExtension
     final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
 
     @Test
-    public void subscribeOnOriginalIsPreserved() throws InterruptedException {
+    void subscribeOnOriginalIsPreserved() throws InterruptedException {
         final Thread testThread = currentThread();
         final CountDownLatch analyzed = new CountDownLatch(1);
         ConcurrentLinkedQueue<AssertionError> errors = new ConcurrentLinkedQueue<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletionStageTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletionStageTest.java
@@ -57,7 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SingleToCompletionStageTest {
+class SingleToCompletionStageTest {
     @RegisterExtension
     final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor(ST_THREAD_PREFIX_NAME);
 
@@ -71,25 +71,25 @@ public class SingleToCompletionStageTest {
     private static final String JUNIT_THREAD_PREFIX = "Test worker";
 
     @BeforeAll
-    public static void beforeClass() {
+    static void beforeClass() {
         jdkExecutor = java.util.concurrent.Executors.newCachedThreadPool(
                 r -> new Thread(r, JDK_THREAD_NAME_PREFIX + '-' + threadCount.incrementAndGet()));
     }
 
     @AfterAll
-    public static void afterClass() {
+    static void afterClass() {
         if (jdkExecutor != null) {
             jdkExecutor.shutdown();
         }
     }
 
     @BeforeEach
-    public void beforeTest() {
+    void beforeTest() {
         source = new LegacyTestSingle<>(executorExtension.executor(), true, true);
     }
 
     @Test
-    public void completableFutureFromSingleToCompletionStageToCompletableFutureFailure() {
+    void completableFutureFromSingleToCompletionStageToCompletableFutureFailure() {
         CompletableFuture<Long> input = new CompletableFuture<>();
         CompletableFuture<Long> output = Single.fromStage(input).toCompletionStage().toCompletableFuture()
                 .whenComplete((v, c) -> { })
@@ -101,7 +101,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void completableFutureFromSingleToCompletionStageToCompletableFutureSuccess() throws Exception {
+    void completableFutureFromSingleToCompletionStageToCompletableFutureSuccess() throws Exception {
         CompletableFuture<Long> input = new CompletableFuture<>();
         CompletableFuture<Long> output = Single.fromStage(input).toCompletionStage().toCompletableFuture()
                 .exceptionally(cause -> 2L)
@@ -113,7 +113,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void nestedInADifferentFuture() throws Exception {
+    void nestedInADifferentFuture() throws Exception {
         String result = CompletableFuture.completedFuture("foo")
                 .thenCompose(s -> succeeded(s + "bar").toCompletionStage())
                 .get();
@@ -121,24 +121,24 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void thenApply() throws Exception {
+    void thenApply() throws Exception {
         thenApply(source.toCompletionStage().thenApply(SingleToCompletionStageTest::strLenStThread), "thenApply");
     }
 
     @Test
-    public void thenApplyNull() throws Exception {
+    void thenApplyNull() throws Exception {
         thenApply(source.toCompletionStage().thenApplyAsync(SingleToCompletionStageTest::strLenJdkForkJoinThread),
                 null);
     }
 
     @Test
-    public void thenApplyAsync() throws Exception {
+    void thenApplyAsync() throws Exception {
         thenApply(source.toCompletionStage().thenApplyAsync(SingleToCompletionStageTest::strLenJdkForkJoinThread),
                 "thenApplyAsync");
     }
 
     @Test
-    public void thenApplyAsyncExecutor() throws Exception {
+    void thenApplyAsyncExecutor() throws Exception {
         thenApply(source.toCompletionStage().thenApplyAsync(SingleToCompletionStageTest::strLenJdkThread, jdkExecutor),
                 "thenApplyAsyncExecutor");
     }
@@ -150,7 +150,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void thenApplyListenAfterComplete() throws Exception {
+    void thenApplyListenAfterComplete() throws Exception {
         String expected1 = "one";
         CompletionStage<String> stage1 = source.toCompletionStage();
 
@@ -166,12 +166,12 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void thenApplyTransformData() throws Exception {
+    void thenApplyTransformData() throws Exception {
         thenApplyTransformData(stage1 -> stage1.thenApply(SingleToCompletionStageTest::strLenJUnitThread));
     }
 
     @Test
-    public void thenApplyAsyncListenAfterComplete() throws Exception {
+    void thenApplyAsyncListenAfterComplete() throws Exception {
         String expected1 = "one";
         CompletionStage<String> stage1 = source.toCompletionStage();
 
@@ -189,7 +189,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void thenApplyAsyncTransformData() throws Exception {
+    void thenApplyAsyncTransformData() throws Exception {
         thenApplyTransformData(stage1 -> stage1.thenApplyAsync(SingleToCompletionStageTest::strLenJdkThread,
                 jdkExecutor));
     }
@@ -207,7 +207,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void thenApplyMultipleTimesOnlySubscribesOnce() throws Exception {
+    void thenApplyMultipleTimesOnlySubscribesOnce() throws Exception {
         String expected1 = "one";
         CompletionStage<String> stage1 = source.toCompletionStage();
 
@@ -226,26 +226,26 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void thenAccept() throws Exception {
+    void thenAccept() throws Exception {
         AtomicReference<String> stringRef = new AtomicReference<>();
         thenAccept(source.toCompletionStage().thenAccept(stThread(stringRef)), stringRef, "thenAccept");
     }
 
     @Test
-    public void thenAcceptNull() throws Exception {
+    void thenAcceptNull() throws Exception {
         AtomicReference<String> stringRef = new AtomicReference<>();
         thenAccept(source.toCompletionStage().thenAccept(stThread(stringRef)), stringRef, null);
     }
 
     @Test
-    public void thenAcceptAsync() throws Exception {
+    void thenAcceptAsync() throws Exception {
         AtomicReference<String> stringRef = new AtomicReference<>();
         thenAccept(source.toCompletionStage().thenAcceptAsync(jdkForkJoinThread(stringRef)), stringRef,
                 "thenAcceptAsync");
     }
 
     @Test
-    public void thenAcceptAsyncExecutor() throws Exception {
+    void thenAcceptAsyncExecutor() throws Exception {
         AtomicReference<String> stringRef = new AtomicReference<>();
         thenAccept(source.toCompletionStage().thenAcceptAsync(jdkThread(stringRef), jdkExecutor), stringRef,
                 "thenAcceptAsyncExecutor");
@@ -260,12 +260,12 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void thenAcceptConsumeData() throws Exception {
+    void thenAcceptConsumeData() throws Exception {
         thenAcceptConsumeData((stage1, ref) -> stage1.thenAccept(junitThread(ref)));
     }
 
     @Test
-    public void thenAcceptAsyncConsumeData() throws Exception {
+    void thenAcceptAsyncConsumeData() throws Exception {
         thenAcceptConsumeData((stage1, ref) -> stage1.thenAcceptAsync(jdkThread(ref), jdkExecutor));
     }
 
@@ -285,19 +285,19 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void thenRun() throws Exception {
+    void thenRun() throws Exception {
         AtomicBoolean aBoolean = new AtomicBoolean();
         thenRun(source.toCompletionStage().thenRun(trueStThread(aBoolean)), aBoolean, "thenRun");
     }
 
     @Test
-    public void thenRunAsync() throws Exception {
+    void thenRunAsync() throws Exception {
         AtomicBoolean aBoolean = new AtomicBoolean();
         thenRun(source.toCompletionStage().thenRunAsync(trueJdkForkJoinThread(aBoolean)), aBoolean, "thenRunAsync");
     }
 
     @Test
-    public void thenRunAsyncExecutor() throws Exception {
+    void thenRunAsyncExecutor() throws Exception {
         AtomicBoolean aBoolean = new AtomicBoolean();
         thenRun(source.toCompletionStage().thenRunAsync(trueJdkThread(aBoolean), jdkExecutor),
                 aBoolean, "thenRunAsyncExecutor");
@@ -312,12 +312,12 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void thenRunAfterData() throws Exception {
+    void thenRunAfterData() throws Exception {
         thenRunAfterData((stage1, ref) -> stage1.thenRun(trueJUnitThread(ref)));
     }
 
     @Test
-    public void thenRunAsyncAfterData() throws Exception {
+    void thenRunAsyncAfterData() throws Exception {
         thenRunAfterData((stage1, ref) -> stage1.thenRunAsync(trueJdkThread(ref), jdkExecutor));
     }
 
@@ -337,26 +337,26 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void thenCombine() throws Exception {
+    void thenCombine() throws Exception {
         CompletableFuture<Double> other = new CompletableFuture<>();
         thenCombine(other, source.toCompletionStage().thenCombine(other, strLenDoubleStOrJdkThread()), "foo", 123);
     }
 
     @Test
-    public void thenCombineNull() throws Exception {
+    void thenCombineNull() throws Exception {
         CompletableFuture<Double> other = new CompletableFuture<>();
         thenCombine(other, source.toCompletionStage().thenCombine(other, strLenDoubleStOrJdkThread()), null, 1236);
     }
 
     @Test
-    public void thenCombineAsync() throws Exception {
+    void thenCombineAsync() throws Exception {
         CompletableFuture<Double> other = new CompletableFuture<>();
         thenCombine(other, source.toCompletionStage().thenCombineAsync(other, strLenDoubleJdkForkJoinThread()), "foo",
                 123);
     }
 
     @Test
-    public void thenCombineAsyncExecutor() throws Exception {
+    void thenCombineAsyncExecutor() throws Exception {
         CompletableFuture<Double> other = new CompletableFuture<>();
         thenCombine(other, source.toCompletionStage().thenCombineAsync(other, strLenDoubleJdkThread(), jdkExecutor),
                 "foo", 123);
@@ -371,7 +371,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void thenAcceptBoth() throws Exception {
+    void thenAcceptBoth() throws Exception {
         AtomicReference<String> strRef = new AtomicReference<>();
         AtomicReference<Long> lngRef = new AtomicReference<>();
         CompletableFuture<Long> other = new CompletableFuture<>();
@@ -383,7 +383,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void thenAcceptBothNull() throws Exception {
+    void thenAcceptBothNull() throws Exception {
         AtomicReference<String> strRef = new AtomicReference<>();
         AtomicReference<Long> lngRef = new AtomicReference<>();
         CompletableFuture<Long> other = new CompletableFuture<>();
@@ -395,7 +395,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void thenAcceptBothAsync() throws Exception {
+    void thenAcceptBothAsync() throws Exception {
         AtomicReference<String> strRef = new AtomicReference<>();
         AtomicReference<Long> lngRef = new AtomicReference<>();
         CompletableFuture<Long> other = new CompletableFuture<>();
@@ -407,7 +407,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void thenAcceptBothAsyncExecutor() throws Exception {
+    void thenAcceptBothAsyncExecutor() throws Exception {
         AtomicReference<String> strRef = new AtomicReference<>();
         AtomicReference<Long> lngRef = new AtomicReference<>();
         CompletableFuture<Long> other = new CompletableFuture<>();
@@ -431,28 +431,28 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void runAfterBoth() throws Exception {
+    void runAfterBoth() throws Exception {
         CompletableFuture<Long> other = new CompletableFuture<>();
         runAfterBoth(other, source.toCompletionStage().runAfterBoth(other,
                 SingleToCompletionStageTest::verifyInStOrJdkThread), "foo", 123L);
     }
 
     @Test
-    public void runAfterBothNull() throws Exception {
+    void runAfterBothNull() throws Exception {
         CompletableFuture<Long> other = new CompletableFuture<>();
         runAfterBoth(other, source.toCompletionStage().runAfterBoth(other,
                 SingleToCompletionStageTest::verifyInStOrJdkThread), null, 1223L);
     }
 
     @Test
-    public void runAfterBothAsync() throws Exception {
+    void runAfterBothAsync() throws Exception {
         CompletableFuture<Long> other = new CompletableFuture<>();
         runAfterBoth(other, source.toCompletionStage().runAfterBothAsync(other,
                 SingleToCompletionStageTest::verifyInJdkForkJoinThread), "bar", 123L);
     }
 
     @Test
-    public void runAfterBothAsyncExecutor() throws Exception {
+    void runAfterBothAsyncExecutor() throws Exception {
         CompletableFuture<Long> other = new CompletableFuture<>();
         runAfterBoth(other, source.toCompletionStage().runAfterBothAsync(other,
                 SingleToCompletionStageTest::verifyInJdkExecutorThread, jdkExecutor), "bar", 123L);
@@ -468,28 +468,28 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void applyToEither() throws Exception {
+    void applyToEither() throws Exception {
         CompletableFuture<String> other = new CompletableFuture<>();
         applyToEither(other, source.toCompletionStage().applyToEither(other,
                 SingleToCompletionStageTest::strLenStOrJdkThread), "foo", "bar");
     }
 
     @Test
-    public void applyToEitherNull() throws Exception {
+    void applyToEitherNull() throws Exception {
         CompletableFuture<String> other = new CompletableFuture<>();
         applyToEither(other, source.toCompletionStage().applyToEither(other,
                 SingleToCompletionStageTest::strLenStOrJdkThread), null, null);
     }
 
     @Test
-    public void applyToEitherAsync() throws Exception {
+    void applyToEitherAsync() throws Exception {
         CompletableFuture<String> other = new CompletableFuture<>();
         applyToEither(other, source.toCompletionStage().applyToEitherAsync(other,
                 SingleToCompletionStageTest::strLenJdkForkJoinThread), "foo", "bar");
     }
 
     @Test
-    public void applyToEitherAsyncExecutor() throws Exception {
+    void applyToEitherAsyncExecutor() throws Exception {
         CompletableFuture<String> other = new CompletableFuture<>();
         applyToEither(other, source.toCompletionStage().applyToEitherAsync(other,
                 SingleToCompletionStageTest::strLenJdkThread, jdkExecutor), "foo", "bar");
@@ -505,7 +505,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void acceptEither() throws Exception {
+    void acceptEither() throws Exception {
         CompletableFuture<String> other = new CompletableFuture<>();
         AtomicReference<String> strRef = new AtomicReference<>();
         acceptEither(other, source.toCompletionStage().acceptEither(other, stOrJdkThread(strRef)), strRef, "foo",
@@ -513,14 +513,14 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void acceptEitherNull() throws Exception {
+    void acceptEitherNull() throws Exception {
         CompletableFuture<String> other = new CompletableFuture<>();
         AtomicReference<String> strRef = new AtomicReference<>();
         acceptEither(other, source.toCompletionStage().acceptEither(other, stOrJdkThread(strRef)), strRef, null, null);
     }
 
     @Test
-    public void acceptEitherAsync() throws Exception {
+    void acceptEitherAsync() throws Exception {
         CompletableFuture<String> other = new CompletableFuture<>();
         AtomicReference<String> strRef = new AtomicReference<>();
         acceptEither(other, source.toCompletionStage().acceptEitherAsync(other, jdkForkJoinThread(strRef)), strRef,
@@ -528,7 +528,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void acceptEitherAsyncExecutor() throws Exception {
+    void acceptEitherAsyncExecutor() throws Exception {
         CompletableFuture<String> other = new CompletableFuture<>();
         AtomicReference<String> strRef = new AtomicReference<>();
         acceptEither(other, source.toCompletionStage().acceptEitherAsync(other, jdkThread(strRef), jdkExecutor),
@@ -547,28 +547,28 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void runAfterEither() throws Exception {
+    void runAfterEither() throws Exception {
         CompletableFuture<String> other = new CompletableFuture<>();
         runAfterEither(other, source.toCompletionStage().runAfterEither(other,
                 SingleToCompletionStageTest::verifyInStOrJdkThread), "foo", "bar");
     }
 
     @Test
-    public void runAfterEitherNull() throws Exception {
+    void runAfterEitherNull() throws Exception {
         CompletableFuture<String> other = new CompletableFuture<>();
         runAfterEither(other, source.toCompletionStage().runAfterEither(other,
                 SingleToCompletionStageTest::verifyInStOrJdkThread), null, null);
     }
 
     @Test
-    public void runAfterEitherAsync() throws Exception {
+    void runAfterEitherAsync() throws Exception {
         CompletableFuture<String> other = new CompletableFuture<>();
         runAfterEither(other, source.toCompletionStage().runAfterEitherAsync(other,
                 SingleToCompletionStageTest::verifyInJdkForkJoinThread), "foo", null);
     }
 
     @Test
-    public void runAfterEitherAsyncExecutor() throws Exception {
+    void runAfterEitherAsyncExecutor() throws Exception {
         CompletableFuture<String> other = new CompletableFuture<>();
         runAfterEither(other, source.toCompletionStage().runAfterEitherAsync(other,
                 SingleToCompletionStageTest::verifyInJdkExecutorThread, jdkExecutor), "foo", null);
@@ -584,7 +584,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void thenCompose() throws Exception {
+    void thenCompose() throws Exception {
         CompletableFuture<Integer> other = new CompletableFuture<>();
         AtomicReference<String> strRef = new AtomicReference<>();
         thenCompose(other, source.toCompletionStage().thenCompose(str -> {
@@ -595,7 +595,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void thenComposeNull() throws Exception {
+    void thenComposeNull() throws Exception {
         CompletableFuture<Integer> other = new CompletableFuture<>();
         AtomicReference<String> strRef = new AtomicReference<>();
         thenCompose(other, source.toCompletionStage().thenCompose(str -> {
@@ -606,7 +606,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void thenComposeAsync() throws Exception {
+    void thenComposeAsync() throws Exception {
         CompletableFuture<Integer> other = new CompletableFuture<>();
         AtomicReference<String> strRef = new AtomicReference<>();
         thenCompose(other, source.toCompletionStage().thenComposeAsync(str -> {
@@ -617,7 +617,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void thenComposeAsyncExecutor() throws Exception {
+    void thenComposeAsyncExecutor() throws Exception {
         CompletableFuture<Integer> other = new CompletableFuture<>();
         AtomicReference<String> strRef = new AtomicReference<>();
         thenCompose(other, source.toCompletionStage().thenComposeAsync(str -> {
@@ -639,13 +639,13 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void exceptionally() throws Exception {
+    void exceptionally() throws Exception {
         String expected = "foo";
         exceptionally(source.toCompletionStage().exceptionally(t -> expected), expected);
     }
 
     @Test
-    public void exceptionallyNull() throws Exception {
+    void exceptionallyNull() throws Exception {
         exceptionally(source.toCompletionStage().exceptionally(t -> null), null);
     }
 
@@ -656,7 +656,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void whenComplete() throws Exception {
+    void whenComplete() throws Exception {
         AtomicReference<String> strRef = new AtomicReference<>();
         whenComplete(source.toCompletionStage().whenComplete((s, t) -> {
             verifyInStExecutorThread();
@@ -665,7 +665,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void whenCompleteNull() throws Exception {
+    void whenCompleteNull() throws Exception {
         AtomicReference<String> strRef = new AtomicReference<>();
         whenComplete(source.toCompletionStage().whenComplete((s, t) -> {
             verifyInStExecutorThread();
@@ -674,7 +674,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void whenCompleteAsync() throws Exception {
+    void whenCompleteAsync() throws Exception {
         AtomicReference<String> strRef = new AtomicReference<>();
         whenComplete(source.toCompletionStage().whenCompleteAsync((s, t) -> {
             verifyInJdkForkJoinThread();
@@ -683,7 +683,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void whenCompleteAsyncExecutor() throws Exception {
+    void whenCompleteAsyncExecutor() throws Exception {
         AtomicReference<String> strRef = new AtomicReference<>();
         whenComplete(source.toCompletionStage().whenCompleteAsync((s, t) -> {
             verifyInJdkExecutorThread();
@@ -701,7 +701,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void handle() throws Exception {
+    void handle() throws Exception {
         AtomicReference<String> strRef = new AtomicReference<>();
         handle(source.toCompletionStage().handle((s, t) -> {
             verifyInStExecutorThread();
@@ -711,7 +711,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void handleNull() throws Exception {
+    void handleNull() throws Exception {
         AtomicReference<String> strRef = new AtomicReference<>();
         handle(source.toCompletionStage().handle((s, t) -> {
             verifyInStExecutorThread();
@@ -721,7 +721,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void handleAsync() throws Exception {
+    void handleAsync() throws Exception {
         AtomicReference<String> strRef = new AtomicReference<>();
         handle(source.toCompletionStage().handleAsync((s, t) -> {
             verifyInJdkForkJoinThread();
@@ -731,7 +731,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void handleAsyncExecutor() throws Exception {
+    void handleAsyncExecutor() throws Exception {
         AtomicReference<String> strRef = new AtomicReference<>();
         handle(source.toCompletionStage().handleAsync((s, t) -> {
             verifyInJdkExecutorThread();
@@ -750,7 +750,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void cancellationBeforeListen() throws InterruptedException {
+    void cancellationBeforeListen() throws InterruptedException {
         CompletionStage<String> stage = source.toCompletionStage();
         AtomicReference<Throwable> causeRef = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
@@ -763,7 +763,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void blockingCancellationBeforeListen() {
+    void blockingCancellationBeforeListen() {
         assertThrows(CancellationException.class,
                 () -> {
 
@@ -785,7 +785,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void cancellationAfterListen() throws InterruptedException {
+    void cancellationAfterListen() throws InterruptedException {
         CountDownLatch cancelLatch = new CountDownLatch(1);
         CompletionStage<String> stage = source.afterCancel(cancelLatch::countDown).toCompletionStage();
         AtomicReference<Throwable> causeRef = new AtomicReference<>();
@@ -801,7 +801,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void blockingCancellationAfterListen() {
+    void blockingCancellationAfterListen() {
         assertThrows(CancellationException.class, () -> {
             CountDownLatch cancelLatch = new CountDownLatch(1);
             CompletionStage<String> stage = source.afterCancel(cancelLatch::countDown).toCompletionStage();
@@ -823,7 +823,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void cancellationOnDependentCancelsSource() throws InterruptedException {
+    void cancellationOnDependentCancelsSource() throws InterruptedException {
         CountDownLatch cancelLatch = new CountDownLatch(1);
         CompletionStage<String> stage = source.afterCancel(cancelLatch::countDown).toCompletionStage();
         AtomicReference<Throwable> causeRef = new AtomicReference<>();
@@ -843,7 +843,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void synchronousNormalTerminationDoesNotCancel() {
+    void synchronousNormalTerminationDoesNotCancel() {
         AtomicInteger cancelCount = new AtomicInteger();
         String expected = "done";
         Single<String> single = succeeded(expected).whenCancel(cancelCount::incrementAndGet);
@@ -852,7 +852,7 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void asynchronousNormalTerminationDoesNotCancel() {
+    void asynchronousNormalTerminationDoesNotCancel() {
         AtomicInteger cancelCount = new AtomicInteger();
         String expected = "done";
         CompletableFuture<String> future = source.whenCancel(cancelCount::incrementAndGet)
@@ -863,22 +863,22 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void blockingGetAsync() throws Exception {
+    void blockingGetAsync() throws Exception {
         blockingGetAsync(source.toCompletionStage().toCompletableFuture(), "foo");
     }
 
     @Test
-    public void blockingGetAsyncNull() throws Exception {
+    void blockingGetAsyncNull() throws Exception {
         blockingGetAsync(source.toCompletionStage().toCompletableFuture(), null);
     }
 
     @Test
-    public void futureGetAsync() throws Exception {
+    void futureGetAsync() throws Exception {
         blockingGetAsync(source.toFuture(), "foo");
     }
 
     @Test
-    public void futureGetAsyncNull() throws Exception {
+    void futureGetAsyncNull() throws Exception {
         blockingGetAsync(source.toFuture(), null);
     }
 
@@ -889,22 +889,22 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void blockingGetSync() throws Exception {
+    void blockingGetSync() throws Exception {
         blockingGetSync(source.toCompletionStage().toCompletableFuture(), "foo");
     }
 
     @Test
-    public void blockingGetSyncNull() throws Exception {
+    void blockingGetSyncNull() throws Exception {
         blockingGetSync(source.toCompletionStage().toCompletableFuture(), null);
     }
 
     @Test
-    public void futureGetSync() throws Exception {
+    void futureGetSync() throws Exception {
         blockingGetSync(source.toFuture(), "foo");
     }
 
     @Test
-    public void futureGetSyncNull() throws Exception {
+    void futureGetSyncNull() throws Exception {
         blockingGetSync(source.toFuture(), null);
     }
 
@@ -915,12 +915,12 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void blockingGetAsyncError() {
+    void blockingGetAsyncError() {
         blockingGetAsyncError(source.toCompletionStage().toCompletableFuture());
     }
 
     @Test
-    public void futureGetAsyncError() {
+    void futureGetAsyncError() {
         blockingGetAsyncError(source.toFuture());
     }
 
@@ -933,12 +933,12 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void blockingGetSyncError() {
+    void blockingGetSyncError() {
         blockingGetSyncError(source.toCompletionStage().toCompletableFuture());
     }
 
     @Test
-    public void futureGetSyncError() {
+    void futureGetSyncError() {
         blockingGetSyncError(source.toFuture());
     }
 
@@ -951,12 +951,12 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void blockingGetTimeoutExpire() {
+    void blockingGetTimeoutExpire() {
         blockingGetTimeoutExpire(source.toCompletionStage().toCompletableFuture());
     }
 
     @Test
-    public void futureGetTimeoutExpire() {
+    void futureGetTimeoutExpire() {
         blockingGetTimeoutExpire(source.toFuture());
     }
 
@@ -967,12 +967,12 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void blockingGetTimeoutSuccess() throws Exception {
+    void blockingGetTimeoutSuccess() throws Exception {
         blockingGetTimeoutSuccess(source.toCompletionStage().toCompletableFuture());
     }
 
     @Test
-    public void futureGetTimeoutSuccess() throws Exception {
+    void futureGetTimeoutSuccess() throws Exception {
         blockingGetTimeoutSuccess(source.toFuture());
     }
 
@@ -983,12 +983,12 @@ public class SingleToCompletionStageTest {
     }
 
     @Test
-    public void blockingGetTimeoutError() {
+    void blockingGetTimeoutError() {
         blockingGetTimeoutError(source.toCompletionStage().toCompletableFuture());
     }
 
     @Test
-    public void futureGetTimeoutError() {
+    void futureGetTimeoutError() {
         blockingGetTimeoutError(source.toFuture());
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToFutureTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToFutureTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-public class SingleToFutureTest extends AbstractToFutureTest<Integer> {
+class SingleToFutureTest extends AbstractToFutureTest<Integer> {
 
     private final TestSingle<Integer> source = new TestSingle.Builder<Integer>().build(subscriber -> {
         subscriber.onSubscribe(mockCancellable);
@@ -63,7 +63,7 @@ public class SingleToFutureTest extends AbstractToFutureTest<Integer> {
     }
 
     @Test
-    public void testSucceededNull() throws Exception {
+    void testSucceededNull() throws Exception {
         Future<Integer> future = toFuture();
         exec.executor().schedule(() -> source.onSuccess(null), 10, MILLISECONDS);
         assertThat(future.get(), is(nullValue()));
@@ -73,7 +73,7 @@ public class SingleToFutureTest extends AbstractToFutureTest<Integer> {
     }
 
     @Test
-    public void testSucceededThrowable() throws Exception {
+    void testSucceededThrowable() throws Exception {
         TestSingle<Throwable> throwableSingle = new TestSingle<>();
         Future<Throwable> future = throwableSingle.toFuture();
         exec.executor().schedule(() -> throwableSingle.onSuccess(DELIBERATE_EXCEPTION), 10, MILLISECONDS);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToPublisherTest.java
@@ -41,7 +41,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class SingleToPublisherTest {
+class SingleToPublisherTest {
 
     @RegisterExtension
     final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
@@ -49,7 +49,7 @@ public class SingleToPublisherTest {
     private final TestPublisherSubscriber<String> verifier = new TestPublisherSubscriber<>();
 
     @Test
-    public void testSuccessBeforeRequest() {
+    void testSuccessBeforeRequest() {
         toSource(Single.succeeded("Hello").toPublisher()).subscribe(verifier);
         verifier.awaitSubscription().request(1);
         assertThat(verifier.takeOnNext(), is("Hello"));
@@ -57,14 +57,14 @@ public class SingleToPublisherTest {
     }
 
     @Test
-    public void testFailureBeforeRequest() {
+    void testFailureBeforeRequest() {
         toSource(Single.<String>failed(DELIBERATE_EXCEPTION).toPublisher()).subscribe(verifier);
         verifier.awaitSubscription().request(1);
         assertThat(verifier.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void testSuccessAfterRequest() {
+    void testSuccessAfterRequest() {
         TestSingle<String> single = new TestSingle<>();
         toSource(single.toPublisher()).subscribe(verifier);
         verifier.awaitSubscription().request(1);
@@ -74,14 +74,14 @@ public class SingleToPublisherTest {
     }
 
     @Test
-    public void testFailedFuture() {
+    void testFailedFuture() {
         toSource(Single.<String>failed(DELIBERATE_EXCEPTION).toPublisher()).subscribe(verifier);
         verifier.awaitSubscription().request(1);
         assertThat(verifier.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void testCancelBeforeRequest() {
+    void testCancelBeforeRequest() {
         toSource(Single.succeeded("Hello").toPublisher()).subscribe(verifier);
         verifier.awaitSubscription();
         assertThat(verifier.pollOnNext(10, MILLISECONDS), is(nullValue()));
@@ -89,7 +89,7 @@ public class SingleToPublisherTest {
     }
 
     @Test
-    public void testCancelAfterRequest() {
+    void testCancelAfterRequest() {
         toSource(Single.succeeded("Hello").toPublisher()).subscribe(verifier);
         verifier.awaitSubscription().request(1);
         assertThat(verifier.takeOnNext(), is("Hello"));
@@ -98,14 +98,14 @@ public class SingleToPublisherTest {
     }
 
     @Test
-    public void testInvalidRequestN() {
+    void testInvalidRequestN() {
         toSource(Single.succeeded("Hello").toPublisher()).subscribe(verifier);
         verifier.awaitSubscription().request(-1);
         assertThat(verifier.awaitOnError(), instanceOf(IllegalArgumentException.class));
     }
 
     @Test
-    public void testSuccessAfterInvalidRequestN() {
+    void testSuccessAfterInvalidRequestN() {
         TestSingle<String> single = new TestSingle<>();
         toSource(single.toPublisher()).subscribe(verifier);
         verifier.awaitSubscription().request(-1);
@@ -115,7 +115,7 @@ public class SingleToPublisherTest {
     }
 
     @Test
-    public void exceptionInTerminalCallsOnError() {
+    void exceptionInTerminalCallsOnError() {
         toSource(Single.succeeded("Hello").toPublisher().afterOnNext(n -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(verifier);
@@ -126,7 +126,7 @@ public class SingleToPublisherTest {
     }
 
     @Test
-    public void subscribeOnOriginalIsPreserved() throws Exception {
+    void subscribeOnOriginalIsPreserved() throws Exception {
         final Thread testThread = currentThread();
         final CountDownLatch analyzed = new CountDownLatch(1);
         ConcurrentLinkedQueue<AssertionError> errors = new ConcurrentLinkedQueue<>();
@@ -149,7 +149,7 @@ public class SingleToPublisherTest {
     }
 
     @Test
-    public void publishOnOriginalIsPreservedOnCompleteFromRequest() throws Exception {
+    void publishOnOriginalIsPreservedOnCompleteFromRequest() throws Exception {
         ConcurrentLinkedQueue<AssertionError> errors = new ConcurrentLinkedQueue<>();
         io.servicetalk.concurrent.test.internal.TestPublisherSubscriber<String> subscriber =
                 new io.servicetalk.concurrent.test.internal.TestPublisherSubscriber<>();
@@ -166,7 +166,7 @@ public class SingleToPublisherTest {
     }
 
     @Test
-    public void publishOnOriginalIsPreservedOnCompleteFromOnSuccess() throws Exception {
+    void publishOnOriginalIsPreservedOnCompleteFromOnSuccess() throws Exception {
         ConcurrentLinkedQueue<AssertionError> errors = new ConcurrentLinkedQueue<>();
         io.servicetalk.concurrent.test.internal.TestPublisherSubscriber<String> subscriber =
                 new io.servicetalk.concurrent.test.internal.TestPublisherSubscriber<>();
@@ -181,7 +181,7 @@ public class SingleToPublisherTest {
     }
 
     @Test
-    public void publishOnOriginalIsPreservedOnError() throws Exception {
+    void publishOnOriginalIsPreservedOnError() throws Exception {
         ConcurrentLinkedQueue<AssertionError> errors = new ConcurrentLinkedQueue<>();
         io.servicetalk.concurrent.test.internal.TestPublisherSubscriber<String> subscriber = new
                 io.servicetalk.concurrent.test.internal.TestPublisherSubscriber<>();
@@ -196,7 +196,7 @@ public class SingleToPublisherTest {
     }
 
     @Test
-    public void publishOnOriginalIsPreservedOnInvalidRequestN() throws Exception {
+    void publishOnOriginalIsPreservedOnInvalidRequestN() throws Exception {
         ConcurrentLinkedQueue<AssertionError> errors = new ConcurrentLinkedQueue<>();
         io.servicetalk.concurrent.test.internal.TestPublisherSubscriber<String> subscriber =
                 new io.servicetalk.concurrent.test.internal.TestPublisherSubscriber<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SubscribeShareContextTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SubscribeShareContextTest.java
@@ -24,19 +24,19 @@ import static io.servicetalk.concurrent.api.Single.succeeded;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class SubscribeShareContextTest {
+class SubscribeShareContextTest {
 
-    public static final AsyncContextMap.Key<String> KEY = AsyncContextMap.Key.newKey("share-context-key");
+    static final AsyncContextMap.Key<String> KEY = AsyncContextMap.Key.newKey("share-context-key");
 
     @Test
-    public void contextIsShared() throws Exception {
+    void contextIsShared() throws Exception {
         AsyncContext.put(KEY, "v1");
         succeeded(1).beforeOnSuccess(__ -> AsyncContext.put(KEY, "v2")).subscribeShareContext().toFuture().get();
         assertThat("Unexpected value found in the context.", AsyncContext.get(KEY), is("v2"));
     }
 
     @Test
-    public void contextIsNotSharedIfNotLastOperator() throws Exception {
+    void contextIsNotSharedIfNotLastOperator() throws Exception {
         // When we support this feature, then we can change this test
         AsyncContext.put(KEY, "v1");
         succeeded(1).beforeOnSuccess(__ -> AsyncContext.put(KEY, "v2"))

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SubscribeTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public final class SubscribeTest {
+final class SubscribeTest {
 
     private LegacyTestSingle<Integer> source;
     private Consumer<Integer> resultConsumer;
@@ -35,21 +35,21 @@ public final class SubscribeTest {
 
     @SuppressWarnings("unchecked")
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         source = new LegacyTestSingle<>();
         resultConsumer = (Consumer<Integer>) mock(Consumer.class);
         cancellable = source.subscribe(resultConsumer);
     }
 
     @Test
-    public void testSubscribe() {
+    void testSubscribe() {
         source.onSuccess(1);
         verify(resultConsumer).accept(1);
         verifyNoMoreInteractions(resultConsumer);
     }
 
     @Test
-    public void testCancel() {
+    void testCancel() {
         source.verifyNotCancelled();
         cancellable.cancel();
         source.verifyCancelled();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SupplierSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SupplierSingleTest.java
@@ -35,20 +35,20 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class SupplierSingleTest {
+class SupplierSingleTest {
     private static final RuntimeException DELIBERATE_EXCEPTION = new IllegalArgumentException();
 
     private Supplier<Integer> factory;
 
     @SuppressWarnings("unchecked")
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         factory = mock(Supplier.class);
         when(factory.get()).thenReturn(1);
     }
 
     @Test
-    public void testEverySubscribeCreatesNew() {
+    void testEverySubscribeCreatesNew() {
         final Single<Integer> source = Single.fromSupplier(factory);
         listenAndVerify(source);
         listenAndVerify(source);
@@ -65,7 +65,7 @@ public class SupplierSingleTest {
     }
 
     @Test
-    public void testOnError() {
+    void testOnError() {
         when(factory.get()).thenThrow(IllegalArgumentException.class);
 
         final Single<Integer> source = Single.fromSupplier(factory);
@@ -83,7 +83,7 @@ public class SupplierSingleTest {
     }
 
     @Test
-    public void cancelInterrupts() throws Exception {
+    void cancelInterrupts() throws Exception {
         final Single<Integer> source = Single.fromSupplier(factory);
         final CountDownLatch latch = new CountDownLatch(1);
 
@@ -118,7 +118,7 @@ public class SupplierSingleTest {
     }
 
     @Test
-    public void onSubscribeThrows() {
+    void onSubscribeThrows() {
         final Single<Integer> source = Single.fromSupplier(factory);
 
         @SuppressWarnings("unchecked")

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/TimeoutSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/TimeoutSingleTest.java
@@ -47,21 +47,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class TimeoutSingleTest {
+class TimeoutSingleTest {
     @RegisterExtension
-    public final ExecutorExtension<TestExecutor> executorExtension = ExecutorExtension.withTestExecutor();
+    final ExecutorExtension<TestExecutor> executorExtension = ExecutorExtension.withTestExecutor();
 
     private LegacyTestSingle<Integer> source = new LegacyTestSingle<>(false, false);
-    public final TestSingleSubscriber<Integer> subscriber = new TestSingleSubscriber<>();
+    final TestSingleSubscriber<Integer> subscriber = new TestSingleSubscriber<>();
     private TestExecutor testExecutor;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         testExecutor = executorExtension.executor();
     }
 
     @Test
-    public void executorScheduleThrows() {
+    void executorScheduleThrows() {
         toSource(source.timeout(1, NANOSECONDS, new DelegatingExecutor(testExecutor) {
             @Override
             public Cancellable schedule(final Runnable task, final long delay, final TimeUnit unit) {
@@ -76,7 +76,7 @@ public class TimeoutSingleTest {
     }
 
     @Test
-    public void noDataOnCompletionNoTimeout() {
+    void noDataOnCompletionNoTimeout() {
         init();
 
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -88,7 +88,7 @@ public class TimeoutSingleTest {
     }
 
     @Test
-    public void noDataOnErrorNoTimeout() {
+    void noDataOnErrorNoTimeout() {
         init();
 
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -100,7 +100,7 @@ public class TimeoutSingleTest {
     }
 
     @Test
-    public void subscriptionCancelAlsoCancelsTimer() {
+    void subscriptionCancelAlsoCancelsTimer() {
         init();
 
         subscriber.awaitSubscription().cancel();
@@ -110,7 +110,7 @@ public class TimeoutSingleTest {
     }
 
     @Test
-    public void noDataAndTimeout() {
+    void noDataAndTimeout() {
         init();
 
         // Sleep for at least as much time as the expiration time, because we just subscribed data.
@@ -122,7 +122,7 @@ public class TimeoutSingleTest {
     }
 
     @Test
-    public void justSubscribeTimeout() {
+    void justSubscribeTimeout() {
         DelayedOnSubscribeSingle<Integer> delayedSingle = new DelayedOnSubscribeSingle<>();
 
         init(delayedSingle, false);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentSubscriptionTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentSubscriptionTest.java
@@ -40,11 +40,11 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class ConcurrentSubscriptionTest {
+class ConcurrentSubscriptionTest {
     private final TestSubscription subscription = new TestSubscription();
 
     @Test
-    public void singleThreadSingleRequest() throws InterruptedException {
+    void singleThreadSingleRequest() throws InterruptedException {
         Subscription concurrent = ConcurrentSubscription.wrap(subscription);
         final long demand = Long.MAX_VALUE;
         concurrent.request(demand);
@@ -53,7 +53,7 @@ public class ConcurrentSubscriptionTest {
     }
 
     @Test
-    public void singleThreadMultipleRequest() throws InterruptedException {
+    void singleThreadMultipleRequest() throws InterruptedException {
         Subscription concurrent = ConcurrentSubscription.wrap(subscription);
         final int demand = 100;
         for (int i = 0; i < demand; ++i) {
@@ -64,14 +64,14 @@ public class ConcurrentSubscriptionTest {
     }
 
     @Test
-    public void singleThreadCancel() {
+    void singleThreadCancel() {
         Subscription concurrent = ConcurrentSubscription.wrap(subscription);
         concurrent.cancel();
         assertTrue(subscription.isCancelled());
     }
 
     @Test
-    public void singleThreadCancelDeliveredIfRequestThrows() throws InterruptedException {
+    void singleThreadCancelDeliveredIfRequestThrows() throws InterruptedException {
         CountDownLatch cancelledLatch = new CountDownLatch(1);
         Subscription concurrent = ConcurrentSubscription.wrap(new Subscription() {
             @Override
@@ -95,7 +95,7 @@ public class ConcurrentSubscriptionTest {
     }
 
     @Test
-    public void singleThreadReentrant() {
+    void singleThreadReentrant() {
         final ReentrantSubscription reentrantSubscription = new ReentrantSubscription(50);
         final Subscription concurrent = ConcurrentSubscription.wrap(reentrantSubscription);
         reentrantSubscription.outerSubscription(concurrent);
@@ -104,7 +104,7 @@ public class ConcurrentSubscriptionTest {
     }
 
     @Test
-    public void singleThreadInvalidRequestN() {
+    void singleThreadInvalidRequestN() {
         Subscription concurrent = ConcurrentSubscription.wrap(subscription);
         final long invalidN = ThreadLocalRandom.current().nextLong(Long.MIN_VALUE, 1);
         concurrent.request(invalidN);
@@ -112,12 +112,12 @@ public class ConcurrentSubscriptionTest {
     }
 
     @Test
-    public void multiThreadRequest() throws ExecutionException, InterruptedException {
+    void multiThreadRequest() throws ExecutionException, InterruptedException {
         multiThread(300, false);
     }
 
     @Test
-    public void multiThreadCancel() throws ExecutionException, InterruptedException {
+    void multiThreadCancel() throws ExecutionException, InterruptedException {
         multiThread(250, true);
     }
 
@@ -157,7 +157,7 @@ public class ConcurrentSubscriptionTest {
     }
 
     @Test
-    public void multiThreadCancelNotDeliveredIfRequestThrows() throws Exception {
+    void multiThreadCancelNotDeliveredIfRequestThrows() throws Exception {
         ExecutorService executorService = newFixedThreadPool(1);
         try {
             CyclicBarrier barrier = new CyclicBarrier(2);
@@ -201,7 +201,7 @@ public class ConcurrentSubscriptionTest {
     }
 
     @Test
-    public void multiThreadReentrant() throws Exception {
+    void multiThreadReentrant() throws Exception {
         ExecutorService executorService = newFixedThreadPool(1);
         try {
             final ReentrantSubscription reentrantSubscription = new ReentrantSubscription(50);
@@ -228,12 +228,12 @@ public class ConcurrentSubscriptionTest {
     }
 
     @Test
-    public void multiThreadInvalidRequestN() throws Exception {
+    void multiThreadInvalidRequestN() throws Exception {
         multiThreadInvalidRequestN(false);
     }
 
     @Test
-    public void multiThreadInvalidRequestNCancel() throws Exception {
+    void multiThreadInvalidRequestNCancel() throws Exception {
         multiThreadInvalidRequestN(true);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentTerminalSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentTerminalSubscriberTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class ConcurrentTerminalSubscriberTest {
+class ConcurrentTerminalSubscriberTest {
     @RegisterExtension
     final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
 
@@ -52,62 +52,62 @@ public class ConcurrentTerminalSubscriberTest {
     private final TestSubscription subscription = new TestSubscription();
 
     @Test
-    public void concurrentOnSubscribeWithOnNextAndOnComplete() throws Exception {
+    void concurrentOnSubscribeWithOnNextAndOnComplete() throws Exception {
         concurrentOnSubscribe(true, true);
     }
 
     @Test
-    public void concurrentOnSubscribeWithOnComplete() throws Exception {
+    void concurrentOnSubscribeWithOnComplete() throws Exception {
         concurrentOnSubscribe(true, false);
     }
 
     @Test
-    public void concurrentOnSubscribeWithOnNextAndOnError() throws Exception {
+    void concurrentOnSubscribeWithOnNextAndOnError() throws Exception {
         concurrentOnSubscribe(false, true);
     }
 
     @Test
-    public void concurrentOnSubscribeWithOnError() throws Exception {
+    void concurrentOnSubscribeWithOnError() throws Exception {
         concurrentOnSubscribe(false, false);
     }
 
     @Test
-    public void concurrentOnNextWithOnComplete() throws Exception {
+    void concurrentOnNextWithOnComplete() throws Exception {
         concurrentOnNext(true);
     }
 
     @Test
-    public void concurrentOnNextWithOnError() throws Exception {
+    void concurrentOnNextWithOnError() throws Exception {
         concurrentOnNext(false);
     }
 
     @Test
-    public void concurrentOnCompleteWithOnComplete() throws Exception {
+    void concurrentOnCompleteWithOnComplete() throws Exception {
         concurrentOnComplete(true, true);
     }
 
     @Test
-    public void concurrentOnCompleteWithOnError() throws Exception {
+    void concurrentOnCompleteWithOnError() throws Exception {
         concurrentOnComplete(true, false);
     }
 
     @Test
-    public void concurrentOnErrorWithOnComplete() throws Exception {
+    void concurrentOnErrorWithOnComplete() throws Exception {
         concurrentOnComplete(false, true);
     }
 
     @Test
-    public void concurrentOnErrorWithOnError() throws Exception {
+    void concurrentOnErrorWithOnError() throws Exception {
         concurrentOnComplete(false, false);
     }
 
     @Test
-    public void reentrySynchronousOnNextAllowedOnComplete() {
+    void reentrySynchronousOnNextAllowedOnComplete() {
         reentrySynchronousOnNextAllowed(true);
     }
 
     @Test
-    public void reentrySynchronousOnNextAllowedOnError() {
+    void reentrySynchronousOnNextAllowedOnError() {
         reentrySynchronousOnNextAllowed(false);
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderCompletableTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class SignalOffloaderCompletableTest {
+class SignalOffloaderCompletableTest {
 
     private enum OffloaderTestParam {
         THREAD_BASED {
@@ -88,7 +88,7 @@ public class SignalOffloaderCompletableTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         if (state != null) {
             state.shutdown();
             state = null;
@@ -97,7 +97,7 @@ public class SignalOffloaderCompletableTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void offloadingSubscriberShouldNotOffloadCancellable(OffloaderTestParam offloader)
+    void offloadingSubscriberShouldNotOffloadCancellable(OffloaderTestParam offloader)
             throws Exception {
         init(offloader);
         Subscriber offloadedSubscriber = state.offloader.offloadCancellable(state.subscriber);
@@ -110,7 +110,7 @@ public class SignalOffloaderCompletableTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void offloadingCancellableShouldNotOffloadSubscriber(OffloaderTestParam offloader)
+    void offloadingCancellableShouldNotOffloadSubscriber(OffloaderTestParam offloader)
             throws Exception {
         init(offloader);
         Subscriber offloaded = state.offloader.offloadCancellable(state.subscriber);
@@ -123,7 +123,7 @@ public class SignalOffloaderCompletableTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void offloadSubscriber(OffloaderTestParam offloader) throws Exception {
+    void offloadSubscriber(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
@@ -133,7 +133,7 @@ public class SignalOffloaderCompletableTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void cancelShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader)
+    void cancelShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader)
             throws Exception {
         init(offloader);
         Subscriber offloadedCancellable = state.offloader.offloadCancellable(state.subscriber);
@@ -145,7 +145,7 @@ public class SignalOffloaderCompletableTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void onErrorShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader)
+    void onErrorShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader)
             throws Exception {
         init(offloader);
         Subscriber offloadedCancellable = state.offloader.offloadCancellable(state.subscriber);
@@ -156,7 +156,7 @@ public class SignalOffloaderCompletableTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void onCompleteShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader)
+    void onCompleteShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader)
             throws Exception {
         init(offloader);
         Subscriber offloadedCancellable = state.offloader.offloadCancellable(state.subscriber);
@@ -167,7 +167,7 @@ public class SignalOffloaderCompletableTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void onSubscribeThrows(OffloaderTestParam offloader) throws Exception {
+    void onSubscribeThrows(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloadedWhenThrows(offloaded);
@@ -177,7 +177,7 @@ public class SignalOffloaderCompletableTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void onSuccessThrows(OffloaderTestParam offloader) throws Exception {
+    void onSuccessThrows(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
@@ -187,7 +187,7 @@ public class SignalOffloaderCompletableTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void onErrorThrows(OffloaderTestParam offloader) throws Exception {
+    void onErrorThrows(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
@@ -197,7 +197,7 @@ public class SignalOffloaderCompletableTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void offloadPostTermination(OffloaderTestParam offloader) throws Exception {
+    void offloadPostTermination(OffloaderTestParam offloader) throws Exception {
         assumeTrue(offloader.isSupportsTermination(), "Termination test not supported by this offloader.");
         init(offloader);
         Subscriber offloaded = state.offloader.offloadSubscriber(state.subscriber);
@@ -209,7 +209,7 @@ public class SignalOffloaderCompletableTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void executorRejectsForHandleSubscribe(OffloaderTestParam offloader) {
+    void executorRejectsForHandleSubscribe(OffloaderTestParam offloader) {
         init(offloader);
         ThreadBasedSignalOffloader rejectOffloader = new ThreadBasedSignalOffloader(from(task -> {
             throw new RejectedExecutionException();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderConcurrentCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderConcurrentCompletableTest.java
@@ -41,7 +41,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
-public class SignalOffloaderConcurrentCompletableTest {
+class SignalOffloaderConcurrentCompletableTest {
 
     private enum OffloaderTestParam {
         THREAD_BASED {
@@ -67,13 +67,13 @@ public class SignalOffloaderConcurrentCompletableTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         state.shutdown();
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void concurrentSignalsMultipleEntities(OffloaderTestParam offloader)
+    void concurrentSignalsMultipleEntities(OffloaderTestParam offloader)
             throws Exception {
         init(offloader);
         final int entityCount = 100;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderConcurrentPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderConcurrentPublisherTest.java
@@ -49,7 +49,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
-public class SignalOffloaderConcurrentPublisherTest {
+class SignalOffloaderConcurrentPublisherTest {
     private enum OffloaderTestParam {
         THREAD_BASED {
             @Override
@@ -70,13 +70,13 @@ public class SignalOffloaderConcurrentPublisherTest {
     private OffloaderHolder state;
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         state.shutdown();
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void concurrentSignalsMultipleEntities(OffloaderTestParam offloader)
+    void concurrentSignalsMultipleEntities(OffloaderTestParam offloader)
             throws Exception {
         state = offloader.get();
         final int entityCount = 100;
@@ -103,7 +103,7 @@ public class SignalOffloaderConcurrentPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void concurrentSignalsFromSubscriberAndSubscription(OffloaderTestParam offloader)
+    void concurrentSignalsFromSubscriberAndSubscription(OffloaderTestParam offloader)
             throws Exception {
         state = offloader.get();
         OffloaderHolder.SubscriberSubscriptionPair pair = state.newPair(10_000);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderConcurrentSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderConcurrentSingleTest.java
@@ -42,7 +42,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
-public class SignalOffloaderConcurrentSingleTest {
+class SignalOffloaderConcurrentSingleTest {
     private OffloaderHolder state;
 
     private enum OffloaderTestParam {
@@ -67,13 +67,13 @@ public class SignalOffloaderConcurrentSingleTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         state.shutdown();
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void concurrentSignalsMultipleEntities(OffloaderTestParam offloader) throws Exception {
+    void concurrentSignalsMultipleEntities(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         final int entityCount = 100;
         final OffloaderHolder.SubscriberCancellablePair[] pairs =

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderPublisherTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class SignalOffloaderPublisherTest {
+class SignalOffloaderPublisherTest {
 
     private enum OffloaderTestParam {
         THREAD_BASED {
@@ -89,7 +89,7 @@ public class SignalOffloaderPublisherTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         if (state != null) {
             state.shutdown();
             state = null;
@@ -98,14 +98,14 @@ public class SignalOffloaderPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void offloadSignal(OffloaderTestParam offloader) throws Exception {
+    void offloadSignal(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         state.offloadSignalAndAwait("Hello");
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void offloadSignalShouldTerminateOffloader(OffloaderTestParam offloader) {
+    void offloadSignalShouldTerminateOffloader(OffloaderTestParam offloader) {
         assumeTrue(offloader.isSupportsTermination(), "Termination test not supported by this offloader.");
         init(offloader);
         assertThrows(IllegalStateException.class, () -> state.offloadSignalAndAwait("Hello")
@@ -115,7 +115,7 @@ public class SignalOffloaderPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void offloadingSubscriberShouldNotOffloadSubscription(OffloaderTestParam offloader) throws Exception {
+    void offloadingSubscriberShouldNotOffloadSubscription(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber<? super String> offloadSubscription = state.offloader.offloadSubscription(state.subscriber);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(offloadSubscription);
@@ -128,7 +128,7 @@ public class SignalOffloaderPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void offloadingSubscriptionShouldNotOffloadSubscriber(OffloaderTestParam offloader) throws Exception {
+    void offloadingSubscriptionShouldNotOffloadSubscriber(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscription(state.subscriber);
 
@@ -142,7 +142,7 @@ public class SignalOffloaderPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void offloadSubscriber(OffloaderTestParam offloader) throws Exception {
+    void offloadSubscriber(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
@@ -153,7 +153,7 @@ public class SignalOffloaderPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void cancelShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader) throws Exception {
+    void cancelShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber<? super String> offloadedSubscription = state.offloader.offloadSubscription(state.subscriber);
         Subscriber<? super String> offloadedSubscriber = state.offloader.offloadSubscriber(offloadedSubscription);
@@ -164,7 +164,7 @@ public class SignalOffloaderPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void onErrorShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader) throws Exception {
+    void onErrorShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber<? super String> offloadedSubscription = state.offloader.offloadSubscription(state.subscriber);
         Subscriber<? super String> offloadedSubscriber = state.offloader.offloadSubscriber(offloadedSubscription);
@@ -174,7 +174,7 @@ public class SignalOffloaderPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void onCompleteShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader) throws Exception {
+    void onCompleteShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber<? super String> offloadedSubscription = state.offloader.offloadSubscription(state.subscriber);
         Subscriber<? super String> offloadedSubscriber = state.offloader.offloadSubscriber(offloadedSubscription);
@@ -184,7 +184,7 @@ public class SignalOffloaderPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void onNextSupportsNull(OffloaderTestParam offloader) throws Exception {
+    void onNextSupportsNull(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
@@ -195,7 +195,7 @@ public class SignalOffloaderPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void onSubscribeThrows(OffloaderTestParam offloader) throws Exception {
+    void onSubscribeThrows(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloadedWhenThrows(offloaded);
@@ -205,7 +205,7 @@ public class SignalOffloaderPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void onNextThrows(OffloaderTestParam offloader) throws Exception {
+    void onNextThrows(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
@@ -217,7 +217,7 @@ public class SignalOffloaderPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void onErrorThrows(OffloaderTestParam offloader) throws Exception {
+    void onErrorThrows(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
@@ -227,7 +227,7 @@ public class SignalOffloaderPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void onCompleteThrows(OffloaderTestParam offloader) throws Exception {
+    void onCompleteThrows(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
@@ -237,7 +237,7 @@ public class SignalOffloaderPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void offloadPostTermination(OffloaderTestParam offloader) throws Exception {
+    void offloadPostTermination(OffloaderTestParam offloader) throws Exception {
         assumeTrue(offloader.isSupportsTermination(), "Termination test not supported by this offloader.");
         init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
@@ -249,35 +249,35 @@ public class SignalOffloaderPublisherTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void negative1RequestIsPropagated(OffloaderTestParam offloader) throws Exception {
+    void negative1RequestIsPropagated(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         testInvalidRequestNIsPropagated(-1, Long.MIN_VALUE);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void negative2RequestIsPropagated(OffloaderTestParam offloader) throws Exception {
+    void negative2RequestIsPropagated(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         testInvalidRequestNIsPropagated(-2, Long.MIN_VALUE);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void negative3RequestIsPropagated(OffloaderTestParam offloader) throws Exception {
+    void negative3RequestIsPropagated(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         testInvalidRequestNIsPropagated(-3, -3);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void zeroRequestIsPropagated(OffloaderTestParam offloader) throws Exception {
+    void zeroRequestIsPropagated(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         testInvalidRequestNIsPropagated(0, Long.MIN_VALUE);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void executorRejectsForHandleSubscribe(OffloaderTestParam offloader) {
+    void executorRejectsForHandleSubscribe(OffloaderTestParam offloader) {
         init(offloader);
         ThreadBasedSignalOffloader rejectedOffloader = new ThreadBasedSignalOffloader(from(task -> {
             throw new RejectedExecutionException();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/SignalOffloaderSingleTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class SignalOffloaderSingleTest {
+class SignalOffloaderSingleTest {
 
     private enum OffloaderTestParam {
         THREAD_BASED {
@@ -88,7 +88,7 @@ public class SignalOffloaderSingleTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         if (state != null) {
             state.shutdown();
             state = null;
@@ -97,7 +97,7 @@ public class SignalOffloaderSingleTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void offloadingSubscriberShouldNotOffloadCancellable(OffloaderTestParam offloader)
+    void offloadingSubscriberShouldNotOffloadCancellable(OffloaderTestParam offloader)
             throws Exception {
         init(offloader);
         Subscriber<? super String> offloadedSubscriber = state.offloader.offloadCancellable(state.subscriber);
@@ -110,7 +110,7 @@ public class SignalOffloaderSingleTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void offloadingCancellableShouldNotOffloadSubscriber(OffloaderTestParam offloader)
+    void offloadingCancellableShouldNotOffloadSubscriber(OffloaderTestParam offloader)
             throws Exception {
         init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadCancellable(state.subscriber);
@@ -123,7 +123,7 @@ public class SignalOffloaderSingleTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void offloadSubscriber(OffloaderTestParam offloader) throws Exception {
+    void offloadSubscriber(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
@@ -133,7 +133,7 @@ public class SignalOffloaderSingleTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void cancelShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader)
+    void cancelShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader)
             throws Exception {
         init(offloader);
         Subscriber<? super String> offloadedCancellable = state.offloader.offloadCancellable(state.subscriber);
@@ -145,7 +145,7 @@ public class SignalOffloaderSingleTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void onErrorShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader)
+    void onErrorShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader)
             throws Exception {
         init(offloader);
         Subscriber<? super String> offloadedCancellable = state.offloader.offloadCancellable(state.subscriber);
@@ -156,7 +156,7 @@ public class SignalOffloaderSingleTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void onSuccessShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader)
+    void onSuccessShouldTerminateOffloadingWithMultipleEntities(OffloaderTestParam offloader)
             throws Exception {
         init(offloader);
         Subscriber<? super String> offloadedCancellable = state.offloader.offloadCancellable(state.subscriber);
@@ -167,7 +167,7 @@ public class SignalOffloaderSingleTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void onSuccessSupportsNull(OffloaderTestParam offloader) throws Exception {
+    void onSuccessSupportsNull(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
@@ -176,7 +176,7 @@ public class SignalOffloaderSingleTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void onSubscribeThrows(OffloaderTestParam offloader) throws Exception {
+    void onSubscribeThrows(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloadedWhenThrows(offloaded);
@@ -186,7 +186,7 @@ public class SignalOffloaderSingleTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void onSuccessThrows(OffloaderTestParam offloader) throws Exception {
+    void onSuccessThrows(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
@@ -196,7 +196,7 @@ public class SignalOffloaderSingleTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void onErrorThrows(OffloaderTestParam offloader) throws Exception {
+    void onErrorThrows(OffloaderTestParam offloader) throws Exception {
         init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
         state.verifyOnSubscribeOffloaded(offloaded);
@@ -206,7 +206,7 @@ public class SignalOffloaderSingleTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void offloadPostTermination(OffloaderTestParam offloader) throws Exception {
+    void offloadPostTermination(OffloaderTestParam offloader) throws Exception {
         assumeTrue(offloader.isSupportsTermination(), "Termination test not supported by this offloader.");
         init(offloader);
         Subscriber<? super String> offloaded = state.offloader.offloadSubscriber(state.subscriber);
@@ -218,7 +218,7 @@ public class SignalOffloaderSingleTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @EnumSource(OffloaderTestParam.class)
-    public void executorRejectsForHandleSubscribe(OffloaderTestParam offloader) {
+    void executorRejectsForHandleSubscribe(OffloaderTestParam offloader) {
         init(offloader);
         ThreadBasedSignalOffloader rejectOffloader = new ThreadBasedSignalOffloader(from(task -> {
             throw new RejectedExecutionException();

--- a/servicetalk-gradle-plugin-internal/src/main/resources/io/servicetalk/gradle/plugin/internal/pmd/basic.xml
+++ b/servicetalk-gradle-plugin-internal/src/main/resources/io/servicetalk/gradle/plugin/internal/pmd/basic.xml
@@ -42,6 +42,7 @@
 
   <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP"/>
   <rule ref="category/java/bestpractices.xml/CheckResultSet"/>
+  <rule ref="category/java/bestpractices.xml/JUnit5TestShouldBePackagePrivate" />
   <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
 
   <rule ref="category/java/codestyle.xml/ExtendsObject"/>
@@ -51,5 +52,6 @@
   <rule ref="category/java/performance.xml/BooleanInstantiation"/>
 
   <rule ref="category/java/design.xml/CollapsibleIfStatements"/>
+  <rule ref="category/java/design.xml/MutableStaticState" />
   <rule ref="category/java/design.xml/SimplifiedTernary"/>
 </ruleset>

--- a/servicetalk-grpc-internal/src/test/java/io/servicetalk/grpc/internal/DeadlineUtilsTest.java
+++ b/servicetalk-grpc-internal/src/test/java/io/servicetalk/grpc/internal/DeadlineUtilsTest.java
@@ -32,11 +32,12 @@ import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DeadlineUtilsTest {
+class DeadlineUtilsTest {
 
     private static final Duration EXCESSIVE_TIMEOUT = GRPC_MAX_TIMEOUT.plusNanos(1);
     private static final Duration INFINITE_TIMEOUT = Duration.ofHours(EIGHT_NINES + 1);
 
+    @SuppressWarnings("unused")
     private static Stream<Arguments> testMakeTimeoutHeader() {
         return Stream.of(
                 Arguments.of(null, null),
@@ -55,12 +56,13 @@ public class DeadlineUtilsTest {
 
     @ParameterizedTest
     @MethodSource
-    public void testMakeTimeoutHeader(Duration duration, CharSequence expected) {
+    void testMakeTimeoutHeader(Duration duration, CharSequence expected) {
         CharSequence result = makeTimeoutHeader(duration);
         assertTrue(CharSequences.contentEquals(expected, result),
                 () -> "Expected: '" + expected + "' Found: '" + result + "'");
     }
 
+    @SuppressWarnings("unused")
     private static Stream<Arguments> testParseTimeoutHeader() {
         return Stream.of(
                 Arguments.of(Duration.ZERO, "0n"),
@@ -75,11 +77,12 @@ public class DeadlineUtilsTest {
 
     @ParameterizedTest
     @MethodSource
-    public void testParseTimeoutHeader(Duration expected, CharSequence headerValue) {
+    void testParseTimeoutHeader(Duration expected, CharSequence headerValue) {
         Duration timeout = parseTimeoutHeader(headerValue);
         assertEquals(expected, timeout);
     }
 
+    @SuppressWarnings("unused")
     private static Stream<Arguments> testRoundTripping() {
         return Stream.of(
                 Arguments.of("0n"),
@@ -94,7 +97,7 @@ public class DeadlineUtilsTest {
 
     @ParameterizedTest
     @MethodSource
-    public void testRoundTripping(CharSequence expected) {
+    void testRoundTripping(CharSequence expected) {
         Duration parsed = parseTimeoutHeader(expected);
         CharSequence result = makeTimeoutHeader(parsed);
         assertTrue(CharSequences.contentEquals(expected, result),

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -171,13 +171,13 @@ public class ProtocolCompatibilityTest {
     }
 
     @DataPoints("ssl")
-    public static boolean[] ssl = {false, true};
+    public static final boolean[] SSL = {false, true};
 
     @DataPoints("streaming")
-    public static boolean[] streaming = {false, true};
+    public static final boolean[] STREAMING = {false, true};
 
     @DataPoints("compression")
-    public static String[] compression = {"gzip", "identity", null};
+    public static final String[] COMPRESSION = {"gzip", "identity", null};
 
     @Rule
     public final Timeout timeout = new ServiceTalkTestTimeout();

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/FormUrlEncodedHttpDeserializerTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/FormUrlEncodedHttpDeserializerTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class FormUrlEncodedHttpDeserializerTest {
+class FormUrlEncodedHttpDeserializerTest {
 
     @Test
     void formParametersAreDeserialized() {

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/FormUrlEncodedHttpSerializerTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/FormUrlEncodedHttpSerializerTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class FormUrlEncodedHttpSerializerTest {
+class FormUrlEncodedHttpSerializerTest {
 
     private static final FormUrlEncodedHttpSerializer SERIALIZER = FormUrlEncodedHttpSerializer.UTF8;
 

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/InvalidMetadataValuesTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/InvalidMetadataValuesTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @SuppressWarnings("ConstantConditions")
-public class InvalidMetadataValuesTest {
+class InvalidMetadataValuesTest {
 
     @SuppressWarnings("unused")
     private static Stream<Arguments> data() throws ExecutionException, InterruptedException {

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/SimpleHttpRequesterFilterTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/SimpleHttpRequesterFilterTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.mock;
 /**
  * This is a test-case for the {@link AbstractHttpRequesterFilterTest} HTTP request filter test utilities.
  */
-public class SimpleHttpRequesterFilterTest extends AbstractHttpRequesterFilterTest {
+class SimpleHttpRequesterFilterTest extends AbstractHttpRequesterFilterTest {
 
     private static final class HeaderEnrichingRequestFilter implements StreamingHttpClientFilterFactory,
                                                                        StreamingHttpConnectionFilterFactory {

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/StreamingHttpPayloadHolderTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/StreamingHttpPayloadHolderTest.java
@@ -60,7 +60,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class StreamingHttpPayloadHolderTest {
+class StreamingHttpPayloadHolderTest {
 
     private enum UpdateMode {
         None,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractEchoServerBasedHttpRequesterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractEchoServerBasedHttpRequesterTest.java
@@ -28,6 +28,7 @@ import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.ExecutionException;
@@ -52,15 +53,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-public abstract class AbstractEchoServerBasedHttpRequesterTest {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractEchoServerBasedHttpRequesterTest {
 
     @RegisterExtension
     static final ExecutionContextExtension CTX = ExecutionContextExtension.immediate().setClassLevel(true);
 
-    static ServerContext serverContext;
+    ServerContext serverContext;
 
     @BeforeAll
-    public static void startServer() throws Exception {
+    void startServer() throws Exception {
         serverContext = forAddress(localAddress(0))
             .ioExecutor(CTX.ioExecutor())
             .executionStrategy(noOffloadsStrategy())
@@ -68,7 +70,7 @@ public abstract class AbstractEchoServerBasedHttpRequesterTest {
     }
 
     @AfterAll
-    public static void stopServer() throws Exception {
+    void stopServer() throws Exception {
         serverContext.closeAsync().toFuture().get();
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractH2DuplexHandlerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractH2DuplexHandlerTest.java
@@ -67,7 +67,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class AbstractH2DuplexHandlerTest {
+class AbstractH2DuplexHandlerTest {
 
     private static final HttpHeadersFactory HEADERS_FACTORY = H2HeadersFactory.INSTANCE;
 
@@ -331,7 +331,7 @@ public class AbstractH2DuplexHandlerTest {
 
     @ParameterizedTest
     @EnumSource(Variant.class)
-    public void emptyMessageWrittenAsSingleFrame(Variant param) {
+    void emptyMessageWrittenAsSingleFrame(Variant param) {
         setUp(param);
         HttpMetaData msg;
         switch (variant) {
@@ -357,7 +357,7 @@ public class AbstractH2DuplexHandlerTest {
 
     @ParameterizedTest
     @EnumSource(Variant.class)
-    public void noDataFramesForEmptyBuffers(Variant param) {
+    void noDataFramesForEmptyBuffers(Variant param) {
         setUp(param);
         Buffer[] payload = {EMPTY_BUFFER, DEFAULT_ALLOCATOR.fromAscii("data"), EMPTY_BUFFER};
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -143,7 +143,7 @@ public abstract class AbstractNettyHttpServerTest {
     }
 
     @BeforeAll
-    public static void createIoExecutors() {
+    static void createIoExecutors() {
         clientIoExecutor = NettyIoExecutors.createIoExecutor(new IoThreadFactory("client-io-executor"));
         serverIoExecutor = NettyIoExecutors.createIoExecutor(new IoThreadFactory("server-io-executor"));
     }
@@ -222,13 +222,13 @@ public abstract class AbstractNettyHttpServerTest {
     }
 
     @AfterEach
-    public void stopServer() throws Exception {
+    void stopServer() throws Exception {
         newCompositeCloseable().appendAll(httpConnection, httpClient, clientExecutor, serverContext, serverExecutor)
                 .close();
     }
 
     @AfterAll
-    public static void shutdownClientIoExecutor() throws Exception {
+    static void shutdownClientIoExecutor() throws Exception {
         newCompositeCloseable().appendAll(clientIoExecutor, serverIoExecutor).close();
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BasicAuthHttpServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BasicAuthHttpServiceFilterTest.java
@@ -38,7 +38,7 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.util.Base64.getEncoder;
 import static java.util.Objects.requireNonNull;
 
-public class BasicAuthHttpServiceFilterTest {
+class BasicAuthHttpServiceFilterTest {
 
     private static final class BasicUserInfo {
 
@@ -56,7 +56,7 @@ public class BasicAuthHttpServiceFilterTest {
     private static final String REALM_VALUE = "hw_realm";
 
     @Test
-    public void verifyAsyncContext() throws Exception {
+    void verifyAsyncContext() throws Exception {
         verifyServerFilterAsyncContextVisibility(appendServiceFilterFactory(
                 new StreamingHttpServiceFilterFactory() {
                     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BasicAuthStrategyInfluencerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BasicAuthStrategyInfluencerTest.java
@@ -68,7 +68,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class BasicAuthStrategyInfluencerTest {
+class BasicAuthStrategyInfluencerTest {
     private static final String IO_EXECUTOR_NAME_PREFIX = "io-executor";
 
     @Nullable

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BlockingStreamingHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BlockingStreamingHttpServiceAsyncContextTest.java
@@ -27,7 +27,7 @@ import static io.servicetalk.http.api.HttpResponseStatus.BAD_REQUEST;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static java.lang.Thread.currentThread;
 
-public class BlockingStreamingHttpServiceAsyncContextTest extends AbstractHttpServiceAsyncContextTest {
+class BlockingStreamingHttpServiceAsyncContextTest extends AbstractHttpServiceAsyncContextTest {
 
     @Override
     protected ServerContext serverWithEmptyAsyncContextService(HttpServerBuilder serverBuilder,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientClosureRaceTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientClosureRaceTest.java
@@ -50,7 +50,7 @@ import static java.net.InetAddress.getLoopbackAddress;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
 @Timeout(90)
-public class ClientClosureRaceTest {
+class ClientClosureRaceTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClientClosureRaceTest.class);
     private static final int ITERATIONS = 600;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -67,7 +67,7 @@ import static io.servicetalk.http.netty.InvokingThreadsRecorder.userStrategy;
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.userStrategyNoVerify;
 import static java.util.Arrays.asList;
 
-public class ClientEffectiveStrategyTest {
+class ClientEffectiveStrategyTest {
 
     private Params params;
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentCodingHttpServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentCodingHttpServiceFilterTest.java
@@ -23,10 +23,10 @@ import static io.servicetalk.encoding.api.Identity.identity;
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
 import static java.util.Collections.singletonList;
 
-public class ContentCodingHttpServiceFilterTest {
+class ContentCodingHttpServiceFilterTest {
 
     @Test
-    public void verifyAsyncContext() throws Exception {
+    void verifyAsyncContext() throws Exception {
         verifyServerFilterAsyncContextVisibility(new ContentCodingHttpServiceFilter(singletonList(identity())));
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
@@ -84,7 +84,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class ContentHeadersTest extends AbstractNettyHttpServerTest {
+class ContentHeadersTest extends AbstractNettyHttpServerTest {
 
     private static final DefaultHttpHeadersFactory headersFactory = new DefaultHttpHeadersFactory(false, false);
     private static final String EXISTING_CONTENT = "Hello World!";

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
@@ -67,7 +67,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class FlushStrategyOnServerTest {
+class FlushStrategyOnServerTest {
 
     @RegisterExtension
     static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulCloseTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulCloseTest.java
@@ -38,7 +38,7 @@ import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAnd
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-public class GracefulCloseTest {
+class GracefulCloseTest {
 
     private enum TrailerAddType {
         Regular,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -1095,7 +1095,7 @@ class H2PriorKnowledgeFeatureParityTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] client={0}, h2PriorKnowledge={1}")
     @MethodSource("clientExecutors")
-    public void clientFilterAsyncContext(HttpTestExecutionStrategy strategy,
+    void clientFilterAsyncContext(HttpTestExecutionStrategy strategy,
                                          boolean h2PriorKnowledge) throws Exception {
         setUp(strategy, h2PriorKnowledge);
         InetSocketAddress serverAddress = bindHttpEchoServer();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilterTest.java
@@ -43,7 +43,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
-public class HostHeaderHttpRequesterFilterTest {
+class HostHeaderHttpRequesterFilterTest {
 
     private enum HttpVersionConfig {
         HTTP_1_0 {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionContextProtocolTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionContextProtocolTest.java
@@ -42,7 +42,7 @@ import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAnd
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-public class HttpConnectionContextProtocolTest {
+class HttpConnectionContextProtocolTest {
 
     private enum Config {
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -101,7 +101,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-public class HttpRequestEncoderTest {
+class HttpRequestEncoderTest {
     private static final BufferAllocator allocator = DEFAULT_ALLOCATOR;
     private static final StreamingHttpRequestResponseFactory reqRespFactory =
             new DefaultStreamingHttpRequestResponseFactory(allocator, DefaultHttpHeadersFactory.INSTANCE, HTTP_1_1);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseEncoderTest.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class HttpResponseEncoderTest {
+class HttpResponseEncoderTest {
     private enum TransferEncoding {
         ContentLength,
         Chunked,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
@@ -44,7 +44,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class HttpsProxyTest {
+class HttpsProxyTest {
 
     private final ProxyTunnel proxyTunnel = new ProxyTunnel();
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionAcceptorTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionAcceptorTest.java
@@ -54,7 +54,7 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class NettyHttpServerConnectionAcceptorTest extends AbstractNettyHttpServerTest {
+class NettyHttpServerConnectionAcceptorTest extends AbstractNettyHttpServerTest {
 
     enum FilterMode {
         ACCEPT_ALL(true, (executor, context) -> completed()),

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PartitionedHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PartitionedHttpClientTest.java
@@ -66,7 +66,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class PartitionedHttpClientTest {
+class PartitionedHttpClientTest {
 
 
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RedirectingClientAndConnectionFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RedirectingClientAndConnectionFilterTest.java
@@ -45,7 +45,7 @@ import static org.hamcrest.Matchers.equalTo;
  * This test-case is for integration testing the {@link RedirectingHttpRequesterFilter} with the various types
  * of {@link HttpClient} and {@link HttpConnection} builders.
  */
-public final class RedirectingClientAndConnectionFilterTest extends AbstractHttpRequesterFilterTest {
+final class RedirectingClientAndConnectionFilterTest extends AbstractHttpRequesterFilterTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {0}-{1}")
     @MethodSource("requesterTypes")

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RequestTargetDecoderHttpServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RequestTargetDecoderHttpServiceFilterTest.java
@@ -21,10 +21,10 @@ import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
 
-public class RequestTargetDecoderHttpServiceFilterTest {
+class RequestTargetDecoderHttpServiceFilterTest {
 
     @Test
-    public void verifyAsyncContext() throws Exception {
+    void verifyAsyncContext() throws Exception {
         verifyServerFilterAsyncContextVisibility(new RequestTargetDecoderHttpServiceFilter());
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RequestTargetEncoderHttpServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RequestTargetEncoderHttpServiceFilterTest.java
@@ -21,10 +21,10 @@ import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
 
-public class RequestTargetEncoderHttpServiceFilterTest {
+class RequestTargetEncoderHttpServiceFilterTest {
 
     @Test
-    public void verifyAsyncContext() throws Exception {
+    void verifyAsyncContext() throws Exception {
         verifyServerFilterAsyncContextVisibility(new RequestTargetEncoderHttpServiceFilter());
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
@@ -68,7 +68,7 @@ import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class ServerEffectiveStrategyTest {
+class ServerEffectiveStrategyTest {
 
     @Nullable
     private Params params;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkContentCodingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkContentCodingTest.java
@@ -71,7 +71,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ServiceTalkContentCodingTest extends BaseContentCodingTest {
+class ServiceTalkContentCodingTest extends BaseContentCodingTest {
 
     private static final BiFunction<Scenario, List<Throwable>, StreamingHttpServiceFilterFactory> REQ_FILTER =
             (scenario, errors) -> new StreamingHttpServiceFilterFactory() {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
@@ -68,7 +68,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class StreamObserverTest {
+class StreamObserverTest {
 
 
 
@@ -85,7 +85,7 @@ public class StreamObserverTest {
     private final HttpClient client;
     private final CountDownLatch requestReceived = new CountDownLatch(1);
 
-    public StreamObserverTest() {
+    StreamObserverTest() {
         clientTransportObserver = mock(TransportObserver.class, "clientTransportObserver");
         clientConnectionObserver = mock(ConnectionObserver.class, "clientConnectionObserver");
         clientMultiplexedObserver = mock(MultiplexedObserver.class, "clientMultiplexedObserver");

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingHttpServiceAsyncContextTest.java
@@ -35,7 +35,7 @@ import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
 import static java.lang.Thread.currentThread;
 
-public class StreamingHttpServiceAsyncContextTest extends AbstractHttpServiceAsyncContextTest {
+class StreamingHttpServiceAsyncContextTest extends AbstractHttpServiceAsyncContextTest {
 
     @Test
     void newRequestsGetFreshContextImmediate() throws Exception {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TimeoutHttpServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TimeoutHttpServiceFilterTest.java
@@ -23,10 +23,10 @@ import java.time.Duration;
 
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
 
-public class TimeoutHttpServiceFilterTest {
+class TimeoutHttpServiceFilterTest {
 
     @Test
-    public void verifyAsyncContext() throws Exception {
+    void verifyAsyncContext() throws Exception {
         verifyServerFilterAsyncContextVisibility(new TimeoutHttpServiceFilter(Duration.ofDays(1), true));
     }
 }

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilterTest.java
@@ -63,7 +63,7 @@ abstract class AbstractTimeoutHttpFilterTest {
                                                        Single<StreamingHttpResponse> responseSingle);
 
     @Test
-    public void constructorValidatesDuration() {
+    void constructorValidatesDuration() {
         //noinspection ConstantConditions
         assertThrows(NullPointerException.class, () -> newFilter(null));
         assertThrows(IllegalArgumentException.class, () -> newFilter(Duration.ZERO));
@@ -72,7 +72,7 @@ abstract class AbstractTimeoutHttpFilterTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    public void responseTimeout(boolean fullRequestResponse) {
+    void responseTimeout(boolean fullRequestResponse) {
         TestSingle<StreamingHttpResponse> responseSingle = new TestSingle<>();
         StepVerifiers.create(applyFilter(ofNanos(1L), fullRequestResponse, responseSingle))
                 .expectError(TimeoutException.class)
@@ -82,13 +82,13 @@ abstract class AbstractTimeoutHttpFilterTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    public void responseWithZeroTimeout(boolean fullRequestResponse) {
+    void responseWithZeroTimeout(boolean fullRequestResponse) {
         responseWithNonPositiveTimeout(ZERO, fullRequestResponse);
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    public void responseWithNegativeTimeout(boolean fullRequestResponse) {
+    void responseWithNegativeTimeout(boolean fullRequestResponse) {
         responseWithNonPositiveTimeout(ofNanos(1L).negated(), fullRequestResponse);
     }
 
@@ -102,7 +102,7 @@ abstract class AbstractTimeoutHttpFilterTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    public void responseCompletesBeforeTimeout(boolean fullRequestResponse) {
+    void responseCompletesBeforeTimeout(boolean fullRequestResponse) {
         TestSingle<StreamingHttpResponse> responseSingle = new TestSingle<>();
         StepVerifiers.create(applyFilter(ofSeconds(DEFAULT_TIMEOUT_SECONDS / 2), fullRequestResponse, responseSingle))
                 .then(() -> immediate().schedule(() -> responseSingle.onSuccess(mock(StreamingHttpResponse.class)),
@@ -113,7 +113,7 @@ abstract class AbstractTimeoutHttpFilterTest {
     }
 
     @Test
-    public void payloadBodyTimeout() {
+    void payloadBodyTimeout() {
         TestPublisher<Buffer> payloadBody = new TestPublisher<>();
         AtomicBoolean responseSucceeded = new AtomicBoolean();
         StepVerifiers.create(applyFilter(ofMillis(100L), true, responseWith(payloadBody))
@@ -127,7 +127,7 @@ abstract class AbstractTimeoutHttpFilterTest {
     }
 
     @Test
-    public void payloadBodyDoesNotTimeoutWhenIgnored() {
+    void payloadBodyDoesNotTimeoutWhenIgnored() {
         Duration timeout = ofMillis(100L);
         TestPublisher<Buffer> payloadBody = new TestPublisher<>();
         AtomicBoolean responseSucceeded = new AtomicBoolean();
@@ -147,7 +147,7 @@ abstract class AbstractTimeoutHttpFilterTest {
     }
 
     @Test
-    public void subscribeToPayloadBodyAfterTimeout() {
+    void subscribeToPayloadBodyAfterTimeout() {
         Duration timeout = ofMillis(100L);
         TestPublisher<Buffer> payloadBody = new TestPublisher<>();
         AtomicReference<StreamingHttpResponse> response = new AtomicReference<>();
@@ -163,7 +163,7 @@ abstract class AbstractTimeoutHttpFilterTest {
     }
 
     @Test
-    public void payloadBodyCompletesBeforeTimeout() {
+    void payloadBodyCompletesBeforeTimeout() {
         TestPublisher<Buffer> payloadBody = new TestPublisher<>();
         AtomicReference<StreamingHttpResponse> response = new AtomicReference<>();
         StepVerifiers.create(applyFilter(ofSeconds(DEFAULT_TIMEOUT_SECONDS / 2), true, responseWith(payloadBody)))


### PR DESCRIPTION
Motivation:

Two new rules that were introduced with PMD 6.35 make sense to have enabled in our codebase too
to verify we follow that rule and catch early offenders.
Rules:
- https://pmd.github.io/pmd-6.35.0/pmd_rules_java_bestpractices.html#junit5testshouldbepackageprivate
- https://pmd.github.io/pmd-6.35.0/pmd_rules_java_design.html#mutablestaticstate

Modifications:

Enabled the rules in the global ruleset.

Result:

More code checks in place.

Depends on: https://github.com/apple/servicetalk/pull/1595