### PR TITLE
Enable CI for `0.41` branch

### DIFF
--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -1,7 +1,7 @@
 name: PR Builder
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, '0.41' ]
 jobs:
   build:
     name: Build JDK ${{ matrix.java }} ${{ matrix.os }}

--- a/.github/workflows/ci-prq.yml
+++ b/.github/workflows/ci-prq.yml
@@ -1,7 +1,7 @@
 name: PR Quality
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, '0.41' ]
 jobs:
   quality:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -1,7 +1,7 @@
 name: Snapshot Publisher
 on:
   push:
-    branches: [ main ]
+    branches: [ main, '0.41' ]
     tags-ignore:
       - "[0-9]+.[0-9]+.[0-9]+"
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,10 +1,10 @@
 name: CodeQL
 on:
   push:
-    branches: [ main ]
+    branches: [ main, '0.41' ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [ main, '0.41' ]
   schedule:
     - cron: '0 13 * * 1'
 


### PR DESCRIPTION
Motivation:

`0.41` branch will be used for a while until we stabilize API. We plan
to backport all bux fixes and improvements that do not impact API into
that branch. We need to enable CI in order to provide snapshots of
`0.41.X` versions and validate any PRs that we will need to open for
that branch.

Modifications:
- Add `0.41` to the list of branches for all CI configurations;

Result:

CI will publish snapshots for `0.41` branch and validate all PRs.