### PR TITLE
Migrate servicetalk-opentracing-http tests to JUnit 5 (#1568)

### DIFF
--- a/servicetalk-opentracing-http/build.gradle
+++ b/servicetalk-opentracing-http/build.gradle
@@ -41,7 +41,10 @@ dependencies {
   testImplementation project(":servicetalk-opentracing-log4j2")
   testImplementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
   testImplementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
-  testImplementation "junit:junit:$junitVersion"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+  testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TestUtils.java
+++ b/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TestUtils.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.log4j2.mdc.utils.LoggerStringWriter.assertContainsMdcPair;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 final class TestUtils {
     static final String[] TRACING_TEST_LOG_LINE_PREFIX = new String[] {
@@ -79,7 +79,7 @@ final class TestUtils {
                     break;
                 }
             }
-            assertTrue("could not find log line with prefix: " + prefix, foundMatch);
+            assertTrue(foundMatch, "could not find log line with prefix: " + prefix);
         }
     }
 

--- a/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpServiceFilterTest.java
+++ b/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpServiceFilterTest.java
@@ -17,7 +17,6 @@ package io.servicetalk.opentracing.http;
 
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.data.jackson.JacksonSerializationProvider;
 import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.api.HttpRequest;
@@ -38,12 +37,12 @@ import io.servicetalk.opentracing.inmemory.api.InMemorySpan;
 import io.servicetalk.transport.api.ServerContext;
 
 import io.opentracing.Tracer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,32 +80,30 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-public class TracingHttpServiceFilterTest {
+@ExtendWith(MockitoExtension.class)
+class TracingHttpServiceFilterTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(TracingHttpServiceFilterTest.class);
     private static final HttpSerializationProvider httpSerializer = jsonSerializer(new JacksonSerializationProvider());
-
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
 
     @Mock
     private Tracer mockTracer;
 
-    @Before
+    @BeforeEach
     public void setup() {
         initMocks(this);
         LoggerStringWriter.reset();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         LoggerStringWriter.remove();
     }
@@ -134,7 +131,7 @@ public class TracingHttpServiceFilterTest {
     }
 
     @Test
-    public void testRequestWithTraceKey() throws Exception {
+    void testRequestWithTraceKey() throws Exception {
         CountingInMemorySpanEventListener spanListener = new CountingInMemorySpanEventListener();
         try (ServerContext context = buildServer(spanListener)) {
             try (HttpClient client = forSingleAddress(serverHostAndPort(context)).build()) {
@@ -167,7 +164,7 @@ public class TracingHttpServiceFilterTest {
     }
 
     @Test
-    public void testRequestWithoutTraceKey() throws Exception {
+    void testRequestWithoutTraceKey() throws Exception {
         final String requestUrl = "/foo";
         CountingInMemorySpanEventListener spanListener = new CountingInMemorySpanEventListener();
         try (ServerContext context = buildServer(spanListener)) {
@@ -198,7 +195,7 @@ public class TracingHttpServiceFilterTest {
     }
 
     @Test
-    public void tracerThrowsReturnsErrorResponse() throws Exception {
+    void tracerThrowsReturnsErrorResponse() throws Exception {
         when(mockTracer.buildSpan(any())).thenThrow(DELIBERATE_EXCEPTION);
         try (ServerContext context = HttpServers.forAddress(localAddress(0))
                 .appendServiceFilter(new TracingHttpServiceFilter(mockTracer, "testServer"))
@@ -212,7 +209,7 @@ public class TracingHttpServiceFilterTest {
     }
 
     @Test
-    public void verifyAsyncContext() throws Exception {
+    void verifyAsyncContext() throws Exception {
         final DefaultInMemoryTracer tracer = new DefaultInMemoryTracer.Builder(SCOPE_MANAGER).build();
         verifyServerFilterAsyncContextVisibility(new TracingHttpServiceFilter(tracer, "testServer"));
     }


### PR DESCRIPTION
Motivation:

- JUnit 5 leverages features from Java 8 or later, such as lambda functions, making tests more powerful and easier to maintain.
- JUnit 5 has added some very useful new features for describing, organizing, and executing tests. For instance, tests get better display names and can be organized hierarchically.
- JUnit 5 is organized into multiple libraries, so only the features you need are imported into your project. With build systems such as Maven and Gradle, including the right libraries is easy.
- JUnit 5 can use more than one extension at a time, which JUnit 4 could not (only one runner could be used at a time). This means you can easily combine the Spring extension with other extensions (such as your own custom extension).

Modifications:

- Unit tests have been migrated from JUnit 4 to JUnit 5

Result:

Module servicetalk-opentracing-http now runs tests using JUnit 5