### PR TITLE
Publisher#flatMapMergeSingle catch an propagate unexpected errors downstream

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
@@ -330,7 +330,7 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
             drainPending();
         }
 
-        private void enqueueFailed(Object item) {
+        private static void enqueueFailed(Object item) {
             LOGGER.error("Queue should be unbounded, but an offer failed for item {}!", item);
             // Note that we throw even if the item represents a terminal signal (even though we don't expect another
             // terminal signal to be delivered from the upstream source because we are already terminated). If we fail

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
@@ -306,7 +306,7 @@ final class PublisherFlatMapSingle<T, R> extends AbstractAsynchronousPublisherOp
             }
         }
 
-        private void enqueueFailed(Object item) {
+        private static void enqueueFailed(Object item) {
             LOGGER.error("Queue should be unbounded, but an offer failed for item {}!", item);
             // Note that we throw even if the item represents a terminal signal (even though we don't expect another
             // terminal signal to be delivered from the upstream source because we are already terminated). If we fail

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
@@ -44,9 +44,7 @@ import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateS
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
-import static io.servicetalk.concurrent.internal.ThrowableUtils.catchUnexpected;
 import static io.servicetalk.utils.internal.PlatformDependent.newUnboundedMpscQueue;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
@@ -237,15 +235,28 @@ final class PublisherFlatMapSingle<T, R> extends AbstractAsynchronousPublisherOp
             }
         }
 
+        private void onErrorHoldingLock(Throwable cause) {
+            try {
+                doCancel(true);
+            } finally {
+                sendToTarget(error(cause));
+            }
+        }
+
         private void tryEmitItem(final Object item) {
             if (tryAcquireLock(emittingUpdater, this)) { // fast path. no concurrency, avoid the queue and emit.
                 try {
                     sendToTarget(item);
+                    // Call doDrainPostProcessing inside the lock so if an exception is thrown we can propagate an
+                    // error terminal downstream and ignore future signals.
                     doDrainPostProcessing(1);
-                } finally {
-                    if (!releaseLock(emittingUpdater, this)) {
-                        drainPending();
-                    }
+                } catch (Throwable cause) {
+                    onErrorHoldingLock(cause);
+                    return; // Poison emittingUpdater. We prematurely terminated, other signals should be ignored.
+                }
+                // Release lock after we handle errors, because error handling needs to poison the lock.
+                if (!releaseLock(emittingUpdater, this)) {
+                    drainPending();
                 }
             } else { // slow path. there is concurrency, so just go through the queue.
                 enqueueAndDrain(item);
@@ -261,30 +272,25 @@ final class PublisherFlatMapSingle<T, R> extends AbstractAsynchronousPublisherOp
 
         private void drainPending() {
             long drainCount = 0;
-            Throwable delayedCause = null;
             boolean tryAcquire = true;
             while (tryAcquire && tryAcquireLock(emittingUpdater, this)) {
                 try {
                     Object t;
                     while ((t = pending.poll()) != null) {
                         ++drainCount;
-                        try {
-                            sendToTarget(t);
-                        } catch (Throwable cause) {
-                            delayedCause = catchUnexpected(delayedCause, cause);
-                        }
+                        sendToTarget(t);
                     }
-                } finally {
-                    tryAcquire = !releaseLock(emittingUpdater, this);
+                    // Call doDrainPostProcessing inside the lock so if an exception is thrown we can propagate an
+                    // error terminal downstream and ignore future signals.
+                    if (drainCount != 0) {
+                        doDrainPostProcessing(drainCount);
+                    }
+                } catch (Throwable cause) {
+                    onErrorHoldingLock(cause);
+                    return; // Poison emittingUpdater. We prematurely terminated, other signals should be ignored.
                 }
-            }
-
-            if (delayedCause != null) {
-                throwException(delayedCause);
-            }
-
-            if (drainCount != 0) {
-                doDrainPostProcessing(drainCount);
+                // Release lock after we handle errors, because error handling needs to poison the lock.
+                tryAcquire = !releaseLock(emittingUpdater, this);
             }
         }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
@@ -24,6 +24,8 @@ import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -39,6 +41,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 
@@ -103,9 +106,11 @@ class PublisherFlatMapMergeTest {
         }
     }
 
-    @Test
-    void singleToPublisherOnNextErrorPropagated() {
-        toSource(publisher.flatMapMerge(x -> succeeded(x).toPublisher(), 2)
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void singleToPublisherOnNextErrorPropagated(boolean delayError) {
+        Function<? super Integer, ? extends Publisher<? extends Integer>> func = x -> succeeded(x).toPublisher();
+        toSource((delayError ? publisher.flatMapMerge(func, 2) : publisher.flatMapMergeDelayError(func, 2))
                 .<Integer>map(y -> {
                     throw DELIBERATE_EXCEPTION;
                 })).subscribe(subscriber);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
@@ -110,7 +110,7 @@ class PublisherFlatMapMergeTest {
     @ValueSource(booleans = {true, false})
     void singleToPublisherOnNextErrorPropagated(boolean delayError) {
         Function<? super Integer, ? extends Publisher<? extends Integer>> func = x -> succeeded(x).toPublisher();
-        toSource((delayError ? publisher.flatMapMerge(func, 2) : publisher.flatMapMergeDelayError(func, 2))
+        toSource((delayError ? publisher.flatMapMergeDelayError(func, 2) : publisher.flatMapMerge(func, 2))
                 .<Integer>map(y -> {
                     throw DELIBERATE_EXCEPTION;
                 })).subscribe(subscriber);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
@@ -104,7 +104,7 @@ class PublisherFlatMapMergeTest {
     }
 
     @Test
-    public void singleToPublisherOnNextErrorPropagated() {
+    void singleToPublisherOnNextErrorPropagated() {
         toSource(publisher.flatMapMerge(x -> succeeded(x).toPublisher(), 2)
                 .<Integer>map(y -> {
                     throw DELIBERATE_EXCEPTION;


### PR DESCRIPTION
Motivation:
Publisher#flatMapMergeSingle relies upon the upstream source to catch
unexpected exceptions, cleanup necessary state, and propagate an error
back downstream. However in the event the upstream source is a Single it
will not be able to propagate an error downstream because it has already
sent a terminal signal (multiple terminal signals not allowed by the
RS spec). This means the upstream can at best log/swallow the error and
downstream may not be notified of the failure.

Modifications:
- Publisher#flatMapMergeSingle exception handling is modified to instead
  of propagating the exception upstream, exceptions are caught, upstream
  is cancelled, and the exception is propagated downstream.

Result:
Publisher#flatMapMergeSingle usages where downstream operators may throw
will cancel upstream and propagate and error downstream.