### PR TITLE
Update Jersey 2.32 -> 2.34

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ javaxJaxbCoreVersion=2.3.0.1
 javaxJaxbImplVersion=2.3.3
 
 jaxRsVersion=2.1.6
-jerseyVersion=2.32
+jerseyVersion=2.34
 
 reactiveStreamsVersion=1.0.3
 jcToolsVersion=3.3.0

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultJerseyStreamingHttpRouter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultJerseyStreamingHttpRouter.java
@@ -40,6 +40,7 @@ import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.internal.util.collection.Ref;
 import org.glassfish.jersey.server.ApplicationHandler;
 import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.spi.Container;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -234,7 +235,8 @@ final class DefaultJerseyStreamingHttpRouter implements StreamingHttpService {
                 requestURI,
                 req.method().name(),
                 UNAUTHENTICATED_SECURITY_CONTEXT,
-                new MapPropertiesDelegate(), null);
+                new MapPropertiesDelegate(),
+                new ResourceConfig());
 
         req.headers().forEach(h ->
                 containerRequest.getHeaders().add(h.getKey().toString(), h.getValue().toString()));
@@ -283,7 +285,7 @@ final class DefaultJerseyStreamingHttpRouter implements StreamingHttpService {
         private CloseSignalHandoffAbleContainerRequest(final URI baseUri, final URI requestUri, final String httpMethod,
                                                       final SecurityContext securityContext,
                                                       final PropertiesDelegate propertiesDelegate,
-                                                      @Nullable final Configuration configuration) {
+                                                      final Configuration configuration) {
             super(baseUri, requestUri, httpMethod, securityContext, propertiesDelegate, configuration);
         }
 


### PR DESCRIPTION
Motivation:
Some users reported that ServiceTalk was incompatible with Jersey 2.34
release. Updating revealed that an API change in Jersey is responsible;
the `Configuration` object may no longer be null for
`InboundMessageContext`.
Modifications:
Dependency is updated. Providing a default `ResourceConfig` appears
to be sufficient for `InboundMessageContext`.
Result:
Jersey updated.