### PR TITLE
Migrate servicetalk-transport-netty-internal tests to JUnit 5 (#1568)

### DIFF
--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -42,13 +42,16 @@ dependencies {
   testImplementation project(":servicetalk-concurrent-api-test")
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+  testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testFixturesImplementation "junit:junit:$junitVersion"
   testFixturesImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-transport-netty-internal/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-transport-netty-internal/gradle/spotbugs/test-exclusions.xml
@@ -25,4 +25,9 @@
     <Source name="~.*Test\.java"/>
     <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
   </Match>
+  <!-- jUnit5 requires @Nested test classes to be non-static -->
+  <Match>
+    <Source name="~.*Test\.java"/>
+    <Bug pattern="SIC_INNER_SHOULD_BE_STATIC"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractOutOfEventloopTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractOutOfEventloopTest.java
@@ -15,8 +15,6 @@
  */
 package io.servicetalk.transport.netty.internal;
 
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
-
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -25,10 +23,8 @@ import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.local.LocalChannel;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
@@ -41,15 +37,12 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 public abstract class AbstractOutOfEventloopTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
     protected Channel channel;
     private EventLoopGroup eventLoopGroup;
     protected BlockingQueue<Integer> pendingFlush;
     protected BlockingQueue<Integer> written;
 
-    @Before
+    @BeforeEach
     public void setUp() throws InterruptedException {
         eventLoopGroup = new DefaultEventLoopGroup(2);
         channel = new LocalChannel();
@@ -79,7 +72,7 @@ public abstract class AbstractOutOfEventloopTest {
 
     public abstract void setup0();
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         written.clear();
         channel.close().await(DEFAULT_TIMEOUT_SECONDS, SECONDS);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
@@ -17,7 +17,6 @@ package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.api.test.StepVerifiers;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.ConnectionInfo.Protocol;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
@@ -26,10 +25,8 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.ssl.SslCloseCompletionEvent;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.concurrent.api.Executors.immediate;
@@ -48,9 +45,6 @@ abstract class AbstractSslCloseNotifyAlertHandlingTest {
 
     protected static final String BEGIN = "MSG_BEGIN";
     protected static final String END = "MSG_END";
-
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
 
     protected final EmbeddedDuplexChannel channel;
     protected final DefaultNettyConnection<String, String> conn;
@@ -86,7 +80,7 @@ abstract class AbstractSslCloseNotifyAlertHandlingTest {
                 .toFuture().get();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         try {
             // Make sure the connection and channel are closed after each test:
@@ -106,7 +100,7 @@ abstract class AbstractSslCloseNotifyAlertHandlingTest {
     }
 
     @Test
-    public void neverUsedIdleConnection() {
+    void neverUsedIdleConnection() {
         closeNotifyAndVerifyClosing();
     }
 

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractWriteTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractWriteTest.java
@@ -21,8 +21,8 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -41,7 +41,7 @@ public abstract class AbstractWriteTest {
     protected CompletableSource.Subscriber completableSubscriber;
     protected FailingWriteHandler failingWriteHandler;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         completableSubscriber = mock(CompletableSource.Subscriber.class);
         failingWriteHandler = new FailingWriteHandler();
@@ -49,7 +49,7 @@ public abstract class AbstractWriteTest {
         demandEstimator = mock(WriteDemandEstimator.class);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         channel.finishAndReleaseAll();
         channel.close().await();

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/BuilderUtilsTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/BuilderUtilsTest.java
@@ -18,7 +18,7 @@ package io.servicetalk.transport.netty.internal;
 import io.servicetalk.transport.api.HostAndPort;
 
 import io.netty.util.NetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -28,13 +28,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class BuilderUtilsTest {
+class BuilderUtilsTest {
 
     @Test
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
-    public void toResolvedInetSocketAddressFromIPv4() {
+    void toResolvedInetSocketAddressFromIPv4() {
         final String localhostIp4Address = NetUtil.LOCALHOST4.getHostAddress();
         InetSocketAddress address = toResolvedInetSocketAddress(HostAndPort.of(localhostIp4Address, 8080));
         assertThat(address.isUnresolved(), is(false));
@@ -44,7 +44,7 @@ public class BuilderUtilsTest {
 
     @Test
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
-    public void toResolvedInetSocketAddressFromIPv6() {
+    void toResolvedInetSocketAddressFromIPv6() {
         final String localhostIp6Address = NetUtil.LOCALHOST6.getHostAddress();
         InetSocketAddress address = toResolvedInetSocketAddress(HostAndPort.of(localhostIp6Address, 8080));
         assertThat(address.isUnresolved(), is(false));
@@ -53,7 +53,7 @@ public class BuilderUtilsTest {
     }
 
     @Test
-    public void toResolvedInetSocketAddressFromUnresolved() {
+    void toResolvedInetSocketAddressFromUnresolved() {
         Throwable t = assertThrows(IllegalArgumentException.class,
                 () -> toResolvedInetSocketAddress(HostAndPort.of("unresolved-hostname", 8080)));
         assertThat(t.getCause(), instanceOf(UnknownHostException.class));

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/CopyByteBufHandlerTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/CopyByteBufHandlerTest.java
@@ -23,7 +23,7 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.DatagramPacket;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.net.InetSocketAddress;
@@ -37,29 +37,29 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-public class CopyByteBufHandlerTest {
+class CopyByteBufHandlerTest {
 
     @Test
-    public void doesNotAcceptPooledAllocator() {
+    void doesNotAcceptPooledAllocator() {
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                 () -> new CopyByteBufHandler(PooledByteBufAllocator.DEFAULT));
         assertThat(ex.getMessage(), equalTo("ByteBufAllocator must be unpooled"));
     }
 
     @Test
-    public void acceptsUnpooledAllocator() {
+    void acceptsUnpooledAllocator() {
         assertThat(new CopyByteBufHandler(UnpooledByteBufAllocator.DEFAULT), is(notNullValue()));
     }
 
     @Test
-    public void doesNotProcessByteBufHolder() {
+    void doesNotProcessByteBufHolder() {
         CopyByteBufHandler handler = new CopyByteBufHandler(UnpooledByteBufAllocator.DEFAULT);
         ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
         ByteBuf buf = mock(ByteBuf.class);
@@ -74,7 +74,7 @@ public class CopyByteBufHandlerTest {
     }
 
     @Test
-    public void copiesAndReleasesPooledByteBuf() {
+    void copiesAndReleasesPooledByteBuf() {
         ByteBufAllocator pooledAllocator = PooledByteBufAllocator.DEFAULT;
         ByteBufAllocator unpooledAllocator = UnpooledByteBufAllocator.DEFAULT;
         CopyByteBufHandler handler = new CopyByteBufHandler(unpooledAllocator);
@@ -102,7 +102,7 @@ public class CopyByteBufHandlerTest {
     }
 
     @Test
-    public void forwardsOtherTypes() {
+    void forwardsOtherTypes() {
         CopyByteBufHandler handler = new CopyByteBufHandler(UnpooledByteBufAllocator.DEFAULT);
         ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
         ArgumentCaptor<String> valueCapture = ArgumentCaptor.forClass(String.class);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/EWMAWriteDemandEstimatorTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/EWMAWriteDemandEstimatorTest.java
@@ -15,27 +15,28 @@
  */
 package io.servicetalk.transport.netty.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class EWMAWriteDemandEstimatorTest {
+class EWMAWriteDemandEstimatorTest {
     private static final String DUMMY_OBJECT = "dummy";
+
     @Test
-    public void testNoRequestIfLowCapacity() {
+    void testNoRequestIfLowCapacity() {
         EWMAWriteDemandEstimator supplier = new EWMAWriteDemandEstimator();
         assertThat("Unexpected request-n.", supplier.getRequestNForCapacity(2), is(0L));
     }
 
     @Test
-    public void testRequestNNoRecord() {
+    void testRequestNNoRecord() {
         EWMAWriteDemandEstimator supplier = new EWMAWriteDemandEstimator();
         assertThat("Unexpected requestN.", supplier.estimateRequestN(8), is(1L));
     }
 
     @Test
-    public void testRequestNWithRecord() {
+    void testRequestNWithRecord() {
         EWMAWriteDemandEstimator supplier = new EWMAWriteDemandEstimator();
         supplier.onItemWrite(DUMMY_OBJECT, 1, 2);
         supplier.onItemWrite(DUMMY_OBJECT, 3, 5);
@@ -43,7 +44,7 @@ public class EWMAWriteDemandEstimatorTest {
     }
 
     @Test
-    public void testRepeatRequestNSameMaxSize() {
+    void testRepeatRequestNSameMaxSize() {
         EWMAWriteDemandEstimator supplier = new EWMAWriteDemandEstimator(5);
         assertThat("Unexpected requestN.", supplier.estimateRequestN(5), is(1L));
         supplier.onItemWrite(DUMMY_OBJECT, 100, 99);
@@ -53,7 +54,7 @@ public class EWMAWriteDemandEstimatorTest {
     }
 
     @Test
-    public void testMultipleOnItemWrittenWithIncreaseInCapacity() {
+    void testMultipleOnItemWrittenWithIncreaseInCapacity() {
         EWMAWriteDemandEstimator supplier = new EWMAWriteDemandEstimator(3);
         assertThat("Unexpected requestN.", supplier.estimateRequestN(10), is(3L));
         supplier.onItemWrite(DUMMY_OBJECT, 100, 99);
@@ -62,7 +63,7 @@ public class EWMAWriteDemandEstimatorTest {
     }
 
     @Test
-    public void testZeroSizeWrite() {
+    void testZeroSizeWrite() {
         EWMAWriteDemandEstimator supplier = new EWMAWriteDemandEstimator(1);
         assertThat("Unexpected requestN.", supplier.estimateRequestN(10), is(10L));
         for (int i = 0; i < 1000; ++i) {
@@ -72,7 +73,7 @@ public class EWMAWriteDemandEstimatorTest {
     }
 
     @Test
-    public void weightMovesToSteadyState() {
+    void weightMovesToSteadyState() {
         EWMAWriteDemandEstimator supplier = new EWMAWriteDemandEstimator(10);
         assertThat("Unexpected requestN.", supplier.estimateRequestN(10), is(1L));
         supplier.onItemWrite(DUMMY_OBJECT, 100, 98);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/FlushOutsideEventloopTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/FlushOutsideEventloopTest.java
@@ -22,7 +22,7 @@ import io.servicetalk.transport.netty.internal.FlushStrategy.FlushSender;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopWriteObserver;
 
 import io.netty.channel.EventLoop;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.transport.netty.internal.Flush.composeFlushes;
@@ -30,7 +30,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
-public class FlushOutsideEventloopTest extends AbstractOutOfEventloopTest {
+class FlushOutsideEventloopTest extends AbstractOutOfEventloopTest {
 
     private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
     private TestPublisher<Integer> src;
@@ -49,7 +49,7 @@ public class FlushOutsideEventloopTest extends AbstractOutOfEventloopTest {
     }
 
     @Test
-    public void testWriteAndFlushOutsideEventloop() throws Exception {
+    void testWriteAndFlushOutsideEventloop() throws Exception {
         EventLoop executor = getDifferentEventloopThanChannel();
         executor.submit(() -> src.onNext(1)).get();
         flushSender.flush();
@@ -59,7 +59,7 @@ public class FlushOutsideEventloopTest extends AbstractOutOfEventloopTest {
     }
 
     @Test
-    public void testWriteFromOutsideEventloopThenWriteAndFlushOnEventloop() throws Exception {
+    void testWriteFromOutsideEventloopThenWriteAndFlushOnEventloop() throws Exception {
         EventLoop executor = getDifferentEventloopThanChannel();
         executor.submit(() -> src.onNext(1)).get();
         channel.eventLoop().submit(() -> {
@@ -71,7 +71,7 @@ public class FlushOutsideEventloopTest extends AbstractOutOfEventloopTest {
     }
 
     @Test
-    public void testWriteInEventloopThenWriteAndFlushOutsideEventloop() throws Exception {
+    void testWriteInEventloopThenWriteAndFlushOutsideEventloop() throws Exception {
         EventLoop executor = getDifferentEventloopThanChannel();
         channel.eventLoop().submit(() -> src.onNext(1)).get();
         executor.submit(() -> {
@@ -83,7 +83,7 @@ public class FlushOutsideEventloopTest extends AbstractOutOfEventloopTest {
     }
 
     @Test
-    public void testWriteFromEventloopAndFlushOutsideEventloop() throws Exception {
+    void testWriteFromEventloopAndFlushOutsideEventloop() throws Exception {
         EventLoop executor = getDifferentEventloopThanChannel();
         channel.eventLoop().submit(() -> src.onNext(1)).get();
         executor.submit(() -> flushSender.flush()).get();

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/FlushStrategiesTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/FlushStrategiesTest.java
@@ -20,34 +20,34 @@ import io.servicetalk.concurrent.api.TestSubscription;
 import io.servicetalk.transport.netty.internal.FlushStrategy.FlushSender;
 import io.servicetalk.transport.netty.internal.FlushStrategy.WriteEventsListener;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.transport.netty.internal.FlushStrategies.flushOnEach;
 import static io.servicetalk.transport.netty.internal.FlushStrategies.flushOnEnd;
 import static io.servicetalk.transport.netty.internal.FlushStrategies.flushWith;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
-public class FlushStrategiesTest {
+class FlushStrategiesTest {
 
     private FlushSender flushSender;
     private TestPublisher<String> durationSource;
     private WriteEventsListener listener;
     private TestSubscription subscription = new TestSubscription();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         flushSender = mock(FlushSender.class);
         durationSource = new TestPublisher<>();
     }
 
     @Test
-    public void testFlushOnEach() {
+    void testFlushOnEach() {
         setupFor(flushOnEach());
         listener.itemWritten(1);
         listener.itemWritten(2);
@@ -55,19 +55,19 @@ public class FlushStrategiesTest {
     }
 
     @Test
-    public void testBatchFlush() {
+    void testBatchFlush() {
         setupForBatch(2);
         testBatch(2, 2);
     }
 
     @Test
-    public void testNoFlushForBatch() {
+    void testNoFlushForBatch() {
         setupForBatch(3);
         testBatch(3, 2);
     }
 
     @Test
-    public void testFlushOnDuration() {
+    void testFlushOnDuration() {
         setupForBatch(5);
         testBatch(5, 2);
         durationSource.onNext("Flush");
@@ -75,7 +75,7 @@ public class FlushStrategiesTest {
     }
 
     @Test
-    public void testBatchFlushWriteCancel() {
+    void testBatchFlushWriteCancel() {
         setupForBatch(5);
         durationSource.onSubscribe(subscription);
         testBatch(5, 2);
@@ -84,13 +84,13 @@ public class FlushStrategiesTest {
     }
 
     @Test
-    public void testSourceEmitErrorForFlushOnEach() {
+    void testSourceEmitErrorForFlushOnEach() {
         setupFor(flushOnEach());
         listener.writeTerminated();
     }
 
     @Test
-    public void testSourceEmitErrorForBatchFlush() {
+    void testSourceEmitErrorForBatchFlush() {
         setupForBatch(2);
         durationSource.onSubscribe(subscription);
         listener.writeTerminated();
@@ -98,7 +98,7 @@ public class FlushStrategiesTest {
     }
 
     @Test
-    public void testDurationComplete() {
+    void testDurationComplete() {
         setupForBatch(2);
         durationSource.onComplete();
         listener.itemWritten(1);
@@ -108,7 +108,7 @@ public class FlushStrategiesTest {
     }
 
     @Test
-    public void testDurationEmitError() {
+    void testDurationEmitError() {
         setupForBatch(2);
         durationSource.onError(DELIBERATE_EXCEPTION);
         verifyZeroInteractions(flushSender);
@@ -118,7 +118,7 @@ public class FlushStrategiesTest {
     }
 
     @Test
-    public void testDurationEmitErrorPostComplete() {
+    void testDurationEmitErrorPostComplete() {
         setupForBatch(2);
         listener.writeTerminated();
         durationSource.onError(DELIBERATE_EXCEPTION);
@@ -126,7 +126,7 @@ public class FlushStrategiesTest {
     }
 
     @Test
-    public void testDurationCompletePostComplete() {
+    void testDurationCompletePostComplete() {
         setupForBatch(2);
         listener.itemWritten(1);
         listener.writeTerminated();
@@ -135,7 +135,7 @@ public class FlushStrategiesTest {
     }
 
     @Test
-    public void testFlushOnEndComplete() {
+    void testFlushOnEndComplete() {
         setupFor(flushOnEnd());
         listener.itemWritten(1);
         verifyFlush(0);
@@ -144,7 +144,7 @@ public class FlushStrategiesTest {
     }
 
     @Test
-    public void testFlushWith() {
+    void testFlushWith() {
         setupFor(flushWith(durationSource));
         durationSource.onSubscribe(subscription);
         listener.itemWritten(1);
@@ -157,7 +157,7 @@ public class FlushStrategiesTest {
     }
 
     @Test
-    public void testFlushWithWriteCancelCancelsSource() {
+    void testFlushWithWriteCancelCancelsSource() {
         setupFor(flushWith(durationSource));
         durationSource.onSubscribe(subscription);
         listener.writeCancelled();

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/FlushStrategyHolderTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/FlushStrategyHolderTest.java
@@ -17,22 +17,22 @@ package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.Cancellable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 
-public class FlushStrategyHolderTest {
+class FlushStrategyHolderTest {
 
     private final FlushStrategyHolder holder;
 
-    public FlushStrategyHolderTest() {
+    FlushStrategyHolderTest() {
         holder = new FlushStrategyHolder(mock(FlushStrategy.class));
     }
 
     @Test
-    public void updateWhenOriginal() {
+    void updateWhenOriginal() {
         FlushStrategy prev = holder.currentStrategy();
         FlushStrategy next = mock(FlushStrategy.class);
         Cancellable revert =
@@ -43,7 +43,7 @@ public class FlushStrategyHolderTest {
     }
 
     @Test
-    public void revertNoOpOnMismatch() {
+    void revertNoOpOnMismatch() {
         FlushStrategy prev = holder.currentStrategy();
         FlushStrategy next1 = mock(FlushStrategy.class);
         Cancellable revert1 =

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/FlushTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/FlushTest.java
@@ -20,8 +20,8 @@ import io.servicetalk.concurrent.api.TestSubscription;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 import io.servicetalk.transport.netty.internal.FlushStrategy.FlushSender;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -31,19 +31,19 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
-public class FlushTest extends AbstractFlushTest {
+class FlushTest extends AbstractFlushTest {
 
     private final TestPublisher<String> source = new TestPublisher<>();
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
     private FlushSender flushSender;
     private MockFlushStrategy strategy;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         strategy = new MockFlushStrategy();
         toSource(super.setup(source, strategy)).subscribe(subscriber);
@@ -51,7 +51,7 @@ public class FlushTest extends AbstractFlushTest {
     }
 
     @Test
-    public void testFlushOnEach() {
+    void testFlushOnEach() {
         writeAndFlush("Hello");
 
         verifyWriteAndFlushAfter("Hello");
@@ -59,7 +59,7 @@ public class FlushTest extends AbstractFlushTest {
     }
 
     @Test
-    public void testBatchFlush() {
+    void testBatchFlush() {
         writeAndFlush("Hello1", "Hello2", "Hello3");
 
         verifyWriteAndFlushAfter("Hello1", "Hello2", "Hello3");
@@ -67,7 +67,7 @@ public class FlushTest extends AbstractFlushTest {
     }
 
     @Test
-    public void testMultipleBatchFlush() {
+    void testMultipleBatchFlush() {
         writeAndFlush("Hello1", "Hello2", "Hello3");
 
         verifyWriteAndFlushAfter("Hello1", "Hello2", "Hello3");
@@ -80,7 +80,7 @@ public class FlushTest extends AbstractFlushTest {
     }
 
     @Test
-    public void testCancel() {
+    void testCancel() {
         final TestSubscription subscription = new TestSubscription();
         source.onSubscribe(subscription);
         subscriber.awaitSubscription().cancel();
@@ -95,14 +95,14 @@ public class FlushTest extends AbstractFlushTest {
     }
 
     @Test
-    public void testSourceComplete() {
+    void testSourceComplete() {
         source.onComplete();
         subscriber.awaitOnComplete();
         strategy.verifyWriteTerminated();
     }
 
     @Test
-    public void testSourceEmitError() {
+    void testSourceEmitError() {
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
         strategy.verifyWriteTerminated();

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/GlobalExecutionContextTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/GlobalExecutionContextTest.java
@@ -15,12 +15,9 @@
  */
 package io.servicetalk.transport.netty.internal;
 
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.transport.api.ExecutionContext;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 
@@ -28,13 +25,10 @@ import static io.servicetalk.transport.netty.internal.GlobalExecutionContext.glo
 import static io.servicetalk.transport.netty.internal.NettyIoExecutors.toNettyIoExecutor;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-public class GlobalExecutionContextTest {
-
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
+class GlobalExecutionContextTest {
 
     @Test
-    public void testGetGlobalExecutionContext() throws InterruptedException {
+    void testGetGlobalExecutionContext() throws InterruptedException {
         ExecutionContext gec = globalExecutionContext();
         CountDownLatch scheduleLatch = new CountDownLatch(2);
         gec.executor().schedule(scheduleLatch::countDown, 1, SECONDS);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelListenableAsyncCloseableTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelListenableAsyncCloseableTest.java
@@ -19,12 +19,11 @@ import io.servicetalk.concurrent.Cancellable;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static io.servicetalk.concurrent.api.Executors.immediate;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -32,10 +31,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class NettyChannelListenableAsyncCloseableTest {
+@ExtendWith(MockitoExtension.class)
+class NettyChannelListenableAsyncCloseableTest {
 
-    @Rule
-    public final MockitoRule rule = MockitoJUnit.rule();
     @Mock
     Channel channel;
     @Mock
@@ -43,14 +41,14 @@ public class NettyChannelListenableAsyncCloseableTest {
 
     NettyChannelListenableAsyncCloseable fixture;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         fixture = new NettyChannelListenableAsyncCloseable(channel, immediate());
         when(channel.closeFuture()).thenReturn(channelCloseFuture);
     }
 
     @Test
-    public void cancellingOnCloseShouldNotCancelFuture() {
+    void cancellingOnCloseShouldNotCancelFuture() {
         fixture.onClose().afterOnSubscribe(Cancellable::cancel).subscribe();
         verify(channelCloseFuture, never()).cancel(anyBoolean());
     }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherRefCountTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherRefCountTest.java
@@ -16,17 +16,14 @@
 package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 import io.servicetalk.transport.api.ConnectionInfo.Protocol;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
 
 import io.netty.buffer.ByteBuf;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
@@ -42,15 +39,13 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
-public class NettyChannelPublisherRefCountTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
+class NettyChannelPublisherRefCountTest {
 
     private final TestPublisherSubscriber<Object> subscriber = new TestPublisherSubscriber<>();
     private Publisher<Object> publisher;
     private EmbeddedDuplexChannel channel;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         channel = new EmbeddedDuplexChannel(false);
         publisher = DefaultNettyConnection.initChannel(channel, DEFAULT_ALLOCATOR, immediate(), x -> false,
@@ -59,7 +54,7 @@ public class NettyChannelPublisherRefCountTest {
                 .read();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (!channel.close().await(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
             throw new IllegalStateException("Channel close not finished in 1 second.");
@@ -67,7 +62,7 @@ public class NettyChannelPublisherRefCountTest {
     }
 
     @Test
-    public void testRefCountedLeaked() {
+    void testRefCountedLeaked() {
         toSource(publisher).subscribe(subscriber);
         subscriber.awaitSubscription().request(3);
         ByteBuf buffer = channel.alloc().buffer();

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherTest.java
@@ -21,7 +21,6 @@ import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.internal.DuplicateSubscribeException;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 import io.servicetalk.transport.api.ConnectionInfo.Protocol;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
@@ -31,11 +30,9 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
@@ -64,20 +61,18 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class NettyChannelPublisherTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
+class NettyChannelPublisherTest {
 
     private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
     private final TestPublisherSubscriber<Integer> subscriber2 = new TestPublisherSubscriber<>();
@@ -86,7 +81,7 @@ public class NettyChannelPublisherTest {
     private boolean nextItemTerminal;
     private boolean readRequested;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         setUp(integer -> nextItemTerminal);
     }
@@ -107,7 +102,7 @@ public class NettyChannelPublisherTest {
         channel.config().setAutoRead(false);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (!channel.close().await(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
             throw new IllegalStateException("Channel close not finished in 1 second.");
@@ -156,7 +151,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void errorFromOnSubscribeResumeTerminatesOnce() throws Exception {
+    void errorFromOnSubscribeResumeTerminatesOnce() throws Exception {
         channel.close().await();
         @SuppressWarnings("unchecked")
         Subscriber<Integer> mockSubscriber = mock(Subscriber.class);
@@ -171,22 +166,22 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testNettyHandlerSendsQueuedDataOnShutdownInputFromCancel() throws Exception {
+    void testNettyHandlerSendsQueuedDataOnShutdownInputFromCancel() throws Exception {
         testCancelThenResubscribeDeliversErrorAndNotQueuedData(false, true);
     }
 
     @Test
-    public void testNettyHandlerSendsQueuedDataOnShutdownInputFromClose() throws Exception {
+    void testNettyHandlerSendsQueuedDataOnShutdownInputFromClose() throws Exception {
         testCancelThenResubscribeDeliversErrorAndNotQueuedData(true, true);
     }
 
     @Test
-    public void testCancelThenReadThenResubscribeDeliversErrorAndNotQueuedData() throws Exception {
+    void testCancelThenReadThenResubscribeDeliversErrorAndNotQueuedData() throws Exception {
         testCancelThenResubscribeDeliversErrorAndNotQueuedData(true, false);
     }
 
     @Test
-    public void testCancelThenResubscribeDeliversErrorAndNotQueuedData() throws Exception {
+    void testCancelThenResubscribeDeliversErrorAndNotQueuedData() throws Exception {
         testCancelThenResubscribeDeliversErrorAndNotQueuedData(false, false);
     }
 
@@ -226,7 +221,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testSupplyEqualsDemand() {
+    void testSupplyEqualsDemand() {
         toSource(publisher).subscribe(subscriber);
         subscriber.awaitSubscription().request(3);
         fireChannelRead(1, 2);
@@ -238,7 +233,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testSupplyLessThanDemand() {
+    void testSupplyLessThanDemand() {
         toSource(publisher).subscribe(subscriber);
         subscriber.awaitSubscription().request(4);
         fireChannelRead(1, 2);
@@ -250,7 +245,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testDemandLessThanSupply() {
+    void testDemandLessThanSupply() {
         toSource(publisher).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         fireChannelRead(1, 2);
@@ -264,7 +259,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testBufferDrainOnClose() throws Exception {
+    void testBufferDrainOnClose() throws Exception {
         toSource(publisher).subscribe(subscriber);
         fireChannelReadToBuffer(1, 2);
         channel.close().await();
@@ -274,7 +269,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testErrorBufferedWithExactDemand() {
+    void testErrorBufferedWithExactDemand() {
         toSource(publisher).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         fireChannelRead(1, 2);
@@ -286,7 +281,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testErrorBufferedWithMoreDemand() {
+    void testErrorBufferedWithMoreDemand() {
         toSource(publisher).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         fireChannelRead(1, 2);
@@ -298,14 +293,14 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testErrorWithNoDemandNoBuffer() {
+    void testErrorWithNoDemandNoBuffer() {
         toSource(publisher).subscribe(subscriber);
         channel.pipeline().fireExceptionCaught(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void testErrorWithNoDemandAndBuffer() {
+    void testErrorWithNoDemandAndBuffer() {
         toSource(publisher).subscribe(subscriber);
         fireChannelReadToBuffer(1);
         channel.pipeline().fireExceptionCaught(DELIBERATE_EXCEPTION);
@@ -315,7 +310,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testErrorNoEmission() {
+    void testErrorNoEmission() {
         toSource(publisher).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         channel.pipeline().fireExceptionCaught(DELIBERATE_EXCEPTION);
@@ -323,7 +318,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testConcurrentSubscribers() {
+    void testConcurrentSubscribers() {
         toSource(publisher).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         fireChannelRead(1);
@@ -344,7 +339,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testSequentialSubscriptionsNoCarryOverDemand() {
+    void testSequentialSubscriptionsNoCarryOverDemand() {
         nextItemTerminal = true;
         toSource(publisher).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
@@ -360,7 +355,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testSequentialSubscriptionsCarryOverDemand() {
+    void testSequentialSubscriptionsCarryOverDemand() {
         nextItemTerminal = true;
         toSource(publisher).subscribe(subscriber);
         subscriber.awaitSubscription().request(3);
@@ -380,7 +375,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testBufferBetweenSubscriptions() {
+    void testBufferBetweenSubscriptions() {
         nextItemTerminal = true;
         toSource(publisher).subscribe(subscriber);
         subscriber.awaitSubscription().request(3);
@@ -396,7 +391,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testCancelBeforeTerminal() {
+    void testCancelBeforeTerminal() {
         toSource(publisher).subscribe(subscriber);
         subscriber.awaitSubscription().request(3);
         fireChannelRead(1);
@@ -406,7 +401,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testCancelAfterTerminal() {
+    void testCancelAfterTerminal() {
         toSource(publisher).subscribe(subscriber);
         subscriber.awaitSubscription().request(3);
         nextItemTerminal = true;
@@ -418,7 +413,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testDelayedCancel() {
+    void testDelayedCancel() {
         nextItemTerminal = true;
         toSource(publisher).subscribe(subscriber);
         subscriber.awaitSubscription().request(3);
@@ -441,7 +436,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testDelayedRequestN() {
+    void testDelayedRequestN() {
         nextItemTerminal = true;
         toSource(publisher).subscribe(subscriber);
         subscriber.awaitSubscription().request(3);
@@ -467,7 +462,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testEmitItemsWithNoSubscriber() {
+    void testEmitItemsWithNoSubscriber() {
         nextItemTerminal = true;
         fireChannelReadToBuffer(1);
         toSource(publisher).subscribe(subscriber);
@@ -477,7 +472,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testCancelFromWithinComplete() {
+    void testCancelFromWithinComplete() {
         final AtomicReference<Object> resultRef = new AtomicReference<>();
         fireChannelReadToBuffer(1);
         nextItemTerminal = true;
@@ -502,14 +497,14 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testSubscribePostChannelClose() throws Exception {
+    void testSubscribePostChannelClose() throws Exception {
         channel.close().await();
         toSource(publisher).subscribe(subscriber);
         assertThat(subscriber.awaitOnError(), instanceOf(ClosedChannelException.class));
     }
 
     @Test
-    public void testTwoSubscribersPostChannelClose() throws Exception {
+    void testTwoSubscribersPostChannelClose() throws Exception {
         channel.close().await();
         toSource(publisher).subscribe(subscriber);
         assertThat(subscriber.awaitOnError(), instanceOf(ClosedChannelException.class));
@@ -522,7 +517,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testQueuedCompleteAndFatalErrorExactDemand() {
+    void testQueuedCompleteAndFatalErrorExactDemand() {
         toSource(publisher).subscribe(subscriber);
         nextItemTerminal = true;
         fireChannelReadToBuffer(1);
@@ -533,7 +528,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testQueuedCompleteAndFatalErrorMoreDemand() {
+    void testQueuedCompleteAndFatalErrorMoreDemand() {
         toSource(publisher).subscribe(subscriber);
         nextItemTerminal = true;
         fireChannelReadToBuffer(1);
@@ -544,7 +539,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testQueuedErrorAndFatalErrorExactDemand() {
+    void testQueuedErrorAndFatalErrorExactDemand() {
         toSource(publisher).subscribe(subscriber);
         fireChannelReadToBuffer(1);
         channel.pipeline().fireExceptionCaught(DELIBERATE_EXCEPTION);
@@ -555,7 +550,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testQueuedErrorAndFatalErrorMoreDemand() {
+    void testQueuedErrorAndFatalErrorMoreDemand() {
         toSource(publisher).subscribe(subscriber);
         fireChannelReadToBuffer(1);
         channel.pipeline().fireExceptionCaught(DELIBERATE_EXCEPTION);
@@ -566,7 +561,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void invalidRequestNDoesCancel() {
+    void invalidRequestNDoesCancel() {
         toSource(publisher).subscribe(subscriber);
         fireChannelReadToBuffer(1, 2, 3);
         subscriber.awaitSubscription().request(1);
@@ -582,17 +577,17 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testChannelReadThrowsRequestBeforeChannelRead() {
+    void testChannelReadThrowsRequestBeforeChannelRead() {
         testChannelReadThrows(false);
     }
 
     @Test
-    public void testChannelReadThrowsRequestAfterChannelRead() {
+    void testChannelReadThrowsRequestAfterChannelRead() {
         testChannelReadThrows(true);
     }
 
     @Test
-    public void resubscribePostErrorEmitsError() {
+    void resubscribePostErrorEmitsError() {
         toSource(publisher).subscribe(subscriber);
         fireChannelReadToBuffer(1, 2, 3);
         subscriber.awaitSubscription().request(3);
@@ -609,7 +604,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testSubscribeAndRequestWithinOnCompleteWithPendingData() throws Exception {
+    void testSubscribeAndRequestWithinOnCompleteWithPendingData() throws Exception {
         // With data queued up for multiple payloads in NettyChannelPublisher, when an existing subscriber terminates
         // and a new Subscriber requests data synchronously from the previous terminal signal, the demand should be
         // fulfilled synchronously using the pending data.
@@ -635,7 +630,7 @@ public class NettyChannelPublisherTest {
     }
 
     @Test
-    public void testSubscribeAndRequestWithinOnErrorWithPendingData() {
+    void testSubscribeAndRequestWithinOnErrorWithPendingData() {
         // With data and a fatal error queued up in NettyChannelPublisher, when an existing subscriber terminates and a
         // new Subscriber requests data synchronously from the previous terminal signal, the demand should trigger
         // observing a ClosedChannelException.

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/OverlappingCapacityAwareEstimatorTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/OverlappingCapacityAwareEstimatorTest.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.transport.netty.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
@@ -32,10 +32,10 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
-public class OverlappingCapacityAwareEstimatorTest {
+class OverlappingCapacityAwareEstimatorTest {
 
     @Test
-    public void testRequestNNoItemWrite() {
+    void testRequestNNoItemWrite() {
         OverlappingCapacityAwareEstimator supplier = newSupplier(() -> 100);
         requestNAndVerify(supplier, 10, 100L);
         verify(supplier).getRequestNForCapacity(10);
@@ -43,7 +43,7 @@ public class OverlappingCapacityAwareEstimatorTest {
     }
 
     @Test
-    public void testSupplyLessThanDemandNoCapacityChange() {
+    void testSupplyLessThanDemandNoCapacityChange() {
         OverlappingCapacityAwareEstimator supplier = newSupplier(() -> 100);
         requestNAndVerify(supplier, 10, 100L);
         verify(supplier).getRequestNForCapacity(10);
@@ -54,7 +54,7 @@ public class OverlappingCapacityAwareEstimatorTest {
     }
 
     @Test
-    public void testSupplyLessThanDemandCapacityIncrease() {
+    void testSupplyLessThanDemandCapacityIncrease() {
         AtomicLong toRequest = new AtomicLong(2);
         OverlappingCapacityAwareEstimator supplier = newSupplier(toRequest::get);
         requestNAndVerify(supplier, 10, 2L);
@@ -68,7 +68,7 @@ public class OverlappingCapacityAwareEstimatorTest {
     }
 
     @Test
-    public void testSupplyLessThanDemandCapacityDecrease() {
+    void testSupplyLessThanDemandCapacityDecrease() {
         AtomicLong toRequest = new AtomicLong(2);
         OverlappingCapacityAwareEstimator supplier = newSupplier(toRequest::get);
         requestNAndVerify(supplier, 10, 2L);
@@ -81,7 +81,7 @@ public class OverlappingCapacityAwareEstimatorTest {
     }
 
     @Test
-    public void testSupplyEqualsThanDemandCapacityIncrease() {
+    void testSupplyEqualsThanDemandCapacityIncrease() {
         AtomicLong toRequest = new AtomicLong(1);
         OverlappingCapacityAwareEstimator supplier = newSupplier(toRequest::get);
         requestNAndVerify(supplier, 10, 1L);
@@ -95,7 +95,7 @@ public class OverlappingCapacityAwareEstimatorTest {
     }
 
     @Test
-    public void testSupplyEqualsThanDemandCapacityDecrease() {
+    void testSupplyEqualsThanDemandCapacityDecrease() {
         AtomicLong toRequest = new AtomicLong(1);
         OverlappingCapacityAwareEstimator supplier = newSupplier(toRequest::get);
         requestNAndVerify(supplier, 10, 1L);
@@ -109,7 +109,7 @@ public class OverlappingCapacityAwareEstimatorTest {
     }
 
     @Test
-    public void testSupplyEqualsDemandNoCapacityChange() {
+    void testSupplyEqualsDemandNoCapacityChange() {
         OverlappingCapacityAwareEstimator supplier = newSupplier(() -> 1);
         requestNAndVerify(supplier, 10, 1L);
         verify(supplier).getRequestNForCapacity(10);
@@ -121,7 +121,7 @@ public class OverlappingCapacityAwareEstimatorTest {
     }
 
     @Test
-    public void testNegativeSize() {
+    void testNegativeSize() {
         OverlappingCapacityAwareEstimator supplier = newSupplier(() -> 2);
         requestNAndVerify(supplier, 10, 2L);
         verify(supplier).getRequestNForCapacity(10);
@@ -131,7 +131,7 @@ public class OverlappingCapacityAwareEstimatorTest {
     }
 
     @Test
-    public void testPredictionZeroAndNoOutstanding() {
+    void testPredictionZeroAndNoOutstanding() {
         AtomicLong toRequest = new AtomicLong(0);
         OverlappingCapacityAwareEstimator supplier = newSupplier(toRequest::get);
         requestNAndVerify(supplier, 10, 1L);
@@ -140,7 +140,7 @@ public class OverlappingCapacityAwareEstimatorTest {
     }
 
     @Test
-    public void testPredictionZeroAndSomeOutstanding() {
+    void testPredictionZeroAndSomeOutstanding() {
         AtomicLong toRequest = new AtomicLong(5);
         OverlappingCapacityAwareEstimator supplier = newSupplier(toRequest::get);
         requestNAndVerify(supplier, 10, 5L);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/RandomDataUtilsTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/RandomDataUtilsTest.java
@@ -15,16 +15,16 @@
  */
 package io.servicetalk.transport.netty.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.transport.netty.internal.RandomDataUtils.randomCharSequenceOfByteLength;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class RandomDataUtilsTest {
+class RandomDataUtilsTest {
     @Test
-    public void charSequenceOfByteLength() {
+    void charSequenceOfByteLength() {
         for (int i = 0; i < 128; i++) {
             testRandomCharSequenceOfByteLength(i);
         }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandlerTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandlerTest.java
@@ -17,7 +17,6 @@ package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.api.DefaultThreadFactory;
 import io.servicetalk.concurrent.api.Executors;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent;
 import io.servicetalk.transport.netty.internal.CloseHandler.DiscardFurtherInboundEvent;
 import io.servicetalk.transport.netty.internal.CloseHandler.OutboundDataEndEvent;
@@ -46,19 +45,16 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.SocketChannelConfig;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.EventExecutor;
-import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.rules.TestWatcher;
-import org.junit.rules.Timeout;
-import org.junit.runner.Description;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.extension.TestWatcher;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,45 +83,42 @@ import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.PR
 import static io.servicetalk.transport.netty.internal.CloseHandler.forPipelinedRequestResponse;
 import static io.servicetalk.transport.netty.internal.EventLoopAwareNettyIoExecutors.toEventLoopAwareNettyIoExecutor;
 import static io.servicetalk.transport.netty.internal.NettyIoExecutors.createIoExecutor;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.CI;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.FC;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.IB;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.IC;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.ID;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.IE;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.IH;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.IS;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.OB;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.OC;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.OE;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.OH;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.OS;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.SR;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Events.UC;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.ExpectEvent.CCI;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.ExpectEvent.CCO;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.ExpectEvent.GUC;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.ExpectEvent.NIL;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.ExpectEvent.PCI;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.ExpectEvent.PCO;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Mode.C;
-import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.Scenarios.Mode.S;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioEvents.CI;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioEvents.FC;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioEvents.IB;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioEvents.IC;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioEvents.ID;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioEvents.IE;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioEvents.IH;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioEvents.IS;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioEvents.OB;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioEvents.OC;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioEvents.OE;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioEvents.OH;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioEvents.OS;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioEvents.SR;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioEvents.UC;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioExpectEvent.CCI;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioExpectEvent.CCO;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioExpectEvent.GUC;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioExpectEvent.NIL;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioExpectEvent.PCI;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioExpectEvent.PCO;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioMode.C;
+import static io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest.ScenarioMode.S;
 import static java.lang.Boolean.TRUE;
 import static java.lang.Integer.toHexString;
 import static java.lang.Thread.NORM_PRIORITY;
 import static java.util.Arrays.asList;
 import static java.util.Objects.hash;
 import static java.util.stream.Collectors.toSet;
-import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
@@ -135,22 +128,159 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(Enclosed.class)
-public class RequestResponseCloseHandlerTest {
+class RequestResponseCloseHandlerTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RequestResponseCloseHandlerTest.class);
 
-    @RunWith(Parameterized.class)
-    public static class Scenarios {
+    // Helps debug failed tests, by printing the internal state
+    private static class ScenarioFailedPendingWatcher implements TestWatcher {
+        @Override
+        public void testFailed(final ExtensionContext context, final Throwable cause) {
+            final RequestResponseCloseHandler h = ((Scenarios) context.getRequiredTestInstance()).h;
+            LOGGER.error("Test Failed – Pending state: {}", toHexString(h.state() << 24 | h.pending()), cause);
+        }
+    }
 
-        @Rule
-        public final TestWatcher pendingWatcher = new FailedPendingWatcher();
+    protected enum ScenarioMode {
+        C,  // Client
+        S,  // Server
+    }
 
-        private Mode mode;
-        private List<Events> events;
-        private ExpectEvent expectEvent;
-        private String desc;
-        private String location; // Inferred from parameters
+    protected enum ScenarioEvents {
+        IB, IE, IC, // emit Input Begin/End/Closing
+        OB, OE, OC, // emit Output Begin/End/Closing
+        IS, OS,     // emit Input/Output Socket closed
+        SR,         // validate Socket TCP RST -> SO_LINGER=0
+        UC,         // emit User Closing
+        IH, OH, FC, // validate Input/Output Half-close, Full-Close
+        ID,         // validate Input discarding
+        CI, CO,     // emit Inbound/Outbound close (read cancellation, write subscriber termination)
+    }
+
+    protected enum ScenarioExpectEvent {
+        NIL(null), // No event, not closed
+        PCO(PROTOCOL_CLOSING_OUTBOUND),
+        PCI(PROTOCOL_CLOSING_INBOUND),
+        GUC(GRACEFUL_USER_CLOSING),
+        CCO(CHANNEL_CLOSED_OUTBOUND),
+        CCI(CHANNEL_CLOSED_INBOUND);
+
+        @Nullable
+        private final CloseEvent ce;
+
+        ScenarioExpectEvent(@Nullable CloseEvent c) {
+            this.ce = c;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static Collection<Object[]> scenariosData() { // If inserting lines here, adjust the `offset` variable below
+        StackTraceElement se = Thread.currentThread().getStackTrace()[1];
+        List<Object[]> params = asList(new Object[][]{
+                {C, e(OB, OE, IB, IE), NIL, "sequential, no close"},
+                {C, e(OB, OE, IB, OB, OE, IE, IB, IE), NIL, "pipelined, no close"},
+                {C, e(OB, OC, OE, IB, IE, FC), PCO, "sequential, closing outbound"},
+                {C, e(OB, OE, OB, OC, OE, IB, IE, IB, IE, FC), PCO, "pipelined, closing outbound"},
+                {C, e(OB, OE, OB, OC, IB, OE, IE, IB, IE, FC), PCO, "pipelined, full dup, closing outbound"},
+                {C, e(OB, IB, IC, OE, IE, FC), PCI, "full dup, closing inbound"},
+                {C, e(OB, OE, IB, OB, IC, IE, FC), PCI, "server closes 1st request, 2nd request discarded"},
+                {C, e(OB, IB, OE, IC, IE, FC), PCI, "pipelined, closing inbound"},
+                {C, e(OB, IB, IC, IE, OE, FC), PCI, "pipelined, full dup, closing inbound"},
+                {C, e(OB, OE, IB, IC, IE, FC), PCI, "sequential, closing inbound"},
+                {C, e(OB, UC, OE, IB, IE, FC), GUC, "sequential, user close"},
+                {C, e(OB, IB, OE, OB, UC, OE, IE, IB, IE, FC), GUC, "pipelined req graceful close"},
+                {C, e(OB, IB, UC, OE, IE, FC), GUC, "interleaved, user close"},
+                {C, e(OB, OE, IB, IE, UC, FC), GUC, "sequential, idle, user close"},
+                {C, e(OB, IB, OE, IE, UC, FC), GUC, "interleaved, idle, user close"},
+                {C, e(OB, IB, IE, OE, UC, FC), GUC, "interleaved full dup, idle, user close"},
+                {C, e(OB, IB, UC, IE, OE, FC), GUC, "interleaved full dup, user close"},
+                {C, e(OB, OE, IS, FC), CCI, "abrupt input close after complete write, resp abort"},
+                {C, e(IS, FC), CCI, "idle, inbound closed"},
+                {C, e(OB, IS, SR, FC), CCI, "req abort, inbound closed"},
+                {C, e(OB, IB, OE, OB, IC, IE, FC), PCI, "pipelined req abort after inbound close"},
+                {C, e(OB, IB, OE, IS, FC), CCI, "req complete, resp abort, inbound closed"},
+                {C, e(OB, IB, IE, IS, OE, FC), CCI, "continue write read completed, inbound closed"},
+                {C, e(OS, FC), CCO, "idle, outbound closed"},
+                {C, e(OB, OS, SR, FC), CCO, "req abort, outbound closed"},
+                {C, e(OB, OE, OB, IB, OS, SR, IE, FC), CCO, "new req abort, complete read, outbound closed"},
+                {C, e(OB, OE, OS, IB, IE, FC), CCO, "req complete, complete read, outbound closed"},
+                {C, e(OB, IB, IE, OS, SR, FC), CCO, "outbound closed while not reading"},
+                {C, e(OB, IB, OS, SR, IE, FC), CCO, "outbound closed while reading"},
+                {C, e(OB, OE, OB, OS, SR, IB, IE, FC), CCO, "outbound closed while not reading, 2 pending"},
+                {C, e(OB, OE, OB, OE, OB, OS, SR, IB, IE, IB, IE, FC), CCO, "outbound closed while not reading, >2 pending"},
+                {C, e(OB, OE, OB, OE, OB, IB, OS, SR, IE, IB, IE, FC), CCO, "outbound closed while reading, >2 pending"},
+                {C, e(OB, IB, IS, OE, FC), CCI, "inbound closed when reading, finish pending request"},
+                {S, e(IS, FC), CCI, "idle, inbound closed"},
+                {S, e(IB, OB, IE, IS, OE, FC), CCI, "continue resp, req completed, inbound closed"},
+                {S, e(IB, OB, OE, IS, SR, FC), CCI, "req aborted, resp completed, inbound closed"},
+                {S, e(IB, OB, IE, IB, IS, SR, OE, OB, OE, FC), CCI, "new req abort, complete responses, inbound closed"},
+                {S, e(OS, FC), CCO, "idle, outbound closed"},
+                {S, e(IB, OS, SR, FC), CCO, "req aborted, outbound closed"},
+                {S, e(IB, OB, OS, IE, FC), CCO, "continue req, outbound shutdown, no reset"},
+                {S, e(IB, OB, OS, IS, FC), CCO, "outbound shutdown, inbound shutdown, no reset"},
+                {S, e(IB, OB, OE, OS, IE, FC), CCO, "resp completed, complete req, outbound closed"},
+                {S, e(IB, OB, IE, IB, OS, SR, FC), CCO, "new req abort, resp abort, outbound closed"},
+                {S, e(IB, OB, OE, IE, IB, OS, SR, FC), CCO, "new req abort, complete resp, outbound closed"},
+                {S, e(IB, IE, OB, OE), NIL, "sequential, no close"},
+                {S, e(IB, IE, OB, IB, IE, OE, OB, OE), NIL, "pipelined, no close"},
+                {S, e(IB, IE, IB, OB, OC, ID, OE, OH, IS, FC), PCO, "pipelined, closing outbound"},
+                {S, e(IB, IE, IB, IE, OB, OC, ID, OE, OH, IS, FC), PCO, "pipelined, closing outbound, drop pending!"},
+                {S, e(IB, IE, OB, OC, ID, OE, OH, IS, FC), PCO, "sequential, closing outbound"},
+                {S, e(IB, OB, OC, IE, ID, OE, OH, IS, FC), PCO, "interleaved, closing outbound"},
+                {S, e(IB, OB, OC, OE, IE, ID, OH, IS, FC), PCO, "interleaved full dup, closing outbound"},
+                {S, e(IB, OB, OC, IE, ID, IS, OE, FC), PCO, "interleaved, input shutdowns, closing outbound"},
+                {S, e(IB, OB, IE, IB, IC, OE, OB, IE, ID, OE, FC), PCI, "pipelined, closing inbound, drain"},
+                {S, e(IB, IE, OB, IB, IC, IE, ID, OE, OB, OE, FC), PCI, "pipelined, closing inbound"},
+                {S, e(IB, IE, OB, IB, IE, UC, ID, OE, OB, OE, OH, IS, FC), GUC, "pipelined, user closing, drain"},
+                {S, e(IB, IC, OB, OE, IE, FC), PCI, "pipelined full dup, closing inbound"},
+                {S, e(IB, OB, IE, IB, IC, IE, ID, OE, OB, OE, FC), PCI, "pipelined, closing inbound"},
+                {S, e(IB, OB, IC, OE, IE, FC), PCI, "pipelined, full dup, closing inbound"},
+                {S, e(IB, IC, IE, ID, OB, OE, FC), PCI, "sequential, closing inbound"},
+                {S, e(UC, ID, OH, IS, FC), GUC, "recently open connection, idle, user close"},
+                {S, e(IB, UC, IE, ID, OB, OE, OH, IS, FC), GUC, "sequential, during req, user close"},
+                {S, e(IB, IE, UC, ID, OB, OE, OH, IS, FC), GUC, "sequential, user close"},
+                {S, e(IB, IE, UC, ID, IS, OB, OE, FC), GUC, "sequential, input shutdown before resp, user close"},
+                {S, e(IB, IE, UC, ID, OB, IS, OE, FC), GUC, "sequential, input shutdown after resp, user close"},
+                {S, e(IB, IE, OB, UC, ID, OE, OH, IS, FC), GUC, "sequential, during resp, user close"},
+                {S, e(IB, IE, OB, OE, UC, ID, OH, IS, FC), GUC, "sequential, idle, user close"},
+                {S, e(IB, IE, OB, OE, UC, ID, OH, CI, IS, FC), GUC, "sequential, idle, read cancelled, user close"},
+                {S, e(IB, UC, OB, IE, ID, OE, OH, IS, FC), GUC, "interleaved, before resp, user close"},
+                {S, e(IB, OB, UC, IE, ID, OE, OH, IS, FC), GUC, "interleaved, user close"},
+                {S, e(IB, OB, IE, UC, ID, OE, OH, IS, FC), GUC, "interleaved, after req, user close"},
+                {S, e(IB, OB, IE, OE, UC, ID, OH, IS, FC), GUC, "interleaved, idle, user close"},
+                {S, e(IB, UC, OB, OE, IE, ID, OH, IS, FC), GUC, "interleaved full dup, before resp, user close"},
+                {S, e(IB, OB, UC, OE, IE, ID, OH, IS, FC), GUC, "interleaved full dup, user close"},
+                {S, e(IB, OB, UC, OE, IE, ID, OH, CI, IS, FC), GUC, "interleaved full dup, read cancelled, user close"},
+                {S, e(IB, OB, OE, UC, IE, ID, OH, IS, FC), GUC, "interleaved full dup, after resp, user close"},
+                {S, e(IB, OB, OE, IE, UC, ID, OH, IS, FC), GUC, "interleaved full dup, idle, user close"},
+                {S, e(IB, IE, OB, OE, IS, FC), CCI, "sequential, idle, inbound closed"},
+                {S, e(IB, OB, IS, SR, OE, FC), CCI, "inbound closed while reading no pipeline"},
+                {S, e(IB, IS, SR, OB, OE, FC), CCI, "inbound closed while reading delay close until response"},
+                {S, e(IB, IE, IB, IS, SR, OB, OE, OB, OE, FC), CCI, "inbound closed while not writing pipelined, 2 pending"},
+                {S, e(IB, IE, IB, OB, IS, SR, OE, OB, OE, FC), CCI, "inbound closed while writing pipelined, 1 pending"},
+                {S, e(IB, IE, IB, IE, IB, IS, SR, OB, OE, OB, OE, OB, OE, FC), CCI, "inbound closed while not writing pipelined, >2 pending"},
+                {S, e(IB, IE, IB, IE, IB, OB, IS, SR, OE, OB, OE, OB, OE, FC), CCI, "inbound closed while writing pipelined, >2 pending"},
+                {S, e(IB, IE, IS, OB, OS, FC), CCI, "Input closed after read, outbound closed while writing"},
+                {S, e(IB, IE, IS, OS, FC), CCI, "Input closed after read, outbound closed while writing"},
+        });
+        String fileName = se.getFileName();
+        int offset = se.getLineNumber() + 2; // Lines between `se` and first parameter
+        for (int i = 0; i < params.size(); i++) { // Appends param location as last entry
+            Object[] o = params.get(i);
+            params.set(i, new Object[]{o[0], o[1], o[2], o[3], fileName + ":" + (offset + i)});
+        }
+        Set<Integer> uniques = params.stream().map(objs -> hash(objs[0], objs[1], objs[2])).collect(toSet());
+        assertEquals(uniques.size(), params.size(), "Duplicate test scenario?");
+        return params;
+    }
+
+    private static List<ScenarioEvents> e(ScenarioEvents... args) {
+        return asList(args);
+    }
+
+    @Nested
+    @ExtendWith(ScenarioFailedPendingWatcher.class)
+    class Scenarios {
 
         private ChannelHandlerContext ctx;
         private SocketChannel channel;
@@ -163,164 +293,10 @@ public class RequestResponseCloseHandlerTest {
         private AtomicBoolean outputShutdown = new AtomicBoolean();
         private SocketChannelConfig scc;
 
-        public Scenarios(final Mode mode, final List<Events> events, final ExpectEvent expectEvent,
-                         final String desc, final String location) {
-            this.mode = mode;
-            this.events = events;
-            this.expectEvent = expectEvent;
-            this.desc = desc;
-            this.location = location;
-        }
-
-        protected enum Mode {
-            C,  // Client
-            S,  // Server
-        }
-
-        protected enum Events {
-            IB, IE, IC, // emit Input Begin/End/Closing
-            OB, OE, OC, // emit Output Begin/End/Closing
-            IS, OS,     // emit Input/Output Socket closed
-            SR,         // validate Socket TCP RST -> SO_LINGER=0
-            UC,         // emit User Closing
-            IH, OH, FC, // validate Input/Output Half-close, Full-Close
-            ID,         // validate Input discarding
-            CI, CO,     // emit Inbound/Outbound close (read cancellation, write subscriber termination)
-        }
-
-        protected enum ExpectEvent {
-            NIL(null), // No event, not closed
-            PCO(PROTOCOL_CLOSING_OUTBOUND),
-            PCI(PROTOCOL_CLOSING_INBOUND),
-            GUC(GRACEFUL_USER_CLOSING),
-            CCO(CHANNEL_CLOSED_OUTBOUND),
-            CCI(CHANNEL_CLOSED_INBOUND);
-
-            @Nullable
-            private final CloseEvent ce;
-
-            ExpectEvent(@Nullable CloseEvent c) {
-                this.ce = c;
-            }
-        }
-
-        @Parameters(name = "{index}. {3} - {0} {1} = {2}")
-        public static Collection<Object[]> data() { // If inserting lines here, adjust the `offset` variable below
-            StackTraceElement se = Thread.currentThread().getStackTrace()[1];
-            List<Object[]> params = asList(new Object[][]{
-                    // {Mode, Events, ExpectedEvent, Desc} - IGNORE disables test-case, keep contiguous on single line
-                    {C, e(OB, OE, IB, IE), NIL, "sequential, no close"},
-                    {C, e(OB, OE, IB, OB, OE, IE, IB, IE), NIL, "pipelined, no close"},
-                    {C, e(OB, OC, OE, IB, IE, FC), PCO, "sequential, closing outbound"},
-                    {C, e(OB, OE, OB, OC, OE, IB, IE, IB, IE, FC), PCO, "pipelined, closing outbound"},
-                    {C, e(OB, OE, OB, OC, IB, OE, IE, IB, IE, FC), PCO, "pipelined, full dup, closing outbound"},
-                    {C, e(OB, IB, IC, OE, IE, FC), PCI, "full dup, closing inbound"},
-                    {C, e(OB, OE, IB, OB, IC, IE, FC), PCI, "server closes 1st request, 2nd request discarded"},
-                    {C, e(OB, IB, OE, IC, IE, FC), PCI, "pipelined, closing inbound"},
-                    {C, e(OB, IB, IC, IE, OE, FC), PCI, "pipelined, full dup, closing inbound"},
-                    {C, e(OB, OE, IB, IC, IE, FC), PCI, "sequential, closing inbound"},
-                    {C, e(OB, UC, OE, IB, IE, FC), GUC, "sequential, user close"},
-                    {C, e(OB, IB, OE, OB, UC, OE, IE, IB, IE, FC), GUC, "pipelined req graceful close"},
-                    {C, e(OB, IB, UC, OE, IE, FC), GUC, "interleaved, user close"},
-                    {C, e(OB, OE, IB, IE, UC, FC), GUC, "sequential, idle, user close"},
-                    {C, e(OB, IB, OE, IE, UC, FC), GUC, "interleaved, idle, user close"},
-                    {C, e(OB, IB, IE, OE, UC, FC), GUC, "interleaved full dup, idle, user close"},
-                    {C, e(OB, IB, UC, IE, OE, FC), GUC, "interleaved full dup, user close"},
-                    {C, e(OB, OE, IS, FC), CCI, "abrupt input close after complete write, resp abort"},
-                    {C, e(IS, FC), CCI, "idle, inbound closed"},
-                    {C, e(OB, IS, SR, FC), CCI, "req abort, inbound closed"},
-                    {C, e(OB, IB, OE, OB, IC, IE, FC), PCI, "pipelined req abort after inbound close"},
-                    {C, e(OB, IB, OE, IS, FC), CCI, "req complete, resp abort, inbound closed"},
-                    {C, e(OB, IB, IE, IS, OE, FC), CCI, "continue write read completed, inbound closed"},
-                    {C, e(OS, FC), CCO, "idle, outbound closed"},
-                    {C, e(OB, OS, SR, FC), CCO, "req abort, outbound closed"},
-                    {C, e(OB, OE, OB, IB, OS, SR, IE, FC), CCO, "new req abort, complete read, outbound closed"},
-                    {C, e(OB, OE, OS, IB, IE, FC), CCO, "req complete, complete read, outbound closed"},
-                    {C, e(OB, IB, IE, OS, SR, FC), CCO, "outbound closed while not reading"},
-                    {C, e(OB, IB, OS, SR, IE, FC), CCO, "outbound closed while reading"},
-                    {C, e(OB, OE, OB, OS, SR, IB, IE, FC), CCO, "outbound closed while not reading, 2 pending"},
-                    {C, e(OB, OE, OB, OE, OB, OS, SR, IB, IE, IB, IE, FC), CCO, "outbound closed while not reading, >2 pending"},
-                    {C, e(OB, OE, OB, OE, OB, IB, OS, SR, IE, IB, IE, FC), CCO, "outbound closed while reading, >2 pending"},
-                    {C, e(OB, IB, IS, OE, FC), CCI, "inbound closed when reading, finish pending request"},
-                    {S, e(IS, FC), CCI, "idle, inbound closed"},
-                    {S, e(IB, OB, IE, IS, OE, FC), CCI, "continue resp, req completed, inbound closed"},
-                    {S, e(IB, OB, OE, IS, SR, FC), CCI, "req aborted, resp completed, inbound closed"},
-                    {S, e(IB, OB, IE, IB, IS, SR, OE, OB, OE, FC), CCI, "new req abort, complete responses, inbound closed"},
-                    {S, e(OS, FC), CCO, "idle, outbound closed"},
-                    {S, e(IB, OS, SR, FC), CCO, "req aborted, outbound closed"},
-                    {S, e(IB, OB, OS, IE, FC), CCO, "continue req, outbound shutdown, no reset"},
-                    {S, e(IB, OB, OS, IS, FC), CCO, "outbound shutdown, inbound shutdown, no reset"},
-                    {S, e(IB, OB, OE, OS, IE, FC), CCO, "resp completed, complete req, outbound closed"},
-                    {S, e(IB, OB, IE, IB, OS, SR, FC), CCO, "new req abort, resp abort, outbound closed"},
-                    {S, e(IB, OB, OE, IE, IB, OS, SR, FC), CCO, "new req abort, complete resp, outbound closed"},
-                    {S, e(IB, IE, OB, OE), NIL, "sequential, no close"},
-                    {S, e(IB, IE, OB, IB, IE, OE, OB, OE), NIL, "pipelined, no close"},
-                    {S, e(IB, IE, IB, OB, OC, ID, OE, OH, IS, FC), PCO, "pipelined, closing outbound"},
-                    {S, e(IB, IE, IB, IE, OB, OC, ID, OE, OH, IS, FC), PCO, "pipelined, closing outbound, drop pending!"},
-                    {S, e(IB, IE, OB, OC, ID, OE, OH, IS, FC), PCO, "sequential, closing outbound"},
-                    {S, e(IB, OB, OC, IE, ID, OE, OH, IS, FC), PCO, "interleaved, closing outbound"},
-                    {S, e(IB, OB, OC, OE, IE, ID, OH, IS, FC), PCO, "interleaved full dup, closing outbound"},
-                    {S, e(IB, OB, OC, IE, ID, IS, OE, FC), PCO, "interleaved, input shutdowns, closing outbound"},
-                    {S, e(IB, OB, IE, IB, IC, OE, OB, IE, ID, OE, FC), PCI, "pipelined, closing inbound, drain"},
-                    {S, e(IB, IE, OB, IB, IC, IE, ID, OE, OB, OE, FC), PCI, "pipelined, closing inbound"},
-                    {S, e(IB, IE, OB, IB, IE, UC, ID, OE, OB, OE, OH, IS, FC), GUC, "pipelined, user closing, drain"},
-                    {S, e(IB, IC, OB, OE, IE, FC), PCI, "pipelined full dup, closing inbound"},
-                    {S, e(IB, OB, IE, IB, IC, IE, ID, OE, OB, OE, FC), PCI, "pipelined, closing inbound"},
-                    {S, e(IB, OB, IC, OE, IE, FC), PCI, "pipelined, full dup, closing inbound"},
-                    {S, e(IB, IC, IE, ID, OB, OE, FC), PCI, "sequential, closing inbound"},
-                    {S, e(UC, ID, OH, IS, FC), GUC, "recently open connection, idle, user close"},
-                    {S, e(IB, UC, IE, ID, OB, OE, OH, IS, FC), GUC, "sequential, during req, user close"},
-                    {S, e(IB, IE, UC, ID, OB, OE, OH, IS, FC), GUC, "sequential, user close"},
-                    {S, e(IB, IE, UC, ID, IS, OB, OE, FC), GUC, "sequential, input shutdown before resp, user close"},
-                    {S, e(IB, IE, UC, ID, OB, IS, OE, FC), GUC, "sequential, input shutdown after resp, user close"},
-                    {S, e(IB, IE, OB, UC, ID, OE, OH, IS, FC), GUC, "sequential, during resp, user close"},
-                    {S, e(IB, IE, OB, OE, UC, ID, OH, IS, FC), GUC, "sequential, idle, user close"},
-                    {S, e(IB, IE, OB, OE, UC, ID, OH, CI, IS, FC), GUC, "sequential, idle, read cancelled, user close"},
-                    {S, e(IB, UC, OB, IE, ID, OE, OH, IS, FC), GUC, "interleaved, before resp, user close"},
-                    {S, e(IB, OB, UC, IE, ID, OE, OH, IS, FC), GUC, "interleaved, user close"},
-                    {S, e(IB, OB, IE, UC, ID, OE, OH, IS, FC), GUC, "interleaved, after req, user close"},
-                    {S, e(IB, OB, IE, OE, UC, ID, OH, IS, FC), GUC, "interleaved, idle, user close"},
-                    {S, e(IB, UC, OB, OE, IE, ID, OH, IS, FC), GUC, "interleaved full dup, before resp, user close"},
-                    {S, e(IB, OB, UC, OE, IE, ID, OH, IS, FC), GUC, "interleaved full dup, user close"},
-                    {S, e(IB, OB, UC, OE, IE, ID, OH, CI, IS, FC), GUC, "interleaved full dup, read cancelled, user close"},
-                    {S, e(IB, OB, OE, UC, IE, ID, OH, IS, FC), GUC, "interleaved full dup, after resp, user close"},
-                    {S, e(IB, OB, OE, IE, UC, ID, OH, IS, FC), GUC, "interleaved full dup, idle, user close"},
-                    {S, e(IB, IE, OB, OE, IS, FC), CCI, "sequential, idle, inbound closed"},
-                    {S, e(IB, OB, IS, SR, OE, FC), CCI, "inbound closed while reading no pipeline"},
-                    {S, e(IB, IS, SR, OB, OE, FC), CCI, "inbound closed while reading delay close until response"},
-                    {S, e(IB, IE, IB, IS, SR, OB, OE, OB, OE, FC), CCI, "inbound closed while not writing pipelined, 2 pending"},
-                    {S, e(IB, IE, IB, OB, IS, SR, OE, OB, OE, FC), CCI, "inbound closed while writing pipelined, 1 pending"},
-                    {S, e(IB, IE, IB, IE, IB, IS, SR, OB, OE, OB, OE, OB, OE, FC), CCI, "inbound closed while not writing pipelined, >2 pending"},
-                    {S, e(IB, IE, IB, IE, IB, OB, IS, SR, OE, OB, OE, OB, OE, FC), CCI, "inbound closed while writing pipelined, >2 pending"},
-                    {S, e(IB, IE, IS, OB, OS, FC), CCI, "Input closed after read, outbound closed while writing"},
-                    {S, e(IB, IE, IS, OS, FC), CCI, "Input closed after read, outbound closed while writing"},
-            });
-            String fileName = se.getFileName();
-            int offset = se.getLineNumber() + 3; // Lines between `se` and first parameter
-            for (int i = 0; i < params.size(); i++) { // Appends param location as last entry
-                Object[] o = params.get(i);
-                params.set(i, new Object[]{o[0], o[1], o[2], o[3], fileName + ":" + (offset + i)});
-            }
-            Set<Integer> uniques = params.stream().map(objs -> hash(objs[0], objs[1], objs[2])).collect(toSet());
-            assertEquals("Duplicate test scenario?", uniques.size(), params.size());
-            return params;
-        }
-
-        // Helps debug failed tests, by printing the internal state
-        private class FailedPendingWatcher extends TestWatcher {
-            @Override
-            protected void failed(final Throwable e, final Description description) {
-                LOGGER.error("Test Failed – Pending state: {}", toHexString(h.state() << 24 | h.pending()), e);
-            }
-        }
-
         /**
          * Simulates netty channel behavior, behavior verified by {@link ChannelBehavior} below.
          */
-        @Before
-        public void setup() {
-            // A description prefixed with "IGNORE " will not fail the suite!
-            assumeThat(desc, desc, not(startsWith("IGNORE ")));
+        private void setUp(final ScenarioMode mode) {
             ctx = mock(ChannelHandlerContext.class);
             channel = mock(SocketChannel.class, "[id: 0xmocked, L:mocked - R:mocked]");
             when(ctx.channel()).thenReturn(channel);
@@ -380,20 +356,23 @@ public class RequestResponseCloseHandlerTest {
         }
 
         private void assertCanRead() {
-            assertTrue("Channel Closed (read) - testcase invalid or bug?", !closed.get() && !inputShutdown.get());
+            assertTrue(!closed.get() && !inputShutdown.get(), "Channel Closed (read) - testcase invalid or bug?");
         }
 
         private void assertCanWrite() {
-            assertTrue("Channel Closed (write) - testcase invalid or bug?", !closed.get() && !outputShutdown.get());
+            assertTrue(!closed.get() && !outputShutdown.get(), "Channel Closed (write) - testcase invalid or bug?");
         }
 
-        @Test
-        public void simulate() {
+        @ParameterizedTest(name = "{index}. {3} - {0} {1} = {2}, {4}")
+        @MethodSource("io.servicetalk.transport.netty.internal.RequestResponseCloseHandlerTest#scenariosData")
+        void simulate(final ScenarioMode mode, final List<ScenarioEvents> events, final ScenarioExpectEvent expectEvent,
+                      final String desc, final String location) {
+            setUp(mode);
             LOGGER.debug("Test.Params: ({})", location); // Intellij jump to parameter format, don't change!
-            LOGGER.debug("[{}] {} - {} = {}", desc, mode, events, expectEvent);
+            LOGGER.debug("{} - {} {} = {}", desc, mode, events, expectEvent);
             InOrder order = inOrder(h, channel, pipeline, scc);
             verify(h).registerEventHandler(eq(channel), any());
-            for (Events event : events) {
+            for (ScenarioEvents event : events) {
                 LOGGER.debug("{}", event);
                 switch (event) {
                     case IB:
@@ -474,7 +453,7 @@ public class RequestResponseCloseHandlerTest {
                 }
             }
             assertThat("Expected CloseEvent", observedEvent, equalTo(expectEvent.ce));
-            for (Events c : Events.values()) {
+            for (ScenarioEvents c : ScenarioEvents.values()) {
                 if (!events.contains(c)) {
                     switch (c) {
                         case IB:
@@ -535,19 +514,13 @@ public class RequestResponseCloseHandlerTest {
                 }
             }
         }
-
-        private static List<Events> e(Events... args) {
-            return asList(args);
-        }
     }
 
-    public static class RequestResponseUserEventTest {
-
-        @Rule
-        public final Timeout timeout = new ServiceTalkTestTimeout();
+    @Nested
+    class RequestResponseUserEventTest {
 
         @Test
-        public void clientOutboundDataEndEventEmitsUserEventAlways() {
+        void clientOutboundDataEndEventEmitsUserEventAlways() {
             AtomicBoolean ab = new AtomicBoolean(false);
             final EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter() {
                 @Override
@@ -566,7 +539,7 @@ public class RequestResponseCloseHandlerTest {
         }
 
         @Test
-        public void serverOutboundDataEndEventDoesntEmitUntilClosing() {
+        void serverOutboundDataEndEventDoesntEmitUntilClosing() {
             AtomicBoolean ab = new AtomicBoolean(false);
             final EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter() {
                 @Override
@@ -585,7 +558,7 @@ public class RequestResponseCloseHandlerTest {
         }
 
         @Test
-        public void serverOutboundDataEndEventDoesntEmitUntilClosingAndIdle() throws Exception {
+        void serverOutboundDataEndEventDoesntEmitUntilClosingAndIdle() throws Exception {
             AtomicBoolean ab = new AtomicBoolean(false);
             final EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter() {
                 @Override
@@ -618,7 +591,7 @@ public class RequestResponseCloseHandlerTest {
         }
 
         @Test
-        public void serverOutboundDataEndEventEmitsUserEventWhenClosing() {
+        void serverOutboundDataEndEventEmitsUserEventWhenClosing() {
             AtomicBoolean ab = new AtomicBoolean(false);
             final EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter() {
                 @Override
@@ -639,17 +612,15 @@ public class RequestResponseCloseHandlerTest {
     }
 
     // Sanity checks to validate assumptions in above mock behavior
-    public static class ChannelBehavior {
+    @Nested
+    class ChannelBehavior {
 
-        @Rule
-        public final Timeout timeout = new ServiceTalkTestTimeout();
-
-        @ClassRule
-        public static final ExecutionContextRule C_CTX = new ExecutionContextRule(() -> DEFAULT_ALLOCATOR,
+        @RegisterExtension
+        public final ExecutionContextExtension clientCtx = new ExecutionContextExtension(() -> DEFAULT_ALLOCATOR,
                 () -> createIoExecutor(
                         new DefaultThreadFactory("client-thread", true, NORM_PRIORITY)), Executors::immediate);
-        @ClassRule
-        public static final ExecutionContextRule S_CTX = new ExecutionContextRule(() -> DEFAULT_ALLOCATOR,
+        @RegisterExtension
+        public final ExecutionContextExtension serverCtx = new ExecutionContextExtension(() -> DEFAULT_ALLOCATOR,
                 () -> createIoExecutor(
                         new DefaultThreadFactory("server-thread", true, NORM_PRIORITY)), Executors::immediate);
 
@@ -665,7 +636,7 @@ public class RequestResponseCloseHandlerTest {
         private final CountDownLatch serverInputShutdownReadCompleteLatch = new CountDownLatch(1);
         private final CountDownLatch serverOutputShutdownLatch = new CountDownLatch(1);
 
-        @Before
+        @BeforeEach
         @SuppressWarnings("unchecked")
         public void setup() throws InterruptedException {
             ssChannel = startServer();
@@ -673,7 +644,7 @@ public class RequestResponseCloseHandlerTest {
             connectedLatch.await();
         }
 
-        @After
+        @AfterEach
         public void dispose() {
             cChannel.close().syncUninterruptibly();
             sChannel.close().syncUninterruptibly();
@@ -683,7 +654,7 @@ public class RequestResponseCloseHandlerTest {
         // Based on TcpServerInitializer
         private ServerSocketChannel startServer() {
             EventLoopAwareNettyIoExecutor eventLoopAwareNettyIoExecutor =
-                    toEventLoopAwareNettyIoExecutor(S_CTX.ioExecutor());
+                    toEventLoopAwareNettyIoExecutor(serverCtx.ioExecutor());
             EventLoop loop = eventLoopAwareNettyIoExecutor.eventLoopGroup().next();
 
             ServerBootstrap bs = new ServerBootstrap();
@@ -722,7 +693,7 @@ public class RequestResponseCloseHandlerTest {
         // Based on TcpConnector
         private SocketChannel connectClient(InetSocketAddress address) {
             EventLoopAwareNettyIoExecutor eventLoopAwareNettyIoExecutor =
-                    toEventLoopAwareNettyIoExecutor(C_CTX.ioExecutor());
+                    toEventLoopAwareNettyIoExecutor(clientCtx.ioExecutor());
             EventLoop loop = eventLoopAwareNettyIoExecutor.eventLoopGroup().next();
 
             Bootstrap bs = new Bootstrap();
@@ -756,7 +727,7 @@ public class RequestResponseCloseHandlerTest {
         }
 
         @Test
-        public void clientCloseEmitsNoShutdownEventsOnClient() {
+        void clientCloseEmitsNoShutdownEventsOnClient() {
             cChannel.close().syncUninterruptibly();
             assertThat(clientOutputShutdownLatch.getCount(), equalTo(1L));
             assertThat(clientInputShutdownLatch.getCount(), equalTo(1L));
@@ -767,7 +738,7 @@ public class RequestResponseCloseHandlerTest {
         }
 
         @Test
-        public void clientCloseEmitsServerInputShutdownImmediatelyAndOutputAfterWriting() throws Exception {
+        void clientCloseEmitsServerInputShutdownImmediatelyAndOutputAfterWriting() throws Exception {
             cChannel.close().syncUninterruptibly();
             serverInputShutdownReadCompleteLatch.await();
             serverInputShutdownLatch.await();
@@ -781,7 +752,7 @@ public class RequestResponseCloseHandlerTest {
         }
 
         @Test
-        public void clientShutdownOutputEmitsClientOutputShutdownAndServerInputShutdown() throws Exception {
+        void clientShutdownOutputEmitsClientOutputShutdownAndServerInputShutdown() throws Exception {
             cChannel.shutdownOutput().syncUninterruptibly();
             clientOutputShutdownLatch.await();
             serverInputShutdownReadCompleteLatch.await();
@@ -795,9 +766,8 @@ public class RequestResponseCloseHandlerTest {
         }
 
         @Test
-        public void serverShutdownInputEmitsServerInputShutdownReadCompleteOnly() throws Exception {
-            assumeThat("Windows doesn't emit ChannelInputShutdownReadComplete. Investigation Required.", sChannel,
-                    is(Matchers.not(instanceOf(NioSocketChannel.class))));
+        void serverShutdownInputEmitsServerInputShutdownReadCompleteOnly() throws Exception {
+            assumeFalse(sChannel instanceof NioSocketChannel, "Windows doesn't emit ChannelInputShutdownReadComplete. Investigation Required.");
             sChannel.shutdownInput().syncUninterruptibly();
             serverInputShutdownReadCompleteLatch.await();
             assertThat(serverInputShutdownLatch.getCount(), is(1L));
@@ -810,7 +780,7 @@ public class RequestResponseCloseHandlerTest {
         }
 
         @Test
-        public void serverCloseEmitsNoShutdownEventsOnServer() {
+        void serverCloseEmitsNoShutdownEventsOnServer() {
             sChannel.close().syncUninterruptibly();
             assertThat(serverOutputShutdownLatch.getCount(), equalTo(1L));
             assertThat(serverInputShutdownLatch.getCount(), equalTo(1L));
@@ -821,7 +791,7 @@ public class RequestResponseCloseHandlerTest {
         }
 
         @Test
-        public void serverCloseEmitsClientInputShutdownImmediatelyAndOutputAfterWriting() throws Exception {
+        void serverCloseEmitsClientInputShutdownImmediatelyAndOutputAfterWriting() throws Exception {
             sChannel.close().syncUninterruptibly();
             clientInputShutdownReadCompleteLatch.await();
             clientInputShutdownLatch.await();
@@ -868,21 +838,21 @@ public class RequestResponseCloseHandlerTest {
         }
 
         @Test
-        public void socketOptionsSucceedWhenInputShutdown() throws InterruptedException {
+        void socketOptionsSucceedWhenInputShutdown() throws InterruptedException {
             sChannel.shutdownOutput();
             clientInputShutdownLatch.await();
             cChannel.config().setSoLinger(0);
         }
 
         @Test
-        public void socketOptionsSucceedWhenOutputShutdown() throws InterruptedException {
+        void socketOptionsSucceedWhenOutputShutdown() throws InterruptedException {
             cChannel.shutdownOutput();
             clientOutputShutdownLatch.await();
             cChannel.config().setSoLinger(0);
         }
 
         @Test
-        public void socketOptionsFailWhenInAndOutputShutdown() throws InterruptedException {
+        void socketOptionsFailWhenInAndOutputShutdown() throws InterruptedException {
             sChannel.shutdownOutput();
             cChannel.shutdownOutput();
             clientInputShutdownLatch.await();
@@ -891,14 +861,14 @@ public class RequestResponseCloseHandlerTest {
         }
 
         @Test
-        public void socketOptionsSucceedWhenServerCloses() throws InterruptedException {
+        void socketOptionsSucceedWhenServerCloses() throws InterruptedException {
             sChannel.close();
             clientInputShutdownLatch.await();
             cChannel.config().setSoLinger(0);
         }
 
         @Test
-        public void socketOptionsFailWhenServerClosesAndOutputShutdown() throws InterruptedException {
+        void socketOptionsFailWhenServerClosesAndOutputShutdown() throws InterruptedException {
             cChannel.shutdownOutput();
             sChannel.close();
             clientInputShutdownLatch.await();
@@ -907,7 +877,7 @@ public class RequestResponseCloseHandlerTest {
         }
 
         @Test
-        public void socketOptionsFailWhenServerRstCloses() throws InterruptedException {
+        void socketOptionsFailWhenServerRstCloses() throws InterruptedException {
             sChannel.config().setSoLinger(0);
             sChannel.close();
             clientInputShutdownLatch.await();
@@ -915,7 +885,7 @@ public class RequestResponseCloseHandlerTest {
         }
 
         @Test
-        public void socketOptionsFailWhenServerRstClosesAndOutputShutdown() throws InterruptedException {
+        void socketOptionsFailWhenServerRstClosesAndOutputShutdown() throws InterruptedException {
             cChannel.shutdownOutput();
             sChannel.config().setSoLinger(0);
             sChannel.close();

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertClientHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertClientHandlingTest.java
@@ -18,21 +18,21 @@ package io.servicetalk.transport.netty.internal;
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.api.test.StepVerifiers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.channels.ClosedChannelException;
 
 import static io.servicetalk.concurrent.api.Processors.newPublisherProcessor;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 
-public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotifyAlertHandlingTest {
+class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotifyAlertHandlingTest {
 
-    public SslCloseNotifyAlertClientHandlingTest() throws Exception {
+    SslCloseNotifyAlertClientHandlingTest() throws Exception {
         super(true);
     }
 
     @Test
-    public void afterExchangeIdleConnection() {
+    void afterExchangeIdleConnection() {
         sendRequest();
         StepVerifiers.create(conn.read())
                 .then(() -> channel.writeInbound(BEGIN))
@@ -45,7 +45,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
     }
 
     @Test
-    public void afterRequestBeforeReadingResponse() {
+    void afterRequestBeforeReadingResponse() {
         sendRequest();
         StepVerifiers.create(conn.read())
                 .then(this::closeNotifyAndVerifyClosing)
@@ -54,7 +54,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
     }
 
     @Test
-    public void afterRequestWhileReadingResponse() {
+    void afterRequestWhileReadingResponse() {
         sendRequest();
         StepVerifiers.create(conn.read())
                 .then(() -> channel.writeInbound(BEGIN))
@@ -65,7 +65,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
     }
 
     @Test
-    public void whileWritingRequestBeforeReadingResponse() {
+    void whileWritingRequestBeforeReadingResponse() {
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
         StepVerifiers.create(conn.write(fromSource(writeSource)).merge(conn.read()))
                 .then(() -> {
@@ -78,7 +78,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
     }
 
     @Test
-    public void whileWritingRequestAndReadingResponse() {
+    void whileWritingRequestAndReadingResponse() {
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
         StepVerifiers.create(conn.write(fromSource(writeSource)).merge(conn.read()))
                 .then(() -> {
@@ -94,7 +94,7 @@ public class SslCloseNotifyAlertClientHandlingTest extends AbstractSslCloseNotif
     }
 
     @Test
-    public void whileWritingRequestAfterReadingResponse() {
+    void whileWritingRequestAfterReadingResponse() {
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
         StepVerifiers.create(conn.write(fromSource(writeSource)).merge(conn.read()))
                 .then(() -> {

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertServerHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertServerHandlingTest.java
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.api.test.StepVerifiers;
 import io.servicetalk.transport.netty.internal.CloseHandler.CloseEventObservedException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.channels.ClosedChannelException;
 
@@ -30,14 +30,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
-public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotifyAlertHandlingTest {
+class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotifyAlertHandlingTest {
 
-    public SslCloseNotifyAlertServerHandlingTest() throws Exception {
+    SslCloseNotifyAlertServerHandlingTest() throws Exception {
         super(false);
     }
 
     @Test
-    public void afterExchangeIdleConnection() {
+    void afterExchangeIdleConnection() {
         receiveRequest();
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
         StepVerifiers.create(conn.write(fromSource(writeSource)))
@@ -55,7 +55,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
     }
 
     @Test
-    public void afterRequestBeforeSendingResponse() {
+    void afterRequestBeforeSendingResponse() {
         receiveRequest();
 
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
@@ -66,7 +66,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
     }
 
     @Test
-    public void afterRequestWhileSendingResponse() {
+    void afterRequestWhileSendingResponse() {
         receiveRequest();
 
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
@@ -80,7 +80,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
     }
 
     @Test
-    public void whileReadingRequestBeforeSendingResponse() {
+    void whileReadingRequestBeforeSendingResponse() {
         StepVerifiers.create(conn.write(fromSource(newPublisherProcessor())).merge(conn.read()))
                 .then(() -> {
                     // Start reading request
@@ -93,7 +93,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
     }
 
     @Test
-    public void whileReadingRequestAndSendingResponse() {
+    void whileReadingRequestAndSendingResponse() {
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
         StepVerifiers.create(conn.write(fromSource(writeSource)).merge(conn.read()))
                 .then(() -> {
@@ -109,7 +109,7 @@ public class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotif
     }
 
     @Test
-    public void whileReadingRequestAfterSendingResponse() {
+    void whileReadingRequestAfterSendingResponse() {
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
         StepVerifiers.create(conn.write(fromSource(writeSource)).merge(conn.read()))
                 .then(() -> {

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberFutureListenersTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberFutureListenersTest.java
@@ -16,7 +16,6 @@
 package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.api.TestSubscription;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopWriteObserver;
 
@@ -29,10 +28,8 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.ReferenceCountUtil;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
 
@@ -52,15 +49,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class WriteStreamSubscriberFutureListenersTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
+class WriteStreamSubscriberFutureListenersTest {
     private final BlockingQueue<ChannelFutureListener> listeners;
     private final EmbeddedChannel channel;
     private final WriteStreamSubscriber subscriber;
 
-    public WriteStreamSubscriberFutureListenersTest() {
+    WriteStreamSubscriberFutureListenersTest() {
         listeners = new LinkedBlockingQueue<>();
         channel = new EmbeddedChannel(new ChannelOutboundHandlerAdapter() {
             @Override
@@ -81,20 +75,20 @@ public class WriteStreamSubscriberFutureListenersTest {
         assertThat("No items requested.", subscription.requested(), greaterThan(0L));
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         channel.close().sync().await();
     }
 
     @Test
-    public void singleWriteAndFlush() throws Exception {
+    void singleWriteAndFlush() throws Exception {
         ChannelFutureListener listener1 = doWrite();
         channel.flush();
         verifyListenerInvokedWithSuccess(listener1);
     }
 
     @Test
-    public void multipleWritesThenFlush() throws Exception {
+    void multipleWritesThenFlush() throws Exception {
         ChannelFutureListener listener1 = doWrite();
         ChannelFutureListener listener2 = doWrite();
         channel.flush();
@@ -104,7 +98,7 @@ public class WriteStreamSubscriberFutureListenersTest {
     }
 
     @Test
-    public void multipleWritesMultipleFlushes() throws Exception {
+    void multipleWritesMultipleFlushes() throws Exception {
         ChannelFutureListener listener1 = doWrite();
         channel.flush();
         verifyListenerInvokedWithSuccess(listener1);
@@ -115,7 +109,7 @@ public class WriteStreamSubscriberFutureListenersTest {
     }
 
     @Test
-    public void singleWriteThenSourceComplete() throws Exception {
+    void singleWriteThenSourceComplete() throws Exception {
         ChannelFutureListener listener1 = doWrite();
         subscriber.onComplete();
         verifyZeroInteractions(listener1);
@@ -125,7 +119,7 @@ public class WriteStreamSubscriberFutureListenersTest {
     }
 
     @Test
-    public void singleWriteThenSourceFail() throws Exception {
+    void singleWriteThenSourceFail() throws Exception {
         ChannelFutureListener listener1 = doWrite();
         subscriber.onError(DELIBERATE_EXCEPTION);
         verifyZeroInteractions(listener1);
@@ -135,7 +129,7 @@ public class WriteStreamSubscriberFutureListenersTest {
     }
 
     @Test
-    public void multipleWriteThenSourceComplete() throws Exception {
+    void multipleWriteThenSourceComplete() throws Exception {
         ChannelFutureListener listener1 = doWrite();
         ChannelFutureListener listener2 = doWrite();
         subscriber.onComplete();
@@ -148,7 +142,7 @@ public class WriteStreamSubscriberFutureListenersTest {
     }
 
     @Test
-    public void multipleWriteThenSourceFail() throws Exception {
+    void multipleWriteThenSourceFail() throws Exception {
         ChannelFutureListener listener1 = doWrite();
         ChannelFutureListener listener2 = doWrite();
         subscriber.onError(DELIBERATE_EXCEPTION);
@@ -161,7 +155,7 @@ public class WriteStreamSubscriberFutureListenersTest {
     }
 
     @Test
-    public void synchronousCompleteWrite() throws Exception {
+    void synchronousCompleteWrite() throws Exception {
         Channel mockChannel = mock(Channel.class);
         EventLoop mockEventLoop = mock(EventLoop.class);
         when(mockEventLoop.inEventLoop()).thenReturn(true);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberOutOfEventloopTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberOutOfEventloopTest.java
@@ -21,7 +21,7 @@ import io.servicetalk.concurrent.CompletableSource.Processor;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopWriteObserver;
 
 import io.netty.channel.EventLoop;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
 
@@ -33,11 +33,11 @@ import static java.util.function.UnaryOperator.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
-public class WriteStreamSubscriberOutOfEventloopTest extends AbstractOutOfEventloopTest {
+class WriteStreamSubscriberOutOfEventloopTest extends AbstractOutOfEventloopTest {
 
     private WriteStreamSubscriber subscriber;
 
@@ -50,17 +50,17 @@ public class WriteStreamSubscriberOutOfEventloopTest extends AbstractOutOfEventl
     }
 
     @Test
-    public void writeOnDifferntEventLoopThenWriteOnSameEventLoop() throws Exception {
+    void writeOnDifferntEventLoopThenWriteOnSameEventLoop() throws Exception {
         testWriteFromDifferentEventLoops(getDifferentEventloopThanChannel(), channel.eventLoop());
     }
 
     @Test
-    public void writeOnSameEventLoopThenWriteOnDifferntEventLoop() throws Exception {
+    void writeOnSameEventLoopThenWriteOnDifferntEventLoop() throws Exception {
         testWriteFromDifferentEventLoops(channel.eventLoop(), getDifferentEventloopThanChannel());
     }
 
     @Test
-    public void testWriteFromEventloop() throws Exception {
+    void testWriteFromEventloop() throws Exception {
         channel.eventLoop().submit(() -> subscriber.onNext(1))
                 .addListener(future -> {
                     subscriber.onNext(2);
@@ -70,7 +70,7 @@ public class WriteStreamSubscriberOutOfEventloopTest extends AbstractOutOfEventl
     }
 
     @Test
-    public void testWriteFromOutsideEventloop() throws Exception {
+    void testWriteFromOutsideEventloop() throws Exception {
         subscriber.onNext(1);
         subscriber.onNext(2);
         subscriber.onComplete();
@@ -79,7 +79,7 @@ public class WriteStreamSubscriberOutOfEventloopTest extends AbstractOutOfEventl
     }
 
     @Test
-    public void testTerminalOrder() throws Exception {
+    void testTerminalOrder() throws Exception {
         Processor subject = newCompletableProcessor();
         CompletableSource.Subscriber subscriber = new CompletableSource.Subscriber() {
             @Override

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberTest.java
@@ -18,8 +18,8 @@ package io.servicetalk.transport.netty.internal;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopWriteObserver;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.channels.ClosedChannelException;
 
@@ -39,13 +39,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class WriteStreamSubscriberTest extends AbstractWriteTest {
+class WriteStreamSubscriberTest extends AbstractWriteTest {
 
     private WriteStreamSubscriber subscriber;
     private Subscription subscription;
     private CloseHandler closeHandler;
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -58,7 +58,7 @@ public class WriteStreamSubscriberTest extends AbstractWriteTest {
     }
 
     @Test
-    public void testSingleItem() {
+    void testSingleItem() {
         WriteInfo info = writeAndFlush("Hello");
         subscriber.onComplete();
         verifyListenerSuccessful();
@@ -68,7 +68,7 @@ public class WriteStreamSubscriberTest extends AbstractWriteTest {
     }
 
     @Test
-    public void testMultipleItem() {
+    void testMultipleItem() {
         WriteInfo info1 = writeAndFlush("Hello1");
         WriteInfo info2 = writeAndFlush("Hello2");
         WriteInfo info3 = writeAndFlush("Hello3");
@@ -80,21 +80,21 @@ public class WriteStreamSubscriberTest extends AbstractWriteTest {
     }
 
     @Test
-    public void testOnErrorNoWrite() throws InterruptedException {
+    void testOnErrorNoWrite() throws InterruptedException {
         subscriber.onError(DELIBERATE_EXCEPTION);
         verify(this.completableSubscriber).onError(DELIBERATE_EXCEPTION);
         assertChannelClose();
     }
 
     @Test
-    public void testOnCompleteNoWrite() {
+    void testOnCompleteNoWrite() {
         subscriber.onComplete();
         verify(this.completableSubscriber).onComplete();
         verifyZeroInteractions(closeHandler);
     }
 
     @Test
-    public void testOnErrorPostWrite() throws InterruptedException {
+    void testOnErrorPostWrite() throws InterruptedException {
         writeAndFlush("Hello");
         channel.flushOutbound();
         subscriber.onError(DELIBERATE_EXCEPTION);
@@ -104,7 +104,7 @@ public class WriteStreamSubscriberTest extends AbstractWriteTest {
     }
 
     @Test
-    public void testCancelBeforeOnSubscribe() {
+    void testCancelBeforeOnSubscribe() {
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber,
                 UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity());
         subscription = mock(Subscription.class);
@@ -115,14 +115,14 @@ public class WriteStreamSubscriberTest extends AbstractWriteTest {
     }
 
     @Test
-    public void testCancelAfterOnSubscribe() {
+    void testCancelAfterOnSubscribe() {
         subscriber.cancel();
         verify(subscription).cancel();
         verifyZeroInteractions(closeHandler);
     }
 
     @Test
-    public void testRequestMoreBeforeOnSubscribe() {
+    void testRequestMoreBeforeOnSubscribe() {
         reset(completableSubscriber);
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber,
                 UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity());
@@ -138,17 +138,17 @@ public class WriteStreamSubscriberTest extends AbstractWriteTest {
     }
 
     @Test
-    public void writeFailureClosesChannel() throws Exception {
+    void writeFailureClosesChannel() throws Exception {
         failingWriteClosesChannel(() -> failingWriteHandler.failNextWritePromise());
     }
 
     @Test
-    public void uncaughtWriteExceptionClosesChannel() throws Exception {
+    void uncaughtWriteExceptionClosesChannel() throws Exception {
         failingWriteClosesChannel(() -> failingWriteHandler.throwFromNextWrite());
     }
 
     @Test
-    public void onNextAfterChannelClose() {
+    void onNextAfterChannelClose() {
         subscriber.channelClosed(new ClosedChannelException());
         subscriber.onNext("Hello");
         channel.runPendingTasks();


### PR DESCRIPTION
Motivation:

- JUnit 5 leverages features from Java 8 or later, such as lambda functions, making tests more powerful and easier to maintain.
- JUnit 5 has added some very useful new features for describing, organizing, and executing tests. For instance, tests get better display names and can be organized hierarchically.
- JUnit 5 is organized into multiple libraries, so only the features you need are imported into your project. With build systems such as Maven and Gradle, including the right libraries is easy.
- JUnit 5 can use more than one extension at a time, which JUnit 4 could not (only one runner could be used at a time). This means you can easily combine the Spring extension with other extensions (such as your own custom extension).

Modifications:

- Unit tests have been migrated from JUnit 4 to JUnit 5

Result:

Module servicetalk-transport-netty-internal now runs tests using JUnit 5