### PR TITLE
Deprecate publishAndSubscribeOn

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -1424,12 +1424,16 @@ public abstract class Completable {
      * @param executor {@link Executor} to use.
      * @return A new {@link Completable} that will use the passed {@link Executor} to invoke all methods
      * {@link Subscriber}, {@link Cancellable} and {@link #handleSubscribe(CompletableSource.Subscriber)}.
-     * @deprecated This operator has been deprecated because of upcoming behavior changes in how the operator does
-     * offloading. Previously the subscribe would be offloaded for the entire subscribe chain, not just the portion
-     * preceding the offload operator and the publish would be offloaded from the source, not just for the operators
-     * following the operator. This change in behaviour means that it no longer makes sense to fuse the offloading of
-     * publish and subscribe as the location of the operators in the execution chain is now significant and publish and
-     * subscribe offloading, when required, will typically be placed in different locations. Use separate
+     * @deprecated This operator has been deprecated because of upcoming behavior changes in how offloading via
+     * operators is done. Originally offloading for subscribe/subscription was applied at the "bottom" of chain
+     * (logically the last operator in the chain closest to the subscriber), and offloading for subscriber was applied
+     * at the "top" of the operator chain (logically the first operator in the chain after the async source). The
+     * current offloading doesn't respect the order in which the operators are applied, the offloading is the same
+     * regardless of where the operators are placed in the chain. However, this behavior will soon change to instead
+     * respect operator placement order and apply offloading exactly where the offloading operators are applied in the
+     * chain. This change in behavior means that it no longer makes sense to fuse the offloading of publish and
+     * subscribe as the location of the operators in the chain will now be significant. Publish and subscribe
+     * offloading, when required, will typically be placed in different locations. Use separate, appropriately placed,
      * {@link #subscribeOn(Executor)} and {@link #publishOn(Executor)} operators instead.
      */
     @Deprecated

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -1424,7 +1424,15 @@ public abstract class Completable {
      * @param executor {@link Executor} to use.
      * @return A new {@link Completable} that will use the passed {@link Executor} to invoke all methods
      * {@link Subscriber}, {@link Cancellable} and {@link #handleSubscribe(CompletableSource.Subscriber)}.
+     * @deprecated This operator has been deprecated because of upcoming behavior changes in how the operator does
+     * offloading. Previously the subscribe would be offloaded for the entire subscribe chain, not just the portion
+     * preceding the offload operator and the publish would be offloaded from the source, not just for the operators
+     * following the operator. This change in behaviour means that it no longer makes sense to fuse the offloading of
+     * publish and subscribe as the location of the operators in the execution chain is now significant and publish and
+     * subscribe offloading, when required, will typically be placed in different locations. Use separate
+     * {@link #subscribeOn(Executor)} and {@link #publishOn(Executor)} operators instead.
      */
+    @Deprecated
     public final Completable publishAndSubscribeOn(Executor executor) {
         return PublishAndSubscribeOnCompletables.publishAndSubscribeOn(this, executor);
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2900,12 +2900,13 @@ public abstract class Publisher<T> {
      * operators is done. Originally offloading for subscribe/subscription was applied at the "bottom" of chain
      * (logically the last operator in the chain closest to the subscriber), and offloading for subscriber was applied
      * at the "top" of the operator chain (logically the first operator in the chain after the async source). The
-     * offloading done was the same regardless of where the operator was placed in the chain. However, this behavior
-     * will soon change to instead apply offloading exactly where the offloading operators are applied in the chain.
-     * This change in behavior means that it no longer makes sense to fuse the offloading of publish and subscribe as
-     * the location of the operators in the execution chain is now significant. Publish and subscribe offloading, when
-     * required, will typically be placed in different locations. Use separate {@link #subscribeOn(Executor)} and
-     * {@link #publishOn(Executor)} operators instead.
+     * current offloading doesn't respect the order in which the operators are applied, the offloading is the same
+     * regardless of where the operators are placed in the chain. However, this behavior will soon change to instead
+     * respect operator placement order and apply offloading exactly where the offloading operators are applied in the
+     * chain. This change in behavior means that it no longer makes sense to fuse the offloading of publish and
+     * subscribe as the location of the operators in the chain will now be significant. Publish and subscribe
+     * offloading, when required, will typically be placed in different locations. Use separate, appropriately placed,
+     * {@link #subscribeOn(Executor)} and {@link #publishOn(Executor)} operators instead.
      */
     @Deprecated
     public final Publisher<T> publishAndSubscribeOn(Executor executor) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2896,7 +2896,15 @@ public abstract class Publisher<T> {
      * @param executor {@link Executor} to use.
      * @return A new {@link Publisher} that will use the passed {@link Executor} to invoke all methods
      * {@link Subscriber}, {@link Subscription} and {@link #handleSubscribe(PublisherSource.Subscriber)}.
+     * @deprecated This operator has been deprecated because of upcoming behavior changes in how the operator does
+     * offloading. Previously the subscribe would be offloaded for the entire subscribe chain, not just the portion
+     * preceding the offload operator and the publish would be offloaded from the source, not just for the operators
+     * following the operator. This change in behaviour means that it no longer makes sense to fuse the offloading of
+     * publish and subscribe as the location of the operators in the execution chain is now significant and publish and
+     * subscribe offloading, when required, will typically be placed in different locations. Use separate
+     * {@link #subscribeOn(Executor)} and {@link #publishOn(Executor)} operators instead.
      */
+    @Deprecated
     public final Publisher<T> publishAndSubscribeOn(Executor executor) {
         return PublishAndSubscribeOnPublishers.publishAndSubscribeOn(this, executor);
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2896,13 +2896,16 @@ public abstract class Publisher<T> {
      * @param executor {@link Executor} to use.
      * @return A new {@link Publisher} that will use the passed {@link Executor} to invoke all methods
      * {@link Subscriber}, {@link Subscription} and {@link #handleSubscribe(PublisherSource.Subscriber)}.
-     * @deprecated This operator has been deprecated because of upcoming behavior changes in how the operator does
-     * offloading. Previously the subscribe would be offloaded for the entire subscribe chain, not just the portion
-     * preceding the offload operator and the publish would be offloaded from the source, not just for the operators
-     * following the operator. This change in behaviour means that it no longer makes sense to fuse the offloading of
-     * publish and subscribe as the location of the operators in the execution chain is now significant and publish and
-     * subscribe offloading, when required, will typically be placed in different locations. Use separate
-     * {@link #subscribeOn(Executor)} and {@link #publishOn(Executor)} operators instead.
+     * @deprecated This operator has been deprecated because of upcoming behavior changes in how offloading via
+     * operators is done. Originally offloading for subscribe/subscription was applied at the "bottom" of chain
+     * (logically the last operator in the chain closest to the subscriber), and offloading for subscriber was applied
+     * at the "top" of the operator chain (logically the first operator in the chain after the async source). The
+     * offloading done was the same regardless of where the operator was placed in the chain. However, this behavior
+     * will soon change to instead apply offloading exactly where the offloading operators are applied in the chain.
+     * This change in behavior means that it no longer makes sense to fuse the offloading of publish and subscribe as
+     * the location of the operators in the execution chain is now significant. Publish and subscribe offloading, when
+     * required, will typically be placed in different locations. Use separate {@link #subscribeOn(Executor)} and
+     * {@link #publishOn(Executor)} operators instead.
      */
     @Deprecated
     public final Publisher<T> publishAndSubscribeOn(Executor executor) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1365,12 +1365,16 @@ public abstract class Single<T> {
      * @param executor {@link Executor} to use.
      * @return A new {@link Single} that will use the passed {@link Executor} to invoke all methods
      * {@link Subscriber}, {@link Cancellable} and {@link #handleSubscribe(SingleSource.Subscriber)}.
-     * @deprecated This operator has been deprecated because of upcoming behavior changes in how the operator does
-     * offloading. Previously the subscribe would be offloaded for the entire subscribe chain, not just the portion
-     * preceding the offload operator and the publish would be offloaded from the source, not just for the operators
-     * following the operator. This change in behaviour means that it no longer makes sense to fuse the offloading of
-     * publish and subscribe as the location of the operators in the execution chain is now significant and publish and
-     * subscribe offloading, when required, will typically be placed in different locations. Use separate
+     * @deprecated This operator has been deprecated because of upcoming behavior changes in how offloading via
+     * operators is done. Originally offloading for subscribe/subscription was applied at the "bottom" of chain
+     * (logically the last operator in the chain closest to the subscriber), and offloading for subscriber was applied
+     * at the "top" of the operator chain (logically the first operator in the chain after the async source). The
+     * current offloading doesn't respect the order in which the operators are applied, the offloading is the same
+     * regardless of where the operators are placed in the chain. However, this behavior will soon change to instead
+     * respect operator placement order and apply offloading exactly where the offloading operators are applied in the
+     * chain. This change in behavior means that it no longer makes sense to fuse the offloading of publish and
+     * subscribe as the location of the operators in the chain will now be significant. Publish and subscribe
+     * offloading, when required, will typically be placed in different locations. Use separate, appropriately placed,
      * {@link #subscribeOn(Executor)} and {@link #publishOn(Executor)} operators instead.
      */
     @Deprecated

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1365,7 +1365,15 @@ public abstract class Single<T> {
      * @param executor {@link Executor} to use.
      * @return A new {@link Single} that will use the passed {@link Executor} to invoke all methods
      * {@link Subscriber}, {@link Cancellable} and {@link #handleSubscribe(SingleSource.Subscriber)}.
+     * @deprecated This operator has been deprecated because of upcoming behavior changes in how the operator does
+     * offloading. Previously the subscribe would be offloaded for the entire subscribe chain, not just the portion
+     * preceding the offload operator and the publish would be offloaded from the source, not just for the operators
+     * following the operator. This change in behaviour means that it no longer makes sense to fuse the offloading of
+     * publish and subscribe as the location of the operators in the execution chain is now significant and publish and
+     * subscribe offloading, when required, will typically be placed in different locations. Use separate
+     * {@link #subscribeOn(Executor)} and {@link #publishOn(Executor)} operators instead.
      */
+    @Deprecated
     public final Single<T> publishAndSubscribeOn(Executor executor) {
         return PublishAndSubscribeOnSingles.publishAndSubscribeOn(this, executor);
     }


### PR DESCRIPTION
Motivation:
Changes in the offloading behavior make this operator much less useful
and, combined with the behavior change, may produce unexpected results.
Instead the `subscribeOn()` and `publishOn()` operators can be used
independently to achieve the same effect.
Modifications:
The `publishAndSubscribeOn()` operator is removed from `Publisher`,
`Single` and `Completable`.
Result:
Deprecation of problematic operator method.