### PR TITLE
Disable offloading for `NettyConnectionContext#transportError()`

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -99,7 +99,7 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
 
     @Override
     public final Single<Throwable> transportError() {
-        return fromSource(transportError).publishOn(executionContext().executor());
+        return fromSource(transportError);
     }
 
     @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -503,7 +503,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
 
     @Override
     public Single<Throwable> transportError() {
-        return fromSource(transportError).publishOn(executionContext().executor());
+        return fromSource(transportError);
     }
 
     /**

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyConnectionContext.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyConnectionContext.java
@@ -49,6 +49,9 @@ public interface NettyConnectionContext extends ConnectionContext {
     /**
      * Returns a {@link Single}&lt;{@link Throwable}&gt; that may terminate with an error, if an error is observed at
      * the transport.
+     * <p>
+     * <b>Note:</b>The {@code Single} is not required to be blocking-safe and should be offloaded if the
+     * {@link io.servicetalk.concurrent.SingleSource.Subscriber} may block.
      *
      * @return a {@link Single}&lt;{@link Throwable}&gt; that may terminate with an error, if an error is observed at
      * the transport.


### PR DESCRIPTION
Motivation:

`NettyConnectionContext` is internal API. We do not expect users to use
it directly. If they do, they have to go through the casting of types and take
care about offloading or use it in a non blocking way.
We applied the same strategy for `NettyConnectionContext#onClosing()` in
#1585.

Modifications:

- Update javadoc for `NettyConnectionContext#transportError()`;
- Remove `publishOn(executor)` from its implementation in
`DefaultNettyConnection` and `H2ParentConnectionContext`;

Result:

Internal API of `NettyConnectionContext#transportError()` does not
apply offloading by default.