### PR TITLE
Migrate `servicetalk-client-api` tests from jUnit4 to jUnit5

### DIFF
--- a/servicetalk-client-api/build.gradle
+++ b/servicetalk-client-api/build.gradle
@@ -30,7 +30,9 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-test-resources")
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
+  testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
 }

--- a/servicetalk-client-api/build.gradle
+++ b/servicetalk-client-api/build.gradle
@@ -32,7 +32,8 @@ dependencies {
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
-  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-client-api/src/test/java/io/servicetalk/client/api/DefaultAutoRetryStrategyProviderTest.java
+++ b/servicetalk-client-api/src/test/java/io/servicetalk/client/api/DefaultAutoRetryStrategyProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import io.servicetalk.concurrent.api.TestCompletable;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.UnknownHostException;
 import java.util.function.UnaryOperator;
@@ -37,7 +37,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.IsNull.nullValue;
 
-public class DefaultAutoRetryStrategyProviderTest {
+class DefaultAutoRetryStrategyProviderTest {
     private static final RetryableConnectException RETRYABLE_EXCEPTION =
             new RetryableConnectException("deliberate exception");
     private static final NoAvailableHostException NO_AVAILABLE_HOST =
@@ -49,14 +49,14 @@ public class DefaultAutoRetryStrategyProviderTest {
     private final TestCompletable sdStatus;
     private final TestCompletableSubscriber retrySubscriber;
 
-    public DefaultAutoRetryStrategyProviderTest() {
+    DefaultAutoRetryStrategyProviderTest() {
         lbEvents = new TestPublisher<>();
         sdStatus = new TestCompletable();
         retrySubscriber = new TestCompletableSubscriber();
     }
 
     @Test
-    public void disableWaitForLb() {
+    void disableWaitForLb() {
         AutoRetryStrategy strategy = newStrategy(Builder::disableWaitForLoadBalancer);
         Completable retry = strategy.apply(1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
@@ -64,7 +64,7 @@ public class DefaultAutoRetryStrategyProviderTest {
     }
 
     @Test
-    public void disableRetryAllRetryableExWithRetryable() {
+    void disableRetryAllRetryableExWithRetryable() {
         AutoRetryStrategy strategy = newStrategy(Builder::disableRetryAllRetryableExceptions);
         Completable retry = strategy.apply(1, RETRYABLE_EXCEPTION);
         toSource(retry).subscribe(retrySubscriber);
@@ -72,7 +72,7 @@ public class DefaultAutoRetryStrategyProviderTest {
     }
 
     @Test
-    public void disableRetryAllRetryableExWithNoAvailableHost() {
+    void disableRetryAllRetryableExWithNoAvailableHost() {
         AutoRetryStrategy strategy = newStrategy(Builder::disableRetryAllRetryableExceptions);
         Completable retry = strategy.apply(1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
@@ -82,7 +82,7 @@ public class DefaultAutoRetryStrategyProviderTest {
     }
 
     @Test
-    public void disableRetryAllRetryableExWithNoAvailableHostAndUnknownHostException() {
+    void disableRetryAllRetryableExWithNoAvailableHostAndUnknownHostException() {
         AutoRetryStrategy strategy = newStrategy(Builder::disableRetryAllRetryableExceptions);
         Completable retry = strategy.apply(1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
@@ -92,7 +92,7 @@ public class DefaultAutoRetryStrategyProviderTest {
     }
 
     @Test
-    public void disableAll() {
+    void disableAll() {
         AutoRetryStrategy strategy = newStrategy(builder ->
                 builder.disableWaitForLoadBalancer()
                         .disableRetryAllRetryableExceptions());
@@ -102,7 +102,7 @@ public class DefaultAutoRetryStrategyProviderTest {
     }
 
     @Test
-    public void defaultForNonRetryableEx() {
+    void defaultForNonRetryableEx() {
         AutoRetryStrategy strategy = newStrategy(identity());
         Completable retry = strategy.apply(1, DELIBERATE_EXCEPTION);
         toSource(retry).subscribe(retrySubscriber);
@@ -110,7 +110,7 @@ public class DefaultAutoRetryStrategyProviderTest {
     }
 
     @Test
-    public void defaultForRetryableEx() {
+    void defaultForRetryableEx() {
         AutoRetryStrategy strategy = newStrategy(identity());
         Completable retry = strategy.apply(1, RETRYABLE_EXCEPTION);
         toSource(retry).subscribe(retrySubscriber);
@@ -118,7 +118,7 @@ public class DefaultAutoRetryStrategyProviderTest {
     }
 
     @Test
-    public void defaultForNoAvailableHost() {
+    void defaultForNoAvailableHost() {
         AutoRetryStrategy strategy = newStrategy(identity());
         Completable retry = strategy.apply(1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
@@ -128,7 +128,7 @@ public class DefaultAutoRetryStrategyProviderTest {
     }
 
     @Test
-    public void defaultForNoAvailableHostOnUnknownHostException() {
+    void defaultForNoAvailableHostOnUnknownHostException() {
         AutoRetryStrategy strategy = newStrategy(identity());
         Completable retry = strategy.apply(1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
@@ -138,7 +138,7 @@ public class DefaultAutoRetryStrategyProviderTest {
     }
 
     @Test
-    public void defaultForNoAvailableHostOnServiceDiscovererError() {
+    void defaultForNoAvailableHostOnServiceDiscovererError() {
         AutoRetryStrategy strategy = newStrategy(identity());
         Completable retry = strategy.apply(1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
@@ -148,7 +148,7 @@ public class DefaultAutoRetryStrategyProviderTest {
     }
 
     @Test
-    public void ignoreSdErrorsForNoAvailableHost() {
+    void ignoreSdErrorsForNoAvailableHost() {
         AutoRetryStrategy strategy = newStrategy(Builder::ignoreServiceDiscovererErrors);
         Completable retry = strategy.apply(1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
@@ -159,7 +159,7 @@ public class DefaultAutoRetryStrategyProviderTest {
     }
 
     @Test
-    public void defaultForNoAvailableHostWhenServiceDiscovererTerminated() {
+    void defaultForNoAvailableHostWhenServiceDiscovererTerminated() {
         AutoRetryStrategy strategy = newStrategy(identity());
         Completable retry = strategy.apply(1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
@@ -169,7 +169,7 @@ public class DefaultAutoRetryStrategyProviderTest {
     }
 
     @Test
-    public void maxRetriesAreHonored() {
+    void maxRetriesAreHonored() {
         AutoRetryStrategy strategy = newStrategy(builder -> builder.maxRetries(1));
         Completable retry = strategy.apply(2, RETRYABLE_EXCEPTION);
         toSource(retry).subscribe(retrySubscriber);

--- a/servicetalk-client-api/src/test/java/io/servicetalk/client/api/DefaultAutoRetryStrategyProviderTest.java
+++ b/servicetalk-client-api/src/test/java/io/servicetalk/client/api/DefaultAutoRetryStrategyProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-client-api/src/test/java/io/servicetalk/client/api/DefaultClientGroupTest.java
+++ b/servicetalk-client-api/src/test/java/io/servicetalk/client/api/DefaultClientGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-client-api/src/test/java/io/servicetalk/client/api/DefaultClientGroupTest.java
+++ b/servicetalk-client-api/src/test/java/io/servicetalk/client/api/DefaultClientGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,16 @@
 package io.servicetalk.client.api;
 
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class DefaultClientGroupTest {
-
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
+class DefaultClientGroupTest {
 
     @Test
-    public void requestingClientFromClosedClientGroupShouldNotHang() throws Exception {
+    void requestingClientFromClosedClientGroupShouldNotHang() throws Exception {
         DefaultClientGroup<String, ListenableAsyncCloseable> cg =
                 new DefaultClientGroup<>(s -> emptyAsyncCloseable());
         cg.closeAsync().toFuture().get();

--- a/servicetalk-client-api/src/test/java/io/servicetalk/client/api/LimitingConnectionFactoryFilterTest.java
+++ b/servicetalk-client-api/src/test/java/io/servicetalk/client/api/LimitingConnectionFactoryFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-client-api/src/test/java/io/servicetalk/client/api/LimitingConnectionFactoryFilterTest.java
+++ b/servicetalk-client-api/src/test/java/io/servicetalk/client/api/LimitingConnectionFactoryFilterTest.java
@@ -73,10 +73,8 @@ class LimitingConnectionFactoryFilterTest {
     void enforceMaxConnections() throws Exception {
         ConnectionFactory<String, ? extends ListenableAsyncCloseable> cf =
                 makeCF(LimitingConnectionFactoryFilter.withMax(1), original);
-        Exception e = assertThrows(ExecutionException.class, () -> {
-            cf.newConnection("c1", null).toFuture().get();
-            cf.newConnection("c2", null).toFuture().get();
-        });
+        cf.newConnection("c1", null).toFuture().get();
+        Exception e = assertThrows(ExecutionException.class, () -> cf.newConnection("c2", null).toFuture().get());
         assertThat(e.getCause(), instanceOf(ConnectException.class));
     }
 

--- a/servicetalk-client-api/src/test/java/io/servicetalk/client/api/LimitingConnectionFactoryFilterTest.java
+++ b/servicetalk-client-api/src/test/java/io/servicetalk/client/api/LimitingConnectionFactoryFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,10 @@ package io.servicetalk.client.api;
 import io.servicetalk.concurrent.CompletableSource.Processor;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.ConnectException;
 import java.util.concurrent.BlockingQueue;
@@ -41,22 +38,19 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class LimitingConnectionFactoryFilterTest {
-    @Rule
-    public final ServiceTalkTestTimeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
+class LimitingConnectionFactoryFilterTest {
 
     private final TestSingleSubscriber<ListenableAsyncCloseable> connectlistener = new TestSingleSubscriber<>();
     private ConnectionFactory<String, ListenableAsyncCloseable> original;
     private BlockingQueue<Processor> connectionOnClose;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         original = newMockConnectionFactory();
         connectionOnClose = new LinkedBlockingQueue<>();
@@ -76,17 +70,18 @@ public class LimitingConnectionFactoryFilterTest {
     }
 
     @Test
-    public void enforceMaxConnections() throws Exception {
+    void enforceMaxConnections() throws Exception {
         ConnectionFactory<String, ? extends ListenableAsyncCloseable> cf =
                 makeCF(LimitingConnectionFactoryFilter.withMax(1), original);
-        cf.newConnection("c1", null).toFuture().get();
-        expectedException.expect(ExecutionException.class);
-        expectedException.expectCause(instanceOf(ConnectException.class));
-        cf.newConnection("c2", null).toFuture().get();
+        Exception e = assertThrows(ExecutionException.class, () -> {
+            cf.newConnection("c1", null).toFuture().get();
+            cf.newConnection("c2", null).toFuture().get();
+        });
+        assertThat(e.getCause(), instanceOf(ConnectException.class));
     }
 
     @Test
-    public void onCloseReleasesPermit() throws Exception {
+    void onCloseReleasesPermit() throws Exception {
         ConnectionFactory<String, ? extends ListenableAsyncCloseable> cf =
                 makeCF(LimitingConnectionFactoryFilter.withMax(1), original);
         cf.newConnection("c1", null).toFuture().get();
@@ -96,7 +91,7 @@ public class LimitingConnectionFactoryFilterTest {
     }
 
     @Test
-    public void cancelReleasesPermit() throws Exception {
+    void cancelReleasesPermit() throws Exception {
         ConnectionFactory<String, ListenableAsyncCloseable> o = newMockConnectionFactory();
         when(o.newConnection(any(), any())).thenReturn(never());
         ConnectionFactory<String, ? extends ListenableAsyncCloseable> cf =


### PR DESCRIPTION
Motivation:

JUnit 5 leverages features from Java 8 or later, such as lambda functions, making tests more powerful and easier to maintain.
JUnit 5 has added some very useful new features for describing, organizing, and executing tests. For instance, tests get better display names and can be organized hierarchically.
JUnit 5 is organized into multiple libraries, so only the features you need are imported into your project. With build systems such as Maven and Gradle, including the right libraries is easy.
JUnit 5 can use more than one extension at a time, which JUnit 4 could not (only one runner could be used at a time). This means you can easily combine the Spring extension with other extensions (such as your own custom extension).
Modifications:

Unit tests have been migrated from JUnit 4 to JUnit 5
Result:
successfully ran ./gradlew :servicetalk-client-api:build
Module servicetalk-client-api now runs tests using JUnit 5