### PR TITLE
Migrate servicetalk-transport-api tests to JUnit 5 (#1568)

### DIFF
--- a/servicetalk-transport-api/build.gradle
+++ b/servicetalk-transport-api/build.gradle
@@ -29,7 +29,10 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-test-resources")
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+  testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-transport-api/src/test/java/io/servicetalk/transport/api/ConnectionAcceptorTest.java
+++ b/servicetalk-transport-api/src/test/java/io/servicetalk/transport/api/ConnectionAcceptorTest.java
@@ -19,15 +19,13 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
-import javax.annotation.Nonnull;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -40,9 +38,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ConnectionAcceptorTest {
-    @Rule
-    public final MockitoRule rule = MockitoJUnit.rule();
+@ExtendWith(MockitoExtension.class)
+class ConnectionAcceptorTest {
     private final TestCompletableSubscriber listener = new TestCompletableSubscriber();
 
     @Mock
@@ -54,7 +51,7 @@ public class ConnectionAcceptorTest {
     private ConnectionAcceptor second;
 
     @Test
-    public void factoryAppend() throws Exception {
+    void factoryAppend() throws Exception {
         ConnectionAcceptorFactory f = ConnectionAcceptorFactory.identity();
         ConcurrentLinkedQueue<Integer> order = new ConcurrentLinkedQueue<>();
         f.append(original -> new OrderVerifyingConnectionAcceptor(original, order, 1))
@@ -65,7 +62,7 @@ public class ConnectionAcceptorTest {
     }
 
     @Test
-    public void chainingCompletedThenCompletedShouldReturnTrue() {
+    void chainingCompletedThenCompletedShouldReturnTrue() {
         setFilterResult(first, Completable.completed());
         setFilterResult(second, Completable.completed());
 
@@ -77,7 +74,7 @@ public class ConnectionAcceptorTest {
     }
 
     @Test
-    public void chainingCompletedThenErrorShouldReturnError() {
+    void chainingCompletedThenErrorShouldReturnError() {
         setFilterResult(first, Completable.completed());
         setFilterResult(second, Completable.failed(DELIBERATE_EXCEPTION));
 
@@ -89,7 +86,7 @@ public class ConnectionAcceptorTest {
     }
 
     @Test
-    public void chainingAfterErrorShouldNotCallNextFilter() {
+    void chainingAfterErrorShouldNotCallNextFilter() {
         setFilterResult(first, Completable.failed(DELIBERATE_EXCEPTION));
 
         applyFilters();
@@ -103,7 +100,6 @@ public class ConnectionAcceptorTest {
         when(filter.accept(context)).thenReturn(resultCompletable);
     }
 
-    @Nonnull
     protected void applyFilters() {
         ConnectionAcceptorFactory f = (original -> original.append(ctx -> second.accept(ctx)));
         f = f.append(original -> original.append(ctx -> first.accept(ctx)));


### PR DESCRIPTION
Motivation:

- JUnit 5 leverages features from Java 8 or later, such as lambda functions, making tests more powerful and easier to maintain.
- JUnit 5 has added some very useful new features for describing, organizing, and executing tests. For instance, tests get better display names and can be organized hierarchically.
- JUnit 5 is organized into multiple libraries, so only the features you need are imported into your project. With build systems such as Maven and Gradle, including the right libraries is easy.
- JUnit 5 can use more than one extension at a time, which JUnit 4 could not (only one runner could be used at a time). This means you can easily combine the Spring extension with other extensions (such as your own custom extension).

Modifications:

- Unit tests have been migrated from JUnit 4 to JUnit 5

Result:

Module servicetalk-transport-api now runs tests using JUnit 5