### PR TITLE
Migrate servicetalk-opentracing-log4j2 tests to JUnit 5 (#1568)

### DIFF
--- a/servicetalk-opentracing-log4j2/build.gradle
+++ b/servicetalk-opentracing-log4j2/build.gradle
@@ -28,8 +28,10 @@ dependencies {
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation testFixtures(project(":servicetalk-log4j2-mdc-utils"))
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
   testImplementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-opentracing-log4j2/src/test/java/io/servicetalk/opentracing/log4j2/ServiceTalkTracingThreadContextMapLog4jProviderTest.java
+++ b/servicetalk-opentracing-log4j2/src/test/java/io/servicetalk/opentracing/log4j2/ServiceTalkTracingThreadContextMapLog4jProviderTest.java
@@ -16,22 +16,22 @@
 package io.servicetalk.opentracing.log4j2;
 
 import org.apache.logging.log4j.ThreadContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class ServiceTalkTracingThreadContextMapLog4jProviderTest {
+class ServiceTalkTracingThreadContextMapLog4jProviderTest {
     @Test
-    public void testProviderLoadsClass() {
+    void testProviderLoadsClass() {
         assertThat(ThreadContext.getThreadContextMap(), is(instanceOf(ServiceTalkTracingThreadContextMap.class)));
     }
 
     @Test
-    public void testNullValues() {
+    void testNullValues() {
         MDC.put("foo", null);
         assertNull(MDC.get("foo"));
     }

--- a/servicetalk-opentracing-log4j2/src/test/java/io/servicetalk/opentracing/log4j2/ServiceTalkTracingThreadContextMapTest.java
+++ b/servicetalk-opentracing-log4j2/src/test/java/io/servicetalk/opentracing/log4j2/ServiceTalkTracingThreadContextMapTest.java
@@ -19,9 +19,9 @@ import io.servicetalk.log4j2.mdc.utils.LoggerStringWriter;
 import io.servicetalk.opentracing.inmemory.DefaultInMemoryTracer;
 import io.servicetalk.opentracing.inmemory.api.InMemorySpan;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -29,30 +29,30 @@ import org.slf4j.MDC;
 import static io.servicetalk.log4j2.mdc.utils.LoggerStringWriter.assertContainsMdcPair;
 import static io.servicetalk.log4j2.mdc.utils.LoggerStringWriter.stableAccumulated;
 import static io.servicetalk.opentracing.asynccontext.AsyncContextInMemoryScopeManager.SCOPE_MANAGER;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class ServiceTalkTracingThreadContextMapTest {
+class ServiceTalkTracingThreadContextMapTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(ServiceTalkTracingThreadContextMapTest.class);
 
-    @Before
+    @BeforeEach
     public void setup() {
         LoggerStringWriter.reset();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         LoggerStringWriter.remove();
     }
 
     @Test
-    public void testNullValues() {
+    void testNullValues() {
         MDC.put("foo", null);
         assertNull(MDC.get("foo"));
     }
 
     @Test
-    public void tracingInfoDisplayedPresentInLogsViaMDC() throws Exception {
+    void tracingInfoDisplayedPresentInLogsViaMDC() throws Exception {
         DefaultInMemoryTracer tracer = new DefaultInMemoryTracer.Builder(SCOPE_MANAGER).build();
         InMemorySpan span = tracer.buildSpan("test").start();
         assertNotNull(span);


### PR DESCRIPTION
Motivation:

- JUnit 5 leverages features from Java 8 or later, such as lambda functions, making tests more powerful and easier to maintain.
- JUnit 5 has added some very useful new features for describing, organizing, and executing tests. For instance, tests get better display names and can be organized hierarchically.
- JUnit 5 is organized into multiple libraries, so only the features you need are imported into your project. With build systems such as Maven and Gradle, including the right libraries is easy.
- JUnit 5 can use more than one extension at a time, which JUnit 4 could not (only one runner could be used at a time). This means you can easily combine the Spring extension with other extensions (such as your own custom extension).

Modifications:

- Unit tests have been migrated from JUnit 4 to JUnit 5

Result:

Module servicetalk-opentracing-log4j2 now runs tests using JUnit 5