### PR TITLE
`Single#concat(Publisher)` potential demand deadlock fix

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleConcatWithPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleConcatWithPublisher.java
@@ -133,13 +133,18 @@ final class SingleConcatWithPublisher<T> extends AbstractNoHandleSubscribePublis
                     }
                     break;
                 } else if (mayBeResultUpdater.compareAndSet(this, oldVal, REQUESTED)) {
+                    // We need to ensure that the queued result is delivered in order (first). Upstream demand is
+                    // delayed via DelayedSubscription until onSubscribe which preserves ordering, and there are some
+                    // scenarios where subscribing to the concat Publisher may block on demand (e.g.
+                    // ConnectablePayloadWriter write) so we need to propagate demand first to prevent deadlock.
+                    if (n != 1) {
+                        super.request(n - 1);
+                    }
+
                     if (oldVal != INITIAL) {
                         @SuppressWarnings("unchecked")
                         final T tVal = (T) oldVal;
                         emitSingleSuccessToTarget(tVal);
-                    }
-                    if (n != 1) {
-                        super.request(n - 1);
                     }
                     break;
                 }


### PR DESCRIPTION
Motivation:
Single#concat(Publisher) may result in deadlock if demand comes after
the Single completes, and the next Publisher blocks in its subscribe
method. This may happen if blocking APIs are used (e.g.
ConnectablePayloadWriter) and the control flow involves
Single#concat(Publisher). ServiceTalk currently only uses this operator
for use in the Publisher#buffer(..) operator.

Modifications:
- SingleConcatWithPublisher#request(long) should deliver demand to super
  class before delivering downstream demand and subscribing. Ordering of
  downstream signals will be preserved because
  DelayedCancellableThenSubscription won't propagate demand upstream
  until onSubscribe is called.

Result:
If downstream requests sufficient demand it will be available to the
concat Publisher as soon as it is subscribed to, and therefore less
potential for deadlock when using blocking APIs and
Single#concat(Publisher).