### PR TITLE
Single#concat(Publisher) onNext error propagation

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleConcatWithPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleConcatWithPublisher.java
@@ -152,7 +152,12 @@ final class SingleConcatWithPublisher<T> extends AbstractNoHandleSubscribePublis
         }
 
         private void emitSingleSuccessToTarget(@Nullable final T result) {
-            target.onNext(result);
+            try {
+                target.onNext(result);
+            } catch (Throwable cause) {
+                target.onError(cause);
+                return;
+            }
             next.subscribeInternal(this);
         }
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.concurrent.api.single;
 
+import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.TestCancellable;
 import io.servicetalk.concurrent.api.TestPublisher;
@@ -54,6 +55,18 @@ class SingleConcatWithPublisherTest {
         toSource(source.concat(next)).subscribe(subscriber);
         source.onSubscribe(cancellable);
         subscriber.awaitSubscription();
+    }
+
+    @Test
+    void onNextErrorPropagated() {
+        subscriber = new TestPublisherSubscriber<>();
+        source = new TestSingle<>();
+        toSource(source.concat(Publisher.never()).<Integer>map(x -> {
+            throw DELIBERATE_EXCEPTION;
+        })).subscribe(subscriber);
+        subscriber.awaitSubscription().request(1);
+        source.onSuccess(1);
+        assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.concurrent.api.single;
 
-import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.TestCancellable;
 import io.servicetalk.concurrent.api.TestPublisher;
@@ -61,12 +60,13 @@ class SingleConcatWithPublisherTest {
     void onNextErrorPropagated() {
         subscriber = new TestPublisherSubscriber<>();
         source = new TestSingle<>();
-        toSource(source.concat(Publisher.never()).<Integer>map(x -> {
+        toSource(source.concat(next).<Integer>map(x -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         source.onSuccess(1);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
+        assertThat(next.isSubscribed(), is(false));
     }
 
     @Test


### PR DESCRIPTION
Motivation:
Single#concat(Publisher) doesn't catch exceptions from downstream
Subscriber#onNext and relies upon upstream to propagate exceptions.
However upstream is a Single and has already terminated by the time the
exception is caught so it cannot send a duplicate terminal signal.

Modifications:
- Single#concat(Publisher) catches exceptions from downstream
  Subscriber#onNext and propagates an error.

Result:
Single#concat(Publisher) is more robust with respect to exception
handling.