### PR TITLE
Remove `backlog(int)` server builder option that was deprecated in #1375

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -76,20 +76,6 @@ public abstract class GrpcServerBuilder {
     public abstract GrpcServerBuilder defaultTimeout(Duration defaultTimeout);
 
     /**
-     * The maximum queue length for incoming connection indications (a request to connect) is set to the backlog
-     * parameter. If a connection indication arrives when the queue is full, the connection may time out.
-     * @deprecated Use {@link #listenSocketOption(SocketOption, Object)} with key
-     * {@link ServiceTalkSocketOptions#SO_BACKLOG}.
-     * @param backlog the backlog to use when accepting connections.
-     * @return {@code this}.
-     */
-    @Deprecated
-    public GrpcServerBuilder backlog(int backlog) {
-        listenSocketOption(ServiceTalkSocketOptions.SO_BACKLOG, backlog);
-        return this;
-    }
-
-    /**
      * Set the SSL/TLS configuration.
      * @param config The configuration to use.
      * @return {@code this}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -69,20 +69,6 @@ public abstract class HttpServerBuilder {
     public abstract HttpServerBuilder protocols(HttpProtocolConfig... protocols);
 
     /**
-     * Sets the maximum queue length for incoming connection indications (a request to connect) is set to the backlog
-     * parameter. If a connection indication arrives when the queue is full, the connection may time out.
-     * @deprecated Use {@link #listenSocketOption(SocketOption, Object)} with key
-     * {@link ServiceTalkSocketOptions#SO_BACKLOG}.
-     * @param backlog the backlog to use when accepting connections.
-     * @return {@code this}.
-     */
-    @Deprecated
-    public HttpServerBuilder backlog(int backlog) {
-        listenSocketOption(ServiceTalkSocketOptions.SO_BACKLOG, backlog);
-        return this;
-    }
-
-    /**
      * Set the SSL/TLS configuration.
      * @param config The configuration to use.
      * @return {@code this}.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -27,7 +27,6 @@ import io.servicetalk.transport.api.ConnectionAcceptor;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServerSslConfig;
-import io.servicetalk.transport.api.ServiceTalkSocketOptions;
 import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketAddress;
@@ -49,21 +48,6 @@ final class DefaultHttpServerBuilder extends HttpServerBuilder {
     @Override
     public HttpServerBuilder protocols(final HttpProtocolConfig... protocols) {
         config.httpConfig().protocols(protocols);
-        return this;
-    }
-
-    /**
-     * Sets the maximum queue length for incoming connection indications (a request to connect) is set to the backlog
-     * parameter. If a connection indication arrives when the queue is full, the connection may time out.
-     *
-     * @deprecated Use {@link #listenSocketOption(SocketOption, Object)} with key
-     * {@link ServiceTalkSocketOptions#SO_BACKLOG}.
-     * @param backlog the backlog to use when accepting connections.
-     * @return {@code this}.
-     */
-    @Deprecated
-    public HttpServerBuilder backlog(int backlog) {
-        listenSocketOption(ServiceTalkSocketOptions.SO_BACKLOG, backlog);
         return this;
     }
 

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
@@ -16,7 +16,6 @@
 package io.servicetalk.tcp.netty.internal;
 
 import io.servicetalk.transport.api.ServerSslConfig;
-import io.servicetalk.transport.api.ServiceTalkSocketOptions;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver;
 
@@ -124,16 +123,5 @@ public final class ReadOnlyTcpServerConfig extends AbstractReadOnlyTcpConfig<Ser
     @SuppressWarnings("rawtypes")
     public Map<ChannelOption, Object> listenOptions() {
         return listenOptions;
-    }
-
-    /**
-     * Returns the maximum queue length for incoming connection indications (a request to connect).
-     * @deprecated Use {@link #listenOptions()} with key {@link ServiceTalkSocketOptions#SO_BACKLOG}.
-     * @return backlog
-     */
-    @Deprecated
-    public int backlog() {
-        final Integer i = (Integer) listenOptions.get(ChannelOption.SO_BACKLOG);
-        return i == null ? 0 : i;
     }
 }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
@@ -99,23 +99,6 @@ public final class TcpServerConfig extends AbstractTcpConfig<ServerSslConfig> {
     }
 
     /**
-     * The maximum queue length for incoming connection indications (a request to connect) is set to the backlog
-     * parameter. If a connection indication arrives when the queue is full, the connection may time out.
-     * @deprecated Use {@link #listenSocketOption(SocketOption, Object)} with
-     * {@link ServiceTalkSocketOptions#SO_BACKLOG}.
-     * @param backlog the backlog to use when accepting connections
-     * @return {@code this}
-     */
-    @Deprecated
-    public TcpServerConfig backlog(final int backlog) {
-        if (backlog < 0) {
-            throw new IllegalArgumentException("backlog must be >= 0");
-        }
-        listenSocketOption(ServiceTalkSocketOptions.SO_BACKLOG, backlog);
-        return this;
-    }
-
-    /**
      * Create a read only view of this object.
      * @return a read only view of this object.
      */


### PR DESCRIPTION
Motivation:

`backlog(int)` builder option was deprecated in #1375 and can be removed
now. Users should use `listenSocketOption(SocketOption, Object)` as an
alternative.

Modifications:

- Remove `backlog(int)` from all server builders;

Result:

No deprecated `backlog(int)` server builder option.