### PR TITLE
Migrate servicetalk-opentracing-zipkin-publisher tests to JUnit 5 (#1568)

### DIFF
--- a/servicetalk-opentracing-zipkin-publisher/build.gradle
+++ b/servicetalk-opentracing-zipkin-publisher/build.gradle
@@ -44,7 +44,10 @@ dependencies {
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-utils-internal")
-  testImplementation "junit:junit:$junitVersion"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
+  testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/ZipkinPublisherTest.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/ZipkinPublisherTest.java
@@ -15,16 +15,13 @@
  */
 package io.servicetalk.opentracing.zipkin.publisher;
 
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.opentracing.inmemory.DefaultInMemoryTracer;
 import io.servicetalk.opentracing.inmemory.api.InMemorySpan;
 import io.servicetalk.opentracing.inmemory.api.InMemoryTracer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import zipkin2.Span;
 import zipkin2.reporter.Reporter;
 
@@ -43,27 +40,24 @@ import static io.opentracing.tag.Tags.SPAN_KIND_PRODUCER;
 import static io.opentracing.tag.Tags.SPAN_KIND_SERVER;
 import static io.servicetalk.opentracing.asynccontext.AsyncContextInMemoryScopeManager.SCOPE_MANAGER;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ZipkinPublisherTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
+class ZipkinPublisherTest {
     private InMemoryTracer tracer;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         tracer = new DefaultInMemoryTracer.Builder(SCOPE_MANAGER).persistLogs(true).build();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
     }
 
     @Test
-    public void testReportSpan() throws ExecutionException, InterruptedException {
+    void testReportSpan() throws ExecutionException, InterruptedException {
         SpanHolder reporter = new SpanHolder();
         try (ZipkinPublisher publisher = buildPublisher(reporter)) {
             InMemorySpan span = buildSpan(SPAN_KIND_SERVER);
@@ -87,7 +81,7 @@ public class ZipkinPublisherTest {
     }
 
     @Test
-    public void testReportSpanSupportsAllKinds() throws ExecutionException, InterruptedException {
+    void testReportSpanSupportsAllKinds() throws ExecutionException, InterruptedException {
         final HashMap<String, Span.Kind> kinds = new HashMap<>();
         kinds.put(SPAN_KIND_CLIENT, Span.Kind.CLIENT);
         kinds.put(SPAN_KIND_SERVER, Span.Kind.SERVER);

--- a/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/SpanUtils.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/SpanUtils.java
@@ -20,8 +20,8 @@ import zipkin2.Span;
 import java.util.Map;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 final class SpanUtils {
 

--- a/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporterTest.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporterTest.java
@@ -15,8 +15,6 @@
  */
 package io.servicetalk.opentracing.zipkin.publisher.reporter;
 
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
-
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -29,11 +27,9 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.nio.NioDatagramChannel;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import zipkin2.Span;
 import zipkin2.codec.SpanBytesDecoder;
 
@@ -51,47 +47,44 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static zipkin2.CheckResult.OK;
 
-public class UdpReporterTest {
+class UdpReporterTest {
     private static final int DEFAULT_MAX_DATAGRAM_PACKET_SIZE = 2048;
     private static final MaxMessagesRecvByteBufAllocator DEFAULT_RECV_BUF_ALLOCATOR =
             new FixedRecvByteBufAllocator(DEFAULT_MAX_DATAGRAM_PACKET_SIZE);
 
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
     private EventLoopGroup group;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         group = new NioEventLoopGroup(2);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         group.shutdownGracefully(0, 0, SECONDS);
     }
 
     @Test
-    public void testJsonV1RoundTrip() throws Exception {
+    void testJsonV1RoundTrip() throws Exception {
         testRoundTrip(Codec.JSON_V1, SpanBytesDecoder.JSON_V1);
     }
 
     @Test
-    public void testJsonV2RoundTrip() throws Exception {
+    void testJsonV2RoundTrip() throws Exception {
         testRoundTrip(Codec.JSON_V2, SpanBytesDecoder.JSON_V2);
     }
 
     @Test
-    public void testThriftRoundTrip() throws Exception {
+    void testThriftRoundTrip() throws Exception {
         testRoundTrip(Codec.THRIFT, SpanBytesDecoder.THRIFT);
     }
 
     @Test
-    public void testProto3RoundTrip() throws Exception {
+    void testProto3RoundTrip() throws Exception {
         testRoundTrip(Codec.PROTO3, SpanBytesDecoder.PROTO3);
     }
 
@@ -109,14 +102,14 @@ public class UdpReporterTest {
     }
 
     @Test
-    public void reportAfterClose() throws Exception {
+    void reportAfterClose() throws Exception {
         try (TestReceiver receiver = new TestReceiver(SpanBytesDecoder.JSON_V2)) {
             UdpReporter reporter = buildReporter((InetSocketAddress) receiver.channel.localAddress(), Codec.JSON_V2);
             assertThat("Unexpected check state.", reporter.check(), is(OK));
             reporter.close();
             assertThat("Unexpected check state.", reporter.check(), is(not(OK)));
-            assertThrows("Report post close accepted.", RuntimeException.class,
-                    () -> reporter.report(newSpan("1")));
+            assertThrows(RuntimeException.class, () -> reporter.report(newSpan("1")),
+                    "Report post close accepted.");
         }
     }
 


### PR DESCRIPTION
Motivation:

- JUnit 5 leverages features from Java 8 or later, such as lambda functions, making tests more powerful and easier to maintain.
- JUnit 5 has added some very useful new features for describing, organizing, and executing tests. For instance, tests get better display names and can be organized hierarchically.
- JUnit 5 is organized into multiple libraries, so only the features you need are imported into your project. With build systems such as Maven and Gradle, including the right libraries is easy.
- JUnit 5 can use more than one extension at a time, which JUnit 4 could not (only one runner could be used at a time). This means you can easily combine the Spring extension with other extensions (such as your own custom extension).

Modifications:

- Unit tests have been migrated from JUnit 4 to JUnit 5

Result:

Module servicetalk-opentracing-zipkin-publisher now runs tests using JUnit 5