### PR TITLE
Remove `allowPrematureClosureBeforePayloadBody()` that was deprecated in #1475

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1SpecExceptions.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1SpecExceptions.java
@@ -65,17 +65,6 @@ public final class H1SpecExceptions {
         /**
          * Allows interpreting connection closures as the end of HTTP/1.1 messages if the receiver did not receive any
          * part of the payload body before the connection closure.
-         * @deprecated Use {@link #allowPrematureClosureBeforePayloadBody(boolean)}.
-         * @return {@code this}
-         */
-        @Deprecated
-        public Builder allowPrematureClosureBeforePayloadBody() {
-            return allowPrematureClosureBeforePayloadBody(true);
-        }
-
-        /**
-         * Allows interpreting connection closures as the end of HTTP/1.1 messages if the receiver did not receive any
-         * part of the payload body before the connection closure.
          * @param allow {@code true} if the receiver should interpret connection closures as the end of HTTP/1.1
          * messages if it did not receive any part of the payload body before the connection closure.
          * @return {@code this}


### PR DESCRIPTION
Motivation:

`H1SpecExceptions.Builder#allowPrematureClosureBeforePayloadBody()`
option was deprecated in #1475 and can be removed now. Users can use
`allowPrematureClosureBeforePayloadBody(boolean)` overload as an
alternative.

Modifications:

- Remove `H1SpecExceptions.Builder#allowPrematureClosureBeforePayloadBody()`;

Result:

No deprecated
`H1SpecExceptions.Builder#allowPrematureClosureBeforePayloadBody()` API.