### PR TITLE
Migrate servicetalk-http-* tests to junit5

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExecutionStrategyInContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExecutionStrategyInContextTest.java
@@ -16,7 +16,6 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.BlockingStreamingHttpClient;
 import io.servicetalk.http.api.HttpClient;
@@ -36,7 +35,6 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicReference;
@@ -51,7 +49,6 @@ import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@ExtendWith(TimeoutTracingInfoExtension.class)
 class ExecutionStrategyInContextTest {
 
     @Nullable

--- a/servicetalk-http-router-predicate/build.gradle
+++ b/servicetalk-http-router-predicate/build.gradle
@@ -31,7 +31,11 @@ dependencies {
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-transport-netty")
   testImplementation project(":servicetalk-test-resources")
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
+  testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+  testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/BaseHttpPredicateRouterBuilderTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/BaseHttpPredicateRouterBuilderTest.java
@@ -18,7 +18,6 @@ package io.servicetalk.http.router.predicate;
 import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.buffer.api.ReadOnlyBufferAllocators;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.http.api.BlockingStreamingHttpResponseFactory;
 import io.servicetalk.http.api.DefaultHttpHeadersFactory;
 import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
@@ -31,13 +30,12 @@ import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.api.TestHttpServiceContext;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Answer;
 
 import java.util.Iterator;
@@ -53,32 +51,27 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public abstract class BaseHttpPredicateRouterBuilderTest {
-    static final BufferAllocator allocator = ReadOnlyBufferAllocators.DEFAULT_RO_ALLOCATOR;
+    private static final BufferAllocator allocator = ReadOnlyBufferAllocators.DEFAULT_RO_ALLOCATOR;
     static final StreamingHttpRequestResponseFactory reqRespFactory =
             new DefaultStreamingHttpRequestResponseFactory(allocator, DefaultHttpHeadersFactory.INSTANCE, HTTP_1_1);
 
-    @Rule
-    public final MockitoRule rule = MockitoJUnit.rule().silent();
-    @Rule
-    public final ExpectedException expected = ExpectedException.none();
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
-    @Mock
+    @Mock(lenient = true)
     StreamingHttpService serviceA, serviceB, serviceC, serviceD, serviceE, fallbackService;
-    @Mock
+    @Mock(lenient = true)
     HttpExecutionContext executionCtx;
-    @Mock
+    @Mock(lenient = true)
     TestHttpServiceContext ctx;
-    @Mock
+    @Mock(lenient = true)
     StreamingHttpRequest request;
     @Mock
     HttpHeaders headers;
     @Mock
     Single<StreamingHttpResponse> responseA, responseB, responseC, responseD, responseE, fallbackResponse;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         when(executionCtx.executor()).thenReturn(immediate());
         when(executionCtx.executionStrategy()).thenReturn(defaultStrategy());

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/DefaultFallbackServiceTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/DefaultFallbackServiceTest.java
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpService;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
@@ -27,12 +27,12 @@ import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN_UTF_8;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseStatus.NOT_FOUND;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class DefaultFallbackServiceTest extends BaseHttpPredicateRouterBuilderTest {
+class DefaultFallbackServiceTest extends BaseHttpPredicateRouterBuilderTest {
 
     @Test
-    public void testDefaultFallbackService() throws Exception {
+    void testDefaultFallbackService() throws Exception {
         final StreamingHttpService fixture = DefaultFallbackServiceStreaming.instance();
 
         final Single<StreamingHttpResponse> responseSingle = fixture.handle(ctx, request, reqRespFactory);

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilderCookieTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilderCookieTest.java
@@ -18,20 +18,20 @@ package io.servicetalk.http.router.predicate;
 import io.servicetalk.http.api.HttpSetCookie;
 import io.servicetalk.http.api.StreamingHttpService;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import static java.util.Collections.emptyIterator;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.when;
 
-public class HttpPredicateRouterBuilderCookieTest extends BaseHttpPredicateRouterBuilderTest {
+class HttpPredicateRouterBuilderCookieTest extends BaseHttpPredicateRouterBuilderTest {
 
     @Mock
     HttpSetCookie cookie1, cookie2;
 
     @Test
-    public void testWhenCookieIsPresent() {
+    void testWhenCookieIsPresent() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenCookie("session").isPresent().thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -45,7 +45,7 @@ public class HttpPredicateRouterBuilderCookieTest extends BaseHttpPredicateRoute
     }
 
     @Test
-    public void testWhenCookieIs() {
+    void testWhenCookieIs() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenCookie("session").value(cookie1::equals).thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -68,7 +68,7 @@ public class HttpPredicateRouterBuilderCookieTest extends BaseHttpPredicateRoute
     }
 
     @Test
-    public void testWhenCookieValues() {
+    void testWhenCookieValues() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenCookie("session").values(new AnyMatchPredicate<>(cookie1)).thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilderHeaderTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilderHeaderTest.java
@@ -17,22 +17,22 @@ package io.servicetalk.http.router.predicate;
 
 import io.servicetalk.http.api.StreamingHttpService;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.regex.Pattern;
 
 import static java.util.Collections.emptyIterator;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
-public class HttpPredicateRouterBuilderHeaderTest extends BaseHttpPredicateRouterBuilderTest {
+class HttpPredicateRouterBuilderHeaderTest extends BaseHttpPredicateRouterBuilderTest {
 
     @Test
-    public void testWhenHeaderIsPresent() {
+    void testWhenHeaderIsPresent() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenHeader("host").isPresent().thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -46,7 +46,7 @@ public class HttpPredicateRouterBuilderHeaderTest extends BaseHttpPredicateRoute
     }
 
     @Test
-    public void testWhenHeaderFirstValue() {
+    void testWhenHeaderFirstValue() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenHeader("host").firstValue("localhost").thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -69,7 +69,7 @@ public class HttpPredicateRouterBuilderHeaderTest extends BaseHttpPredicateRoute
     }
 
     @Test
-    public void testWhenHeaderFirstValueMatches() {
+    void testWhenHeaderFirstValueMatches() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenHeader("host").firstValueMatches("127\\..*").thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -89,7 +89,7 @@ public class HttpPredicateRouterBuilderHeaderTest extends BaseHttpPredicateRoute
     }
 
     @Test
-    public void testWhenHeaderFirstValueMatchesPattern() {
+    void testWhenHeaderFirstValueMatchesPattern() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenHeader("host").firstValueMatches(Pattern.compile("127\\..*", CASE_INSENSITIVE))
                 .thenRouteTo(serviceA)
@@ -110,7 +110,7 @@ public class HttpPredicateRouterBuilderHeaderTest extends BaseHttpPredicateRoute
     }
 
     @Test
-    public void testWhenHeaderValues() {
+    void testWhenHeaderValues() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenHeader("host").values(new AnyMatchPredicate<>("localhost")).thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -130,7 +130,7 @@ public class HttpPredicateRouterBuilderHeaderTest extends BaseHttpPredicateRoute
     }
 
     @Test
-    public void testMultipleHeaderRoutes() {
+    void testMultipleHeaderRoutes() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenHeader("host").firstValue("a.com").thenRouteTo(serviceA)
                 .whenHeader("host").firstValue("b.com").thenRouteTo(serviceB)

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilderQueryTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilderQueryTest.java
@@ -17,19 +17,19 @@ package io.servicetalk.http.router.predicate;
 
 import io.servicetalk.http.api.StreamingHttpService;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.regex.Pattern;
 
 import static java.util.Collections.emptyIterator;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.when;
 
-public class HttpPredicateRouterBuilderQueryTest extends BaseHttpPredicateRouterBuilderTest {
+class HttpPredicateRouterBuilderQueryTest extends BaseHttpPredicateRouterBuilderTest {
 
     @Test
-    public void testWhenQueryParamIsPresent() {
+    void testWhenQueryParamIsPresent() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenQueryParam("page").isPresent().thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -43,7 +43,7 @@ public class HttpPredicateRouterBuilderQueryTest extends BaseHttpPredicateRouter
     }
 
     @Test
-    public void testWhenQueryParamFirstValue() {
+    void testWhenQueryParamFirstValue() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenQueryParam("page").firstValue("home").thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -66,7 +66,7 @@ public class HttpPredicateRouterBuilderQueryTest extends BaseHttpPredicateRouter
     }
 
     @Test
-    public void testWhenQueryParamFirstValueMatches() {
+    void testWhenQueryParamFirstValueMatches() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenQueryParam("page").firstValueMatches("sign.*").thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -89,7 +89,7 @@ public class HttpPredicateRouterBuilderQueryTest extends BaseHttpPredicateRouter
     }
 
     @Test
-    public void testWhenQueryParamFirstValueMatchesPattern() {
+    void testWhenQueryParamFirstValueMatchesPattern() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenQueryParam("page").firstValueMatches(Pattern.compile("sign.*", CASE_INSENSITIVE))
                 .thenRouteTo(serviceA)
@@ -113,7 +113,7 @@ public class HttpPredicateRouterBuilderQueryTest extends BaseHttpPredicateRouter
     }
 
     @Test
-    public void testWhenQueryParamValues() {
+    void testWhenQueryParamValues() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenQueryParam("page").values(new AnyMatchPredicate<>("home")).thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilderTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilderTest.java
@@ -23,7 +23,8 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpService;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.net.SocketAddress;
 import java.util.concurrent.ExecutionException;
@@ -37,21 +38,20 @@ import static io.servicetalk.http.api.HttpRequestMethod.GET;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
 import static io.servicetalk.http.api.HttpRequestMethod.PUT;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuilderTest {
-    final CompleteTestCompletable completableA = new CompleteTestCompletable();
-    final CompleteTestCompletable completableB = new CompleteTestCompletable();
-    final CompleteTestCompletable completableC = new CompleteTestCompletable();
-    final FailCompletable failCompletable = new FailCompletable();
+class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuilderTest {
+    private final CompleteTestCompletable completableA = new CompleteTestCompletable();
+    private final CompleteTestCompletable completableB = new CompleteTestCompletable();
+    private final CompleteTestCompletable completableC = new CompleteTestCompletable();
+    private final FailCompletable failCompletable = new FailCompletable();
 
     @Test
-    public void testFallback() {
+    void testFallback() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
                 .buildStreaming();
@@ -60,7 +60,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
     }
 
     @Test
-    public void testDefaultFallback() throws Exception {
+    void testDefaultFallback() throws Exception {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .buildStreaming();
 
@@ -71,7 +71,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
     }
 
     @Test
-    public void testWhenMethod() {
+    void testWhenMethod() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenMethod(POST).thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -85,7 +85,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
     }
 
     @Test
-    public void testWhenMethodIsOneOf() {
+    void testWhenMethodIsOneOf() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenMethodIsOneOf(POST, PUT).thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -102,7 +102,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
     }
 
     @Test
-    public void testWhenPathEquals() {
+    void testWhenPathEquals() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenPathEquals("/abc").thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -116,7 +116,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
     }
 
     @Test
-    public void testWhenPathIsOneOf() {
+    void testWhenPathIsOneOf() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenPathIsOneOf("/abc", "/def").thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -133,7 +133,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
     }
 
     @Test
-    public void testWhenPathStartsWith() {
+    void testWhenPathStartsWith() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenPathStartsWith("/abc").thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -150,7 +150,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
     }
 
     @Test
-    public void testWhenPathMatches() {
+    void testWhenPathMatches() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenPathMatches(".*abc").thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -170,7 +170,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
     }
 
     @Test
-    public void testWhenPathMatchesPattern() {
+    void testWhenPathMatchesPattern() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenPathMatches(Pattern.compile(".*ABC", CASE_INSENSITIVE)).thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -187,7 +187,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
     }
 
     @Test
-    public void testWhenIsSsl() {
+    void testWhenIsSsl() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenIsSsl().thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -201,7 +201,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
     }
 
     @Test
-    public void testWhenIsNotSsl() {
+    void testWhenIsNotSsl() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .whenIsNotSsl().thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -215,7 +215,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
     }
 
     @Test
-    public void testWhenPredicate() {
+    void testWhenPredicate() {
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
                 .when(req -> HTTP_1_1.equals(req.version())).thenRouteTo(serviceA)
                 .when((ctx, req) -> true).thenRouteTo(fallbackService)
@@ -228,7 +228,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
     }
 
     @Test
-    public void testWhenBiPredicate() {
+    void testWhenBiPredicate() {
         final SocketAddress addr1 = mock(SocketAddress.class);
         final SocketAddress addr2 = mock(SocketAddress.class);
         final StreamingHttpService service = new HttpPredicateRouterBuilder()
@@ -244,7 +244,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
     }
 
     @Test
-    public void testCloseAsyncClosesAllServices() throws Exception {
+    void testCloseAsyncClosesAllServices() throws Exception {
         when(serviceA.closeAsync()).thenReturn(completableA);
         when(serviceB.closeAsync()).thenReturn(completableB);
         when(serviceC.closeAsync()).thenReturn(completableC);
@@ -271,7 +271,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
     }
 
     @Test
-    public void testCloseAsyncClosesAllServicesWhenFirstOneIsError() throws Exception {
+    void testCloseAsyncClosesAllServicesWhenFirstOneIsError() throws Exception {
         when(serviceA.closeAsync()).thenReturn(failCompletable);
         when(serviceB.closeAsync()).thenReturn(completableB);
         when(serviceC.closeAsync()).thenReturn(completableC);
@@ -285,7 +285,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
         try {
             final Completable completable = service.closeAsync();
             completable.toFuture().get();
-            fail("Expected an exception from `await`");
+            Assertions.fail("Expected an exception from `await`");
         } catch (final ExecutionException e) {
             assertSame(DELIBERATE_EXCEPTION, e.getCause());
         }
@@ -303,7 +303,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
         completableC.verifyListenCalled();
     }
 
-    public static class CompleteTestCompletable extends LegacyTestCompletable {
+    static class CompleteTestCompletable extends LegacyTestCompletable {
         @Override
         public void handleSubscribe(final Subscriber subscriber) {
             super.handleSubscribe(subscriber);
@@ -311,7 +311,7 @@ public class HttpPredicateRouterBuilderTest extends BaseHttpPredicateRouterBuild
         }
     }
 
-    public static class FailCompletable extends LegacyTestCompletable {
+    static class FailCompletable extends LegacyTestCompletable {
         @Override
         public void handleSubscribe(final Subscriber subscriber) {
             super.handleSubscribe(subscriber);

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpServerOverrideOffloadingTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpServerOverrideOffloadingTest.java
@@ -19,7 +19,6 @@ import io.servicetalk.concurrent.CompletableSource.Processor;
 import io.servicetalk.concurrent.api.DefaultThreadFactory;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -31,10 +30,8 @@ import io.servicetalk.http.netty.HttpServers;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
 
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -58,11 +55,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-public class HttpServerOverrideOffloadingTest {
+class HttpServerOverrideOffloadingTest {
     private static final String IO_EXECUTOR_THREAD_NAME_PREFIX = "http-server-io-executor";
-
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
 
     private final IoExecutor ioExecutor;
     private final Executor executor;
@@ -71,7 +65,7 @@ public class HttpServerOverrideOffloadingTest {
     private final HttpClient client;
     private final ServerContext server;
 
-    public HttpServerOverrideOffloadingTest() throws Exception {
+    HttpServerOverrideOffloadingTest() throws Exception {
         ioExecutor = createIoExecutor(new DefaultThreadFactory(IO_EXECUTOR_THREAD_NAME_PREFIX, true,
                 NORM_PRIORITY));
         executor = newCachedThreadExecutor();
@@ -88,8 +82,8 @@ public class HttpServerOverrideOffloadingTest {
         client = HttpClients.forSingleAddress(serverHostAndPort(server)).build();
     }
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    void tearDown() throws Exception {
         newCompositeCloseable().appendAll(client, server, ioExecutor, executor).closeAsync().toFuture().get();
     }
 
@@ -98,7 +92,7 @@ public class HttpServerOverrideOffloadingTest {
     }
 
     @Test
-    public void offloadDifferentRoutes() throws Exception {
+    void offloadDifferentRoutes() throws Exception {
         client.request(client.get("/service1")).toFuture().get();
         assertThat("Service-1 unexpected invocation count.", service1.invoked.get(), is(1));
         assertThat("Service-1, unexpected errors: " + service1.errors, service1.errors, hasSize(0));

--- a/servicetalk-http-security-jersey/build.gradle
+++ b/servicetalk-http-security-jersey/build.gradle
@@ -30,12 +30,15 @@ dependencies {
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-http-router-jersey")
   testImplementation project(":servicetalk-http-utils")
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
+  testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
   testImplementation "net.javacrumbs.json-unit:json-unit-fluent:$jsonUnitVersion"
   testImplementation "org.glassfish.jersey.core:jersey-server:$jerseyVersion"
   testImplementation "org.glassfish.jersey.inject:jersey-hk2:$jerseyVersion"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+  testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 
   testRuntimeOnly project(":servicetalk-test-resources")
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-http-security-jersey/src/test/java/io/servicetalk/http/security/auth/basic/jersey/BasicAuthSecurityContextFiltersTest.java
+++ b/servicetalk-http-security-jersey/src/test/java/io/servicetalk/http/security/auth/basic/jersey/BasicAuthSecurityContextFiltersTest.java
@@ -20,16 +20,15 @@ import io.servicetalk.concurrent.api.AsyncContextMap.Key;
 import io.servicetalk.http.security.auth.basic.jersey.BasicAuthSecurityContextFilters.NoUserInfoBuilder;
 import io.servicetalk.http.security.auth.basic.jersey.BasicAuthSecurityContextFilters.UserInfoBuilder;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.net.URI;
 import java.security.Principal;
@@ -48,12 +47,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-@RunWith(Parameterized.class)
-public class BasicAuthSecurityContextFiltersTest {
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class BasicAuthSecurityContextFiltersTest {
     private static final Principal TEST_PRINCIPAL = () -> "test-name";
     private static final String TEST_USER_INFO = "test-user-info";
-    @Rule
-    public final MockitoRule rule = MockitoJUnit.rule();
 
     @Mock
     private ContainerRequestContext requestCtx;
@@ -61,25 +59,18 @@ public class BasicAuthSecurityContextFiltersTest {
     @Mock
     private UriInfo uriInfo;
 
-    private final boolean globalFilter;
+    private boolean globalFilter;
 
-    public BasicAuthSecurityContextFiltersTest(final boolean globalFilter) {
-        this.globalFilter = globalFilter;
-    }
-
-    @Parameters(name = " {index} global filter? {0}")
-    public static Object[] params() {
-        return new Object[]{true, false};
-    }
-
-    @Before
-    public void setupMocks() {
+    @BeforeEach
+    void setupMocks() {
         when(uriInfo.getRequestUri()).thenReturn(URI.create("https://0.0.0.0"));
         when(requestCtx.getUriInfo()).thenReturn(uriInfo);
     }
 
-    @Test
-    public void principalNoUserInfo() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void principalNoUserInfo(final boolean globalFilter) throws Exception {
+        this.globalFilter = globalFilter;
         final ContainerRequestFilter filter = newFilterBuilder().build();
 
         final ArgumentCaptor<SecurityContext> securityCtxCaptor = ArgumentCaptor.forClass(SecurityContext.class);
@@ -89,8 +80,10 @@ public class BasicAuthSecurityContextFiltersTest {
         assertThat(securityCtxCaptor.getValue().getUserPrincipal(), is(sameInstance(ANONYMOUS_PRINCIPAL)));
     }
 
-    @Test
-    public void principalUserInfo() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void principalUserInfo(final boolean globalFilter) throws Exception {
+        this.globalFilter = globalFilter;
         final Key<Principal> userInfoKey = newKey("basicPrincipal");
         final ContainerRequestFilter filter = newFilterBuilder(userInfoKey).build();
 
@@ -105,8 +98,10 @@ public class BasicAuthSecurityContextFiltersTest {
         assertThat(securityCtxCaptor.getValue().getUserPrincipal(), is(sameInstance(TEST_PRINCIPAL)));
     }
 
-    @Test
-    public void customPrincipalFunctionNoUserInfo() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void customPrincipalFunctionNoUserInfo(final boolean globalFilter) throws Exception {
+        this.globalFilter = globalFilter;
         final ContainerRequestFilter filter = newFilterBuilder()
                 .principalFunction(__ -> TEST_PRINCIPAL)
                 .build();
@@ -118,8 +113,10 @@ public class BasicAuthSecurityContextFiltersTest {
         assertThat(securityCtxCaptor.getValue().getUserPrincipal(), is(sameInstance(TEST_PRINCIPAL)));
     }
 
-    @Test
-    public void customPrincipalFunctionUserInfo() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void customPrincipalFunctionUserInfo(final boolean globalFilter) throws Exception {
+        this.globalFilter = globalFilter;
         final Key<String> userInfoKey = newKey("basicPrincipal");
         final ContainerRequestFilter filter = newFilterBuilder(userInfoKey)
                 .principalFunction((__, userInfo) -> TEST_USER_INFO.equals(userInfo) ? TEST_PRINCIPAL : null)
@@ -136,8 +133,10 @@ public class BasicAuthSecurityContextFiltersTest {
         assertThat(securityCtxCaptor.getValue().getUserPrincipal(), is(sameInstance(TEST_PRINCIPAL)));
     }
 
-    @Test
-    public void customSecurityContextFunctionNoUserInfo() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void customSecurityContextFunctionNoUserInfo(final boolean globalFilter) throws Exception {
+        this.globalFilter = globalFilter;
         final SecurityContext securityContext = mock(SecurityContext.class);
 
         final ContainerRequestFilter filter = newFilterBuilder()
@@ -151,8 +150,10 @@ public class BasicAuthSecurityContextFiltersTest {
         assertThat(securityCtxCaptor.getValue(), is(sameInstance(securityContext)));
     }
 
-    @Test
-    public void customSecurityContextFunctionUserInfo() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void customSecurityContextFunctionUserInfo(final boolean globalFilter) throws Exception {
+        this.globalFilter = globalFilter;
         final SecurityContext securityContext = mock(SecurityContext.class);
 
         final Key<String> userInfoKey = newKey("basicPrincipal");

--- a/servicetalk-http-security-jersey/src/test/java/io/servicetalk/http/security/auth/basic/jersey/GlobalBindingBasicAuthSecurityContextFilterTest.java
+++ b/servicetalk-http-security-jersey/src/test/java/io/servicetalk/http/security/auth/basic/jersey/GlobalBindingBasicAuthSecurityContextFilterTest.java
@@ -19,7 +19,8 @@ import io.servicetalk.concurrent.api.AsyncContextMap.Key;
 import io.servicetalk.http.security.auth.basic.jersey.resources.GlobalBindingResource;
 import io.servicetalk.http.security.auth.basic.jersey.resources.NameBindingResource;
 
-import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -27,10 +28,7 @@ import javax.ws.rs.core.Application;
 
 import static java.util.Collections.singleton;
 
-public class GlobalBindingBasicAuthSecurityContextFilterTest extends AbstractBasicAuthSecurityContextFilterTest {
-    public GlobalBindingBasicAuthSecurityContextFilterTest(final boolean withUserInfo) {
-        super(withUserInfo);
-    }
+class GlobalBindingBasicAuthSecurityContextFilterTest extends AbstractBasicAuthSecurityContextFilterTest {
 
     @Override
     protected Application application(@Nullable final Key<BasicUserInfo> userInfoKey) {
@@ -45,14 +43,18 @@ public class GlobalBindingBasicAuthSecurityContextFilterTest extends AbstractBas
         };
     }
 
-    @Test
-    public void authenticated() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void authenticated(final boolean withUserInfo) throws Exception {
+        setUp(withUserInfo);
         assertBasicAuthSecurityContextPresent(GlobalBindingResource.PATH);
         assertBasicAuthSecurityContextPresent(NameBindingResource.PATH);
     }
 
-    @Test
-    public void notAuthenticated() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void notAuthenticated(final boolean withUserInfo) throws Exception {
+        setUp(withUserInfo);
         assertBasicAuthSecurityContextAbsent(GlobalBindingResource.PATH, false);
         assertBasicAuthSecurityContextAbsent(NameBindingResource.PATH, false);
     }

--- a/servicetalk-http-security-jersey/src/test/java/io/servicetalk/http/security/auth/basic/jersey/NameBindingBasicAuthSecurityContextFilterTest.java
+++ b/servicetalk-http-security-jersey/src/test/java/io/servicetalk/http/security/auth/basic/jersey/NameBindingBasicAuthSecurityContextFilterTest.java
@@ -19,7 +19,8 @@ import io.servicetalk.concurrent.api.AsyncContextMap.Key;
 import io.servicetalk.http.security.auth.basic.jersey.resources.GlobalBindingResource;
 import io.servicetalk.http.security.auth.basic.jersey.resources.NameBindingResource;
 
-import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -27,10 +28,7 @@ import javax.ws.rs.core.Application;
 
 import static java.util.Collections.singleton;
 
-public class NameBindingBasicAuthSecurityContextFilterTest extends AbstractBasicAuthSecurityContextFilterTest {
-    public NameBindingBasicAuthSecurityContextFilterTest(final boolean withUserInfo) {
-        super(withUserInfo);
-    }
+class NameBindingBasicAuthSecurityContextFilterTest extends AbstractBasicAuthSecurityContextFilterTest {
 
     @Override
     protected Application application(@Nullable final Key<BasicUserInfo> userInfoKey) {
@@ -45,14 +43,18 @@ public class NameBindingBasicAuthSecurityContextFilterTest extends AbstractBasic
         };
     }
 
-    @Test
-    public void authenticated() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void authenticated(final boolean withUserInfo) throws Exception {
+        setUp(withUserInfo);
         assertBasicAuthSecurityContextAbsent(GlobalBindingResource.PATH, true);
         assertBasicAuthSecurityContextPresent(NameBindingResource.PATH);
     }
 
-    @Test
-    public void notAuthenticated() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void notAuthenticated(final boolean withUserInfo) throws Exception {
+        setUp(withUserInfo);
         assertBasicAuthSecurityContextAbsent(GlobalBindingResource.PATH, false);
         assertBasicAuthSecurityContextAbsent(NameBindingResource.PATH, false);
     }

--- a/servicetalk-http-security-jersey/src/test/java/io/servicetalk/http/security/auth/basic/jersey/RoleProtectedBasicAuthSecurityContextFilterTest.java
+++ b/servicetalk-http-security-jersey/src/test/java/io/servicetalk/http/security/auth/basic/jersey/RoleProtectedBasicAuthSecurityContextFilterTest.java
@@ -20,18 +20,15 @@ import io.servicetalk.http.security.auth.basic.jersey.resources.RoleProtectedRes
 
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
-import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.annotation.Nullable;
 import javax.ws.rs.core.Application;
 
 import static io.servicetalk.http.api.HttpResponseStatus.FORBIDDEN;
 
-public class RoleProtectedBasicAuthSecurityContextFilterTest extends AbstractBasicAuthSecurityContextFilterTest {
-    public RoleProtectedBasicAuthSecurityContextFilterTest(final boolean withUserInfo) {
-        super(withUserInfo);
-    }
-
+class RoleProtectedBasicAuthSecurityContextFilterTest extends AbstractBasicAuthSecurityContextFilterTest {
     @Override
     protected Application application(@Nullable final Key<BasicUserInfo> userInfoKey) {
         return new ResourceConfig(RoleProtectedResource.class)
@@ -48,18 +45,24 @@ public class RoleProtectedBasicAuthSecurityContextFilterTest extends AbstractBas
                                 .build());
     }
 
-    @Test
-    public void authorized() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void authorized(final boolean withUserInfo) throws Exception {
+        setUp(withUserInfo);
         assertBasicAuthSecurityContextPresent(RoleProtectedResource.PATH + "/user");
     }
 
-    @Test
-    public void notAuthorized() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void notAuthorized(final boolean withUserInfo) throws Exception {
+        setUp(withUserInfo);
         assertBasicAuthSecurityContextAbsent(RoleProtectedResource.PATH + "/admin", true, FORBIDDEN);
     }
 
-    @Test
-    public void notAuthenticated() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void notAuthenticated(final boolean withUserInfo) throws Exception {
+        setUp(withUserInfo);
         assertBasicAuthSecurityContextAbsent(RoleProtectedResource.PATH + "/user", false);
         assertBasicAuthSecurityContextAbsent(RoleProtectedResource.PATH + "/admin", false);
     }

--- a/servicetalk-http-utils/build.gradle
+++ b/servicetalk-http-utils/build.gradle
@@ -33,9 +33,11 @@ dependencies {
   testImplementation project(":servicetalk-buffer-netty")
   testImplementation project(":servicetalk-concurrent-api-test")
   testImplementation project(":servicetalk-test-resources")
-  testImplementation "junit:junit:$junitVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+  testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilterTest.java
@@ -48,7 +48,7 @@ import static java.time.Duration.ofNanos;
 import static java.time.Duration.ofSeconds;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 abstract class AbstractTimeoutHttpFilterTest {
@@ -97,7 +97,7 @@ abstract class AbstractTimeoutHttpFilterTest {
         StepVerifiers.create(applyFilter(__ -> timeout, fullRequestResponse, responseSingle))
                 .expectError(TimeoutException.class)
                 .verify();
-        assertThat("Unexpected subscribe for response single", responseSingle.isSubscribed(), is(false));
+        assertThat("No subscribe for payload body", responseSingle.isSubscribed(), is(true));
     }
 
     @ParameterizedTest
@@ -159,7 +159,7 @@ abstract class AbstractTimeoutHttpFilterTest {
         StepVerifiers.create(immediate().timer(timeout.plusMillis(5L)).concat(response.get().payloadBody()))
                 .expectError(TimeoutException.class)
                 .verify();
-        assertThat("Unexpected subscribe for payload body", payloadBody.isSubscribed(), is(false));
+        assertThat("No subscribe for payload body", payloadBody.isSubscribed(), is(true));
     }
 
     @Test

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/HttpRequestUriUtilsTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/HttpRequestUriUtilsTest.java
@@ -22,11 +22,10 @@ import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.transport.api.ConnectionContext;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.net.ssl.SSLSession;
 
@@ -39,12 +38,12 @@ import static io.servicetalk.http.utils.HttpRequestUriUtils.getEffectiveRequestU
 import static java.net.InetSocketAddress.createUnresolved;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class HttpRequestUriUtilsTest {
-    @Rule
-    public final MockitoRule rule = MockitoJUnit.rule();
+@ExtendWith(MockitoExtension.class)
+class HttpRequestUriUtilsTest {
 
     @Mock
     private ConnectionContext ctx;
@@ -53,7 +52,7 @@ public class HttpRequestUriUtilsTest {
             BufferAllocators.DEFAULT_ALLOCATOR, DefaultHttpHeadersFactory.INSTANCE, HTTP_1_1);
 
     @Test
-    public void originForm() {
+    void originForm() {
         when(ctx.localAddress()).thenReturn(createUnresolved("my.site.com", 80));
 
         final StreamingHttpRequest req = reqRespFactory.get("/some/path.html?query");
@@ -94,7 +93,7 @@ public class HttpRequestUriUtilsTest {
     }
 
     @Test
-    public void originFormWithHostHeader() {
+    void originFormWithHostHeader() {
         final StreamingHttpRequest req = reqRespFactory.get("/some/path.html?query");
         req.headers().set(HOST, "my.site.com:8080");
 
@@ -118,7 +117,7 @@ public class HttpRequestUriUtilsTest {
     }
 
     @Test
-    public void absoluteForm() {
+    void absoluteForm() {
         final StreamingHttpRequest req = reqRespFactory.get("https://my.site.com/some/path.html?query");
 
         assertThat(getEffectiveRequestUri(ctx, req, null, null, false),
@@ -157,7 +156,7 @@ public class HttpRequestUriUtilsTest {
     }
 
     @Test
-    public void absoluteFormWithUserInfo() {
+    void absoluteFormWithUserInfo() {
         final StreamingHttpRequest req = reqRespFactory.get("https://jdoe@my.site.com/some/path.html?query");
 
         assertThat(getEffectiveRequestUri(ctx, req, null, null, true),
@@ -200,7 +199,7 @@ public class HttpRequestUriUtilsTest {
     }
 
     @Test
-    public void authorityForm() {
+    void authorityForm() {
         when(ctx.sslSession()).thenReturn(mock(SSLSession.class));
 
         final StreamingHttpRequest req = reqRespFactory.newRequest(CONNECT, "my.site.com:9876");
@@ -241,7 +240,7 @@ public class HttpRequestUriUtilsTest {
     }
 
     @Test
-    public void asteriskForm() {
+    void asteriskForm() {
         when(ctx.localAddress()).thenReturn(createUnresolved("my.site.com", 443));
         when(ctx.sslSession()).thenReturn(mock(SSLSession.class));
 
@@ -267,7 +266,7 @@ public class HttpRequestUriUtilsTest {
     }
 
     @Test
-    public void asteriskFormWithHostHeader() {
+    void asteriskFormWithHostHeader() {
         final StreamingHttpRequest req = reqRespFactory.newRequest(OPTIONS, "*");
         req.headers().set(HOST, "my.site.com:8080");
 
@@ -306,15 +305,17 @@ public class HttpRequestUriUtilsTest {
                 is("http://jsmith@other.site.com:1234/"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void unsupportedFixedSchemeEffectiveRequestUri() {
+    @Test
+    void unsupportedFixedSchemeEffectiveRequestUri() {
         final StreamingHttpRequest req = reqRespFactory.get("/some/path.html?query");
-        getEffectiveRequestUri(ctx, req, "ftp", null, false);
+        assertThrows(IllegalArgumentException.class,
+                     () -> getEffectiveRequestUri(ctx, req, "ftp", null, false));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void unsupportedFixedSchemeBaseUri() {
+    @Test
+    void unsupportedFixedSchemeBaseUri() {
         final StreamingHttpRequest req = reqRespFactory.get("/some/path.html?query");
-        getBaseRequestUri(ctx, req, "ftp", null, false);
+        assertThrows(IllegalArgumentException.class,
+                     () -> getBaseRequestUri(ctx, req, "ftp", null, false));
     }
 }

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilterTest.java
@@ -17,7 +17,6 @@ package io.servicetalk.http.utils;
 
 import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.http.api.DefaultHttpHeadersFactory;
 import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.HttpExecutionContext;
@@ -32,9 +31,9 @@ import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.StreamingHttpRequester;
 import io.servicetalk.http.api.StreamingHttpResponse;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -74,8 +73,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
@@ -83,7 +81,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class RedirectingHttpRequesterFilterTest {
+class RedirectingHttpRequesterFilterTest {
 
     private static final String REQUESTED_STATUS = "Requested-Status";
     private static final String REQUESTED_LOCATION = "Requested-Location";
@@ -93,13 +91,11 @@ public class RedirectingHttpRequesterFilterTest {
     private static final StreamingHttpRequestResponseFactory reqRespFactory =
             new DefaultStreamingHttpRequestResponseFactory(allocator, DefaultHttpHeadersFactory.INSTANCE, HTTP_1_1);
 
-    @Rule
-    public final ServiceTalkTestTimeout timeout = new ServiceTalkTestTimeout();
 
     private final StreamingHttpRequester httpClient = mock(StreamingHttpRequester.class);
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         when(httpClient.request(any(), any())).thenAnswer(a -> {
             try {
                 StreamingHttpRequest request = a.getArgument(1);
@@ -137,63 +133,63 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void requestWithNegativeMaxRedirects() throws Exception {
+    void requestWithNegativeMaxRedirects() throws Exception {
         testNoRedirectWasDone(-1, GET, MOVED_PERMANENTLY, "/new-location");
     }
 
     @Test
-    public void requestWithZeroMaxRedirects() throws Exception {
+    void requestWithZeroMaxRedirects() throws Exception {
         testNoRedirectWasDone(0, GET, MOVED_PERMANENTLY, "/new-location");
     }
 
     @Test
-    public void requestWithOkStatus() throws Exception {
+    void requestWithOkStatus() throws Exception {
         testNoRedirectWasDone(MAX_REDIRECTS, GET, OK, "/new-location");
     }
 
     @Test
-    public void requestWithNotModifiedStatus() throws Exception {
+    void requestWithNotModifiedStatus() throws Exception {
         testNoRedirectWasDone(MAX_REDIRECTS, GET, NOT_MODIFIED, "/new-location");
     }
 
     @Test
-    public void requestWithUseProxyStatus() throws Exception {
+    void requestWithUseProxyStatus() throws Exception {
         testNoRedirectWasDone(MAX_REDIRECTS, GET, USE_PROXY, "/new-location");
     }
 
     @Test
-    public void requestWith306Status() throws Exception {
+    void requestWith306Status() throws Exception {
         testNoRedirectWasDone(MAX_REDIRECTS, GET, HttpResponseStatus.of(306, ""), "/new-location");
     }
 
     @Test
-    public void requestWith309Status() throws Exception {
+    void requestWith309Status() throws Exception {
         testNoRedirectWasDone(MAX_REDIRECTS, GET, HttpResponseStatus.of(309, ""), "/new-location");
     }
 
     @Test
-    public void requestWithBadRequestStatus() throws Exception {
+    void requestWithBadRequestStatus() throws Exception {
         testNoRedirectWasDone(MAX_REDIRECTS, GET, BAD_REQUEST, "/new-location");
     }
 
     @Test
-    public void requestWithInternalServerErrorStatus() throws Exception {
+    void requestWithInternalServerErrorStatus() throws Exception {
         testNoRedirectWasDone(MAX_REDIRECTS, GET, INTERNAL_SERVER_ERROR, "/new-location");
     }
 
     @Test
-    public void requestWithEmptyLocation() throws Exception {
+    void requestWithEmptyLocation() throws Exception {
         testNoRedirectWasDone(MAX_REDIRECTS, GET, MOVED_PERMANENTLY, null);
     }
 
     @Test
-    public void request307or308WithEmptyLocation() throws Exception {
+    void request307or308WithEmptyLocation() throws Exception {
         testNoRedirectWasDone(MAX_REDIRECTS, GET, TEMPORARY_REDIRECT, null);
         testNoRedirectWasDone(MAX_REDIRECTS, GET, PERMANENT_REDIRECT, null);
     }
 
     @Test
-    public void nonGetOrHeadRequestWithTemporaryRedirect() throws Exception {
+    void nonGetOrHeadRequestWithTemporaryRedirect() throws Exception {
         testNoRedirectWasDone(MAX_REDIRECTS, POST, TEMPORARY_REDIRECT, "/new-location");
         testNoRedirectWasDone(MAX_REDIRECTS, PUT, TEMPORARY_REDIRECT, "/new-location");
         testNoRedirectWasDone(MAX_REDIRECTS, PATCH, TEMPORARY_REDIRECT, "/new-location");
@@ -201,7 +197,7 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void nonGetOrHeadRequestWithPermanentRedirect() throws Exception {
+    void nonGetOrHeadRequestWithPermanentRedirect() throws Exception {
         testNoRedirectWasDone(MAX_REDIRECTS, POST, PERMANENT_REDIRECT, "/new-location");
         testNoRedirectWasDone(MAX_REDIRECTS, PUT, PERMANENT_REDIRECT, "/new-location");
         testNoRedirectWasDone(MAX_REDIRECTS, PATCH, PERMANENT_REDIRECT, "/new-location");
@@ -209,16 +205,16 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void traceOptionsRequestsDoesNotRedirect() throws Exception {
+    void traceOptionsRequestsDoesNotRedirect() throws Exception {
         testNoRedirectWasDone(MAX_REDIRECTS, TRACE, SEE_OTHER, "/new-location");
         testNoRedirectWasDone(MAX_REDIRECTS, OPTIONS, SEE_OTHER, "/new-location");
     }
 
     @Test
-    public void connectRequestsDoesNotRedirect() {
+    void connectRequestsDoesNotRedirect() {
         try {
             testNoRedirectWasDone(MAX_REDIRECTS, CONNECT, SEE_OTHER, "/new-location");
-            fail();
+            Assertions.fail();
         } catch (Exception e) {
             assertThat(e, instanceOf(ExecutionException.class));
             assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
@@ -244,7 +240,7 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void maxRedirectsReached() throws Exception {
+    void maxRedirectsReached() throws Exception {
         AtomicInteger counter = new AtomicInteger();
         when(httpClient.request(any(), any())).thenAnswer(a -> createRedirectResponse(counter.incrementAndGet()));
 
@@ -258,7 +254,7 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void requestWithNullResponse() throws Exception {
+    void requestWithNullResponse() throws Exception {
         when(httpClient.request(any(), any())).thenReturn(succeeded(null));
 
         StreamingHttpClient client = newClient(new RedirectingHttpRequesterFilter(false));
@@ -273,37 +269,37 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void requestForRedirectWithMultipleChoices() throws Exception {
+    void requestForRedirectWithMultipleChoices() throws Exception {
         testRequestForRedirect(GET, MULTIPLE_CHOICES);
         testRequestForRedirect(HEAD, MULTIPLE_CHOICES);
     }
 
     @Test
-    public void requestForRedirectWithMovedPermanently() throws Exception {
+    void requestForRedirectWithMovedPermanently() throws Exception {
         testRequestForRedirect(GET, MOVED_PERMANENTLY);
         testRequestForRedirect(HEAD, MOVED_PERMANENTLY);
     }
 
     @Test
-    public void requestForRedirectWithFound() throws Exception {
+    void requestForRedirectWithFound() throws Exception {
         testRequestForRedirect(GET, FOUND);
         testRequestForRedirect(HEAD, FOUND);
     }
 
     @Test
-    public void requestForRedirectWithSeeOther() throws Exception {
+    void requestForRedirectWithSeeOther() throws Exception {
         testRequestForRedirect(GET, SEE_OTHER);
         testRequestForRedirect(HEAD, SEE_OTHER);
     }
 
     @Test
-    public void requestForRedirectWithTemporaryRedirect() throws Exception {
+    void requestForRedirectWithTemporaryRedirect() throws Exception {
         testRequestForRedirect(GET, TEMPORARY_REDIRECT);
         testRequestForRedirect(HEAD, TEMPORARY_REDIRECT);
     }
 
     @Test
-    public void requestForRedirectWithPermanentRedirect() throws Exception {
+    void requestForRedirectWithPermanentRedirect() throws Exception {
         testRequestForRedirect(GET, PERMANENT_REDIRECT);
         testRequestForRedirect(HEAD, PERMANENT_REDIRECT);
     }
@@ -323,7 +319,7 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void multipleFollowUpRedirects() throws Exception {
+    void multipleFollowUpRedirects() throws Exception {
         when(httpClient.request(any(), any())).thenReturn(
                 createRedirectResponse(1),
                 createRedirectResponse(2),
@@ -345,7 +341,7 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void getRequestForRedirectWithAbsoluteFormRequestTarget() throws Exception {
+    void getRequestForRedirectWithAbsoluteFormRequestTarget() throws Exception {
         StreamingHttpClient client = newClient(new RedirectingHttpRequesterFilter());
 
         StreamingHttpRequest request = client.get("http://servicetalk.io/path");
@@ -356,7 +352,7 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void redirectForOnlyRelativeWithAbsoluteRelativeLocation() throws Exception {
+    void redirectForOnlyRelativeWithAbsoluteRelativeLocation() throws Exception {
         StreamingHttpClient client = newClient(new RedirectingHttpRequesterFilter());
 
         StreamingHttpRequest request = client.get("/path");
@@ -368,7 +364,7 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void redirectForOnlyRelativeWithAbsoluteRelativeLocationWithPortDoesNotRedirect() throws Exception {
+    void redirectForOnlyRelativeWithAbsoluteRelativeLocationWithPortDoesNotRedirect() throws Exception {
         StreamingHttpClient client = newClient(new RedirectingHttpRequesterFilter(true));
 
         StreamingHttpRequest request = client.get("/path");
@@ -380,7 +376,7 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void redirectForOnlyRelativeWithRelativeLocation() throws Exception {
+    void redirectForOnlyRelativeWithRelativeLocation() throws Exception {
         StreamingHttpClient client = newClient(new RedirectingHttpRequesterFilter(true));
 
         StreamingHttpRequest request = client.get("/path");
@@ -392,7 +388,7 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void redirectForNotOnlyRelativeWithRelativeLocation() throws Exception {
+    void redirectForNotOnlyRelativeWithRelativeLocation() throws Exception {
         StreamingHttpClient client = newClient(new RedirectingHttpRequesterFilter(false));
 
         StreamingHttpRequest request = client.get("http://servicetalk.io/path");
@@ -404,12 +400,12 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void redirectFromHttpToHttps() throws Exception {
+    void redirectFromHttpToHttps() throws Exception {
         crossSchemeRedirects("http", "https");
     }
 
     @Test
-    public void redirectFromHttpsToHttp() throws Exception {
+    void redirectFromHttpsToHttp() throws Exception {
         crossSchemeRedirects("https", "http");
     }
 
@@ -426,7 +422,7 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void redirectForOnlyRelativeWithAbsoluteNonRelativeLocationDoesNotRedirect() throws Exception {
+    void redirectForOnlyRelativeWithAbsoluteNonRelativeLocationDoesNotRedirect() throws Exception {
         StreamingHttpClient client = newClient(new RedirectingHttpRequesterFilter(true));
 
         StreamingHttpRequest request = client.get("/path");
@@ -438,7 +434,7 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void doesNotRedirectIfRemoteHostIsUnknown() throws Exception {
+    void doesNotRedirectIfRemoteHostIsUnknown() throws Exception {
         StreamingHttpClient client = newClient(new RedirectingHttpRequesterFilter(true));
 
         StreamingHttpRequest request = client.get("/path");
@@ -449,12 +445,12 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void absoluteTargetRedirectForOnlyRelativeWithAbsoluteRelativeLocation() throws Exception {
+    void absoluteTargetRedirectForOnlyRelativeWithAbsoluteRelativeLocation() throws Exception {
         absoluteTargetRedirectWithAbsoluteRelativeLocation(true);
     }
 
     @Test
-    public void absoluteTargetRedirectForNotOnlyRelativeWithAbsoluteRelativeLocation() throws Exception {
+    void absoluteTargetRedirectForNotOnlyRelativeWithAbsoluteRelativeLocation() throws Exception {
         absoluteTargetRedirectWithAbsoluteRelativeLocation(false);
     }
 
@@ -469,7 +465,7 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void absoluteTargetRedirectForOnlyRelativeWithAbsoluteRelativeLocationWithoutPath() throws Exception {
+    void absoluteTargetRedirectForOnlyRelativeWithAbsoluteRelativeLocationWithoutPath() throws Exception {
         StreamingHttpClient client = newClient(new RedirectingHttpRequesterFilter(true));
 
         StreamingHttpRequest request = client.get("http://servicetalk.io/path");
@@ -480,7 +476,7 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void absoluteTargetRedirectForOnlyRelativeWithNonRelativeLocationDoesNotRedirect() throws Exception {
+    void absoluteTargetRedirectForOnlyRelativeWithNonRelativeLocationDoesNotRedirect() throws Exception {
         StreamingHttpClient client = newClient(new RedirectingHttpRequesterFilter(true));
 
         StreamingHttpRequest request = client.get("http://servicetalk.io/path");
@@ -491,7 +487,7 @@ public class RedirectingHttpRequesterFilterTest {
     }
 
     @Test
-    public void absoluteTargetRedirectForNotOnlyRelativeWithNonRelativeLocationRedirect() throws Exception {
+    void absoluteTargetRedirectForNotOnlyRelativeWithNonRelativeLocationRedirect() throws Exception {
         StreamingHttpClient client = newClient(new RedirectingHttpRequesterFilter(false));
 
         StreamingHttpRequest request = client.get("http://servicetalk.io/path");

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/RequestTargetEncoderHttpServiceFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/RequestTargetEncoderHttpServiceFilterTest.java
@@ -26,8 +26,8 @@ import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.api.TestHttpServiceContext;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class RequestTargetEncoderHttpServiceFilterTest {
+class RequestTargetEncoderHttpServiceFilterTest {
     private final StreamingHttpService mockService = mock(StreamingHttpService.class);
     private final HttpExecutionContext mockExecutionCtx = mock(HttpExecutionContext.class);
     private final StreamingHttpRequestResponseFactory reqRespFactory = new DefaultStreamingHttpRequestResponseFactory(
@@ -52,8 +52,8 @@ public class RequestTargetEncoderHttpServiceFilterTest {
     private final HttpServiceContext mockCtx = new TestHttpServiceContext(DefaultHttpHeadersFactory.INSTANCE,
             reqRespFactory, mockExecutionCtx);
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         doAnswer((Answer<Single<StreamingHttpResponse>>) invocation -> {
             StreamingHttpRequest request = invocation.getArgument(1);
             StreamingHttpResponse response = mock(StreamingHttpResponse.class);
@@ -64,24 +64,24 @@ public class RequestTargetEncoderHttpServiceFilterTest {
     }
 
     @Test
-    public void noEncodeRequired() throws Exception {
+    void noEncodeRequired() throws Exception {
         String requestTarget = "/path?key=value";
         invokeServiceAssertValue(requestTarget, requestTarget);
     }
 
     @Test
-    public void equalsPreservedForKeyValues() throws Exception {
+    void equalsPreservedForKeyValues() throws Exception {
         invokeServiceAssertValue("/path?key=<value>&key2=value2", "/path?key=%3Cvalue%3E&key2=value2");
     }
 
     @Test
-    public void preexistingEncodePreserved() throws Exception {
+    void preexistingEncodePreserved() throws Exception {
         String requestTarget = "/path?key=a%20b";
         invokeServiceAssertValue(requestTarget, requestTarget);
     }
 
     @Test
-    public void upToSpaceCharsEscaped() throws Exception {
+    void upToSpaceCharsEscaped() throws Exception {
         StringBuilder requestTargetBuilder = new StringBuilder();
         StringBuilder expectedBuilder = new StringBuilder();
         requestTargetBuilder.append("/path?");


### PR DESCRIPTION
Motivation:

JUnit 5 leverages features from Java 8 or later, such as lambda functions, making tests more powerful and easier to maintain.
JUnit 5 has added some very useful new features for describing, organizing, and executing tests. For instance, tests get better display names and can be organized hierarchically.
JUnit 5 is organized into multiple libraries, so only the features you need are imported into your project. With build systems such as Maven and Gradle, including the right libraries is easy.
JUnit 5 can use more than one extension at a time, which JUnit 4 could not (only one runner could be used at a time). This means you can easily combine the Spring extension with other extensions (such as your own custom extension).
Modifications:

Unit tests have been migrated from JUnit 4 to JUnit 5

Result:

Modules servicetalk-http-* now run tests using JUnit 5