### PR TITLE
run GitHub release action publish task without parallel

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -43,7 +43,7 @@ jobs:
           # Build arguments to feed to the single gradlew publish command
           if [ "${{ matrix.java }}" = "8" ]; then
             FIRST_GRADLE_TARGETS=" clean check"
-            SECOND_GRADLE_TARGETS=" publish"
+            SECOND_GRADLE_TARGETS=" --no-parallel publish"
           else
             FIRST_GRADLE_TARGETS=""
             SECOND_GRADLE_TARGETS=""

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -22,7 +22,7 @@ set -eu
 
 function usage() {
   echo "Usage: $0 next_version"
-  echo "nex_version - the next version to update gradle.properties, expected -SNAPSHOT suffix"
+  echo "next_version - the next version to update gradle.properties, expected -SNAPSHOT suffix"
 }
 
 if [ "$#" -ne "1" ]; then


### PR DESCRIPTION
Motivation:
The sonatype repository appears to potentially exhibit a race condition when uploading
artifacts that causes multiple staging repositories to be created.
Modifications:
This change hopefully avoids the apparent race condition by executing publish tasks
serially.
Result:
Successful sonatype upload.