### PR TITLE
Remove SNAPSHOT from validation path for docs

### DIFF
--- a/docs/generation/gradle/validateSite.gradle
+++ b/docs/generation/gradle/validateSite.gradle
@@ -51,7 +51,17 @@ for (location in ["local", "remote"]) {
   def configureValidateHtmlFilesTask = "configureValidate${capitalizedLocation}HtmlFiles"
   def validateHtmlLinksTask = "validate${capitalizedLocation}HtmlLinks"
 
-  def htmlFiles = fileTree("$buildDir/$location").matching { include "**/SNAPSHOT/*.html" }
+  def htmlFiles
+  if (location == "local") {
+		htmlFiles = fileTree("$buildDir/$location").matching {
+	  	include "**/*.html"
+		}
+  } else {
+		// only check the currently generated docs, ignore legacy docs
+		htmlFiles = fileTree("$buildDir/$location").matching {
+	  	include "**/SNAPSHOT/*.html"
+		}
+  }
 
   task(validateSiteTask) {
     dependsOn validateHtmlFilesTask, validateHtmlLinksTask

--- a/docs/generation/gradle/validateSite.gradle
+++ b/docs/generation/gradle/validateSite.gradle
@@ -53,14 +53,14 @@ for (location in ["local", "remote"]) {
 
   def htmlFiles
   if (location == "local") {
-		htmlFiles = fileTree("$buildDir/$location").matching {
-	  	include "**/*.html"
-		}
+        htmlFiles = fileTree("$buildDir/$location").matching {
+        include "**/*.html"
+        }
   } else {
-		// only check the currently generated docs, ignore legacy docs
-		htmlFiles = fileTree("$buildDir/$location").matching {
-	  	include "**/SNAPSHOT/*.html"
-		}
+        // only check the currently generated docs, ignore legacy docs
+        htmlFiles = fileTree("$buildDir/$location").matching {
+        include "**/SNAPSHOT/*.html"
+        }
   }
 
   task(validateSiteTask) {


### PR DESCRIPTION
Motivation:
When validating local docs validate everything but only validate
the current SNAPSHOT when validating remote docs. Remote docs
likely include legacy docs which will fail validation but cannot
be updated.
Modifications:
HTML files path is now customized based on validation location.
Result:
Cleaner, narrower validation.