### PR TITLE
Prevent memory leak if HTTP/1.1 encoding fails

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectEncoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectEncoder.java
@@ -144,7 +144,7 @@ abstract class HttpObjectEncoder<T extends HttpMetaData> extends ChannelOutbound
                 writeShortBE(byteBuf, CRLF_SHORT);
                 headersEncodedSizeAccumulator = HEADERS_WEIGHT_NEW * padSizeForAccumulation(byteBuf.readableBytes()) +
                                                 HEADERS_WEIGHT_HISTORICAL * headersEncodedSizeAccumulator;
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 // Encoding of meta-data can fail or cause expansion of the initial ByteBuf capacity that can fail
                 byteBuf.release();
                 throw e;
@@ -267,7 +267,7 @@ abstract class HttpObjectEncoder<T extends HttpMetaData> extends ChannelOutbound
             try {
                 buf.writeCharSequence(lengthHex, US_ASCII);
                 writeShortBE(buf, CRLF_SHORT);
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 buf.release();
                 throw e;
             }
@@ -293,7 +293,7 @@ abstract class HttpObjectEncoder<T extends HttpMetaData> extends ChannelOutbound
                 writeShortBE(buf, CRLF_SHORT);
                 trailersEncodedSizeAccumulator = TRAILERS_WEIGHT_NEW * padSizeForAccumulation(buf.readableBytes()) +
                         TRAILERS_WEIGHT_HISTORICAL * trailersEncodedSizeAccumulator;
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 // Encoding of trailers can fail or cause expansion of the initial ByteBuf capacity that can fail
                 buf.release();
                 throw e;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpEncoderTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.internal.DeliberateException;
+import io.servicetalk.http.api.HttpHeaders;
+import io.servicetalk.http.api.HttpMetaData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.http.api.DefaultHttpHeadersFactory.INSTANCE;
+import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
+import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+abstract class HttpEncoderTest<T extends HttpMetaData> {
+
+    enum TransferEncoding {
+        ContentLength,
+        Chunked,
+        Variable
+    }
+
+    abstract EmbeddedChannel newEmbeddedChannel();
+
+    abstract T newMetaData(HttpHeaders headers);
+
+    static void consumeEmptyBufferFromTrailers(EmbeddedChannel channel) {
+        // Empty buffer is written when trailers are seen to indicate the end of the request
+        ByteBuf byteBuf = channel.readOutbound();
+        assertFalse(byteBuf.isReadable());
+        byteBuf.release();
+    }
+
+    @Test
+    void internalByteBufReleasedOnMetaDataError() {
+        ByteBuf buf = mock(ByteBuf.class);
+        ByteBufAllocator alloc = mock(ByteBufAllocator.class);
+        when(alloc.directBuffer(anyInt())).thenReturn(buf);
+
+        EmbeddedChannel channel = newEmbeddedChannel();
+        channel.config().setAllocator(alloc);
+
+        assertThrows(IndexOutOfBoundsException.class, () -> channel.writeOutbound(newMetaData(INSTANCE.newHeaders())));
+
+        verify(alloc).directBuffer(anyInt());
+        verify(buf).release();
+    }
+
+    @Test
+    void internalByteBufReleasedOnTrailersError() {
+        ByteBufAllocator alloc = mock(ByteBufAllocator.class);
+        when(alloc.directBuffer(anyInt())).thenReturn(Unpooled.buffer());
+
+        EmbeddedChannel channel = newEmbeddedChannel();
+        channel.config().setAllocator(alloc);
+
+        channel.writeOutbound(newMetaData(INSTANCE.newHeaders().add(TRANSFER_ENCODING, CHUNKED)));
+
+        ByteBuf buf = mock(ByteBuf.class);
+        when(buf.writeMedium(anyInt())).thenThrow(DELIBERATE_EXCEPTION);
+        when(alloc.directBuffer(anyInt())).thenReturn(buf);
+        assertThrows(DeliberateException.class,
+                () -> channel.writeOutbound(INSTANCE.newTrailers().add("trailer-key", "trailer-value")));
+
+        verify(alloc, times(2)).directBuffer(anyInt());
+        verify(buf).release();
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -101,7 +101,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-class HttpRequestEncoderTest {
+class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
+
     private static final BufferAllocator allocator = DEFAULT_ALLOCATOR;
     private static final StreamingHttpRequestResponseFactory reqRespFactory =
             new DefaultStreamingHttpRequestResponseFactory(allocator, DefaultHttpHeadersFactory.INSTANCE, HTTP_1_1);
@@ -116,10 +117,14 @@ class HttpRequestEncoderTest {
             () -> createIoExecutor(new DefaultThreadFactory("client-io", false, NORM_PRIORITY)),
             Executors::newCachedThreadExecutor);
 
-    private enum TransferEncoding {
-        ContentLength,
-        Chunked,
-        Variable
+    @Override
+    EmbeddedChannel newEmbeddedChannel() {
+        return new EmbeddedChannel(new HttpRequestEncoder(new ArrayDeque<>(), 256, 256));
+    }
+
+    @Override
+    HttpRequestMetaData newMetaData(final HttpHeaders headers) {
+        return newRequestMetaData(HTTP_1_1, GET, "/some/path?foo=bar&baz=yyy", headers);
     }
 
     @Test
@@ -386,17 +391,6 @@ class HttpRequestEncoderTest {
                 throw new Error();
         }
         return actualMetaData;
-    }
-
-    private static void consumeEmptyBufferFromTrailers(EmbeddedChannel channel) {
-        // Empty buffer is written when trailers are seen to indicate the end of the request
-        ByteBuf byteBuf = channel.readOutbound();
-        assertFalse(byteBuf.isReadable());
-        byteBuf.release();
-    }
-
-    private static EmbeddedChannel newEmbeddedChannel() {
-        return new EmbeddedChannel(new HttpRequestEncoder(new ArrayDeque<>(), 256, 256));
     }
 
     @Test

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseEncoderTest.java
@@ -48,11 +48,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class HttpResponseEncoderTest {
-    private enum TransferEncoding {
-        ContentLength,
-        Chunked,
-        Variable
+class HttpResponseEncoderTest extends HttpEncoderTest<HttpResponseMetaData> {
+
+    @Override
+    EmbeddedChannel newEmbeddedChannel() {
+        return new EmbeddedChannel(new HttpResponseEncoder(new ArrayDeque<>(), 256, 256));
+    }
+
+    @Override
+    HttpResponseMetaData newMetaData(final HttpHeaders headers) {
+        return newResponseMetaData(HTTP_1_1, OK, headers);
     }
 
     @Test
@@ -336,16 +341,5 @@ class HttpResponseEncoderTest {
                 throw new Error();
         }
         return actualMetaData;
-    }
-
-    private static void consumeEmptyBufferFromTrailers(EmbeddedChannel channel) {
-        // Empty buffer is written when trailers are seen to indicate the end of the request
-        ByteBuf byteBuf = channel.readOutbound();
-        assertFalse(byteBuf.isReadable());
-        byteBuf.release();
-    }
-
-    private static EmbeddedChannel newEmbeddedChannel() {
-        return new EmbeddedChannel(new HttpResponseEncoder(new ArrayDeque<>(), 256, 256));
     }
 }


### PR DESCRIPTION
Motivation:

When `HttpObjectEncoder` encodes meta-data or trailers an error may
happen, which will cause a leak of internal `ByteBuf`. It may happen if
any of the encoding object throw or if it tries to expand the size of
that internal `ByteBuf` without success.

Modifications:

- try-catch meta-data and trailers encoding and release the tmp
`ByteBuf` in case of any failures;

Result:

Internal `ByteBuf` does not leak in case of an error in
`HttpObjectEncoder`.