### PR TITLE
Remove `recoverWith` operators that were deprecated in #1435

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -573,32 +573,6 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Recover from any error emitted by this {@link Publisher} by using another {@link Publisher} provided by the
-     * passed {@code nextFactory}.
-     * <p>
-     * This method provides similar capabilities to a try/catch block in sequential programming:
-     * <pre>{@code
-     *     List<T> results;
-     *     try {
-     *         results = resultOfThisPublisher();
-     *     } catch (Throwable cause) {
-     *         // Note that nextFactory returning a error Publisher is like re-throwing (nextFactory shouldn't throw).
-     *         results = nextFactory.apply(cause);
-     *     }
-     *     return results;
-     * }</pre>
-     * @deprecated Use {@link #onErrorResume(Function)}.
-     * @param nextFactory Returns the next {@link Publisher}, when this {@link Publisher} emits an error.
-     * @return A {@link Publisher} that recovers from an error from this {@code Publisher} by using another
-     * {@link Publisher} provided by the passed {@code nextFactory}.
-     * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX catch operator.</a>
-     */
-    @Deprecated
-    public final Publisher<T> recoverWith(Function<Throwable, ? extends Publisher<? extends T>> nextFactory) {
-        return onErrorResume(nextFactory);
-    }
-
-    /**
      * Map each element of this {@link Publisher} into a {@link Publisher}&lt;{@link R}&gt; and flatten all signals
      * emitted from each mapped {@link Publisher}&lt;{@link R}&gt; into the returned
      * {@link Publisher}&lt;{@link R}&gt;.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -354,31 +354,6 @@ public abstract class Single<T> {
     }
 
     /**
-     * Recover from any error emitted by this {@link Single} by using another {@link Single} provided by the
-     * passed {@code nextFactory}.
-     * <p>
-     * This method provides similar capabilities to a try/catch block in sequential programming:
-     * <pre>{@code
-     *     T result;
-     *     try {
-     *         result = resultOfThisSingle();
-     *     } catch (Throwable cause) {
-     *         // Note that nextFactory returning a error Single is like re-throwing (nextFactory shouldn't throw).
-     *         result = nextFactory.apply(cause);
-     *     }
-     *     return result;
-     * }</pre>
-     * @deprecated Use {@link #onErrorResume(Function)}.
-     * @param nextFactory Returns the next {@link Single}, when this {@link Single} emits an error.
-     * @return A {@link Single} that recovers from an error from this {@link Single} by using another
-     * {@link Single} provided by the passed {@code nextFactory}.
-     */
-    @Deprecated
-    public final Single<T> recoverWith(Function<? super Throwable, ? extends Single<? extends T>> nextFactory) {
-        return onErrorResume(nextFactory);
-    }
-
-    /**
      * Returns a {@link Single} that mirrors emissions from the {@link Single} returned by {@code next}.
      * Any error emitted by this {@link Single} is forwarded to the returned {@link Single}.
      * <p>


### PR DESCRIPTION
Motivation:

`recoverWith` operators for `Publisher` and `Single` were deprecated in
#1435 and can be removed now.

Modifications:

- Remove `Publisher#recoverWith`;
- Remove `Single#recoverWith`;

Result:

No deprecated operators on `Publisher` and `Single` API.