### PR TITLE
Removing deprecated methods from MultiAddressHttpClientBuilder

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseHttpBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseHttpBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ abstract class BaseHttpBuilder<ResolvedAddress> {
      * This setting disables the default filter such that no {@code Host} header will be manipulated.
      *
      * @return {@code this}
-     * @see MultiAddressHttpClientBuilder#unresolvedAddressToHost(Function)
+     * @see SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)
      */
     public abstract BaseHttpBuilder<ResolvedAddress> disableHostHeaderFallback();
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,8 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.buffer.api.BufferAllocator;
-import io.servicetalk.client.api.AutoRetryStrategyProvider;
-import io.servicetalk.client.api.ConnectionFactoryFilter;
-import io.servicetalk.client.api.ServiceDiscoverer;
-import io.servicetalk.client.api.ServiceDiscovererEvent;
-import io.servicetalk.logging.api.LogLevel;
-import io.servicetalk.transport.api.IoExecutor;
+import io.servicetalk.transport.api.ExecutionContext;
 
-import java.net.SocketOption;
-import java.util.function.BooleanSupplier;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static io.servicetalk.http.api.StrategyInfluencerAwareConversions.toMultiAddressConditionalFilterFactory;
@@ -42,8 +33,7 @@ import static java.util.Objects.requireNonNull;
  * @param <R> the type of address after resolution (resolved address)
  * @see <a href="https://tools.ietf.org/html/rfc7230#section-5.3.2">absolute-form rfc7230#section-5.3.2</a>
  */
-public abstract class MultiAddressHttpClientBuilder<U, R>
-        extends HttpClientBuilder<U, R, ServiceDiscovererEvent<R>> {
+public abstract class MultiAddressHttpClientBuilder<U, R> {
     /**
      * Initializes the {@link SingleAddressHttpClientBuilder} for each new client.
      * @param <U> The unresolved address type.
@@ -76,207 +66,12 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
     }
 
     /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#ioExecutor(IoExecutor)} on the last argument of
-     * {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract MultiAddressHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#executionStrategy(HttpExecutionStrategy)} on the last argument of
-     * {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract MultiAddressHttpClientBuilder<U, R> executionStrategy(HttpExecutionStrategy strategy);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#bufferAllocator(BufferAllocator)} on the last argument of
-     * {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract MultiAddressHttpClientBuilder<U, R> bufferAllocator(BufferAllocator allocator);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#socketOption(SocketOption, Object)} on the last argument of
-     * {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract <T> MultiAddressHttpClientBuilder<U, R> socketOption(SocketOption<T> option, T value);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#enableWireLogging(String, LogLevel, BooleanSupplier)} on the last argument
-     * of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract MultiAddressHttpClientBuilder<U, R> enableWireLogging(String loggerName,
-                                                                          LogLevel logLevel,
-                                                                          BooleanSupplier logUserData);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#protocols(HttpProtocolConfig...)} on the last argument of
-     * {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract MultiAddressHttpClientBuilder<U, R> protocols(HttpProtocolConfig... protocols);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} on the last argument of
-     * {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract MultiAddressHttpClientBuilder<U, R> disableHostHeaderFallback();
-
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#allowDropResponseTrailers(boolean)} on the last argument of
-     * {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract MultiAddressHttpClientBuilder<U, R> allowDropResponseTrailers(boolean allowDrop);
-
-    /**
      * Set a function which can customize options for each {@link StreamingHttpClient} that is built.
      * @param initializer Initializes the {@link SingleAddressHttpClientBuilder} used to build new
      * {@link StreamingHttpClient}s.
      * @return {@code this}
      */
     public abstract MultiAddressHttpClientBuilder<U, R> initializer(SingleAddressInitializer<U, R> initializer);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#appendConnectionFilter(StreamingHttpConnectionFilterFactory)} on the last
-     * argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract MultiAddressHttpClientBuilder<U, R> appendConnectionFilter(
-            StreamingHttpConnectionFilterFactory factory);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#appendConnectionFilter(Predicate, StreamingHttpConnectionFilterFactory)} on
-     * the last argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public MultiAddressHttpClientBuilder<U, R> appendConnectionFilter(Predicate<StreamingHttpRequest> predicate,
-                                                                      StreamingHttpConnectionFilterFactory factory) {
-        return (MultiAddressHttpClientBuilder<U, R>) super.appendConnectionFilter(predicate, factory);
-    }
-
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#appendConnectionFactoryFilter(ConnectionFactoryFilter)} on the last
-     * argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract MultiAddressHttpClientBuilder<U, R> appendConnectionFactoryFilter(
-            ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> factory);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#autoRetryStrategy(AutoRetryStrategyProvider)} on the last
-     * argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract MultiAddressHttpClientBuilder<U, R> autoRetryStrategy(
-            AutoRetryStrategyProvider autoRetryStrategyProvider);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#serviceDiscoverer(ServiceDiscoverer)} on the last
-     * argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract MultiAddressHttpClientBuilder<U, R> serviceDiscoverer(
-            ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#retryServiceDiscoveryErrors(ServiceDiscoveryRetryStrategy)} on the last
-     * argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract MultiAddressHttpClientBuilder<U, R> retryServiceDiscoveryErrors(
-            ServiceDiscoveryRetryStrategy<R, ServiceDiscovererEvent<R>> retryStrategy);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#loadBalancerFactory(HttpLoadBalancerFactory)} on the last
-     * argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract
-    MultiAddressHttpClientBuilder<U, R> loadBalancerFactory(HttpLoadBalancerFactory<R> loadBalancerFactory);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)} on the last
-     * argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract MultiAddressHttpClientBuilder<U, R> unresolvedAddressToHost(
-            Function<U, CharSequence> unresolvedAddressToHostFunction);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#appendClientFilter(StreamingHttpClientFilterFactory)} on the last
-     * argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract MultiAddressHttpClientBuilder<U, R> appendClientFilter(StreamingHttpClientFilterFactory factory);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#appendClientFilter(Predicate, StreamingHttpClientFilterFactory)} on the
-     * last argument of {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public MultiAddressHttpClientBuilder<U, R> appendClientFilter(final Predicate<StreamingHttpRequest> predicate,
-                                                                  final StreamingHttpClientFilterFactory factory) {
-        return (MultiAddressHttpClientBuilder<U, R>) super.appendClientFilter(predicate, factory);
-    }
 
     /**
      * Appends the filter to the chain of filters used to decorate the {@link StreamingHttpClient} created by this
@@ -336,4 +131,38 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
      * @return {@code this}.
      */
     public abstract MultiAddressHttpClientBuilder<U, R> maxRedirects(int maxRedirects);
+
+    /**
+     * Builds a new {@link StreamingHttpClient}, using a default {@link ExecutionContext}.
+     *
+     * @return A new {@link StreamingHttpClient}
+     */
+    public abstract StreamingHttpClient buildStreaming();
+
+    /**
+     * Builds a new {@link HttpClient}, using a default {@link ExecutionContext}.
+     *
+     * @return A new {@link HttpClient}
+     */
+    public final HttpClient build() {
+        return buildStreaming().asClient();
+    }
+
+    /**
+     * Creates a new {@link BlockingStreamingHttpClient}, using a default {@link ExecutionContext}.
+     *
+     * @return {@link BlockingStreamingHttpClient}
+     */
+    public final BlockingStreamingHttpClient buildBlockingStreaming() {
+        return buildStreaming().asBlockingStreamingClient();
+    }
+
+    /**
+     * Creates a new {@link BlockingHttpClient}, using a default {@link ExecutionContext}.
+     *
+     * @return {@link BlockingHttpClient}
+     */
+    public final BlockingHttpClient buildBlocking() {
+        return buildStreaming().asBlockingClient();
+    }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -15,12 +15,7 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.buffer.api.BufferAllocator;
-import io.servicetalk.client.api.AutoRetryStrategyProvider;
 import io.servicetalk.client.api.ClientGroup;
-import io.servicetalk.client.api.ConnectionFactoryFilter;
-import io.servicetalk.client.api.ServiceDiscoverer;
-import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.CompositeCloseable;
@@ -29,36 +24,26 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.SubscribableCompletable;
 import io.servicetalk.http.api.FilterableReservedStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
-import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategy;
-import io.servicetalk.http.api.HttpLoadBalancerFactory;
-import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.MultiAddressHttpClientBuilder;
 import io.servicetalk.http.api.MultiAddressHttpClientFilterFactory;
-import io.servicetalk.http.api.ServiceDiscoveryRetryStrategy;
 import io.servicetalk.http.api.StreamingHttpClient;
-import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
-import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.HttpClientBuildContext;
 import io.servicetalk.http.utils.RedirectingHttpRequesterFilter;
-import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.ClientSslConfig;
 import io.servicetalk.transport.api.ClientSslConfigBuilder;
 import io.servicetalk.transport.api.HostAndPort;
-import io.servicetalk.transport.api.IoExecutor;
 
 import java.net.InetSocketAddress;
-import java.net.SocketOption;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
@@ -335,39 +320,6 @@ final class DefaultMultiAddressUrlHttpClientBuilder
     }
 
     @Override
-    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> ioExecutor(final IoExecutor ioExecutor) {
-        builderTemplate.ioExecutor(ioExecutor);
-        return this;
-    }
-
-    @Override
-    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> bufferAllocator(
-            final BufferAllocator allocator) {
-        builderTemplate.bufferAllocator(allocator);
-        return this;
-    }
-
-    @Override
-    public <T> MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> socketOption(
-            final SocketOption<T> option, final T value) {
-        builderTemplate.socketOption(option, value);
-        return this;
-    }
-
-    @Override
-    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> enableWireLogging(
-            final String loggerName, final LogLevel logLevel, final BooleanSupplier logUserData) {
-        builderTemplate.enableWireLogging(loggerName, logLevel, logUserData);
-        return this;
-    }
-
-    @Override
-    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> protocols(HttpProtocolConfig... protocols) {
-        builderTemplate.protocols(protocols);
-        return this;
-    }
-
-    @Override
     public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> initializer(
             final SingleAddressInitializer<HostAndPort, InetSocketAddress> initializer) {
         this.singleAddressInitializer = requireNonNull(initializer);
@@ -375,56 +327,8 @@ final class DefaultMultiAddressUrlHttpClientBuilder
     }
 
     @Override
-    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> appendConnectionFilter(
-            final StreamingHttpConnectionFilterFactory factory) {
-        builderTemplate.appendConnectionFilter(factory);
-        return this;
-    }
-
-    @Override
-    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> appendConnectionFactoryFilter(
-            final ConnectionFactoryFilter<InetSocketAddress, FilterableStreamingHttpConnection> factory) {
-        builderTemplate.appendConnectionFactoryFilter(factory);
-        return this;
-    }
-
-    @Override
-    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> appendClientFilter(
-            final StreamingHttpClientFilterFactory function) {
-        clientFilterFactory = appendClientFilter(clientFilterFactory, function.asMultiAddressClientFilter());
-        return this;
-    }
-
-    @Override
-    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> disableHostHeaderFallback() {
-        builderTemplate.disableHostHeaderFallback();
-        return this;
-    }
-
-    @Override
-    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> allowDropResponseTrailers(
-            final boolean allowDrop) {
-        builderTemplate.allowDropResponseTrailers(allowDrop);
-        return this;
-    }
-
-    @Override
-    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> autoRetryStrategy(
-            final AutoRetryStrategyProvider autoRetryStrategyProvider) {
-        builderTemplate.autoRetryStrategy(autoRetryStrategyProvider);
-        return this;
-    }
-
-    @Override
     public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> maxRedirects(final int maxRedirects) {
         this.maxRedirects = maxRedirects;
-        return this;
-    }
-
-    @Override
-    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> unresolvedAddressToHost(
-            Function<HostAndPort, CharSequence> unresolvedAddressToHostFunction) {
-        this.unresolvedAddressToHostFunction = requireNonNull(unresolvedAddressToHostFunction);
         return this;
     }
 
@@ -441,34 +345,5 @@ final class DefaultMultiAddressUrlHttpClientBuilder
         requireNonNull(next);
         builderTemplate.appendToStrategyInfluencer(next);
         return current == null ? next : (group, client) -> current.create(group, next.create(group, client));
-    }
-
-    @Override
-    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> serviceDiscoverer(
-            final ServiceDiscoverer<HostAndPort, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>> sd) {
-        builderTemplate.serviceDiscoverer(sd);
-        return this;
-    }
-
-    @Override
-    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> retryServiceDiscoveryErrors(
-            final ServiceDiscoveryRetryStrategy<InetSocketAddress,
-                    ServiceDiscovererEvent<InetSocketAddress>> retryStrategy) {
-        builderTemplate.retryServiceDiscoveryErrors(retryStrategy);
-        return this;
-    }
-
-    @Override
-    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> loadBalancerFactory(
-            final HttpLoadBalancerFactory<InetSocketAddress> loadBalancerFactory) {
-        builderTemplate.loadBalancerFactory(loadBalancerFactory);
-        return this;
-    }
-
-    @Override
-    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> executionStrategy(
-            final HttpExecutionStrategy strategy) {
-        builderTemplate.executionStrategy(strategy);
-        return this;
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
@@ -44,8 +44,9 @@ class DefaultMultiAddressUrlHttpClientBuilderTest {
     @Test
     void buildWithDefaults() throws Exception {
         StreamingHttpRequester newRequester = HttpClients.forMultiAddressUrl()
-                .ioExecutor(CTX.ioExecutor())
-                .executionStrategy(defaultStrategy(CTX.executor()))
+                .initializer((scheme, address, builder) -> builder
+                        .ioExecutor(CTX.ioExecutor())
+                        .executionStrategy(defaultStrategy(CTX.executor())))
                 .buildStreaming();
         assertNotNull(newRequester);
         newRequester.closeAsync().toFuture().get();
@@ -54,8 +55,9 @@ class DefaultMultiAddressUrlHttpClientBuilderTest {
     @Test
     void buildAggregatedWithDefaults() throws Exception {
         HttpRequester newAggregatedRequester = HttpClients.forMultiAddressUrl()
-                .ioExecutor(CTX.ioExecutor())
-                .executionStrategy(defaultStrategy(CTX.executor()))
+                .initializer((scheme, address, builder) -> builder
+                        .ioExecutor(CTX.ioExecutor())
+                        .executionStrategy(defaultStrategy(CTX.executor())))
                 .build();
         assertNotNull(newAggregatedRequester);
         newAggregatedRequester.closeAsync().toFuture().get();
@@ -64,8 +66,9 @@ class DefaultMultiAddressUrlHttpClientBuilderTest {
     @Test
     void buildBlockingWithDefaults() throws Exception {
         BlockingStreamingHttpRequester newBlockingRequester = HttpClients.forMultiAddressUrl()
-                .ioExecutor(CTX.ioExecutor())
-                .executionStrategy(defaultStrategy(CTX.executor()))
+                .initializer((scheme, address, builder) -> builder
+                        .ioExecutor(CTX.ioExecutor())
+                        .executionStrategy(defaultStrategy(CTX.executor())))
                 .buildBlockingStreaming();
         assertNotNull(newBlockingRequester);
         newBlockingRequester.close();
@@ -74,8 +77,9 @@ class DefaultMultiAddressUrlHttpClientBuilderTest {
     @Test
     void buildBlockingAggregatedWithDefaults() throws Exception {
         BlockingHttpRequester newBlockingAggregatedRequester = HttpClients.forMultiAddressUrl()
-                .ioExecutor(CTX.ioExecutor())
-                .executionStrategy(defaultStrategy(CTX.executor()))
+                .initializer((scheme, address, builder) -> builder
+                        .ioExecutor(CTX.ioExecutor())
+                        .executionStrategy(defaultStrategy(CTX.executor())))
                 .buildBlocking();
         assertNotNull(newBlockingAggregatedRequester);
         newBlockingAggregatedRequester.close();
@@ -87,8 +91,9 @@ class DefaultMultiAddressUrlHttpClientBuilderTest {
         ServiceDiscoverer<HostAndPort, InetSocketAddress,
                 ServiceDiscovererEvent<InetSocketAddress>> mockedServiceDiscoverer = mock(ServiceDiscoverer.class);
         StreamingHttpRequester newRequester = HttpClients.forMultiAddressUrl(mockedServiceDiscoverer)
-                .ioExecutor(CTX.ioExecutor())
-                .executionStrategy(defaultStrategy(CTX.executor()))
+                .initializer((scheme, address, builder) -> builder
+                        .ioExecutor(CTX.ioExecutor())
+                        .executionStrategy(defaultStrategy(CTX.executor())))
                 .buildStreaming();
         newRequester.closeAsync().toFuture().get();
         verify(mockedServiceDiscoverer, never()).closeAsync();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
@@ -98,7 +98,7 @@ class MultiAddressUrlHttpClientTest {
         afterClassCloseables = newCompositeCloseable();
 
         client = afterClassCloseables.append(HttpClients.forMultiAddressUrl()
-                .serviceDiscoverer(sdThatSupportsInvalidHostname())
+                .initializer((scheme, address, builder) -> builder.serviceDiscoverer(sdThatSupportsInvalidHostname()))
                 .buildStreaming());
 
         httpService = (ctx, request, factory) -> {


### PR DESCRIPTION
Motivation:

The overridden methods from BaseHttpBuilder have been deprecated and
it's safe to remove them. A `SingleAddressInitializer` serves the
purpose of configuring the individual address' clients.

Modifications:

- Removed inheritance of `HttpClientBuilder` and transitive
  `BaseHttpBuilder` from `MultiAddressHttpClientBuilder`,
- Removed deprecated methods.

Result:

The old methods are gone and the dependency on a base class meant for
single address builders is also removed. The new mechanism using
`SingleAddressInitializer` is the only correct way to configure
individual underlying clients used by `MultiAddressHttpClientBuilder`.