### PR TITLE
Mark any exception before the first message is written as retryable

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
@@ -142,7 +142,7 @@ final class HeaderUtils {
 
     static ScanWithMapper<Object, Object> insertTrailersMapper() {
         return new ScanWithMapper<Object, Object>() {
-            @Nullable
+
             private boolean sawHeaders;
 
             @Nullable

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
@@ -202,7 +202,7 @@ public abstract class CloseHandler {
             this.description = description;
         }
 
-        Throwable wrapError(@Nullable Throwable cause, Channel channel) {
+        CloseEventObservedException wrapError(@Nullable Throwable cause, Channel channel) {
             return new CloseEventObservedException(cause, this, channel);
         }
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -37,13 +37,14 @@ import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
 import io.servicetalk.transport.api.DefaultExecutionContext;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.ExecutionStrategy;
+import io.servicetalk.transport.api.RetryableException;
 import io.servicetalk.transport.api.ServiceTalkSocketOptions;
 import io.servicetalk.transport.netty.internal.CloseHandler.AbortWritesEvent;
 import io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent;
 import io.servicetalk.transport.netty.internal.CloseHandler.CloseEventObservedException;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopDataObserver;
-import io.servicetalk.transport.netty.internal.WriteStreamSubscriber.AbortedFirstWrite;
+import io.servicetalk.transport.netty.internal.WriteStreamSubscriber.AbortedFirstWriteException;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
@@ -61,6 +62,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.SocketAddress;
 import java.net.SocketOption;
+import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -335,30 +337,34 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
 
     private Throwable enrichError(final Throwable t) {
         Throwable throwable;
-        if (t instanceof AbortedFirstWrite) {
-            final Throwable cause = t.getCause();
-            if (closeReason != null) {
-                throwable = new RetryableClosureException(wrapIfReasonIsKnown(cause));
+        CloseEvent closeReason;
+        if (t instanceof AbortedFirstWriteException) {
+            if ((closeReason = this.closeReason) != null) {
+                throwable = new RetryableClosedChannelException(wrapWithCloseReason(closeReason, t.getCause()));
+            } else if (t.getCause() instanceof RetryableException) {
+                // Unwrap additional layer of RetryableException if the cause is already retryable
+                throwable = t.getCause();
+            } else if (t.getCause() instanceof ClosedChannelException) {
+                throwable = new RetryableClosedChannelException((ClosedChannelException) t.getCause());
             } else {
-                throwable = cause;
+                throwable = t;
             }
-        } else if (t instanceof RetryableClosureException) {
+        } else if (t instanceof RetryableClosedChannelException) {
             throwable = t;
         } else {
-            throwable = wrapIfReasonIsKnown(t);
+            if ((closeReason = this.closeReason) != null) {
+                throwable = wrapWithCloseReason(closeReason, t);
+            } else {
+                throwable = enrichProtocolError.apply(t);
+            }
         }
-        throwable = enrichProtocolError.apply(throwable);
         transportError.onSuccess(throwable);
         return throwable;
     }
 
-    private Throwable wrapIfReasonIsKnown(final Throwable t) {
-        final CloseEvent closeReason = this.closeReason;
-        if (closeReason == null) {
-            return t;
-        }
+    private ClosedChannelException wrapWithCloseReason(final CloseEvent closeReason, final Throwable t) {
         if (t instanceof CloseEventObservedException && ((CloseEventObservedException) t).event() == closeReason) {
-            return t;
+            return (ClosedChannelException) t;
         }
         return closeReason.wrapError(t, channel());
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RetryableClosedChannelException.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RetryableClosedChannelException.java
@@ -22,10 +22,16 @@ import java.nio.channels.ClosedChannelException;
 /**
  * Indicates that an error happened due to connection closure, but is retryable.
  */
-class RetryableClosureException extends ClosedChannelException implements RetryableException {
+final class RetryableClosedChannelException extends ClosedChannelException implements RetryableException {
     private static final long serialVersionUID = 2006969744518089407L;
 
-    RetryableClosureException(final Throwable cause) {
+    RetryableClosedChannelException(final ClosedChannelException cause) {
         initCause(cause);
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        // We don't need stack trace because it's just a retryable wrapper for original ClosedChannelException
+        return this;
     }
 }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
@@ -25,6 +25,7 @@ import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 import io.servicetalk.transport.api.ConnectionInfo.Protocol;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
+import io.servicetalk.transport.netty.internal.WriteStreamSubscriber.AbortedFirstWriteException;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundBuffer;
@@ -165,7 +166,9 @@ class DefaultNettyConnectionTest {
     @Test
     void testPublisherErrorFailsWrite() {
         toSource(conn.write(Publisher.failed(DELIBERATE_EXCEPTION))).subscribe(writeListener);
-        assertThat(writeListener.awaitOnError(), is(DELIBERATE_EXCEPTION));
+        final Throwable error = writeListener.awaitOnError();
+        assertThat(error, instanceOf(AbortedFirstWriteException.class));
+        assertThat(error.getCause(), is(DELIBERATE_EXCEPTION));
     }
 
     @Test
@@ -304,7 +307,7 @@ class DefaultNettyConnectionTest {
         toSource(conn.read()).subscribe(subscriber);
         Throwable cause = writeListener.awaitOnError(); // ClosedChannelException was translated
         // Exception should be of type CloseEventObservedException
-        assertThat(cause, instanceOf(RetryableClosureException.class));
+        assertThat(cause, instanceOf(RetryableClosedChannelException.class));
         assertThat(cause.getCause(), instanceOf(ClosedChannelException.class));
         assertThat(cause.getCause().getMessage(), equalTo(
                 "CHANNEL_CLOSED_OUTBOUND(The transport backing this connection has been shutdown (write)) " +
@@ -327,8 +330,10 @@ class DefaultNettyConnectionTest {
         channel.close().syncUninterruptibly();
         toSource(conn.write(publisher)).subscribe(writeListener);
 
-        Throwable cause = writeListener.awaitOnError();
-        // Exception should NOT be of type CloseEventObservedException
+        Throwable error = writeListener.awaitOnError();
+        assertThat(error, instanceOf(RetryableClosedChannelException.class));
+        Throwable cause = error.getCause();
+        // Error cause should NOT be of type CloseEventObservedException
         assertThat(cause, instanceOf(StacklessClosedChannelException.class));
         assertThat(cause.getCause(), nullValue());
         assertThat(cause.getStackTrace()[0].getClassName(), equalTo(DefaultNettyConnection.class.getName()));

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertServerHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertServerHandlingTest.java
@@ -61,7 +61,7 @@ class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotifyAlertH
         PublisherSource.Processor<String, String> writeSource = newPublisherProcessor();
         StepVerifiers.create(conn.write(fromSource(writeSource)))
                 .then(this::closeNotifyAndVerifyClosing)
-                .expectError(RetryableClosureException.class)
+                .expectError(RetryableClosedChannelException.class)
                 .verify();
     }
 
@@ -88,7 +88,7 @@ class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotifyAlertH
                     closeNotifyAndVerifyClosing();
                 })
                 .expectNext(BEGIN)
-                .expectError(RetryableClosureException.class)
+                .expectError(RetryableClosedChannelException.class)
                 .verify();
     }
 


### PR DESCRIPTION
Motivation:

If the `Channel` is already closed before we attempt the first write, we
wrap it with `AbortedFirstWrite` in `WriteStreamSubscriber` and re-wrap
with `RetryableClosureException` in `DefaultNettyConnection`. This
approach has a couple of disadvantages:
1. `AbortedFirstWrite` is not a `RetryableException` and if the
`closeReason` is not known in `DefaultNettyConnection`, the original
exception will be propagated as-is without `RetryableException` marker;
2. `WriteStreamSubscriber` prematurely sets `written` flag before we
attempt the first write, that may also fail even if the `Channel` is not
closed;

Modifications:
- `WriteStreamSubscriber`: mark internal state as `written` only after
the first msg successfully goes through the outbound channel pipeline;
- Rename `AbortedFirstWrite` -> `AbortedFirstWriteException` and make it
retryable `IOException` because it indicates only IO failures;
- Wrap any error that happened before the first msg is written with
`AbortedFirstWriteException`;
- Adjust `DefaultNettyConnection#enrichError` to correctly unwrap
`AbortedFirstWriteException`;
- Adjust tests for new behavior;

Result:

Any failure before the first message is written is marked as retryable.