### PR TITLE
Migrate servicetalk-opentracing-inmemory tests to JUnit 5 (#1568)

### DIFF
--- a/servicetalk-opentracing-inmemory/build.gradle
+++ b/servicetalk-opentracing-inmemory/build.gradle
@@ -25,6 +25,8 @@ dependencies {
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-opentracing-inmemory/src/test/java/io/servicetalk/opentracing/inmemory/DefaultInMemoryTracerTest.java
+++ b/servicetalk-opentracing-inmemory/src/test/java/io/servicetalk/opentracing/inmemory/DefaultInMemoryTracerTest.java
@@ -22,22 +22,22 @@ import io.servicetalk.opentracing.inmemory.api.InMemorySpanContext;
 import io.servicetalk.opentracing.inmemory.api.InMemoryTraceState;
 import io.servicetalk.opentracing.inmemory.api.InMemoryTracer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.opentracing.References.CHILD_OF;
 import static io.opentracing.References.FOLLOWS_FROM;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class DefaultInMemoryTracerTest {
+class DefaultInMemoryTracerTest {
     @Test
-    public void childOfReferenceRespected() {
+    void childOfReferenceRespected() {
         verifyParentReference("childOfReferenceRespected", true);
     }
 
     @Test
-    public void followsFromReferenceRespected() {
+    void followsFromReferenceRespected() {
         verifyParentReference("followsFromReferenceRespected", false);
     }
 


### PR DESCRIPTION
Motivation:

- JUnit 5 leverages features from Java 8 or later, such as lambda functions, making tests more powerful and easier to maintain.
- JUnit 5 has added some very useful new features for describing, organizing, and executing tests. For instance, tests get better display names and can be organized hierarchically.
- JUnit 5 is organized into multiple libraries, so only the features you need are imported into your project. With build systems such as Maven and Gradle, including the right libraries is easy.
- JUnit 5 can use more than one extension at a time, which JUnit 4 could not (only one runner could be used at a time). This means you can easily combine the Spring extension with other extensions (such as your own custom extension).

Modifications:

- Unit tests have been migrated from JUnit 4 to JUnit 5

Result:

Module servicetalk-opentracing-inmemory now runs tests using JUnit 5