### PR TITLE
Remove mistaken `@Deprecated` annotation from `DefaultGrpcClientBuilder#enableWireLogging`

### DIFF
--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
@@ -118,7 +118,6 @@ final class DefaultGrpcClientBuilder<U, R> extends GrpcClientBuilder<U, R> {
         return this;
     }
 
-    @Deprecated
     @Override
     public GrpcClientBuilder<U, R> enableWireLogging(final String loggerName, final LogLevel logLevel,
                                                      final BooleanSupplier logUserData) {


### PR DESCRIPTION
Motivation:

`enableWireLogging(String, LogLevel, BooleanSupplier)` method was
mistakenly marked as `@Deprecated` in `DefaultGrpcClientBuilder`.

Modifications:

- Remove `@Deprecated` annotation from
`DefaultGrpcClientBuilder#enableWireLogging`;

Result:

No misleading annotation.