### PR TITLE
Migrate servicetalk-opentracing-asynccontext tests to JUnit 5 (#1568)

### DIFF
--- a/servicetalk-opentracing-asynccontext/build.gradle
+++ b/servicetalk-opentracing-asynccontext/build.gradle
@@ -24,8 +24,11 @@ dependencies {
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
 
   testImplementation project(":servicetalk-test-resources")
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.slf4j:slf4j-api:$slf4jVersion"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+  testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-opentracing-asynccontext/src/test/java/io/servicetalk/opentracing/asynccontext/AsyncContextInMemoryScopeManagerTest.java
+++ b/servicetalk-opentracing-asynccontext/src/test/java/io/servicetalk/opentracing/asynccontext/AsyncContextInMemoryScopeManagerTest.java
@@ -18,16 +18,19 @@ package io.servicetalk.opentracing.asynccontext;
 import io.servicetalk.opentracing.inmemory.api.InMemorySpan;
 
 import io.opentracing.Scope;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static io.servicetalk.opentracing.asynccontext.AsyncContextInMemoryScopeManager.SCOPE_MANAGER;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-public class AsyncContextInMemoryScopeManagerTest {
+@ExtendWith(MockitoExtension.class)
+class AsyncContextInMemoryScopeManagerTest {
     @Mock
     private InMemorySpan mockSpan;
     @Mock
@@ -35,7 +38,7 @@ public class AsyncContextInMemoryScopeManagerTest {
 
     private AsyncContextInMemoryScopeManager scopeManager = (AsyncContextInMemoryScopeManager) SCOPE_MANAGER;
 
-    @Before
+    @BeforeEach
     public void setup() {
         initMocks(this);
         AsyncContextInMemoryScopeManager.AsyncContextInMemoryScope previousScope = scopeManager.active();
@@ -45,7 +48,7 @@ public class AsyncContextInMemoryScopeManagerTest {
     }
 
     @Test
-    public void closedScopeNotReturnedByActive() {
+    void closedScopeNotReturnedByActive() {
         Scope scope = SCOPE_MANAGER.activate(mockSpan);
         assertSame(scope, scopeManager.active());
         scope.close();
@@ -53,7 +56,7 @@ public class AsyncContextInMemoryScopeManagerTest {
     }
 
     @Test
-    public void previousScopeRestoredAfterCurrentScopeClosed() {
+    void previousScopeRestoredAfterCurrentScopeClosed() {
         Scope previousScope = SCOPE_MANAGER.activate(mockSpan2);
         Scope scope = SCOPE_MANAGER.activate(mockSpan);
         assertSame(scope, scopeManager.active());


### PR DESCRIPTION
Motivation:

- JUnit 5 leverages features from Java 8 or later, such as lambda functions, making tests more powerful and easier to maintain.
- JUnit 5 has added some very useful new features for describing, organizing, and executing tests. For instance, tests get better display names and can be organized hierarchically.
- JUnit 5 is organized into multiple libraries, so only the features you need are imported into your project. With build systems such as Maven and Gradle, including the right libraries is easy.
- JUnit 5 can use more than one extension at a time, which JUnit 4 could not (only one runner could be used at a time). This means you can easily combine the Spring extension with other extensions (such as your own custom extension).

Modifications:

- Unit tests have been migrated from JUnit 4 to JUnit 5

Result:

Module servicetalk-opentracing-asynccontext now runs tests using JUnit 5