### PR TITLE
Migrate servicetalk-dns-discovery-netty tests to JUnit 5 (#1568)

### DIFF
--- a/servicetalk-dns-discovery-netty/build.gradle
+++ b/servicetalk-dns-discovery-netty/build.gradle
@@ -37,8 +37,10 @@ dependencies {
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation "commons-lang:commons-lang:$commonsLangVersion"
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.apache.directory.server:apacheds-protocol-dns:$apacheDirectoryServerVersion"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsClientTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsClientTest.java
@@ -22,15 +22,12 @@ import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.api.BiIntFunction;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 import io.servicetalk.transport.netty.internal.EventLoopAwareNettyIoExecutor;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -67,16 +64,14 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
-public class DefaultDnsClientTest {
+class DefaultDnsClientTest {
     private static final int DEFAULT_TTL = 1;
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
 
     private EventLoopAwareNettyIoExecutor nettyIoExecutor;
     private final TestRecordStore recordStore = new TestRecordStore();
@@ -85,7 +80,7 @@ public class DefaultDnsClientTest {
     private DnsClient client;
 
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         nettyIoExecutor = toEventLoopAwareNettyIoExecutor(createIoExecutor());
 
@@ -107,7 +102,7 @@ public class DefaultDnsClientTest {
         client = dnsClientBuilder().build();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         client.closeAsync().toFuture().get();
         dnsServer.stop();
@@ -116,7 +111,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void singleSrvSingleADiscover() throws Exception {
+    void singleSrvSingleADiscover() throws Exception {
         final String domain = "mysvc.apple.com";
         final String targetDomain = "target.mysvc.apple.com";
         final int targetPort = 9876;
@@ -132,7 +127,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void singleSrvMultipleADiscover() throws Exception {
+    void singleSrvMultipleADiscover() throws Exception {
         final String domain = "mysvc.apple.com";
         final String targetDomain = "target.mysvc.apple.com";
         final int targetPort = 9876;
@@ -151,7 +146,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void multipleSrvSingleADiscover() throws Exception {
+    void multipleSrvSingleADiscover() throws Exception {
         final String domain = "mysvc.apple.com";
         final String targetDomain1 = "target1.mysvc.apple.com";
         final String targetDomain2 = "target2.mysvc.apple.com";
@@ -174,7 +169,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void multipleSrvChangeSingleADiscover() throws Exception {
+    void multipleSrvChangeSingleADiscover() throws Exception {
         final String domain = "mysvc.apple.com";
         final String targetDomain1 = "target1.mysvc.apple.com";
         final String targetDomain2 = "target2.mysvc.apple.com";
@@ -206,7 +201,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void multipleSrvMultipleADiscover() throws Exception {
+    void multipleSrvMultipleADiscover() throws Exception {
         final String domain = "mysvc.apple.com";
         final String targetDomain1 = "target1.mysvc.apple.com";
         final String targetDomain2 = "target2.mysvc.apple.com";
@@ -233,7 +228,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void srvWithCNAMEEntryLowerTTLDoesNotFail() throws Exception {
+    void srvWithCNAMEEntryLowerTTLDoesNotFail() throws Exception {
         final String domain = "sd.servicetalk.io";
         final String srvCNAME = "sdcname.servicetalk.io";
         final String targetDomain1 = "target1.mysvc.servicetalk.io";
@@ -255,12 +250,12 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void srvCNAMEDuplicateAddressesRemoveFail() throws Exception {
+    void srvCNAMEDuplicateAddressesRemoveFail() throws Exception {
         srvCNAMEDuplicateAddresses(false);
     }
 
     @Test
-    public void srvCNAMEDuplicateAddressesRemoveInactive() throws Exception {
+    void srvCNAMEDuplicateAddressesRemoveInactive() throws Exception {
         srvCNAMEDuplicateAddresses(true);
     }
 
@@ -310,7 +305,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void srvInactiveEventsAggregated() throws Exception {
+    void srvInactiveEventsAggregated() throws Exception {
         client.closeAsync().toFuture().get();
         client = dnsClientBuilder().inactiveEventsOnError(true).build();
         final String domain = "sd.servicetalk.io";
@@ -362,7 +357,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void srvRecordRemovalPropagatesError() throws Exception {
+    void srvRecordRemovalPropagatesError() throws Exception {
         final String domain = "sd.servicetalk.io";
         final String targetDomain1 = "target1.mysvc.servicetalk.io";
         final String targetDomain2 = "target2.mysvc.servicetalk.io";
@@ -391,12 +386,12 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void srvDuplicateAddressesNoFilter() throws Exception {
+    void srvDuplicateAddressesNoFilter() throws Exception {
         srvDuplicateAddresses(false);
     }
 
     @Test
-    public void srvDuplicateAddressesFilter() throws Exception {
+    void srvDuplicateAddressesFilter() throws Exception {
         srvDuplicateAddresses(true);
     }
 
@@ -433,12 +428,12 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void srvAAAAFailsGeneratesInactive() throws Exception {
+    void srvAAAAFailsGeneratesInactive() throws Exception {
         srvAAAAFailsGeneratesInactive(true);
     }
 
     @Test
-    public void srvAAAAFailsGeneratesInactiveEvenIfNotRequested() throws Exception {
+    void srvAAAAFailsGeneratesInactiveEvenIfNotRequested() throws Exception {
         srvAAAAFailsGeneratesInactive(false);
     }
 
@@ -476,12 +471,12 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void srvNoMoreSrvRecordsFails() throws Exception {
+    void srvNoMoreSrvRecordsFails() throws Exception {
         srvRecordFailsGeneratesInactive(false);
     }
 
     @Test
-    public void srvNoMoreSrvRecordsGeneratesInactive() throws Exception {
+    void srvNoMoreSrvRecordsGeneratesInactive() throws Exception {
         srvRecordFailsGeneratesInactive(true);
     }
 
@@ -519,7 +514,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void unknownHostDiscover() {
+    void unknownHostDiscover() {
         TestPublisherSubscriber<ServiceDiscovererEvent<InetAddress>> subscriber = dnsQuery("unknown.com");
         Subscription subscription = subscriber.awaitSubscription();
         subscription.request(Long.MAX_VALUE);
@@ -528,7 +523,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void singleADiscover() throws Exception {
+    void singleADiscover() throws Exception {
         final String ip = nextIp();
         final String domain = "servicetalk.io";
         recordStore.addIPv4Address(domain, DEFAULT_TTL, ip);
@@ -546,7 +541,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void singleDiscoverMultipleRecords() throws Exception {
+    void singleDiscoverMultipleRecords() throws Exception {
         final String domain = "servicetalk.io";
         final String[] ips = new String[] {nextIp(), nextIp(), nextIp(), nextIp(), nextIp()};
         recordStore.addIPv4Address(domain, DEFAULT_TTL, ips);
@@ -566,7 +561,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void singleDiscoverDuplicateRecords() throws Exception {
+    void singleDiscoverDuplicateRecords() throws Exception {
         final String dupIp = nextIp();
         final String domain = "servicetalk.io";
         final String[] ips = new String[] {nextIp(), nextIp(), dupIp, dupIp, nextIp()};
@@ -591,7 +586,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void repeatDiscoverMultipleRecords() throws Exception {
+    void repeatDiscoverMultipleRecords() throws Exception {
         final String domain = "servicetalk.io";
         final String[] ips = new String[] {nextIp(), nextIp(), nextIp(), nextIp(), nextIp()};
         recordStore.addIPv4Address(domain, DEFAULT_TTL, ips);
@@ -620,7 +615,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void repeatDiscoverMultipleHosts() throws Exception {
+    void repeatDiscoverMultipleHosts() throws Exception {
         final String ip1 = nextIp();
         final String domain1 = "servicetalk.io";
         final String ip2 = nextIp();
@@ -649,7 +644,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void repeatDiscoverNxDomainAndRecover() throws Exception {
+    void repeatDiscoverNxDomainAndRecover() throws Exception {
         client.closeAsync().toFuture().get();
         client = dnsClientBuilderWithRetry().inactiveEventsOnError(true).build();
         final String ip = nextIp();
@@ -668,7 +663,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void preferIpv4() throws Exception {
+    void preferIpv4() throws Exception {
         client.closeAsync().toFuture().get();
         client = dnsClientBuilder().completeOncePreferredResolved(false)
                 .dnsResolverAddressTypes(IPV4_PREFERRED).build();
@@ -693,7 +688,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void preferIpv4ButOnlyAAAARecordIsPresent() throws Exception {
+    void preferIpv4ButOnlyAAAARecordIsPresent() throws Exception {
         client.closeAsync().toFuture().get();
         client = dnsClientBuilder().dnsResolverAddressTypes(IPV4_PREFERRED).build();
         final String ipv6 = nextIp6();
@@ -712,7 +707,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void acceptOnlyIpv6() throws Exception {
+    void acceptOnlyIpv6() throws Exception {
         client.closeAsync().toFuture().get();
         client = dnsClientBuilder().dnsResolverAddressTypes(IPV6_ONLY).build();
         final String ipv6 = nextIp6();
@@ -728,7 +723,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void exceptionInSubscriberOnNext() throws Exception {
+    void exceptionInSubscriberOnNext() throws Exception {
         final String domain = "servicetalk.io";
         final String ip = nextIp();
         recordStore.addIPv4Address(domain, DEFAULT_TTL, ip);
@@ -741,7 +736,7 @@ public class DefaultDnsClientTest {
     }
 
     @Test
-    public void srvExceptionInSubscriberOnNext() throws Exception {
+    void srvExceptionInSubscriberOnNext() throws Exception {
         client.closeAsync().toFuture().get();
         client = dnsClientBuilder().srvHostNameRepeatDelay(ofMillis(50), ofMillis(10)).build();
         final String domain = "sd.servicetalk.io";

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserverTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserverTest.java
@@ -18,16 +18,13 @@ package io.servicetalk.dns.discovery.netty;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.DnsDiscoveryObserver;
 import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.DnsResolutionObserver;
 import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.ResolutionResult;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.UnknownHostException;
 import java.util.Map;
@@ -51,7 +48,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -60,27 +57,24 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class DnsServiceDiscovererObserverTest {
+class DnsServiceDiscovererObserverTest {
     private static final String HOST_NAME = "servicetalk.io";
     private static final String SERVICE_NAME = "servicetalk";
     private static final String INVALID = "invalid.";
     private static final int DEFAULT_TTL = 1;
 
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
     private final TestRecordStore recordStore = new TestRecordStore();
     private final TestDnsServer dnsServer = new TestDnsServer(recordStore);
     private final CompositeCloseable toClose = newCompositeCloseable();
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         recordStore.addIPv4Address(HOST_NAME, DEFAULT_TTL, nextIp(), nextIp());
         recordStore.addSrv(SERVICE_NAME, HOST_NAME, 443, DEFAULT_TTL);
         dnsServer.start();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         try {
             toClose.closeGracefully();
@@ -101,12 +95,12 @@ public class DnsServiceDiscovererObserverTest {
     }
 
     @Test
-    public void aQueryTriggersNewDiscoveryObserver() throws Exception {
+    void aQueryTriggersNewDiscoveryObserver() throws Exception {
         testNewDiscoveryObserver(DnsClient::dnsQuery, HOST_NAME);
     }
 
     @Test
-    public void srvQueryTriggersNewDiscoveryObserver() throws Exception {
+    void srvQueryTriggersNewDiscoveryObserver() throws Exception {
         testNewDiscoveryObserver(DnsClient::dnsSrvQuery, SERVICE_NAME);
     }
 
@@ -127,7 +121,7 @@ public class DnsServiceDiscovererObserverTest {
     }
 
     @Test
-    public void aQueryTriggersNewResolutionObserver() throws Exception {
+    void aQueryTriggersNewResolutionObserver() throws Exception {
         BlockingQueue<String> newResolution = new LinkedBlockingDeque<>();
         DnsClient client = dnsClient(__ -> name -> {
             newResolution.add(name);
@@ -143,7 +137,7 @@ public class DnsServiceDiscovererObserverTest {
     }
 
     @Test
-    public void srvQueryTriggersNewResolutionObserver() throws Exception {
+    void srvQueryTriggersNewResolutionObserver() throws Exception {
         BlockingQueue<String> newResolution = new LinkedBlockingDeque<>();
         DnsClient client = dnsClient(__ -> name -> {
             newResolution.add(name);
@@ -162,12 +156,12 @@ public class DnsServiceDiscovererObserverTest {
     }
 
     @Test
-    public void aQueryFailedResolution() {
+    void aQueryFailedResolution() {
         testFailedResolution(DnsClient::dnsQuery);
     }
 
     @Test
-    public void srvQueryFailedResolution() {
+    void srvQueryFailedResolution() {
         testFailedResolution(DnsClient::dnsSrvQuery);
     }
 
@@ -192,7 +186,7 @@ public class DnsServiceDiscovererObserverTest {
     }
 
     @Test
-    public void aQueryResolutionResultNoUpdates() throws Exception {
+    void aQueryResolutionResultNoUpdates() throws Exception {
         aQueryResolutionResult(results -> {
             assertResolutionResult(results.take(), 2, 2, 0);
             assertResolutionResult(results.take(), 2, 0, 0);
@@ -200,7 +194,7 @@ public class DnsServiceDiscovererObserverTest {
     }
 
     @Test
-    public void aQueryResolutionResultNewIPsAvailable() throws Exception {
+    void aQueryResolutionResultNewIPsAvailable() throws Exception {
         aQueryResolutionResult(results -> {
             assertResolutionResult(results.take(), 2, 2, 0);
 
@@ -210,7 +204,7 @@ public class DnsServiceDiscovererObserverTest {
     }
 
     @Test
-    public void aQueryResolutionResultOneBecameUnavailable() throws Exception {
+    void aQueryResolutionResultOneBecameUnavailable() throws Exception {
         final String tmpIP = nextIp();
         recordStore.addIPv4Address(HOST_NAME, DEFAULT_TTL, tmpIP);
         aQueryResolutionResult(results -> {
@@ -222,7 +216,7 @@ public class DnsServiceDiscovererObserverTest {
     }
 
     @Test
-    public void aQueryResolutionResultNewAvailableOneUnavailable() throws Exception {
+    void aQueryResolutionResultNewAvailableOneUnavailable() throws Exception {
         final String tmpIP = nextIp();
         recordStore.addIPv4Address(HOST_NAME, DEFAULT_TTL, tmpIP);
         aQueryResolutionResult(results -> {
@@ -235,7 +229,7 @@ public class DnsServiceDiscovererObserverTest {
     }
 
     @Test
-    public void aQueryResolutionResultAllNewIPs() throws Exception {
+    void aQueryResolutionResultAllNewIPs() throws Exception {
         aQueryResolutionResult(results -> {
             assertResolutionResult(results.take(), 2, 2, 0);
 
@@ -273,7 +267,7 @@ public class DnsServiceDiscovererObserverTest {
     }
 
     @Test
-    public void srvQueryResolutionResult() throws Exception {
+    void srvQueryResolutionResult() throws Exception {
         Map<String, ResolutionResult> results = new ConcurrentHashMap<>();
         DnsClient client = dnsClient(__ -> name -> new NoopDnsResolutionObserver() {
             @Override
@@ -293,7 +287,7 @@ public class DnsServiceDiscovererObserverTest {
     }
 
     @Test
-    public void aQueryOnNewDiscoveryThrows() throws Exception {
+    void aQueryOnNewDiscoveryThrows() throws Exception {
         DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
         when(observer.onNewDiscovery(anyString())).thenThrow(DELIBERATE_EXCEPTION);
 
@@ -306,7 +300,7 @@ public class DnsServiceDiscovererObserverTest {
     }
 
     @Test
-    public void srvQueryOnNewDiscoveryThrows() throws Exception {
+    void srvQueryOnNewDiscoveryThrows() throws Exception {
         DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
         when(observer.onNewDiscovery(anyString())).thenThrow(DELIBERATE_EXCEPTION);
 
@@ -319,7 +313,7 @@ public class DnsServiceDiscovererObserverTest {
     }
 
     @Test
-    public void onNewResolutionThrows() throws Exception {
+    void onNewResolutionThrows() throws Exception {
         DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
         DnsDiscoveryObserver discoveryObserver = mock(DnsDiscoveryObserver.class);
         when(observer.onNewDiscovery(anyString())).thenReturn(discoveryObserver);
@@ -335,7 +329,7 @@ public class DnsServiceDiscovererObserverTest {
     }
 
     @Test
-    public void resolutionFailedThrows() throws Exception {
+    void resolutionFailedThrows() throws Exception {
         DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
         DnsDiscoveryObserver discoveryObserver = mock(DnsDiscoveryObserver.class);
         DnsResolutionObserver resolutionObserver = mock(DnsResolutionObserver.class);
@@ -355,7 +349,7 @@ public class DnsServiceDiscovererObserverTest {
     }
 
     @Test
-    public void resolutionCompletedThrows() throws Exception {
+    void resolutionCompletedThrows() throws Exception {
         DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
         DnsDiscoveryObserver discoveryObserver = mock(DnsDiscoveryObserver.class);
         DnsResolutionObserver resolutionObserver = mock(DnsResolutionObserver.class);


### PR DESCRIPTION
Motivation:

- JUnit 5 leverages features from Java 8 or later, such as lambda functions, making tests more powerful and easier to maintain.
- JUnit 5 has added some very useful new features for describing, organizing, and executing tests. For instance, tests get better display names and can be organized hierarchically.
- JUnit 5 is organized into multiple libraries, so only the features you need are imported into your project. With build systems such as Maven and Gradle, including the right libraries is easy.
- JUnit 5 can use more than one extension at a time, which JUnit 4 could not (only one runner could be used at a time). This means you can easily combine the Spring extension with other extensions (such as your own custom extension).

Modifications:

- Unit tests have been migrated from JUnit 4 to JUnit 5

Result:

Module servicetalk-dns-discovery-netty now runs tests using JUnit 5