### PR TITLE
Migrate servicetalk-concurrent-* tests to junit5

### DIFF
--- a/servicetalk-benchmarks/build.gradle
+++ b/servicetalk-benchmarks/build.gradle
@@ -38,8 +38,6 @@ dependencies {
   testImplementation project(":servicetalk-concurrent-internal")
   testImplementation project(":servicetalk-concurrent-api-internal")
   testImplementation project(":servicetalk-test-resources")
-  testImplementation "junit:junit:$junitVersion"
-  testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
 }
 
 jmh {

--- a/servicetalk-client-api-internal/build.gradle
+++ b/servicetalk-client-api-internal/build.gradle
@@ -34,4 +34,6 @@ dependencies {
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-concurrent-api-internal/build.gradle
+++ b/servicetalk-concurrent-api-internal/build.gradle
@@ -33,7 +33,9 @@ dependencies {
   testImplementation project(":servicetalk-buffer-netty")
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-concurrent-test-internal")
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-concurrent-api-internal/build.gradle
+++ b/servicetalk-concurrent-api-internal/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/AbstractHandleSubscribeOffloadedTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/AbstractHandleSubscribeOffloadedTest.java
@@ -21,18 +21,16 @@ import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.internal.OffloaderAwareExecutor;
 import io.servicetalk.concurrent.internal.DelegatingSignalOffloader;
 import io.servicetalk.concurrent.internal.DelegatingSignalOffloaderFactory;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.internal.SignalOffloader;
 import io.servicetalk.concurrent.internal.SignalOffloaderFactory;
 
-import org.junit.Rule;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import static io.servicetalk.concurrent.api.ExecutorRule.withExecutor;
+import static io.servicetalk.concurrent.api.ExecutorExtension.withExecutor;
 import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
 import static io.servicetalk.concurrent.internal.SignalOffloaders.defaultOffloaderFactory;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -41,22 +39,20 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 public abstract class AbstractHandleSubscribeOffloadedTest {
-    public static final String OFFLOAD_THREAD_NAME_PREFIX = "offload-thread";
-    public static final String TIMER_THREAD_NAME_PREFIX = "timer-thread";
-    @Rule
-    public final ExecutorRule executorForOffloadRule =
+    private static final String OFFLOAD_THREAD_NAME_PREFIX = "offload-thread";
+    private static final String TIMER_THREAD_NAME_PREFIX = "timer-thread";
+    @RegisterExtension
+    final ExecutorExtension<Executor> executorForOffloadRule =
             withExecutor(() -> newCachedThreadExecutor(new DefaultThreadFactory(OFFLOAD_THREAD_NAME_PREFIX)));
-    @Rule
-    public final ExecutorRule executorForTimerRule =
+    @RegisterExtension
+    protected final ExecutorExtension<Executor> executorForTimerRule =
             withExecutor(() -> newCachedThreadExecutor(new DefaultThreadFactory(TIMER_THREAD_NAME_PREFIX)));
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
     protected final AtomicReference<Thread> handleSubscribeInvokerRef = new AtomicReference<>();
-    protected final AtomicInteger offloadPublisherSubscribeCalled = new AtomicInteger();
-    protected final AtomicInteger offloadSingleSubscribeCalled = new AtomicInteger();
-    protected final AtomicInteger offloadCompletableSubscribeCalled = new AtomicInteger();
-    protected final AtomicInteger signalOffloaderCreated = new AtomicInteger();
-    protected final SignalOffloaderFactory factory;
+    private final AtomicInteger offloadPublisherSubscribeCalled = new AtomicInteger();
+    private final AtomicInteger offloadSingleSubscribeCalled = new AtomicInteger();
+    private final AtomicInteger offloadCompletableSubscribeCalled = new AtomicInteger();
+    private final AtomicInteger signalOffloaderCreated = new AtomicInteger();
+    private final SignalOffloaderFactory factory;
 
     protected AbstractHandleSubscribeOffloadedTest() {
         factory = new DelegatingSignalOffloaderFactory(defaultOffloaderFactory()) {

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/AbstractHandleSubscribeOffloadedTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/AbstractHandleSubscribeOffloadedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/ExecutorThrowsTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/ExecutorThrowsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/ExecutorThrowsTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/ExecutorThrowsTest.java
@@ -22,13 +22,9 @@ import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.internal.OffloaderAwareExecutor;
 import io.servicetalk.concurrent.internal.DeliberateException;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.LinkedBlockingQueue;
 import javax.annotation.Nullable;
@@ -41,25 +37,17 @@ import static io.servicetalk.concurrent.internal.EmptySubscriptions.EMPTY_SUBSCR
 import static io.servicetalk.concurrent.internal.SignalOffloaders.defaultOffloaderFactory;
 import static io.servicetalk.test.resources.TestUtils.assertNoAsyncErrors;
 
-@RunWith(Parameterized.class)
-public class ExecutorThrowsTest {
+class ExecutorThrowsTest {
 
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
+    private LinkedBlockingQueue<Throwable> errors;
 
-    private final LinkedBlockingQueue<Throwable> errors;
-
-    public ExecutorThrowsTest(@SuppressWarnings("unused") final boolean threadBased) {
+    @BeforeEach
+    void setUp() {
         errors = new LinkedBlockingQueue<>();
     }
 
-    @Parameterized.Parameters(name = " {index} thread based? {0}")
-    public static Object[] params() {
-        return new Object[]{true, false};
-    }
-
     @Test
-    public void publisherExecutorThrows() throws Throwable {
+    void publisherExecutorThrows() {
         Publisher<String> p = new Publisher<String>() {
             @Override
             protected void handleSubscribe(final Subscriber<? super String> subscriber) {
@@ -97,7 +85,7 @@ public class ExecutorThrowsTest {
     }
 
     @Test
-    public void singleExecutorThrows() throws Throwable {
+    void singleExecutorThrows() {
         Single<String> s = new Single<String>() {
             @Override
             protected void handleSubscribe(final SingleSource.Subscriber<? super String> subscriber) {
@@ -130,7 +118,7 @@ public class ExecutorThrowsTest {
     }
 
     @Test
-    public void completableExecutorThrows() throws Throwable {
+    void completableExecutorThrows() {
         Completable c = new Completable() {
             @Override
             protected void handleSubscribe(final CompletableSource.Subscriber subscriber) {
@@ -169,7 +157,7 @@ public class ExecutorThrowsTest {
         return new OffloaderAwareExecutor(original, defaultOffloaderFactory());
     }
 
-    private void verifyError() throws Throwable {
+    private void verifyError() {
         Throwable err = errors.peek();
         if (err != DELIBERATE_EXCEPTION) {
             assertNoAsyncErrors(errors);

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/ReduceOffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/ReduceOffloadingTest.java
@@ -16,11 +16,8 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.api.internal.OffloaderAwareExecutor;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -30,12 +27,10 @@ import static io.servicetalk.concurrent.internal.SignalOffloaders.threadBasedOff
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class ReduceOffloadingTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
+class ReduceOffloadingTest {
 
     @Test
-    public void reduceShouldOffloadOnce() throws Exception {
+    void reduceShouldOffloadOnce() throws Exception {
         Executor executor = newFixedSizeExecutor(1);
         AtomicInteger taskCount = new AtomicInteger();
         Executor wrapped = new OffloaderAwareExecutor(from(task -> {
@@ -43,7 +38,7 @@ public class ReduceOffloadingTest {
             executor.execute(task);
         }), threadBasedOffloaderFactory());
         int sum = Publisher.from(1, 2, 3, 4).publishOn(wrapped)
-                .collect(() -> 0, (cumulative, integer) -> cumulative + integer).toFuture().get();
+                .collect(() -> 0, Integer::sum).toFuture().get();
         assertThat("Unexpected sum.", sum, is(10));
         assertThat("Unexpected tasks submitted.", taskCount.get(), is(1));
         wrapped.closeAsync().toFuture().get();

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/ReduceOffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/ReduceOffloadingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/TaskBasedSignalOffloaderExecutorRejectionTests.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/TaskBasedSignalOffloaderExecutorRejectionTests.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -41,21 +41,21 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class TaskBasedSignalOffloaderExecutorRejectionTests {
+class TaskBasedSignalOffloaderExecutorRejectionTests {
 
     private final AtomicBoolean rejectNextTask = new AtomicBoolean();
     private final AtomicInteger rejectTaskCount = new AtomicInteger();
     private final Executor mockExecutor;
     private final OffloaderAwareExecutor executor;
 
-    public TaskBasedSignalOffloaderExecutorRejectionTests() {
+    TaskBasedSignalOffloaderExecutorRejectionTests() {
         mockExecutor = mock(Executor.class);
         executor = new OffloaderAwareExecutor(mockExecutor, taskBasedOffloaderFactory());
         when(executor.execute(any())).then(invocation -> {
@@ -70,90 +70,90 @@ public class TaskBasedSignalOffloaderExecutorRejectionTests {
     }
 
     @Test
-    public void publisherSubscribeRejects() throws Exception {
+    void publisherSubscribeRejects() throws Exception {
         rejectNextTask.set(true);
         expectFailureAndVerify(from(1).subscribeOn(executor).toFuture());
     }
 
     @Test
-    public void singleSubscribeRejects() throws Exception {
+    void singleSubscribeRejects() throws Exception {
         rejectNextTask.set(true);
         expectFailureAndVerify(succeeded(1).subscribeOn(executor).toFuture());
     }
 
     @Test
-    public void completableSubscribeRejects() throws Exception {
+    void completableSubscribeRejects() throws Exception {
         rejectNextTask.set(true);
         expectFailureAndVerify(completed().subscribeOn(executor).toFuture());
     }
 
     @Test
-    public void publisherOnSubscribeRejects() throws Exception {
+    void publisherOnSubscribeRejects() throws Exception {
         rejectNextTask.set(true);
         expectFailureAndVerify(Publisher.never().publishOn(executor).toFuture());
     }
 
     @Test
-    public void singleOnSubscribeRejects() throws Exception {
+    void singleOnSubscribeRejects() throws Exception {
         rejectNextTask.set(true);
         expectFailureAndVerify(Single.never().publishOn(executor).toFuture());
     }
 
     @Test
-    public void completableOnSubscribeRejects() throws Exception {
+    void completableOnSubscribeRejects() throws Exception {
         rejectNextTask.set(true);
         expectFailureAndVerify(Completable.never().publishOn(executor).toFuture());
     }
 
     @Test
-    public void publisherOnNextRejects() {
+    void publisherOnNextRejects() {
         publisherPublishOnThrows(source -> source.onNext(1));
     }
 
     @Test
-    public void publisherOnCompleteRejects() {
+    void publisherOnCompleteRejects() {
         publisherPublishOnThrows(TestPublisher::onComplete);
     }
 
     @Test
-    public void publisherOnErrorRejects() {
+    void publisherOnErrorRejects() {
         publisherPublishOnThrows(source -> source.onError(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void singleOnSuccessRejects() {
+    void singleOnSuccessRejects() {
         singlePublishOnThrows(source -> source.onSuccess(1));
     }
 
     @Test
-    public void singleOnErrorRejects() {
+    void singleOnErrorRejects() {
         singlePublishOnThrows(source -> source.onError(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void completableOnCompleteRejects() {
+    void completableOnCompleteRejects() {
         completablePublishOnThrows(TestCompletable::onComplete);
     }
 
     @Test
-    public void completableOnErrorRejects() {
+    void completableOnErrorRejects() {
         completablePublishOnThrows(source -> source.onError(DELIBERATE_EXCEPTION));
     }
 
     @Test
-    public void requestNRejects() {
+    void requestNRejects() {
         TestSubscription subscription = subscriptionRejects(s -> s.awaitSubscription().request(1));
         assertThat("Unexpected items requested from Subscription.", subscription.requested(), is(1L));
     }
 
     @Test
-    public void publisherCancelRejects() {
+    void publisherCancelRejects() {
         TestSubscription subscription = subscriptionRejects(sub -> sub.awaitSubscription().cancel());
         assertThat("Subscription not cancelled.", subscription.isCancelled(), is(true));
     }
 
     @Test
-    public void singleCancelRejects() {
+    void singleCancelRejects() {
         TestSingle<Integer> single = new TestSingle<>();
         TestSingleSubscriber<Integer> subscriber = new TestSingleSubscriber<>();
         toSource(single.subscribeOn(executor)).subscribe(subscriber);
@@ -167,7 +167,7 @@ public class TaskBasedSignalOffloaderExecutorRejectionTests {
     }
 
     @Test
-    public void completableCancelRejects() {
+    void completableCancelRejects() {
         TestCompletable single = new TestCompletable();
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         toSource(single.subscribeOn(executor)).subscribe(subscriber);

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/TaskBasedSignalOffloaderExecutorRejectionTests.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/TaskBasedSignalOffloaderExecutorRejectionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/AbstractCompletablePublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/AbstractCompletablePublishAndSubscribeOnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/AbstractCompletablePublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/AbstractCompletablePublishAndSubscribeOnTest.java
@@ -29,7 +29,7 @@ import java.util.function.BiFunction;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public abstract class AbstractCompletablePublishAndSubscribeOnTest extends AbstractPublishAndSubscribeOnTest {
+abstract class AbstractCompletablePublishAndSubscribeOnTest extends AbstractPublishAndSubscribeOnTest {
 
     static final int APP_THREAD = 0;
     static final int ON_SUBSCRIBE_THREAD = 1;

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/HandleSubscribeOffloadedTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/HandleSubscribeOffloadedTest.java
@@ -19,14 +19,14 @@ import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.api.AbstractHandleSubscribeOffloadedTest;
 import io.servicetalk.concurrent.api.Completable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static java.lang.Thread.currentThread;
 
-public class HandleSubscribeOffloadedTest extends AbstractHandleSubscribeOffloadedTest {
+class HandleSubscribeOffloadedTest extends AbstractHandleSubscribeOffloadedTest {
 
     private final Completable source = new Completable() {
         @Override
@@ -38,28 +38,28 @@ public class HandleSubscribeOffloadedTest extends AbstractHandleSubscribeOffload
     };
 
     @Test
-    public void simpleSource() throws Exception {
+    void simpleSource() throws Exception {
         awaitTermination(source.subscribeOn(newOffloadingAwareExecutor()));
         verifyHandleSubscribeInvoker();
         verifyCompletableOffloadCount();
     }
 
     @Test
-    public void withSyncOperatorsAddedAfter() throws Exception {
+    void withSyncOperatorsAddedAfter() throws Exception {
         awaitTermination(source.subscribeOn(newOffloadingAwareExecutor()).beforeOnComplete(() -> { }));
         verifyHandleSubscribeInvoker();
         verifyCompletableOffloadCount();
     }
 
     @Test
-    public void withSyncOperatorsAddedBefore() throws Exception {
+    void withSyncOperatorsAddedBefore() throws Exception {
         awaitTermination(source.beforeOnComplete(() -> { }).subscribeOn(newOffloadingAwareExecutor()));
         verifyHandleSubscribeInvoker();
         verifyCompletableOffloadCount();
     }
 
     @Test
-    public void withAsyncOperatorsAddedAfter() throws Exception {
+    void withAsyncOperatorsAddedAfter() throws Exception {
         awaitTermination(source.subscribeOn(newOffloadingAwareExecutor())
                 .concat(executorForTimerRule.executor().submit(() -> { })));
         verifyHandleSubscribeInvoker();
@@ -67,7 +67,7 @@ public class HandleSubscribeOffloadedTest extends AbstractHandleSubscribeOffload
     }
 
     @Test
-    public void withAsyncOperatorsAddedBefore() throws Exception {
+    void withAsyncOperatorsAddedBefore() throws Exception {
         awaitTermination(source.concat(executorForTimerRule.executor().submit(() -> { }))
                 .subscribeOn(newOffloadingAwareExecutor()));
         verifyHandleSubscribeInvoker();

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/HandleSubscribeOffloadedTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/HandleSubscribeOffloadedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/PublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/PublishAndSubscribeOnTest.java
@@ -17,16 +17,16 @@ package io.servicetalk.concurrent.api.completable;
 
 import io.servicetalk.concurrent.api.Completable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class PublishAndSubscribeOnTest extends AbstractCompletablePublishAndSubscribeOnTest {
+class PublishAndSubscribeOnTest extends AbstractCompletablePublishAndSubscribeOnTest {
 
     @Test
-    public void testNoOffload() throws InterruptedException {
+    void testNoOffload() throws InterruptedException {
         Thread[] capturedThreads = setupAndSubscribe(
                 0, // none
                 (c, e) -> c, offload.executor());
@@ -38,7 +38,7 @@ public class PublishAndSubscribeOnTest extends AbstractCompletablePublishAndSubs
     }
 
     @Test
-    public void testPublishOn() throws InterruptedException {
+    void testPublishOn() throws InterruptedException {
         Thread[] capturedThreads = setupAndSubscribe(
                 2, // onSubscribe, onComplete
                 Completable::publishOn, offload.executor());
@@ -50,7 +50,7 @@ public class PublishAndSubscribeOnTest extends AbstractCompletablePublishAndSubs
     }
 
     @Test
-    public void testSubscribeOn() throws InterruptedException {
+    void testSubscribeOn() throws InterruptedException {
         Thread[] capturedThreads = setupAndSubscribe(
                 1, // subscribe
                 Completable::subscribeOn, offload.executor());
@@ -62,7 +62,7 @@ public class PublishAndSubscribeOnTest extends AbstractCompletablePublishAndSubs
     }
 
     @Test
-    public void testSubscribeOnWithCancel() throws InterruptedException {
+    void testSubscribeOnWithCancel() throws InterruptedException {
         Thread[] capturedThreads = setupAndCancel(
                 2, // subscribe, cancel
                 Completable::subscribeOn, offload.executor());

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/PublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/PublishAndSubscribeOnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/CloseableIteratorBufferAsInputStreamTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/CloseableIteratorBufferAsInputStreamTest.java
@@ -18,9 +18,7 @@ package io.servicetalk.concurrent.api.internal;
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.CloseableIterator;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,16 +31,13 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.rules.ExpectedException.none;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class CloseableIteratorBufferAsInputStreamTest {
-    @Rule
-    public final ExpectedException expected = none();
+class CloseableIteratorBufferAsInputStreamTest {
 
     @Test
-    public void streamEmitsAllDataInSingleRead() throws IOException {
+    void streamEmitsAllDataInSingleRead() throws IOException {
         Buffer src = DEFAULT_RO_ALLOCATOR.fromAscii("1234");
         try (InputStream stream = new CloseableIteratorBufferAsInputStream(createIterator(src))) {
             byte[] data = new byte[4];
@@ -54,7 +49,7 @@ public class CloseableIteratorBufferAsInputStreamTest {
     }
 
     @Test
-    public void streamEmitsAllDataInMultipleReads() throws IOException {
+    void streamEmitsAllDataInMultipleReads() throws IOException {
         Buffer src = DEFAULT_RO_ALLOCATOR.fromAscii("1234");
         try (InputStream stream = new CloseableIteratorBufferAsInputStream(createIterator(src))) {
             byte[] data = new byte[2];
@@ -73,7 +68,7 @@ public class CloseableIteratorBufferAsInputStreamTest {
     }
 
     @Test
-    public void incrementallyFillAnArray() throws IOException {
+    void incrementallyFillAnArray() throws IOException {
         Buffer src = DEFAULT_RO_ALLOCATOR.fromAscii("1234");
         try (InputStream stream = new CloseableIteratorBufferAsInputStream(createIterator(src))) {
             byte[] data = new byte[4];
@@ -91,7 +86,7 @@ public class CloseableIteratorBufferAsInputStreamTest {
     }
 
     @Test
-    public void readRequestMoreThanDataBuffer() throws IOException {
+    void readRequestMoreThanDataBuffer() throws IOException {
         Buffer src = DEFAULT_RO_ALLOCATOR.fromAscii("1234");
         try (InputStream stream = new CloseableIteratorBufferAsInputStream(createIterator(src))) {
             byte[] data = new byte[16];
@@ -103,7 +98,7 @@ public class CloseableIteratorBufferAsInputStreamTest {
     }
 
     @Test
-    public void readRequestLessThanDataBuffer() throws IOException {
+    void readRequestLessThanDataBuffer() throws IOException {
         Buffer src = DEFAULT_RO_ALLOCATOR.fromAscii("1234");
         byte[] data;
         int read;
@@ -116,7 +111,7 @@ public class CloseableIteratorBufferAsInputStreamTest {
     }
 
     @Test
-    public void largerSizeItems() throws IOException {
+    void largerSizeItems() throws IOException {
         Buffer src1 = DEFAULT_RO_ALLOCATOR.fromAscii("1234");
         Buffer src2 = DEFAULT_RO_ALLOCATOR.fromAscii("45678");
         byte[] data;
@@ -132,17 +127,16 @@ public class CloseableIteratorBufferAsInputStreamTest {
     }
 
     @Test
-    public void closeThenReadShouldBeInvalid() throws IOException {
+    void closeThenReadShouldBeInvalid() throws IOException {
         Buffer src = DEFAULT_RO_ALLOCATOR.fromAscii("1234");
         try (InputStream stream = new CloseableIteratorBufferAsInputStream(createIterator(src))) {
             stream.close();
-            expected.expect(instanceOf(IOException.class));
-            stream.read();
+            assertThrows(IOException.class, stream::read);
         }
     }
 
     @Test
-    public void singleByteRead() throws IOException {
+    void singleByteRead() throws IOException {
         Buffer src = DEFAULT_RO_ALLOCATOR.fromAscii("1");
         try (InputStream stream = new CloseableIteratorBufferAsInputStream(createIterator(src))) {
             int read = stream.read();
@@ -152,7 +146,7 @@ public class CloseableIteratorBufferAsInputStreamTest {
     }
 
     @Test
-    public void singleByteReadWithingRange() throws IOException {
+    void singleByteReadWithingRange() throws IOException {
         singleByteReadWithingRange((byte) 0, 0);
         singleByteReadWithingRange((byte) 255, 255);
         singleByteReadWithingRange((byte) -1, 255);
@@ -170,7 +164,7 @@ public class CloseableIteratorBufferAsInputStreamTest {
     }
 
     @Test
-    public void singleByteReadWithEmptyIterable() throws IOException {
+    void singleByteReadWithEmptyIterable() throws IOException {
         Buffer src = DEFAULT_RO_ALLOCATOR.fromAscii("");
         try (InputStream stream = new CloseableIteratorBufferAsInputStream(createIterator(src))) {
             assertThat("Unexpected bytes read.", stream.read(), is(-1));
@@ -182,7 +176,7 @@ public class CloseableIteratorBufferAsInputStreamTest {
     }
 
     @Test
-    public void readWithEmptyIterable() throws IOException {
+    void readWithEmptyIterable() throws IOException {
         Buffer src = DEFAULT_RO_ALLOCATOR.fromAscii("");
         try (InputStream stream = new CloseableIteratorBufferAsInputStream(createIterator(src))) {
             byte[] r = new byte[1];
@@ -195,7 +189,7 @@ public class CloseableIteratorBufferAsInputStreamTest {
     }
 
     @Test
-    public void zeroLengthReadShouldBeValid() throws IOException {
+    void zeroLengthReadShouldBeValid() throws IOException {
         Buffer src = DEFAULT_RO_ALLOCATOR.fromAscii("1");
         try (InputStream stream = new CloseableIteratorBufferAsInputStream(createIterator(src))) {
             byte[] data = new byte[0];
@@ -206,7 +200,7 @@ public class CloseableIteratorBufferAsInputStreamTest {
     }
 
     @Test
-    public void checkAvailableReturnsCorrectlyWithPrefetch() throws IOException {
+    void checkAvailableReturnsCorrectlyWithPrefetch() throws IOException {
         Buffer src = DEFAULT_RO_ALLOCATOR.fromAscii("1234");
         try (InputStream stream = new CloseableIteratorBufferAsInputStream(createIterator(src))) {
             assertThat("Unexpected available return type.", stream.available(), is(0));
@@ -219,7 +213,7 @@ public class CloseableIteratorBufferAsInputStreamTest {
     }
 
     @Test
-    public void completionAndEmptyReadShouldIndicateEOF() throws IOException {
+    void completionAndEmptyReadShouldIndicateEOF() throws IOException {
         Buffer src = DEFAULT_RO_ALLOCATOR.fromAscii("");
         int read;
         try (InputStream stream = new CloseableIteratorBufferAsInputStream(createIterator(src))) {
@@ -230,7 +224,7 @@ public class CloseableIteratorBufferAsInputStreamTest {
     }
 
     @Test
-    public void testNullAndEmptyIteratorValues() throws IOException {
+    void testNullAndEmptyIteratorValues() throws IOException {
         Buffer src1 = DEFAULT_RO_ALLOCATOR.fromAscii("hel");
         Buffer src2 = DEFAULT_RO_ALLOCATOR.fromAscii("");
         Buffer src3 = DEFAULT_RO_ALLOCATOR.fromAscii("lo!");

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/CloseableIteratorBufferAsInputStreamTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/CloseableIteratorBufferAsInputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectableBufferOutputStreamTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectableBufferOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectableBufferOutputStreamTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectableBufferOutputStreamTest.java
@@ -20,15 +20,11 @@ import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,37 +56,33 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
-import static org.junit.rules.ExpectedException.none;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class ConnectableBufferOutputStreamTest {
+class ConnectableBufferOutputStreamTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConnectableBufferOutputStreamTest.class);
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExpectedException expectedException = none();
 
     private final TestPublisherSubscriber<Buffer> subscriber = new TestPublisherSubscriber<>();
     private ConnectableBufferOutputStream cbos;
     private ExecutorService executorService;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         cbos = new ConnectableBufferOutputStream(PREFER_HEAP_ALLOCATOR);
         executorService = Executors.newCachedThreadPool();
     }
 
-    @After
-    public void teardown() {
+    @AfterEach
+    void teardown() {
         executorService.shutdown();
     }
 
     @Test
-    public void subscribeDeliverDataSynchronously() throws Exception {
+    void subscribeDeliverDataSynchronously() throws Exception {
         AtomicReference<Future<?>> futureRef = new AtomicReference<>();
         toSource(cbos.connect().afterOnSubscribe(subscription -> {
             subscriber.awaitSubscription().request(1); // request from the TestPublisherSubscriber!
@@ -118,7 +110,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void subscribeCloseSynchronously() throws Exception {
+    void subscribeCloseSynchronously() throws Exception {
         AtomicReference<Future<?>> futureRef = new AtomicReference<>();
         toSource(cbos.connect().afterOnSubscribe(subscription -> {
             // We want to increase the chance that the writer thread has to wait for the Subscriber to become
@@ -142,18 +134,13 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void writeAfterCloseShouldThrow() throws IOException {
+    void writeAfterCloseShouldThrow() throws IOException {
         cbos.close();
-        expectedException.expect(IOException.class);
-        cbos.write(1);
-
-        // Make sure the Subscription thread isn't blocked.
-        subscriber.awaitSubscription().request(1);
-        subscriber.awaitSubscription().cancel();
+        assertThrows(IOException.class, () -> cbos.write(1));
     }
 
     @Test
-    public void multipleWriteAfterCloseShouldThrow() throws Exception {
+    void multipleWriteAfterCloseShouldThrow() throws Exception {
         Future<?> f = executorService.submit(toRunnable(() -> {
             cbos.write(1);
             cbos.flush();
@@ -180,7 +167,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void connectMultipleWriteAfterCloseShouldThrow() throws Exception {
+    void connectMultipleWriteAfterCloseShouldThrow() throws Exception {
         toSource(cbos.connect()).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
         Future<?> f = executorService.submit(toRunnable(() -> {
@@ -207,7 +194,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void cancelUnblocksWrite() throws Exception {
+    void cancelUnblocksWrite() throws Exception {
         CyclicBarrier afterFlushBarrier = new CyclicBarrier(2);
         Future<?> f = executorService.submit(toRunnable(() -> {
             cbos.write(1);
@@ -238,7 +225,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void connectCancelUnblocksWrite() throws Exception {
+    void connectCancelUnblocksWrite() throws Exception {
         toSource(cbos.connect()).subscribe(subscriber);
         subscriber.awaitSubscription().cancel();
         Future<?> f = executorService.submit(toRunnable(() -> cbos.write(1)));
@@ -259,7 +246,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void closeShouldBeIdempotent() throws Exception {
+    void closeShouldBeIdempotent() throws Exception {
         Future<?> f = executorService.submit(toRunnable(() -> {
             cbos.write(1);
             cbos.flush();
@@ -275,14 +262,14 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void closeShouldBeIdempotentWhenNotSubscribed() throws IOException {
+    void closeShouldBeIdempotentWhenNotSubscribed() throws IOException {
         cbos.connect();
         cbos.close();
         cbos.close(); // should be idempotent
     }
 
     @Test
-    public void multipleConnectWithInvalidRequestnShouldFailConnect() throws Exception {
+    void multipleConnectWithInvalidRequestnShouldFailConnect() throws Exception {
         CountDownLatch onSubscribe = new CountDownLatch(1);
         CountDownLatch onComplete = new CountDownLatch(1);
         AtomicReference<Throwable> errorRef = new AtomicReference<>();
@@ -316,7 +303,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void multipleConnectWhileEmittingShouldFailConnect() throws Exception {
+    void multipleConnectWhileEmittingShouldFailConnect() throws Exception {
         CountDownLatch onNext = new CountDownLatch(1);
         CountDownLatch onComplete = new CountDownLatch(1);
         toSource(cbos.connect()).subscribe(new Subscriber<Buffer>() {
@@ -349,7 +336,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void multipleConnectWhileSubscribedShouldFailConnect() throws Exception {
+    void multipleConnectWhileSubscribedShouldFailConnect() throws Exception {
         CountDownLatch onSubscribe = new CountDownLatch(1);
         CountDownLatch onComplete = new CountDownLatch(1);
         toSource(cbos.connect()).subscribe(new Subscriber<Buffer>() {
@@ -379,7 +366,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void multipleConnectWhileSubscriberFailedShouldFailConnect() throws Exception {
+    void multipleConnectWhileSubscriberFailedShouldFailConnect() throws Exception {
         CountDownLatch onError = new CountDownLatch(1);
         CountDownLatch onComplete = new CountDownLatch(1);
         toSource(cbos.connect()).subscribe(new Subscriber<Buffer>() {
@@ -423,7 +410,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void writeFlushCloseConnectSubscribeRequest() throws Exception {
+    void writeFlushCloseConnectSubscribeRequest() throws Exception {
         Future<?> f = executorService.submit(toRunnable(() -> {
             cbos.write(1);
             cbos.flush();
@@ -438,7 +425,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void connectSubscribeRequestWriteFlushClose() throws Exception {
+    void connectSubscribeRequestWriteFlushClose() throws Exception {
         toSource(cbos.connect()).subscribe(subscriber);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(1);
@@ -453,7 +440,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void connectSubscribeWriteFlushCloseRequest() throws Exception {
+    void connectSubscribeWriteFlushCloseRequest() throws Exception {
         toSource(cbos.connect()).subscribe(subscriber);
         Future<?> f = executorService.submit(toRunnable(() -> {
             cbos.write(1);
@@ -468,7 +455,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void requestWriteSingleWriteSingleFlushClose() throws Exception {
+    void requestWriteSingleWriteSingleFlushClose() throws Exception {
         toSource(cbos.connect()).subscribe(subscriber);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(2);
@@ -484,7 +471,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void requestWriteSingleFlushWriteSingleFlushClose() throws Exception {
+    void requestWriteSingleFlushWriteSingleFlushClose() throws Exception {
         toSource(cbos.connect()).subscribe(subscriber);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(2);
@@ -501,7 +488,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void writeSingleFlushWriteSingleFlushRequestClose() throws Exception {
+    void writeSingleFlushWriteSingleFlushRequestClose() throws Exception {
         toSource(cbos.connect()).subscribe(subscriber);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(1);
@@ -519,7 +506,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void invalidRequestN() throws IOException {
+    void invalidRequestN() throws IOException {
         AtomicReference<Throwable> failure = new AtomicReference<>();
         toSource(cbos.connect()).subscribe(new Subscriber<Buffer>() {
             @Override
@@ -548,7 +535,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void onNextThrows() throws IOException {
+    void onNextThrows() throws IOException {
         AtomicReference<Throwable> failure = new AtomicReference<>();
         toSource(cbos.connect()).subscribe(new Subscriber<Buffer>() {
             @Override
@@ -582,18 +569,17 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void cancelCloses() throws Exception {
+    void cancelCloses() {
         toSource(cbos.connect()).subscribe(subscriber);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         Future<?> f = executorService.submit(toRunnable(() -> cbos.write(1)));
-        expectedException.expect(ExecutionException.class);
-        expectedException.expectCause(is(instanceOf(RuntimeException.class)));
-        f.get();
+        ExecutionException ex = assertThrows(ExecutionException.class, f::get);
+        assertThat(ex.getCause(), instanceOf(RuntimeException.class));
     }
 
     @Test
-    public void cancelCloseAfterWrite() throws Exception {
+    void cancelCloseAfterWrite() throws Exception {
         toSource(cbos.connect()).subscribe(subscriber);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(1);
@@ -605,12 +591,11 @@ public class ConnectableBufferOutputStreamTest {
         assertThat(subscriber.takeOnNext(), is(buf(1)));
 
         subscriber.awaitSubscription().cancel();
-        expectedException.expect(is(instanceOf(IOException.class)));
-        cbos.write(2);
+        assertThrows(IOException.class, () -> cbos.write(2));
     }
 
     @Test
-    public void requestNegativeWrite() throws Exception {
+    void requestNegativeWrite() throws Exception {
         toSource(cbos.connect()).subscribe(subscriber);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(-1);
@@ -628,7 +613,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void writeRequestNegative() throws Exception {
+    void writeRequestNegative() throws Exception {
         toSource(cbos.connect()).subscribe(subscriber);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
         CyclicBarrier cb = new CyclicBarrier(2);
@@ -649,7 +634,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void closeNoWrite() throws Exception {
+    void closeNoWrite() throws Exception {
         CyclicBarrier cb = new CyclicBarrier(2);
         Future<?> f = executorService.submit(toRunnable(() -> {
             cb.await();
@@ -665,7 +650,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void requestWriteArrWriteArrFlushClose() throws Exception {
+    void requestWriteArrWriteArrFlushClose() throws Exception {
         final Publisher<Buffer> connect = cbos.connect();
         toSource(connect).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
@@ -682,7 +667,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void requestWriteArrFlushWriteArrFlushClose() throws Exception {
+    void requestWriteArrFlushWriteArrFlushClose() throws Exception {
         final Publisher<Buffer> connect = cbos.connect();
         toSource(connect).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
@@ -698,7 +683,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void writeArrFlushWriteArrFlushRequestClose() throws Exception {
+    void writeArrFlushWriteArrFlushRequestClose() throws Exception {
         final Publisher<Buffer> connect = cbos.connect();
         toSource(connect).subscribe(subscriber);
         Future<?> f = executorService.submit(toRunnable(() -> {
@@ -715,7 +700,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void requestWriteArrOffWriteArrOffFlushClose() throws Exception {
+    void requestWriteArrOffWriteArrOffFlushClose() throws Exception {
         final Publisher<Buffer> connect = cbos.connect();
         toSource(connect).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
@@ -730,7 +715,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void requestWriteArrOffFlushWriteArrOffFlushClose() throws Exception {
+    void requestWriteArrOffFlushWriteArrOffFlushClose() throws Exception {
         final Publisher<Buffer> connect = cbos.connect();
         toSource(connect).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
@@ -746,7 +731,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void writeArrOffFlushWriteArrOffFlushRequestClose() throws Exception {
+    void writeArrOffFlushWriteArrOffFlushRequestClose() throws Exception {
         final Publisher<Buffer> connect = cbos.connect();
         toSource(connect).subscribe(subscriber);
         Future<?> f = executorService.submit(toRunnable(() -> {
@@ -763,7 +748,7 @@ public class ConnectableBufferOutputStreamTest {
     }
 
     @Test
-    public void multiThreadedProducerConsumer() throws Exception {
+    void multiThreadedProducerConsumer() throws Exception {
 
         final Random r = new Random();
         final long seed = r.nextLong();  // capture seed to have repeatable tests

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectablePayloadWriterTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectablePayloadWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectablePayloadWriterTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectablePayloadWriterTest.java
@@ -18,15 +18,11 @@ package io.servicetalk.concurrent.api.internal;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,36 +52,33 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class ConnectablePayloadWriterTest {
+class ConnectablePayloadWriterTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConnectablePayloadWriterTest.class);
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
 
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
     private ConnectablePayloadWriter<String> cpw;
     private ExecutorService executorService;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         cpw = new ConnectablePayloadWriter<>();
         executorService = Executors.newCachedThreadPool();
     }
 
-    @After
-    public void teardown() {
+    @AfterEach
+    void teardown() {
         executorService.shutdown();
     }
 
     @Test
-    public void subscribeDeliverDataSynchronously() throws Exception {
+    void subscribeDeliverDataSynchronously() throws Exception {
         AtomicReference<Future<?>> futureRef = new AtomicReference<>();
         toSource(cpw.connect().afterOnSubscribe(subscription -> {
             subscriber.awaitSubscription().request(1); // request from the TestPublisherSubscriber!
@@ -113,7 +106,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void subscribeCloseSynchronously() throws Exception {
+    void subscribeCloseSynchronously() throws Exception {
         AtomicReference<Future<?>> futureRef = new AtomicReference<>();
         toSource(cpw.connect().afterOnSubscribe(subscription -> {
             // We want to increase the chance that the writer thread has to wait for the Subscriber to become
@@ -137,18 +130,13 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void writeAfterCloseShouldThrow() throws IOException {
+    void writeAfterCloseShouldThrow() throws IOException {
         cpw.close();
-        expectedException.expect(IOException.class);
-        cpw.write("foo");
-
-        // Make sure the Subscription thread isn't blocked.
-        subscriber.awaitSubscription().request(1);
-        subscriber.awaitSubscription().cancel();
+        assertThrows(IOException.class, () -> cpw.write("foo"));
     }
 
     @Test
-    public void multipleWriteAfterCloseShouldThrow() throws Exception {
+    void multipleWriteAfterCloseShouldThrow() throws Exception {
         Future<?> f = executorService.submit(toRunnable(() -> {
             cpw.write("foo");
             cpw.flush();
@@ -175,7 +163,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void connectMultipleWriteAfterCloseShouldThrow() throws Exception {
+    void connectMultipleWriteAfterCloseShouldThrow() throws Exception {
         toSource(cpw.connect()).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
         Future<?> f = executorService.submit(toRunnable(() -> {
@@ -202,7 +190,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void cancelUnblocksWrite() throws Exception {
+    void cancelUnblocksWrite() throws Exception {
         CyclicBarrier afterFlushBarrier = new CyclicBarrier(2);
         Future<?> f = executorService.submit(toRunnable(() -> {
             cpw.write("foo");
@@ -233,7 +221,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void connectCancelUnblocksWrite() throws Exception {
+    void connectCancelUnblocksWrite() throws Exception {
         toSource(cpw.connect()).subscribe(subscriber);
         subscriber.awaitSubscription().cancel();
         Future<?> f = executorService.submit(toRunnable(() -> cpw.write("foo")));
@@ -261,7 +249,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void closeShouldBeIdempotent() throws Exception {
+    void closeShouldBeIdempotent() throws Exception {
         Future<?> f = executorService.submit(toRunnable(() -> {
             cpw.write("foo");
             cpw.flush();
@@ -277,14 +265,14 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void closeShouldBeIdempotentWhenNotSubscribed() throws IOException {
+    void closeShouldBeIdempotentWhenNotSubscribed() throws IOException {
         cpw.connect();
         cpw.close();
         cpw.close(); // should be idempotent
     }
 
     @Test
-    public void multipleConnectWithInvalidRequestnShouldFailConnect() throws Exception {
+    void multipleConnectWithInvalidRequestnShouldFailConnect() throws Exception {
         CountDownLatch onSubscribe = new CountDownLatch(1);
         CountDownLatch onComplete = new CountDownLatch(1);
         AtomicReference<Throwable> errorRef = new AtomicReference<>();
@@ -318,7 +306,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void multipleConnectWhileEmittingShouldFailConnect() throws Exception {
+    void multipleConnectWhileEmittingShouldFailConnect() throws Exception {
         CountDownLatch onNext = new CountDownLatch(1);
         CountDownLatch onComplete = new CountDownLatch(1);
         toSource(cpw.connect()).subscribe(new Subscriber<String>() {
@@ -351,7 +339,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void multipleConnectWhileSubscribedShouldFailConnect() throws Exception {
+    void multipleConnectWhileSubscribedShouldFailConnect() throws Exception {
         CountDownLatch onSubscribe = new CountDownLatch(1);
         CountDownLatch onComplete = new CountDownLatch(1);
         toSource(cpw.connect()).subscribe(new Subscriber<String>() {
@@ -381,7 +369,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void multipleConnectWhileSubscriberFailedShouldFailConnect() throws Exception {
+    void multipleConnectWhileSubscriberFailedShouldFailConnect() throws Exception {
         CountDownLatch onError = new CountDownLatch(1);
         CountDownLatch onComplete = new CountDownLatch(1);
         toSource(cpw.connect()).subscribe(new Subscriber<String>() {
@@ -425,7 +413,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void writeFlushCloseConnectSubscribeRequest() throws Exception {
+    void writeFlushCloseConnectSubscribeRequest() throws Exception {
         Future<?> f = executorService.submit(toRunnable(() -> {
             cpw.write("foo");
             cpw.flush();
@@ -440,7 +428,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void connectSubscribeRequestWriteFlushClose() throws Exception {
+    void connectSubscribeRequestWriteFlushClose() throws Exception {
         toSource(cpw.connect()).subscribe(subscriber);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(1);
@@ -455,7 +443,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void connectSubscribeWriteFlushCloseRequest() throws Exception {
+    void connectSubscribeWriteFlushCloseRequest() throws Exception {
         toSource(cpw.connect()).subscribe(subscriber);
         Future<?> f = executorService.submit(toRunnable(() -> {
             cpw.write("foo");
@@ -470,7 +458,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void requestWriteSingleWriteSingleFlushClose() throws Exception {
+    void requestWriteSingleWriteSingleFlushClose() throws Exception {
         toSource(cpw.connect()).subscribe(subscriber);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(2);
@@ -486,7 +474,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void requestWriteSingleFlushWriteSingleFlushClose() throws Exception {
+    void requestWriteSingleFlushWriteSingleFlushClose() throws Exception {
         toSource(cpw.connect()).subscribe(subscriber);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(2);
@@ -503,7 +491,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void writeSingleFlushWriteSingleFlushRequestClose() throws Exception {
+    void writeSingleFlushWriteSingleFlushRequestClose() throws Exception {
         toSource(cpw.connect()).subscribe(subscriber);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(1);
@@ -521,7 +509,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void invalidRequestN() throws IOException {
+    void invalidRequestN() throws IOException {
         AtomicReference<Throwable> failure = new AtomicReference<>();
         toSource(cpw.connect()).subscribe(new Subscriber<String>() {
             @Override
@@ -550,7 +538,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void onNextThrows() throws IOException {
+    void onNextThrows() throws IOException {
         AtomicReference<Throwable> failure = new AtomicReference<>();
         toSource(cpw.connect()).subscribe(new Subscriber<String>() {
             @Override
@@ -584,18 +572,17 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void cancelCloses() throws Exception {
+    void cancelCloses() {
         toSource(cpw.connect()).subscribe(subscriber);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         Future<?> f = executorService.submit(toRunnable(() -> cpw.write("foo")));
-        expectedException.expect(ExecutionException.class);
-        expectedException.expectCause(is(instanceOf(RuntimeException.class)));
-        f.get();
+        ExecutionException ex = assertThrows(ExecutionException.class, f::get);
+        assertThat(ex.getCause(), instanceOf(RuntimeException.class));
     }
 
     @Test
-    public void cancelCloseAfterWrite() throws Exception {
+    void cancelCloseAfterWrite() throws Exception {
         toSource(cpw.connect()).subscribe(subscriber);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(1);
@@ -607,12 +594,11 @@ public class ConnectablePayloadWriterTest {
         assertThat(subscriber.takeOnNext(), is("foo"));
 
         subscriber.awaitSubscription().cancel();
-        expectedException.expect(is(instanceOf(IOException.class)));
-        cpw.write("foo");
+        assertThrows(IOException.class, () -> cpw.write("foo"));
     }
 
     @Test
-    public void requestNegativeWrite() throws Exception {
+    void requestNegativeWrite() throws Exception {
         toSource(cpw.connect()).subscribe(subscriber);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(-1);
@@ -630,7 +616,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void writeRequestNegative() throws Exception {
+    void writeRequestNegative() throws Exception {
         toSource(cpw.connect()).subscribe(subscriber);
         assertThat(subscriber.pollOnNext(10, MILLISECONDS), is(nullValue()));
         CyclicBarrier cb = new CyclicBarrier(2);
@@ -651,7 +637,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void closeNoWrite() throws Exception {
+    void closeNoWrite() throws Exception {
         CyclicBarrier cb = new CyclicBarrier(2);
         Future<?> f = executorService.submit(toRunnable(() -> {
             cb.await();
@@ -667,7 +653,7 @@ public class ConnectablePayloadWriterTest {
     }
 
     @Test
-    public void multiThreadedProducerConsumer() throws Exception {
+    void multiThreadedProducerConsumer() throws Exception {
         final Random r = new Random();
         final long seed = r.nextLong();  // capture seed to have repeatable tests
         r.setSeed(seed);

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractPublisherPublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractPublisherPublishAndSubscribeOnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractPublisherPublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractPublisherPublishAndSubscribeOnTest.java
@@ -31,18 +31,18 @@ import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static java.lang.Long.MAX_VALUE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public abstract class AbstractPublisherPublishAndSubscribeOnTest extends AbstractPublishAndSubscribeOnTest {
-    protected static final String ITEM_VALUE = "Hello";
+abstract class AbstractPublisherPublishAndSubscribeOnTest extends AbstractPublishAndSubscribeOnTest {
+    private static final String ITEM_VALUE = "Hello";
 
-    protected static final int APP_THREAD = 0;
-    protected static final int ORIGINAL_SUBSCRIBER_THREAD = 1;
-    protected static final int ORIGINAL_SUBSCRIPTION_THREAD = 2;
-    protected static final int OFFLOADED_SUBSCRIBER_THREAD = 3;
-    protected static final int OFFLOADED_SUBSCRIPTION_THREAD = 4;
+    private static final int APP_THREAD = 0;
+    static final int ORIGINAL_SUBSCRIBER_THREAD = 1;
+    private static final int ORIGINAL_SUBSCRIPTION_THREAD = 2;
+    static final int OFFLOADED_SUBSCRIBER_THREAD = 3;
+    static final int OFFLOADED_SUBSCRIPTION_THREAD = 4;
 
-    protected AbstractPublisherPublishAndSubscribeOnTest() {
+    AbstractPublisherPublishAndSubscribeOnTest() {
         super(new CaptureThreads(5) {
             @Override
             public Thread[] verify() {
@@ -55,15 +55,15 @@ public abstract class AbstractPublisherPublishAndSubscribeOnTest extends Abstrac
         });
     }
 
-    protected Thread[] setupAndSubscribe(
+    Thread[] setupAndSubscribe(
             BiFunction<Publisher<String>, Executor, Publisher<String>> offloadingFunction, Executor executor)
             throws InterruptedException {
         return setupAndSubscribe(-1, offloadingFunction, executor);
     }
 
-    protected Thread[] setupAndSubscribe(int offloadsExpected,
-                                         BiFunction<Publisher<String>, Executor, Publisher<String>> offloadingFunction,
-                                         Executor executor)
+    private Thread[] setupAndSubscribe(int offloadsExpected,
+                                       BiFunction<Publisher<String>, Executor, Publisher<String>> offloadingFunction,
+                                       Executor executor)
             throws InterruptedException {
         CountDownLatch allDone = new CountDownLatch(1);
 

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/HandleSubscribeOffloadedTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/HandleSubscribeOffloadedTest.java
@@ -20,13 +20,13 @@ import io.servicetalk.concurrent.api.AbstractHandleSubscribeOffloadedTest;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.internal.ScalarValueSubscription;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 
 import static java.lang.Thread.currentThread;
 
-public class HandleSubscribeOffloadedTest extends AbstractHandleSubscribeOffloadedTest {
+class HandleSubscribeOffloadedTest extends AbstractHandleSubscribeOffloadedTest {
     private final Publisher<Integer> source = new Publisher<Integer>() {
         @Override
         protected void handleSubscribe(final PublisherSource.Subscriber<? super Integer> subscriber) {
@@ -36,28 +36,28 @@ public class HandleSubscribeOffloadedTest extends AbstractHandleSubscribeOffload
     };
 
     @Test
-    public void simpleSource() throws Exception {
+    void simpleSource() throws Exception {
         awaitTermination(source.subscribeOn(newOffloadingAwareExecutor()));
         verifyHandleSubscribeInvoker();
         verifyPublisherOffloadCount();
     }
 
     @Test
-    public void withSyncOperatorsAddedAfter() throws Exception {
+    void withSyncOperatorsAddedAfter() throws Exception {
         awaitTermination(source.subscribeOn(newOffloadingAwareExecutor()).beforeOnNext(__ -> { }));
         verifyHandleSubscribeInvoker();
         verifyPublisherOffloadCount();
     }
 
     @Test
-    public void withSyncOperatorsAddedBefore() throws Exception {
+    void withSyncOperatorsAddedBefore() throws Exception {
         awaitTermination(source.beforeOnNext(__ -> { }).subscribeOn(newOffloadingAwareExecutor()));
         verifyHandleSubscribeInvoker();
         verifyPublisherOffloadCount();
     }
 
     @Test
-    public void withAsyncOperatorsAddedAfter() throws Exception {
+    void withAsyncOperatorsAddedAfter() throws Exception {
         awaitTermination(source.subscribeOn(newOffloadingAwareExecutor())
                 .flatMapMergeSingle(t -> executorForTimerRule.executor().submit(() -> t)));
         verifyHandleSubscribeInvoker();
@@ -65,7 +65,7 @@ public class HandleSubscribeOffloadedTest extends AbstractHandleSubscribeOffload
     }
 
     @Test
-    public void withAsyncOperatorsAddedBefore() throws Exception {
+    void withAsyncOperatorsAddedBefore() throws Exception {
         awaitTermination(source.flatMapMergeSingle(t -> executorForTimerRule.executor().submit(() -> t))
                 .subscribeOn(newOffloadingAwareExecutor()));
         verifyHandleSubscribeInvoker();

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/HandleSubscribeOffloadedTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/HandleSubscribeOffloadedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/PublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/PublishAndSubscribeOnTest.java
@@ -17,16 +17,16 @@ package io.servicetalk.concurrent.api.publisher;
 
 import io.servicetalk.concurrent.api.Publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class PublishAndSubscribeOnTest extends AbstractPublisherPublishAndSubscribeOnTest {
+class PublishAndSubscribeOnTest extends AbstractPublisherPublishAndSubscribeOnTest {
 
     @Test
-    public void testPublishOn() throws InterruptedException {
+    void testPublishOn() throws InterruptedException {
         Thread[] capturedThreads = setupAndSubscribe(Publisher::publishOn, offload.executor());
         String threads = Arrays.toString(capturedThreads);
         assertThat("Unexpected threads for original source " + threads,
@@ -38,7 +38,7 @@ public class PublishAndSubscribeOnTest extends AbstractPublisherPublishAndSubscr
     }
 
     @Test
-    public void testSubscribeOn() throws InterruptedException {
+    void testSubscribeOn() throws InterruptedException {
         Thread[] capturedThreads = setupAndSubscribe(Publisher::subscribeOn, offload.executor());
         String threads = Arrays.toString(capturedThreads);
         assertThat("Unexpected threads for original source " + threads,

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/PublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/PublishAndSubscribeOnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/AbstractSinglePublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/AbstractSinglePublishAndSubscribeOnTest.java
@@ -28,17 +28,17 @@ import java.util.function.BiFunction;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public abstract class AbstractSinglePublishAndSubscribeOnTest extends AbstractPublishAndSubscribeOnTest {
+abstract class AbstractSinglePublishAndSubscribeOnTest extends AbstractPublishAndSubscribeOnTest {
 
-    protected static final String ITEM_VALUE = "Hello";
+    private static final String ITEM_VALUE = "Hello";
 
-    static final int APP_THREAD = 0;
+    private static final int APP_THREAD = 0;
     static final int ORIGINAL_SUBSCRIBER_THREAD = 1;
     static final int TERMINAL_SIGNAL_THREAD = 2;
 
-    protected AbstractSinglePublishAndSubscribeOnTest() {
+    AbstractSinglePublishAndSubscribeOnTest() {
         super(new CaptureThreads(3) {
             @Override
             public Thread[] verify() {
@@ -51,14 +51,14 @@ public abstract class AbstractSinglePublishAndSubscribeOnTest extends AbstractPu
         });
     }
 
-    protected Thread[] setupAndSubscribe(BiFunction<Single<String>, Executor, Single<String>> offloadingFunction,
-                                         Executor executor) throws InterruptedException {
+    Thread[] setupAndSubscribe(BiFunction<Single<String>, Executor, Single<String>> offloadingFunction,
+                               Executor executor) throws InterruptedException {
         return setupAndSubscribe(-1, offloadingFunction, executor);
     }
 
-    protected Thread[] setupAndSubscribe(int offloadsExpected,
-                                         BiFunction<Single<String>, Executor, Single<String>> offloadingFunction,
-                                         Executor executor) throws InterruptedException {
+    Thread[] setupAndSubscribe(int offloadsExpected,
+                               BiFunction<Single<String>, Executor, Single<String>> offloadingFunction,
+                               Executor executor) throws InterruptedException {
         TestSingle<String> source = new TestSingle.Builder<String>().singleSubscriber().build();
         CountDownLatch subscribed = new CountDownLatch(1 + (offloadsExpected > 0 ? (offloadsExpected - 1) : 0));
         CountDownLatch allDone = new CountDownLatch(1);
@@ -111,15 +111,15 @@ public abstract class AbstractSinglePublishAndSubscribeOnTest extends AbstractPu
         return capturedThreads.verify();
     }
 
-    protected Thread[] setupForCancelAndSubscribe(
+    Thread[] setupForCancelAndSubscribe(
             BiFunction<Single<String>, Executor, Single<String>> offloadingFunction,
             Executor executor) throws InterruptedException {
         return setupForCancelAndSubscribe(-1, offloadingFunction, executor);
     }
 
-    protected Thread[] setupForCancelAndSubscribe(int offloadsExpected,
-            BiFunction<Single<String>, Executor, Single<String>> offloadingFunction,
-            Executor executor) throws InterruptedException {
+    private Thread[] setupForCancelAndSubscribe(int offloadsExpected,
+                                                BiFunction<Single<String>, Executor, Single<String>> offloadingFunction,
+                                                Executor executor) throws InterruptedException {
         TestSingle<String> source = new TestSingle.Builder<String>().singleSubscriber().build();
         CountDownLatch subscribed = new CountDownLatch(1 + (offloadsExpected > 0 ? (offloadsExpected - 1) : 0));
         CountDownLatch allDone = new CountDownLatch(1);

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/AbstractSinglePublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/AbstractSinglePublishAndSubscribeOnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/HandleSubscribeOffloadedTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/HandleSubscribeOffloadedTest.java
@@ -19,12 +19,12 @@ import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.AbstractHandleSubscribeOffloadedTest;
 import io.servicetalk.concurrent.api.Single;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static java.lang.Thread.currentThread;
 
-public class HandleSubscribeOffloadedTest extends AbstractHandleSubscribeOffloadedTest {
+class HandleSubscribeOffloadedTest extends AbstractHandleSubscribeOffloadedTest {
 
     private final Single<Integer> source = new Single<Integer>() {
         @Override
@@ -36,28 +36,28 @@ public class HandleSubscribeOffloadedTest extends AbstractHandleSubscribeOffload
     };
 
     @Test
-    public void simpleSource() throws Exception {
+    void simpleSource() throws Exception {
         source.subscribeOn(newOffloadingAwareExecutor()).toFuture().get();
         verifyHandleSubscribeInvoker();
         verifySingleOffloadCount();
     }
 
     @Test
-    public void withSyncOperatorsAddedAfter() throws Exception {
+    void withSyncOperatorsAddedAfter() throws Exception {
         source.subscribeOn(newOffloadingAwareExecutor()).beforeOnSuccess(__ -> { }).toFuture().get();
         verifyHandleSubscribeInvoker();
         verifySingleOffloadCount();
     }
 
     @Test
-    public void withSyncOperatorsAddedBefore() throws Exception {
+    void withSyncOperatorsAddedBefore() throws Exception {
         source.beforeOnSuccess(__ -> { }).subscribeOn(newOffloadingAwareExecutor()).toFuture().get();
         verifyHandleSubscribeInvoker();
         verifySingleOffloadCount();
     }
 
     @Test
-    public void withAsyncOperatorsAddedAfter() throws Exception {
+    void withAsyncOperatorsAddedAfter() throws Exception {
         source.subscribeOn(newOffloadingAwareExecutor())
                 .flatMap(t -> executorForTimerRule.executor().submit(() -> t))
                 .toFuture().get();
@@ -66,7 +66,7 @@ public class HandleSubscribeOffloadedTest extends AbstractHandleSubscribeOffload
     }
 
     @Test
-    public void withAsyncOperatorsAddedBefore() throws Exception {
+    void withAsyncOperatorsAddedBefore() throws Exception {
         source.flatMap(t -> executorForTimerRule.executor().submit(() -> t))
                 .subscribeOn(newOffloadingAwareExecutor())
                 .toFuture().get();

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/HandleSubscribeOffloadedTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/HandleSubscribeOffloadedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/PublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/PublishAndSubscribeOnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/PublishAndSubscribeOnTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/PublishAndSubscribeOnTest.java
@@ -17,16 +17,16 @@ package io.servicetalk.concurrent.api.single;
 
 import io.servicetalk.concurrent.api.Single;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class PublishAndSubscribeOnTest extends AbstractSinglePublishAndSubscribeOnTest {
+class PublishAndSubscribeOnTest extends AbstractSinglePublishAndSubscribeOnTest {
 
     @Test
-    public void testPublishOn() throws InterruptedException {
+    void testPublishOn() throws InterruptedException {
         Thread[] capturedThreads = setupAndSubscribe(Single::publishOn, offload.executor());
         String threads = Arrays.toString(capturedThreads);
         assertThat("Unexpected threads for original source " + threads,
@@ -36,7 +36,7 @@ public class PublishAndSubscribeOnTest extends AbstractSinglePublishAndSubscribe
     }
 
     @Test
-    public void testSubscribeOn() throws InterruptedException {
+    void testSubscribeOn() throws InterruptedException {
         Thread[] capturedThreads = setupAndSubscribe(1, // subscribe
                 Single::subscribeOn, offload.executor());
         String threads = Arrays.toString(capturedThreads);
@@ -47,7 +47,7 @@ public class PublishAndSubscribeOnTest extends AbstractSinglePublishAndSubscribe
     }
 
     @Test
-    public void testSubscribeOnWithCancel() throws InterruptedException {
+    void testSubscribeOnWithCancel() throws InterruptedException {
         Thread[] capturedThreads = setupForCancelAndSubscribe(Single::subscribeOn, offload.executor());
         String threads = Arrays.toString(capturedThreads);
         assertThat("Unexpected threads for original source " + threads,

--- a/servicetalk-concurrent-api-test/build.gradle
+++ b/servicetalk-concurrent-api-test/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-api-test/build.gradle
+++ b/servicetalk-concurrent-api-test/build.gradle
@@ -27,7 +27,9 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation project(":servicetalk-test-resources")
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/PublisherStepVerifierTest.java
+++ b/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/PublisherStepVerifierTest.java
@@ -19,14 +19,14 @@ import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.concurrent.api.AsyncContextMap;
 import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.concurrent.api.ExecutorRule;
+import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
 import io.servicetalk.concurrent.api.test.InlineStepVerifier.PublisherEvent.StepAssertionError;
 import io.servicetalk.concurrent.internal.DeliberateException;
 
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
@@ -54,19 +54,19 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class PublisherStepVerifierTest {
+class PublisherStepVerifierTest {
     private static final AsyncContextMap.Key<Integer> ASYNC_KEY = AsyncContextMap.Key.newKey();
-    @ClassRule
-    public static final ExecutorRule<Executor> EXECUTOR_RULE = ExecutorRule.newRule();
+    @RegisterExtension
+    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
 
     @Test
-    public void expectSubscription() {
+    void expectSubscription() {
         StepVerifiers.create(from("foo"))
                 .expectSubscription()
                 .expectNext("foo")
@@ -75,7 +75,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectSubscriptionTimeout() {
+    void expectSubscriptionTimeout() {
         CountDownLatch latch = new CountDownLatch(1);
         try {
             verifyException(() ->
@@ -96,7 +96,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void emptyItemsNonEmptyPublisher() {
+    void emptyItemsNonEmptyPublisher() {
         verifyException(() -> StepVerifiers.create(from("foo"))
                 .expectNextSequence(emptyList())
                 .expectComplete()
@@ -104,7 +104,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void emptyItemsEmptyPublisher() {
+    void emptyItemsEmptyPublisher() {
         StepVerifiers.create(empty())
                 .expectNextSequence(emptyList())
                 .expectComplete()
@@ -112,7 +112,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void singleItem() {
+    void singleItem() {
         assertNotNull(StepVerifiers.create(from("foo"))
                 .expectNext("foo")
                 .expectComplete()
@@ -120,7 +120,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void singleItemNull() {
+    void singleItemNull() {
         assertNotNull(StepVerifiers.create(from((String) null))
                 .expectNext((String) null)
                 .expectComplete()
@@ -128,7 +128,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void singleItemDuplicateVerify() throws InterruptedException {
+    void singleItemDuplicateVerify() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(2);
         StepVerifier verifier = StepVerifiers.create(from("foo"))
                 .expectNextConsumed(next -> {
@@ -142,7 +142,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void singleItemLargeTimeout() {
+    void singleItemLargeTimeout() {
         assertNotNull(StepVerifiers.create(from("foo"))
                 .expectNext("foo")
                 .expectComplete()
@@ -150,7 +150,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void twoItems() {
+    void twoItems() {
         StepVerifiers.create(from("foo", "bar"))
                 .expectNext("foo", "bar")
                 .expectComplete()
@@ -158,7 +158,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void twoItemsIterable() {
+    void twoItemsIterable() {
         StepVerifiers.create(from("foo", "bar"))
                 .expectNextSequence(() -> asList("foo", "bar").iterator())
                 .expectComplete()
@@ -166,84 +166,84 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void justError() {
+    void justError() {
         StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .expectError()
                 .verify();
     }
 
     @Test
-    public void justErrorFail() {
+    void justErrorFail() {
         verifyException(() -> StepVerifiers.create(from("foo"))
                 .expectError()
                 .verify(), "expectError");
     }
 
     @Test
-    public void justErrorClass() {
+    void justErrorClass() {
         StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .expectError(DeliberateException.class)
                 .verify();
     }
 
     @Test
-    public void justErrorClassFail() {
+    void justErrorClassFail() {
         verifyException(() -> StepVerifiers.create(from("foo"))
                 .expectError(DeliberateException.class)
                 .verify(), "expectError");
     }
 
     @Test
-    public void justErrorPredicate() {
+    void justErrorPredicate() {
         StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .expectErrorMatches(cause -> cause instanceof DeliberateException)
                 .verify();
     }
 
     @Test
-    public void justErrorPredicateFail() {
+    void justErrorPredicateFail() {
         verifyException(() -> StepVerifiers.create(from("foo"))
                 .expectErrorMatches(cause -> cause instanceof DeliberateException)
                 .verify(), "expectErrorMatches");
     }
 
     @Test
-    public void justErrorConsumer() {
+    void justErrorConsumer() {
         StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .expectErrorConsumed(cause -> assertThat(cause, instanceOf(DeliberateException.class)))
                 .verify();
     }
 
     @Test
-    public void justErrorConsumerFail() {
+    void justErrorConsumerFail() {
         verifyException(() -> StepVerifiers.create(from("foo"))
                 .expectErrorConsumed(cause -> assertThat(cause, instanceOf(DeliberateException.class)))
                 .verify(), "expectErrorConsumed");
     }
 
     @Test
-    public void errorIgnoreNextFails() {
+    void errorIgnoreNextFails() {
         verifyException(() -> StepVerifiers.create(from("foo").concat(failed(DELIBERATE_EXCEPTION)))
                 .expectErrorMatches(cause -> cause instanceof DeliberateException)
                 .verify(), "expectErrorMatches");
     }
 
     @Test
-    public void completeIgnoreNextConsumer() {
+    void completeIgnoreNextConsumer() {
         verifyException(() -> StepVerifiers.create(from("foo"))
                 .expectComplete()
                 .verify(), "expectComplete");
     }
 
     @Test
-    public void justErrorTimeout() {
+    void justErrorTimeout() {
         verifyException(() -> StepVerifiers.create(never())
                 .expectError(DeliberateException.class)
                 .verify(ofNanos(10)), "expectError");
     }
 
     @Test
-    public void onNextThenError() {
+    void onNextThenError() {
         StepVerifiers.create(from("foo").concat(failed(DELIBERATE_EXCEPTION)))
                 .expectNext("foo")
                 .expectError(DeliberateException.class)
@@ -251,7 +251,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void incorrectOnNextExpectation() {
+    void incorrectOnNextExpectation() {
         verifyException(() -> StepVerifiers.create(from("foo"))
                     .expectNext("bar")
                     .expectComplete()
@@ -259,27 +259,27 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void timeoutOnNever() {
+    void timeoutOnNever() {
         verifyException(() -> StepVerifiers.create(never())
             .expectComplete()
             .verify(ofNanos(10)), "expectComplete");
     }
 
     @Test
-    public void expectNextCount() {
+    void expectNextCount() {
         StepVerifiers.create(from("foo", "bar"))
                 .expectNextCount(2)
                 .expectComplete()
                 .verify();
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void expectNextCountZeroInvalid() {
-        StepVerifiers.create(empty()).expectNextCount(0);
+    @Test
+    void expectNextCountZeroInvalid() {
+        assertThrows(IllegalArgumentException.class, () -> StepVerifiers.create(empty()).expectNextCount(0));
     }
 
     @Test
-    public void expectNextCountExpectAfter() {
+    void expectNextCountExpectAfter() {
         StepVerifiers.create(from("foo", "bar"))
                 .expectNextCount(1)
                 .expectNext("bar")
@@ -288,7 +288,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextCountFail() {
+    void expectNextCountFail() {
         verifyException(() -> StepVerifiers.create(from("foo"))
                 .expectNextCount(2)
                 .expectComplete()
@@ -296,7 +296,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextCountRange() {
+    void expectNextCountRange() {
         StepVerifiers.create(from("foo", "bar"))
                 .expectNextCount(0, 2)
                 .expectComplete()
@@ -304,7 +304,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextCountZeroRange() {
+    void expectNextCountZeroRange() {
         StepVerifiers.create(empty())
                 .expectNextCount(0, 2)
                 .expectComplete()
@@ -312,7 +312,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextCountRangeNotEnoughFail() {
+    void expectNextCountRangeNotEnoughFail() {
         verifyException(() -> StepVerifiers.create(from("foo", "bar"))
                 .expectNextCount(3, 4)
                 .expectComplete()
@@ -320,7 +320,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextCountRangeItemsAfterFail() {
+    void expectNextCountRangeItemsAfterFail() {
         verifyException(() -> StepVerifiers.create(from("foo", "bar", "baz"))
                 .expectNextCount(0, 2)
                 .expectComplete()
@@ -328,7 +328,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextPredicate() {
+    void expectNextPredicate() {
         StepVerifiers.create(from("foo"))
                 .expectNextMatches("foo"::equals)
                 .expectComplete()
@@ -336,7 +336,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextPredicateFail() {
+    void expectNextPredicateFail() {
         verifyException(() -> StepVerifiers.create(from("foo"))
                 .expectNextMatches("bar"::equals)
                 .expectComplete()
@@ -344,7 +344,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextConsumer() {
+    void expectNextConsumer() {
         StepVerifiers.create(from("foo"))
                 .expectNextConsumed(next -> assertEquals("foo", next))
                 .expectComplete()
@@ -352,7 +352,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextConsumerTimeout() {
+    void expectNextConsumerTimeout() {
         verifyException(() -> StepVerifiers.create(from("foo").concat(never()))
                 .expectNextConsumed(next -> assertEquals("foo", next))
                 .expectComplete()
@@ -360,7 +360,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextArrayMoreThanActual() {
+    void expectNextArrayMoreThanActual() {
         verifyException(() -> StepVerifiers.create(from("foo"))
                 .expectNext("foo", "bar")
                 .expectComplete()
@@ -368,7 +368,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextIterableMoreThanActual() {
+    void expectNextIterableMoreThanActual() {
         verifyException(() -> StepVerifiers.create(from("foo"))
                 .expectNextSequence(asList("foo", "bar"))
                 .expectComplete()
@@ -376,7 +376,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextArrayLessThanActual() {
+    void expectNextArrayLessThanActual() {
         verifyException(() ->
                 StepVerifiers.create(from("foo", "bar"))
                 .expectNext("foo")
@@ -385,7 +385,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextIterableLessThanActual() {
+    void expectNextIterableLessThanActual() {
         verifyException(() -> StepVerifiers.create(from("foo", "bar"))
                         .expectNextSequence(singletonList("foo"))
                         .expectComplete()
@@ -393,7 +393,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextConsumerFail() {
+    void expectNextConsumerFail() {
         verifyException(() -> StepVerifiers.create(from("foo"))
                 .expectNextConsumed(next -> assertEquals("bar", next))
                 .expectComplete()
@@ -401,7 +401,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextConsumerTypeNonAmbiguousA() {
+    void expectNextConsumerTypeNonAmbiguousA() {
         Consumer<String> item = n -> { };
         StepVerifiers.create(from(item))
                 .expectNext(item)
@@ -410,7 +410,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextConsumerTypeNonAmbiguousB() {
+    void expectNextConsumerTypeNonAmbiguousB() {
         Consumer<String> item = n -> { };
         StepVerifiers.create(from(item))
                 .expectNextConsumed(t -> assertSame(item, t))
@@ -419,7 +419,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextMultiConsumer() {
+    void expectNextMultiConsumer() {
         StepVerifiers.create(from("foo", "bar"))
                 .expectNext(2, nextIterable -> assertThat(nextIterable, contains("foo", "bar")))
                 .expectComplete()
@@ -427,7 +427,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextMultiConsumerFail() {
+    void expectNextMultiConsumerFail() {
         verifyException(() -> StepVerifiers.create(from("foo", "bar"))
                 .expectNext(2, nextIterable -> assertThat(nextIterable, contains("foo")))
                 .expectComplete()
@@ -435,7 +435,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextMultiConsumerMinComplete() {
+    void expectNextMultiConsumerMinComplete() {
         StepVerifiers.create(from("foo"))
                 .expectNext(1, 2, nextIterable -> assertThat(nextIterable, contains("foo")))
                 .expectComplete()
@@ -443,7 +443,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextMultiConsumerMinFail() {
+    void expectNextMultiConsumerMinFail() {
         StepVerifiers.create(from("foo").concat(failed(DELIBERATE_EXCEPTION)))
                 .expectNext(1, 2, nextIterable -> assertThat(nextIterable, contains("foo")))
                 .expectError(DeliberateException.class)
@@ -451,7 +451,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextMultiConsumerZero() {
+    void expectNextMultiConsumerZero() {
         StepVerifiers.create(empty())
                 .expectNext(0, 2, nextIterable -> assertThat(nextIterable, emptyIterable()))
                 .expectComplete()
@@ -459,7 +459,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectNextMultiConsumerTimeout() {
+    void expectNextMultiConsumerTimeout() {
         verifyException(() -> StepVerifiers.create(from("foo", "bar").concat(never()))
                 .expectNext(2, nextIterable -> assertThat(nextIterable, contains("foo", "bar")))
                 .expectComplete()
@@ -467,7 +467,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectOnErrorWhenOnComplete() {
+    void expectOnErrorWhenOnComplete() {
         verifyException(() -> StepVerifiers.create(from("foo"))
                 .expectNext("foo")
                 .expectError(DeliberateException.class)
@@ -475,14 +475,14 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void expectOnCompleteWhenOnError() {
+    void expectOnCompleteWhenOnError() {
         verifyException(() -> StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .expectComplete()
                 .verify(), "expectComplete");
     }
 
     @Test
-    public void noSignalsAfterNextThenCancelSucceeds() {
+    void noSignalsAfterNextThenCancelSucceeds() {
         StepVerifiers.create(from("foo").concat(never()))
                 .expectNext("foo")
                 .expectNoSignals(ofMillis(100))
@@ -491,7 +491,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void noSignalsSubscriptionCompleteFail() {
+    void noSignalsSubscriptionCompleteFail() {
         verifyException(() -> StepVerifiers.create(from("foo"))
                 .expectNoSignals(ofDays(1))
                 .expectComplete()
@@ -499,7 +499,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void noSignalsSubscriptionCancelSucceeds() {
+    void noSignalsSubscriptionCancelSucceeds() {
         // expectNoSignals and subscription event are dequeued/processed sequentially on the Subscriber thread
         // and the scenario isn't instructed to expect the subscription so we pass the test.
         TestSubscription subscription = new TestSubscription();
@@ -514,7 +514,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void noSignalsCompleteFail() {
+    void noSignalsCompleteFail() {
         verifyException(() -> StepVerifiers.create(from("foo"))
                 .expectNext("foo")
                 .expectNoSignals(ofDays(1))
@@ -523,7 +523,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void noSignalsErrorFails() {
+    void noSignalsErrorFails() {
         verifyException(() -> StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .expectSubscription()
                 .expectNoSignals(ofDays(1))
@@ -532,7 +532,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void noSignalsAfterSubscriptionSucceeds() {
+    void noSignalsAfterSubscriptionSucceeds() {
         StepVerifiers.create(never())
                 .expectSubscription()
                 .expectNoSignals(ofMillis(100))
@@ -541,7 +541,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void thenCancelCompleted() {
+    void thenCancelCompleted() {
         StepVerifiers.create(from("foo", "bar"))
                 .expectNext("foo")
                 .thenCancel()
@@ -549,14 +549,14 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void thenCancelFailed() {
+    void thenCancelFailed() {
         StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .thenCancel()
                 .verify();
     }
 
     @Test
-    public void thenRequest() {
+    void thenRequest() {
         StepVerifiers.create(from("foo", "bar"))
                 .thenRequest(Long.MAX_VALUE)
                 .expectNext("foo", "bar")
@@ -565,12 +565,12 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void thenRequestInvalidZero() {
+    void thenRequestInvalidZero() {
         thenRequestInvalid(0);
     }
 
     @Test
-    public void thenRequestInvalidMin() {
+    void thenRequestInvalidMin() {
         thenRequestInvalid(Long.MIN_VALUE);
     }
 
@@ -582,7 +582,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void multipleRequests() {
+    void multipleRequests() {
         TestSubscription subscription = new TestSubscription();
         TestPublisher<String> publisher = new TestPublisher.Builder<String>()
                 .disableAutoOnSubscribe().build();
@@ -602,7 +602,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void requestThenCancel() {
+    void requestThenCancel() {
         TestSubscription subscription = new TestSubscription();
         TestPublisher<String> publisher = new TestPublisher.Builder<String>()
                 .disableAutoOnSubscribe().build();
@@ -620,7 +620,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void thenRun() {
+    void thenRun() {
         PublisherSource.Processor<String, String> processor = newPublisherProcessor();
         StepVerifiers.create(fromSource(processor))
                 .then(() -> {
@@ -633,18 +633,17 @@ public class PublisherStepVerifierTest {
                 .verify();
     }
 
-    @Test(expected = DeliberateException.class)
-    public void thenRunThrows() {
-        StepVerifiers.create(from("foo"))
+    void thenRunThrows() {
+        assertThrows(DeliberateException.class, () -> StepVerifiers.create(from("foo"))
                 .then(() -> {
                     throw DELIBERATE_EXCEPTION;
                 })
                 .expectComplete()
-                .verify();
+                .verify());
     }
 
     @Test
-    public void asyncContextOnComplete() {
+    void asyncContextOnComplete() {
         StepVerifiers.create(from("foo").subscribeOn(EXECUTOR_RULE.executor()))
                 .expectSubscriptionConsumed(s -> {
                     assertNotNull(s);
@@ -659,7 +658,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void asyncContextOnError() {
+    void asyncContextOnError() {
         StepVerifiers.create(from("foo").concat(failed(DELIBERATE_EXCEPTION))
                         .subscribeOn(EXECUTOR_RULE.executor()))
                 .expectSubscriptionConsumed(s -> {
@@ -679,7 +678,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void thenAwaitExitsWhenVerifyComplete() {
+    void thenAwaitExitsWhenVerifyComplete() {
         StepVerifiers.create(from("foo"))
                 .thenAwait(ofDays(1))
                 .expectNext("foo")
@@ -688,7 +687,7 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void thenAwaitRespectsDelaysComplete() {
+    void thenAwaitRespectsDelaysComplete() {
         PublisherSource.Processor<String, String> processor = newPublisherProcessor();
         new InlinePublisherFirstStep<>(processor, new DefaultModifiableTimeSource())
                 .expectSubscription()
@@ -702,12 +701,12 @@ public class PublisherStepVerifierTest {
     }
 
     @Test
-    public void thenAwaitRespectsDelaysEqualsFail() {
+    void thenAwaitRespectsDelaysEqualsFail() {
         thenAwaitRespectsDelaysFail(true);
     }
 
     @Test
-    public void thenAwaitRespectsDelaysGTFail() {
+    void thenAwaitRespectsDelaysGTFail() {
         thenAwaitRespectsDelaysFail(false);
     }
 
@@ -736,7 +735,7 @@ public class PublisherStepVerifierTest {
                         stackTraceElements[0] + " error: " + error,
                 stackTraceElements[0].getClassName(), startsWith(classNamePrefix));
         StackTraceElement testMethodStackTrace = error.testMethodStackTrace();
-        assertEquals("unexpected test method failure: " + testMethodStackTrace, failedTestMethod,
-                testMethodStackTrace.getMethodName());
+        assertEquals(failedTestMethod,
+                testMethodStackTrace.getMethodName(), "unexpected test method failure: " + testMethodStackTrace);
     }
 }

--- a/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/SingleStepVerifierTest.java
+++ b/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/SingleStepVerifierTest.java
@@ -20,12 +20,12 @@ import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.concurrent.api.AsyncContextMap;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.concurrent.api.ExecutorRule;
+import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.internal.DeliberateException;
 
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
@@ -43,18 +43,19 @@ import static java.time.Duration.ofNanos;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SingleStepVerifierTest {
+class SingleStepVerifierTest {
     private static final AsyncContextMap.Key<Integer> ASYNC_KEY = AsyncContextMap.Key.newKey();
-    @ClassRule
-    public static final ExecutorRule<Executor> EXECUTOR_RULE = ExecutorRule.newRule();
+    @RegisterExtension
+    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
 
     @Test
-    public void expectCancellable() {
+    void expectCancellable() {
         StepVerifiers.create(succeeded("foo"))
                 .expectCancellable()
                 .expectSuccess("foo")
@@ -62,7 +63,7 @@ public class SingleStepVerifierTest {
     }
 
     @Test
-    public void expectCancellableTimeout() {
+    void expectCancellableTimeout() {
         CountDownLatch latch = new CountDownLatch(1);
         try {
             verifyException(() -> StepVerifiers.create(succeeded("foo").subscribeOn(EXECUTOR_RULE.executor()))
@@ -81,7 +82,7 @@ public class SingleStepVerifierTest {
     }
 
     @Test
-    public void onSuccessDuplicateVerify() throws InterruptedException {
+    void onSuccessDuplicateVerify() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(2);
         StepVerifier verifier = StepVerifiers.create(succeeded("foo"))
                 .expectCancellableConsumed(cancellable -> {
@@ -95,147 +96,147 @@ public class SingleStepVerifierTest {
     }
 
     @Test
-    public void onSuccessIgnore() {
+    void onSuccessIgnore() {
         StepVerifiers.create(succeeded("foo"))
                 .expectSuccess()
                 .verify();
     }
 
     @Test
-    public void onSuccessIgnoreFail() {
+    void onSuccessIgnoreFail() {
         verifyException(() -> StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .expectSuccess()
                 .verify(), "expectSuccess");
     }
 
     @Test
-    public void onSuccess() {
+    void onSuccess() {
         assertNotNull(StepVerifiers.create(succeeded("foo"))
                 .expectSuccess("foo")
                 .verify());
     }
 
     @Test
-    public void onSuccessFail() {
+    void onSuccessFail() {
         verifyException(() -> StepVerifiers.create(succeeded("foo"))
                 .expectSuccess("bar")
                 .verify(), "expectSuccess");
     }
 
     @Test
-    public void onSuccessPredicate() {
+    void onSuccessPredicate() {
         StepVerifiers.create(succeeded("foo"))
                 .expectSuccessMatches("foo"::equals)
                 .verify();
     }
 
     @Test
-    public void onSuccessPredicateFail() {
+    void onSuccessPredicateFail() {
         verifyException(() -> StepVerifiers.create(succeeded("foo"))
                 .expectSuccessMatches("bar"::equals)
                 .verify(), "expectSuccessMatches");
     }
 
     @Test
-    public void onSuccessConsumer() {
+    void onSuccessConsumer() {
         StepVerifiers.create(succeeded("foo"))
                 .expectSuccessConsumed(t -> assertEquals("foo", t))
                 .verify();
     }
 
     @Test
-    public void onSuccessConsumerFail() {
+    void onSuccessConsumerFail() {
         verifyException(() -> StepVerifiers.create(succeeded("foo"))
                 .expectSuccessConsumed(t -> assertEquals("bar", t))
                 .verify(), "expectSuccessConsumed");
     }
 
     @Test
-    public void onSuccessNull() {
+    void onSuccessNull() {
         assertNotNull(StepVerifiers.create(succeeded(null))
                 .expectSuccess(null)
                 .verify());
     }
 
     @Test
-    public void onSuccessLargeTimeout() {
+    void onSuccessLargeTimeout() {
         assertNotNull(StepVerifiers.create(succeeded("foo"))
                 .expectSuccess("foo")
                 .verify(ofDays(1)));
     }
 
     @Test
-    public void onSuccessTimeout() {
+    void onSuccessTimeout() {
         verifyException(() -> StepVerifiers.create(never())
                 .expectSuccess("foo")
                 .verify(ofNanos(10)), "expectSuccess");
     }
 
     @Test
-    public void onError() {
+    void onError() {
         StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .expectError()
                 .verify();
     }
 
     @Test
-    public void onErrorFail() {
+    void onErrorFail() {
         verifyException(() -> StepVerifiers.create(succeeded("foo"))
                 .expectError()
                 .verify(), "expectError");
     }
 
     @Test
-    public void onErrorClass() {
+    void onErrorClass() {
         StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .expectError(DeliberateException.class)
                 .verify();
     }
 
     @Test
-    public void onErrorClassFail() {
+    void onErrorClassFail() {
         verifyException(() -> StepVerifiers.create(succeeded("foo"))
                 .expectError(DeliberateException.class)
                 .verify(), "expectError");
     }
 
     @Test
-    public void onErrorPredicate() {
+    void onErrorPredicate() {
         StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .expectErrorMatches(error -> error instanceof DeliberateException)
                 .verify();
     }
 
     @Test
-    public void onErrorPredicateFail() {
+    void onErrorPredicateFail() {
         verifyException(() -> StepVerifiers.create(succeeded("foo"))
                 .expectErrorMatches(error -> error instanceof DeliberateException)
                 .verify(), "expectErrorMatches");
     }
 
     @Test
-    public void onErrorConsumer() {
+    void onErrorConsumer() {
         StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .expectErrorConsumed(error -> assertThat(error, is(DELIBERATE_EXCEPTION)))
                 .verify();
     }
 
     @Test
-    public void onErrorConsumerFail() {
+    void onErrorConsumerFail() {
         verifyException(() -> StepVerifiers.create(succeeded("foo"))
                 .expectErrorConsumed(error -> assertThat(error, is(DELIBERATE_EXCEPTION)))
                 .verify(), "expectErrorConsumed");
     }
 
     @Test
-    public void expectOnSuccessWhenOnError() {
+    void expectOnSuccessWhenOnError() {
         verifyException(() -> StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                     .expectSuccess("foo")
                     .verify(), "expectSuccess");
     }
 
     @Test
-    public void noSignalsSubscriptionCancelSucceeds() {
+    void noSignalsSubscriptionCancelSucceeds() {
         // expectNoSignals and subscription event are dequeued/processed sequentially on the Subscriber thread
         // and the scenario isn't instructed to expect the subscription so we pass the test.
         StepVerifiers.create(never())
@@ -245,7 +246,7 @@ public class SingleStepVerifierTest {
     }
 
     @Test
-    public void noSignalsSuccessFail() {
+    void noSignalsSuccessFail() {
         verifyException(() -> StepVerifiers.create(succeeded("foo"))
                 .expectCancellable()
                 .expectNoSignals(ofDays(1))
@@ -254,7 +255,7 @@ public class SingleStepVerifierTest {
     }
 
     @Test
-    public void noSignalsErrorFails() {
+    void noSignalsErrorFails() {
         verifyException(() -> StepVerifiers.create(failed(DELIBERATE_EXCEPTION))
                 .expectCancellable()
                 .expectNoSignals(ofDays(1))
@@ -263,7 +264,7 @@ public class SingleStepVerifierTest {
     }
 
     @Test
-    public void noSignalsAfterSubscriptionSucceeds() {
+    void noSignalsAfterSubscriptionSucceeds() {
         StepVerifiers.create(Single.never())
                 .expectCancellable()
                 .expectNoSignals(ofMillis(100))
@@ -272,21 +273,21 @@ public class SingleStepVerifierTest {
     }
 
     @Test
-    public void thenCancelSucceeded() {
+    void thenCancelSucceeded() {
         StepVerifiers.create(succeeded("foo"))
                 .thenCancel()
                 .verify();
     }
 
     @Test
-    public void thenCancelFailed() {
+    void thenCancelFailed() {
         StepVerifiers.create(Completable.failed(DELIBERATE_EXCEPTION))
                 .thenCancel()
                 .verify();
     }
 
     @Test
-    public void thenRun() {
+    void thenRun() {
         SingleSource.Processor<String, String> processor = newSingleProcessor();
         StepVerifiers.create(fromSource(processor))
                 .then(() -> processor.onSuccess("foo"))
@@ -294,18 +295,18 @@ public class SingleStepVerifierTest {
                 .verify();
     }
 
-    @Test(expected = DeliberateException.class)
-    public void thenRunThrows() {
-        StepVerifiers.create(succeeded("foo"))
+    @Test
+    void thenRunThrows() {
+        assertThrows(DeliberateException.class, () -> StepVerifiers.create(succeeded("foo"))
                 .then(() -> {
                     throw DELIBERATE_EXCEPTION;
                 })
                 .expectSuccess("foo")
-                .verify();
+                .verify());
     }
 
     @Test
-    public void asyncContextOnSuccess() {
+    void asyncContextOnSuccess() {
         StepVerifiers.create(succeeded("foo").subscribeOn(EXECUTOR_RULE.executor()))
                 .expectCancellableConsumed(s -> {
                     assertNotNull(s);
@@ -319,7 +320,7 @@ public class SingleStepVerifierTest {
     }
 
     @Test
-    public void asyncContextOnError() {
+    void asyncContextOnError() {
         StepVerifiers.create(failed(DELIBERATE_EXCEPTION).subscribeOn(EXECUTOR_RULE.executor()))
                 .expectCancellableConsumed(s -> {
                     assertNotNull(s);
@@ -333,7 +334,7 @@ public class SingleStepVerifierTest {
     }
 
     @Test
-    public void thenAwaitRespectsDelaysComplete() {
+    void thenAwaitRespectsDelaysComplete() {
         SingleSource.Processor<String, String> processor = newSingleProcessor();
         new InlineSingleFirstStep<>(processor, new DefaultModifiableTimeSource())
                 .expectCancellable()
@@ -345,12 +346,12 @@ public class SingleStepVerifierTest {
     }
 
     @Test
-    public void thenAwaitRespectsDelaysEqualsFail() {
+    void thenAwaitRespectsDelaysEqualsFail() {
         thenAwaitRespectsDelaysFail(true);
     }
 
     @Test
-    public void thenAwaitRespectsDelaysGTFail() {
+    void thenAwaitRespectsDelaysGTFail() {
         thenAwaitRespectsDelaysFail(false);
     }
 

--- a/servicetalk-concurrent-test-internal/build.gradle
+++ b/servicetalk-concurrent-test-internal/build.gradle
@@ -25,7 +25,9 @@ dependencies {
 
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-test-resources")
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-concurrent-test-internal/build.gradle
+++ b/servicetalk-concurrent-test-internal/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-test-internal/src/test/java/io/servicetalk/concurrent/test/internal/TestCompletableSubscriberTest.java
+++ b/servicetalk-concurrent-test-internal/src/test/java/io/servicetalk/concurrent/test/internal/TestCompletableSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-test-internal/src/test/java/io/servicetalk/concurrent/test/internal/TestCompletableSubscriberTest.java
+++ b/servicetalk-concurrent-test-internal/src/test/java/io/servicetalk/concurrent/test/internal/TestCompletableSubscriberTest.java
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.test.internal;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.PublisherSource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -26,24 +26,24 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 
-public class TestCompletableSubscriberTest {
+class TestCompletableSubscriberTest {
     @Test
-    public void onSubscribe() {
+    void onSubscribe() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         doOnSubscribe(subscriber);
         assertThat(subscriber.pollTerminal(200, MILLISECONDS), is(nullValue()));
     }
 
     @Test
-    public void onSubscribeOnComplete() {
+    void onSubscribeOnComplete() {
         onSubscribeOnTerminal(true);
     }
 
     @Test
-    public void onSubscribeOnError() {
+    void onSubscribeOnError() {
         onSubscribeOnTerminal(false);
     }
 
@@ -55,7 +55,7 @@ public class TestCompletableSubscriberTest {
     }
 
     @Test
-    public void singleItem() {
+    void singleItem() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         doOnSubscribe(subscriber);
         subscriber.onComplete();
@@ -63,7 +63,7 @@ public class TestCompletableSubscriberTest {
     }
 
     @Test
-    public void singleItemCancelBefore() {
+    void singleItemCancelBefore() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         doOnSubscribe(subscriber).cancel();
         subscriber.onComplete();
@@ -71,7 +71,7 @@ public class TestCompletableSubscriberTest {
     }
 
     @Test
-    public void singleItemCancelAfter() {
+    void singleItemCancelAfter() {
         TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
         Cancellable c = doOnSubscribe(subscriber);
         subscriber.onComplete();

--- a/servicetalk-concurrent-test-internal/src/test/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriberTest.java
+++ b/servicetalk-concurrent-test-internal/src/test/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-concurrent-test-internal/src/test/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriberTest.java
+++ b/servicetalk-concurrent-test-internal/src/test/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriberTest.java
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.test.internal;
 
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -27,15 +27,16 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
-public class TestPublisherSubscriberTest {
+class TestPublisherSubscriberTest {
     @Test
-    public void onSubscribe() {
+    void onSubscribe() {
         TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
         doOnSubscribe(subscriber);
         assertThat(subscriber.pollAllOnNext(), is(empty()));
@@ -43,27 +44,27 @@ public class TestPublisherSubscriberTest {
     }
 
     @Test
-    public void onSubscribeOnComplete() {
+    void onSubscribeOnComplete() {
         onSubscribeOnTerminal(true);
     }
 
     @Test
-    public void onSubscribeOnError() {
+    void onSubscribeOnError() {
         onSubscribeOnTerminal(false);
     }
 
     @Test
-    public void onSubscribeOnNextOnComplete() {
+    void onSubscribeOnNextOnComplete() {
         onSubscribeOnNextOnComplete(true);
     }
 
     @Test
-    public void onSubscribeOnNextOnError() {
+    void onSubscribeOnNextOnError() {
         onSubscribeOnNextOnComplete(false);
     }
 
     @Test
-    public void multipleOnNextWithTake() {
+    void multipleOnNextWithTake() {
         TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
         doOnSubscribe(subscriber).request(2);
         subscriber.onNext(null);
@@ -77,7 +78,7 @@ public class TestPublisherSubscriberTest {
     }
 
     @Test
-    public void multipleOnNextWithPollAll() {
+    void multipleOnNextWithPollAll() {
         TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
         doOnSubscribe(subscriber).request(2);
         subscriber.onNext(null);
@@ -89,97 +90,101 @@ public class TestPublisherSubscriberTest {
     }
 
     @Test
-    public void onNextNotConsumedWhenOnCompleteAllowedIfOptIn() {
+    void onNextNotConsumedWhenOnCompleteAllowedIfOptIn() {
         onNextNotConsumedWhenOnCompleteThrows(true, false);
     }
 
     @Test
-    public void onNextNotConsumedWhenOnErrorAllowedIfOptIn() {
+    void onNextNotConsumedWhenOnErrorAllowedIfOptIn() {
         onNextNotConsumedWhenOnCompleteThrows(false, false);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void onNextNoOnSubscribeThrows() {
+    @Test
+    void onNextNoOnSubscribeThrows() {
         TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
-        subscriber.onNext(2);
+        assertThrows(IllegalStateException.class, () -> subscriber.onNext(2));
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void onCompleteNoOnSubscribeThrows() {
+    @Test
+    void onCompleteNoOnSubscribeThrows() {
         TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
-        subscriber.onComplete();
+        assertThrows(IllegalStateException.class, subscriber::onComplete);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void onErrorNoOnSubscribeThrows() {
+    @Test
+    void onErrorNoOnSubscribeThrows() {
         TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
+        assertThrows(IllegalStateException.class, () -> subscriber.onError(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    void onErrorAwaitOnCompleteThrows() {
+        TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
+
+        doOnSubscribe(subscriber);
         subscriber.onError(DELIBERATE_EXCEPTION);
+        assertThrows(IllegalStateException.class, subscriber::awaitOnComplete);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void onErrorAwaitOnCompleteThrows() {
-        TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
-
-        doOnSubscribe(subscriber);
-        subscriber.onError(DELIBERATE_EXCEPTION);
-        subscriber.awaitOnComplete();
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void onCompleteAwaitOnErrorThrows() throws Throwable {
+    @Test
+    void onCompleteAwaitOnErrorThrows() {
         TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
 
         doOnSubscribe(subscriber);
         subscriber.onComplete();
-        throw subscriber.awaitOnError();
+        assertThrows(IllegalStateException.class, () -> {
+            throw subscriber.awaitOnError();
+        });
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void onSubscribeAfterOnSubscribeThrows() {
+    @Test
+    void onSubscribeAfterOnSubscribeThrows() {
         TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
 
         doOnSubscribe(subscriber);
-        doOnSubscribe(subscriber);
+        assertThrows(IllegalStateException.class, () -> doOnSubscribe(subscriber));
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void onSubscribeAfterOnCompleteThrows() {
-        onSubscribeAfterTerminal(true);
+    @Test
+    void onSubscribeAfterOnCompleteThrows() {
+        assertThrows(IllegalStateException.class, () -> onSubscribeAfterTerminal(true));
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void onSubscribeAfterOnErrorThrows() {
-        onSubscribeAfterTerminal(false);
+    @Test
+    void onSubscribeAfterOnErrorThrows() {
+        assertThrows(IllegalStateException.class, () -> onSubscribeAfterTerminal(false));
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void onCompleteAfterOnCompleteThrows() {
-        onCompleteAfterOnCompleteThrows(true, true);
+    @Test
+    void onCompleteAfterOnCompleteThrows() {
+        assertThrows(IllegalStateException.class, () -> onCompleteAfterOnCompleteThrows(true, true));
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void onCompleteAfterOnErrorThrows() {
-        onCompleteAfterOnCompleteThrows(true, false);
+    @Test
+    void onCompleteAfterOnErrorThrows() {
+        assertThrows(IllegalStateException.class, () -> onCompleteAfterOnCompleteThrows(true, false));
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void onErrorAfterOnCompleteThrows() {
-        onCompleteAfterOnCompleteThrows(false, true);
+    @Test
+    void onErrorAfterOnCompleteThrows() {
+        assertThrows(IllegalStateException.class, () -> onCompleteAfterOnCompleteThrows(false, true));
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void onErrorAfterOnErrorThrows() {
-        onCompleteAfterOnCompleteThrows(false, false);
+    @Test
+    void onErrorAfterOnErrorThrows() {
+        assertThrows(IllegalStateException.class, () -> onCompleteAfterOnCompleteThrows(false, false));
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void onNextNotConsumedWhenOnCompleteThrows() {
-        onNextNotConsumedWhenOnCompleteThrows(true, true);
+    @Test
+    void onNextNotConsumedWhenOnCompleteThrows() {
+        assertThrows(IllegalStateException.class,
+                     () -> onNextNotConsumedWhenOnCompleteThrows(true, true));
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void onNextNotConsumedWhenOnErrorThrows() {
-        onNextNotConsumedWhenOnCompleteThrows(false, true);
+    @Test
+    void onNextNotConsumedWhenOnErrorThrows() {
+        assertThrows(IllegalStateException.class,
+                     () -> onNextNotConsumedWhenOnCompleteThrows(false, true));
     }
 
     private static void onSubscribeOnTerminal(boolean onComplete) {

--- a/servicetalk-concurrent-test-internal/src/test/java/io/servicetalk/concurrent/test/internal/TestSingleSubscriberTest.java
+++ b/servicetalk-concurrent-test-internal/src/test/java/io/servicetalk/concurrent/test/internal/TestSingleSubscriberTest.java
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.test.internal;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.PublisherSource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nullable;
@@ -29,24 +29,24 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 
-public class TestSingleSubscriberTest {
+class TestSingleSubscriberTest {
     @Test
-    public void onSubscribe() {
+    void onSubscribe() {
         TestSingleSubscriber<Integer> subscriber = new TestSingleSubscriber<>();
         doOnSubscribe(subscriber);
         assertThat(subscriber.pollTerminal(200, MILLISECONDS), is(nullValue()));
     }
 
     @Test
-    public void onSubscribeOnComplete() {
+    void onSubscribeOnComplete() {
         onSubscribeOnTerminal(true);
     }
 
     @Test
-    public void onSubscribeOnError() {
+    void onSubscribeOnError() {
         onSubscribeOnTerminal(false);
     }
 
@@ -58,17 +58,17 @@ public class TestSingleSubscriberTest {
     }
 
     @Test
-    public void singleItem() {
+    void singleItem() {
         singleItem(ThreadLocalRandom.current().nextInt());
     }
 
     @Test
-    public void singleItemNull() {
+    void singleItemNull() {
         singleItem(null);
     }
 
     @Test
-    public void singleItemCancelBefore() {
+    void singleItemCancelBefore() {
         TestSingleSubscriber<Integer> subscriber = new TestSingleSubscriber<>();
         doOnSubscribe(subscriber).cancel();
         subscriber.onSuccess(10);
@@ -76,7 +76,7 @@ public class TestSingleSubscriberTest {
     }
 
     @Test
-    public void singleItemCancelAfter() {
+    void singleItemCancelAfter() {
         TestSingleSubscriber<Integer> subscriber = new TestSingleSubscriber<>();
         Cancellable c = doOnSubscribe(subscriber);
         subscriber.onSuccess(10);

--- a/servicetalk-concurrent-test-internal/src/test/java/io/servicetalk/concurrent/test/internal/TestSingleSubscriberTest.java
+++ b/servicetalk-concurrent-test-internal/src/test/java/io/servicetalk/concurrent/test/internal/TestSingleSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Motivation:

JUnit 5 leverages features from Java 8 or later, such as lambda functions, making tests more powerful and easier to maintain.
JUnit 5 has added some very useful new features for describing, organizing, and executing tests. For instance, tests get better display names and can be organized hierarchically.
JUnit 5 is organized into multiple libraries, so only the features you need are imported into your project. With build systems such as Maven and Gradle, including the right libraries is easy.
JUnit 5 can use more than one extension at a time, which JUnit 4 could not (only one runner could be used at a time). This means you can easily combine the Spring extension with other extensions (such as your own custom extension).
Modifications:

Unit tests have been migrated from JUnit 4 to JUnit 5

Result:

Modules servicetalk-concurrent-* now run tests and test suits using JUnit 5

#1568