### PR TITLE
Remove `append` methods that were deprecated in #1578

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionFactoryFilter.java
@@ -17,8 +17,6 @@ package io.servicetalk.client.api;
 
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * A contract to decorate {@link ConnectionFactory} instances for the purpose of filtering.
  *
@@ -35,29 +33,6 @@ public interface ConnectionFactoryFilter<ResolvedAddress, C extends ListenableAs
      * @return Decorated {@link ConnectionFactory} that contains the filtering logic.
      */
     ConnectionFactory<ResolvedAddress, C> create(ConnectionFactory<ResolvedAddress, C> original);
-
-    /**
-     * Returns a composed function that first applies the {@code before} function to its input, and then applies
-     * this function to the result.
-     * <p>
-     * The order of execution of these filters are in order of append. If 3 filters are added as follows:
-     * <pre>
-     *     builder.append(filter1).append(filter2).append(filter3)
-     * </pre>
-     * Calling {@link ConnectionFactory} wrapped by this filter chain, the order of invocation of these filters will be:
-     * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; original connection factory
-     * </pre>
-     *
-     * @deprecated Use {@code appendConnectionFactoryFilter(ConnectionFactoryFilter)} at the builder of a client
-     * @param before the function to apply before this function is applied
-     * @return a composed function that first applies the {@code before} function and then applies this function.
-     */
-    @Deprecated
-    default ConnectionFactoryFilter<ResolvedAddress, C> append(ConnectionFactoryFilter<ResolvedAddress, C> before) {
-        requireNonNull(before);
-        return original -> create(before.create(original));
-    }
 
     /**
      * Returns a function that always returns its input {@link ConnectionFactory}.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceFilterFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceFilterFactory.java
@@ -15,8 +15,6 @@
  */
 package io.servicetalk.grpc.api;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * A factory to create <a href="https://www.grpc.io">gRPC</a> service filters.
  *
@@ -33,28 +31,4 @@ public interface GrpcServiceFilterFactory<Filter extends Service, Service> {
      * @return {@link Filter} using the provided {@link Service}.
      */
     Filter create(Service service);
-
-    /**
-     * Returns a composed factory that first applies the {@code before} factory to its input, and then applies
-     * this factory to the result.
-     * <p>
-     * The order of execution of these filters are in order of append. If 3 filters are added as follows:
-     * <pre>
-     *     builder.append(filter1).append(filter2).append(filter3)
-     * </pre>
-     * accepting a request by a service wrapped by this filter chain, the order of invocation of these filters will be:
-     * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; service
-     * </pre>
-     *
-     * @deprecated Use {@link GrpcServiceFactory#appendServiceFilter(GrpcServiceFilterFactory)}
-     * @param before the factory to apply before this factory is applied.
-     * @return a composed factory that first applies the {@code before} factory and then applies this factory.
-     */
-    @Deprecated
-    default GrpcServiceFilterFactory<Filter, Service> append(
-            GrpcServiceFilterFactory<Filter, Service> before) {
-        requireNonNull(before);
-        return service -> create(before.create(service));
-    }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientFilterFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientFilterFactory.java
@@ -43,29 +43,6 @@ public interface MultiAddressHttpClientFilterFactory<U> {
     StreamingHttpClientFilter create(U address, FilterableStreamingHttpClient client);
 
     /**
-     * Returns a composed function that first applies the {@code before} function to its input, and then applies
-     * this function to the result.
-     * <p>
-     * The order of execution of these filters are in order of append. If 3 filters are added as follows:
-     * <pre>
-     *     filter1.append(filter2).append(filter3)
-     * </pre>
-     * Making a request to a client wrapped by this filter chain the order of invocation of these filters will be:
-     * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; client
-     * </pre>
-     *
-     * @deprecated Use {@link MultiAddressHttpClientBuilder#appendClientFilter(MultiAddressHttpClientFilterFactory)}
-     * @param before the function to apply before this function is applied
-     * @return a composed function that first applies the {@code before} function and then applies this function
-     */
-    @Deprecated
-    default MultiAddressHttpClientFilterFactory<U> append(MultiAddressHttpClientFilterFactory<U> before) {
-        requireNonNull(before);
-        return (group, client) -> create(group, before.create(group, client));
-    }
-
-    /**
      * Returns a {@link StreamingHttpClientFilterFactory} that adapts from a
      * {@link MultiAddressHttpClientFilterFactory}.
      *

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilterFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilterFactory.java
@@ -16,7 +16,6 @@
 package io.servicetalk.http.api;
 
 import static io.servicetalk.http.api.StrategyInfluencerAwareConversions.toMultiAddressClientFactory;
-import static java.util.Objects.requireNonNull;
 
 /**
  * A factory for {@link StreamingHttpClientFilter}.
@@ -31,30 +30,6 @@ public interface StreamingHttpClientFilterFactory {
      * @return {@link StreamingHttpClientFilter} using the provided {@link StreamingHttpClientFilter}.
      */
     StreamingHttpClientFilter create(FilterableStreamingHttpClient client);
-
-    /**
-     * Returns a composed function that first applies the {@code before} function to its input, and then applies
-     * this function to the result.
-     * <p>
-     * The order of execution of these filters are in order of append. If 3 filters are added as follows:
-     * <pre>
-     *     filter1.append(filter2).append(filter3)
-     * </pre>
-     * making a request to a client wrapped by this filter chain the order of invocation of these filters will be:
-     * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; client
-     * </pre>
-     *
-     * @deprecated Use {@link HttpClientBuilder#appendClientFilter(StreamingHttpClientFilterFactory)}
-     * @param before the function to apply before this function is applied
-     * @return a composed function that first applies the {@code before}
-     * function and then applies this function
-     */
-    @Deprecated
-    default StreamingHttpClientFilterFactory append(StreamingHttpClientFilterFactory before) {
-        requireNonNull(before);
-        return client -> create(before.create(client));
-    }
 
     /**
      * Returns a {@link MultiAddressHttpClientFilterFactory} that adapts from a

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionFilterFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionFilterFactory.java
@@ -15,8 +15,6 @@
  */
 package io.servicetalk.http.api;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * A factory for {@link StreamingHttpConnectionFilter}.
  */
@@ -30,29 +28,4 @@ public interface StreamingHttpConnectionFilterFactory {
      * @return {@link StreamingHttpConnectionFilter} using the provided {@link FilterableStreamingHttpConnection}.
      */
     StreamingHttpConnectionFilter create(FilterableStreamingHttpConnection connection);
-
-    /**
-     * Returns a composed function that first applies the {@code before} function to its input, and then applies
-     * this function to the result.
-     * <p>
-     * The order of execution of these filters are in order of append. If 3 filters are added as follows:
-     * <pre>
-     *     filter1.append(filter2).append(filter3)
-     * </pre>
-     * making a request to a connection wrapped by this filter chain the order of invocation of these filters will
-     * be:
-     * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; connection
-     * </pre>
-     *
-     * @deprecated Use {@link HttpClientBuilder#appendConnectionFilter(StreamingHttpConnectionFilterFactory)}
-     * @param before the function to apply before this function is applied
-     * @return a composed function that first applies the {@code before}
-     * function and then applies this function
-     */
-    @Deprecated
-    default StreamingHttpConnectionFilterFactory append(StreamingHttpConnectionFilterFactory before) {
-        requireNonNull(before);
-        return connection -> create(before.create(connection));
-    }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceFilterFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceFilterFactory.java
@@ -15,8 +15,6 @@
  */
 package io.servicetalk.http.api;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * A factory for {@link StreamingHttpServiceFilter}.
  */
@@ -30,28 +28,4 @@ public interface StreamingHttpServiceFilterFactory {
      * @return {@link StreamingHttpServiceFilter} using the provided {@link StreamingHttpService}.
      */
     StreamingHttpServiceFilter create(StreamingHttpService service);
-
-    /**
-     * Returns a composed function that first applies the {@code before} function to its input, and then applies
-     * this function to the result.
-     * <p>
-     * The order of execution of these filters are in order of append. If 3 filters are added as follows:
-     * <pre>
-     *     builder.append(filter1).append(filter2).append(filter3)
-     * </pre>
-     * accepting a request by a service wrapped by this filter chain, the order of invocation of these filters will be:
-     * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; service
-     * </pre>
-     *
-     * @deprecated Use {@link HttpServerBuilder#appendServiceFilter(StreamingHttpServiceFilterFactory)}
-     * @param before the function to apply before this function is applied
-     * @return a composed function that first applies the {@code before}
-     * function and then applies this function
-     */
-    @Deprecated
-    default StreamingHttpServiceFilterFactory append(StreamingHttpServiceFilterFactory before) {
-        requireNonNull(before);
-        return service -> create(before.create(service));
-    }
 }


### PR DESCRIPTION
Motivation:

`append` method on each filter factory was deprecated in #1578 and can
be removed now.

Modifications:

- Remove `append` method from `ConnectionFactoryFilter`,
`GrpcServiceFilterFactory`, `MultiAddressHttpClientFilterFactory`,
`StreamingHttpClientFilterFactory`, `StreamingHttpConnectionFilterFactory`,
`StreamingHttpServiceFilterFactory`.

Result:

No deprecated methods on filter factory API.