### PR TITLE
Migrate servicetalk-grpc-* tests to junit5

### DIFF
--- a/servicetalk-grpc-api/build.gradle
+++ b/servicetalk-grpc-api/build.gradle
@@ -37,7 +37,9 @@ dependencies {
   implementation "com.google.protobuf:protobuf-java:$protobufVersion"
 
   testImplementation project(":servicetalk-test-resources")
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -58,9 +58,12 @@ dependencies {
   testImplementation "io.grpc:grpc-stub:$grpcVersion"
   testImplementation "io.netty:netty-tcnative-boringssl-static:$tcnativeVersion"
   testImplementation "jakarta.annotation:jakarta.annotation-api:$javaxAnnotationsApiVersion"
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
+  testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }
 
 protobuf {

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/api/CatchAllHttpServiceFilterTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/api/CatchAllHttpServiceFilterTest.java
@@ -15,14 +15,14 @@
  */
 package io.servicetalk.grpc.api;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
 
-public class CatchAllHttpServiceFilterTest {
+class CatchAllHttpServiceFilterTest {
 
     @Test
-    public void verifyAsyncContext() throws Exception {
+    void verifyAsyncContext() throws Exception {
         verifyServerFilterAsyncContextVisibility(GrpcServerBuilder.CatchAllHttpServiceFilter::new);
     }
 }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ClosureTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ClosureTest.java
@@ -18,7 +18,6 @@ package io.servicetalk.grpc.netty;
 import io.servicetalk.concurrent.GracefulAutoCloseable;
 import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTestBiDiStreamRpc;
 import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTestRequestStreamRpc;
 import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTestResponseStreamRpc;
@@ -31,13 +30,9 @@ import io.servicetalk.grpc.netty.TesterProto.Tester.TestRpc;
 import io.servicetalk.grpc.netty.TesterProto.Tester.TesterService;
 import io.servicetalk.transport.api.ServerContext;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -46,7 +41,6 @@ import static io.servicetalk.concurrent.api.Completable.defer;
 import static io.servicetalk.grpc.netty.GrpcServers.forAddress;
 import static io.servicetalk.grpc.netty.TesterProto.Tester.ServiceFactory;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
-import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -57,24 +51,18 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-@RunWith(Parameterized.class)
-public class ClosureTest {
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
+class ClosureTest {
 
-    private final boolean closeGracefully;
+    private boolean closeGracefully;
 
-    public ClosureTest(final boolean closeGracefully) {
+    private void setUp(final boolean closeGracefully) {
         this.closeGracefully = closeGracefully;
     }
 
-    @Parameterized.Parameters(name = "graceful? => {0}")
-    public static Collection<Boolean> data() {
-        return asList(true, false);
-    }
-
-    @Test
-    public void serviceImplIsClosed() throws Exception {
+    @ParameterizedTest(name = "graceful? => {0}")
+    @ValueSource(booleans = {true, false})
+    void serviceImplIsClosed(final boolean param) throws Exception {
+        setUp(param);
         CloseSignal signal = new CloseSignal(1);
         TesterService svc = setupCloseMock(mock(TesterService.class), signal);
         startServerAndClose(new ServiceFactory(svc), signal);
@@ -82,8 +70,10 @@ public class ClosureTest {
         signal.verifyCloseAtLeastCount(closeGracefully);
     }
 
-    @Test
-    public void blockingServiceImplIsClosed() throws Exception {
+    @ParameterizedTest(name = "graceful? => {0}")
+    @ValueSource(booleans = {true, false})
+    void blockingServiceImplIsClosed(final boolean param) throws Exception {
+        setUp(param);
         CloseSignal signal = new CloseSignal(1);
         BlockingTesterService svc = setupBlockingCloseMock(mock(BlockingTesterService.class), signal);
         startServerAndClose(new ServiceFactory(svc), signal);
@@ -91,8 +81,10 @@ public class ClosureTest {
         signal.verifyCloseAtLeastCount(closeGracefully);
     }
 
-    @Test
-    public void rpcMethodsAreClosed() throws Exception {
+    @ParameterizedTest(name = "graceful? => {0}")
+    @ValueSource(booleans = {true, false})
+    void rpcMethodsAreClosed(final boolean param) throws Exception {
+        setUp(param);
         CloseSignal signal = new CloseSignal(4);
         TestRpc testRpc = setupCloseMock(mock(TestRpc.class), signal);
         TestRequestStreamRpc testRequestStreamRpc = setupCloseMock(mock(TestRequestStreamRpc.class), signal);
@@ -111,8 +103,10 @@ public class ClosureTest {
         signal.verifyClose(closeGracefully);
     }
 
-    @Test
-    public void blockingRpcMethodsAreClosed() throws Exception {
+    @ParameterizedTest(name = "graceful? => {0}")
+    @ValueSource(booleans = {true, false})
+    void blockingRpcMethodsAreClosed(final boolean param) throws Exception {
+        setUp(param);
         CloseSignal signal = new CloseSignal(4);
         BlockingTestRpc testRpc = setupBlockingCloseMock(mock(BlockingTestRpc.class), signal);
         BlockingTestRequestStreamRpc testRequestStreamRpc =
@@ -134,8 +128,10 @@ public class ClosureTest {
         signal.verifyClose(closeGracefully);
     }
 
-    @Test
-    public void mixedModeRpcMethodsAreClosed() throws Exception {
+    @ParameterizedTest(name = "graceful? => {0}")
+    @ValueSource(booleans = {true, false})
+    void mixedModeRpcMethodsAreClosed(final boolean param) throws Exception {
+        setUp(param);
         CloseSignal signal = new CloseSignal(4);
         TestRpc testRpc = setupCloseMock(mock(TestRpc.class), signal);
         TestRequestStreamRpc testRequestStreamRpc = setupCloseMock(mock(TestRequestStreamRpc.class), signal);

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcRouterConfigurationTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcRouterConfigurationTest.java
@@ -16,7 +16,6 @@
 package io.servicetalk.grpc.netty;
 
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.grpc.api.GrpcServiceContext;
 import io.servicetalk.grpc.api.GrpcStatusException;
 import io.servicetalk.grpc.netty.TesterProto.TestRequest;
@@ -35,10 +34,8 @@ import io.servicetalk.grpc.netty.TesterProto.Tester.TestRpc;
 import io.servicetalk.grpc.netty.TesterProto.Tester.TesterService;
 import io.servicetalk.transport.api.ServerContext;
 
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
@@ -57,22 +54,19 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class GrpcRouterConfigurationTest {
+class GrpcRouterConfigurationTest {
 
     private static final TestRequest REQUEST = TestRequest.newBuilder().setName("test").build();
-
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
 
     @Nullable
     private ServerContext serverContext;
     @Nullable
     private BlockingTesterClient client;
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    void tearDown() throws Exception {
         try {
             if (client != null) {
                 client.close();
@@ -95,7 +89,7 @@ public class GrpcRouterConfigurationTest {
     }
 
     @Test
-    public void testMissedRouteThrowsUnimplementedException() throws Exception {
+    void testMissedRouteThrowsUnimplementedException() throws Exception {
         BlockingTesterClient client = createGrpcClient(startGrpcServer(new ServiceFactory.Builder()
                 .test(DEFAULT_STRATEGY_ASYNC_SERVICE)
                 .build()));
@@ -108,7 +102,7 @@ public class GrpcRouterConfigurationTest {
     }
 
     @Test
-    public void testCanNotAppendFilterWithoutImplementingAllRoutes() {
+    void testCanNotAppendFilterWithoutImplementingAllRoutes() {
         Throwable t = assertThrows(IllegalArgumentException.class, () -> startGrpcServer(new ServiceFactory.Builder()
                 .test(DEFAULT_STRATEGY_ASYNC_SERVICE)
                 .build()
@@ -125,7 +119,7 @@ public class GrpcRouterConfigurationTest {
     }
 
     @Test
-    public void testCanNotOverrideAlreadyRegisteredPath() {
+    void testCanNotOverrideAlreadyRegisteredPath() {
         final TesterService asyncService = DEFAULT_STRATEGY_ASYNC_SERVICE;
         final TesterService alternativeAsyncService = CLASS_NO_OFFLOADS_STRATEGY_ASYNC_SERVICE;
         testCanNotOverrideAlreadyRegisteredPath(TestRpc.PATH, builder -> builder
@@ -164,7 +158,7 @@ public class GrpcRouterConfigurationTest {
     }
 
     @Test
-    public void testCanNotOverrideAlreadyRegisteredPathWithAnotherStrategy() {
+    void testCanNotOverrideAlreadyRegisteredPathWithAnotherStrategy() {
         final TesterService asyncService = DEFAULT_STRATEGY_ASYNC_SERVICE;
         testCanNotOverrideAlreadyRegisteredPath(TestRpc.PATH, builder -> builder
                 .test(asyncService)
@@ -201,7 +195,7 @@ public class GrpcRouterConfigurationTest {
     }
 
     @Test
-    public void testCanNotOverrideAlreadyRegisteredPathWithAnotherApi() {
+    void testCanNotOverrideAlreadyRegisteredPathWithAnotherApi() {
         final TesterService asyncService = DEFAULT_STRATEGY_ASYNC_SERVICE;
         final BlockingTesterService blockingService = DEFAULT_STRATEGY_BLOCKING_SERVICE;
 
@@ -248,25 +242,25 @@ public class GrpcRouterConfigurationTest {
     }
 
     @Test
-    public void testCanNotOverrideAlreadyRegisteredPathWithAnotherServiceFactoryAsyncAsync() {
+    void testCanNotOverrideAlreadyRegisteredPathWithAnotherServiceFactoryAsyncAsync() {
         testCanNotOverrideAlreadyRegisteredPath(new ServiceFactory(DEFAULT_STRATEGY_ASYNC_SERVICE),
                 new ServiceFactory(CLASS_NO_OFFLOADS_STRATEGY_ASYNC_SERVICE));
     }
 
     @Test
-    public void testCanNotOverrideAlreadyRegisteredPathWithAnotherServiceFactoryAsyncBlocking() {
+    void testCanNotOverrideAlreadyRegisteredPathWithAnotherServiceFactoryAsyncBlocking() {
         testCanNotOverrideAlreadyRegisteredPath(new ServiceFactory(DEFAULT_STRATEGY_ASYNC_SERVICE),
                 new ServiceFactory(DEFAULT_STRATEGY_BLOCKING_SERVICE));
     }
 
     @Test
-    public void testCanNotOverrideAlreadyRegisteredPathWithAnotherServiceFactoryBlockingBlocking() {
+    void testCanNotOverrideAlreadyRegisteredPathWithAnotherServiceFactoryBlockingBlocking() {
         testCanNotOverrideAlreadyRegisteredPath(new ServiceFactory(DEFAULT_STRATEGY_BLOCKING_SERVICE),
                 new ServiceFactory(CLASS_NO_OFFLOADS_STRATEGY_BLOCKING_SERVICE));
     }
 
     @Test
-    public void testCanNotOverrideAlreadyRegisteredPathWithAnotherServiceFactoryBlockingAsync() {
+    void testCanNotOverrideAlreadyRegisteredPathWithAnotherServiceFactoryBlockingAsync() {
         testCanNotOverrideAlreadyRegisteredPath(new ServiceFactory(DEFAULT_STRATEGY_BLOCKING_SERVICE),
                 new ServiceFactory(DEFAULT_STRATEGY_ASYNC_SERVICE));
     }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcUdsTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcUdsTest.java
@@ -24,36 +24,38 @@ import io.grpc.examples.helloworld.Greeter.ClientFactory;
 import io.grpc.examples.helloworld.Greeter.GreeterService;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.grpc.netty.GrpcClients.forResolvedAddress;
 import static io.servicetalk.grpc.netty.GrpcServers.forAddress;
 import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
 import static io.servicetalk.transport.netty.internal.AddressUtils.newSocketAddress;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class GrpcUdsTest {
+class GrpcUdsTest {
+    @Nullable
     private static IoExecutor ioExecutor;
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    static void beforeClass() {
         ioExecutor = createIoExecutor(new IoThreadFactory("io-executor"));
     }
 
-    @AfterClass
-    public static void afterClass() throws ExecutionException, InterruptedException {
+    @AfterAll
+    static void afterClass() throws ExecutionException, InterruptedException {
         ioExecutor.closeAsync().toFuture().get();
     }
 
     @Test
-    public void udsRoundTrip() throws Exception {
-        assumeTrue(ioExecutor.isUnixDomainSocketSupported());
+    void udsRoundTrip() throws Exception {
+        Assumptions.assumeTrue(ioExecutor.isUnixDomainSocketSupported());
         String greetingPrefix = "Hello ";
         String name = "foo";
         String expectedResponse = greetingPrefix + name;
@@ -64,7 +66,7 @@ public class GrpcUdsTest {
              BlockingGreeterClient client = forResolvedAddress(serverContext.listenAddress())
                      .buildBlocking(new ClientFactory())) {
             assertEquals(expectedResponse,
-                    client.sayHello(HelloRequest.newBuilder().setName(name).build()).getMessage());
+                                    client.sayHello(HelloRequest.newBuilder().setName(name).build()).getMessage());
         }
     }
 }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/HttpResponseUponGrpcRequestTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/HttpResponseUponGrpcRequestTest.java
@@ -21,8 +21,8 @@ import io.servicetalk.grpc.netty.TesterProto.TestRequest;
 import io.servicetalk.http.netty.HttpServers;
 import io.servicetalk.transport.api.ServerContext;
 
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.concurrent.ExecutionException;
 
@@ -37,17 +37,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public final class HttpResponseUponGrpcRequestTest {
+final class HttpResponseUponGrpcRequestTest {
 
-    private ServerContext serverContext;
-    private TesterProto.Tester.BlockingTesterClient client;
+    private final TesterProto.Tester.BlockingTesterClient client;
 
-    public HttpResponseUponGrpcRequestTest() throws Exception {
+    HttpResponseUponGrpcRequestTest() throws Exception {
         final String responsePayload = "non-grpc error!";
-        serverContext = HttpServers.forAddress(localAddress(0))
+        ServerContext serverContext = HttpServers.forAddress(localAddress(0))
                 .protocols(h2Default())
                 .listenAndAwait((ctx, request, responseFactory) ->
                         succeeded(responseFactory.badRequest().payloadBody(responsePayload, textSerializer())));
@@ -57,43 +56,43 @@ public final class HttpResponseUponGrpcRequestTest {
     }
 
     @Test
-    public void testBlockingAggregated() {
+    void testBlockingAggregated() {
         assertThrowsGrpcStatusException(() -> client.test(request()));
     }
 
     @Test
-    public void testBlockingRequestStreaming() {
+    void testBlockingRequestStreaming() {
         assertThrowsGrpcStatusException(() -> client.testRequestStream(singletonList(request())));
     }
 
     @Test
-    public void testBlockingResponseStreaming() {
+    void testBlockingResponseStreaming() {
         assertThrowsGrpcStatusException(() -> client.testResponseStream(request()).forEach(__ -> { /* noop */ }));
     }
 
     @Test
-    public void testBlockingBiDiStreaming() {
+    void testBlockingBiDiStreaming() {
         assertThrowsGrpcStatusException(() -> client.testBiDiStream(singletonList(request()))
                 .forEach(__ -> { /* noop */ }));
     }
 
     @Test
-    public void testAggregated() {
+    void testAggregated() {
         assertThrowsExecutionException(() -> client.asClient().test(request()).toFuture().get());
     }
 
     @Test
-    public void testRequestStreaming() {
+    void testRequestStreaming() {
         assertThrowsExecutionException(() -> client.asClient().testRequestStream(from(request())).toFuture().get());
     }
 
     @Test
-    public void testResponseStreaming() {
+    void testResponseStreaming() {
         assertThrowsExecutionException(() -> client.asClient().testResponseStream(request()).toFuture().get());
     }
 
     @Test
-    public void testBiDiStreaming() {
+    void testBiDiStreaming() {
         assertThrowsExecutionException(() -> client.asClient().testBiDiStream(from(request())).toFuture().get());
     }
 
@@ -101,14 +100,14 @@ public final class HttpResponseUponGrpcRequestTest {
         return TestRequest.newBuilder().setName("request").build();
     }
 
-    private static void assertThrowsExecutionException(ThrowingRunnable runnable) {
-        ExecutionException ex = assertThrows(ExecutionException.class, runnable);
+    private static void assertThrowsExecutionException(Executable executable) {
+        ExecutionException ex = assertThrows(ExecutionException.class, executable);
         assertThat(ex.getCause(), is(instanceOf(GrpcStatusException.class)));
         assertGrpcStatusException((GrpcStatusException) ex.getCause());
     }
 
-    private static void assertThrowsGrpcStatusException(ThrowingRunnable runnable) {
-        assertGrpcStatusException(assertThrows(GrpcStatusException.class, runnable));
+    private static void assertThrowsGrpcStatusException(Executable executable) {
+        assertGrpcStatusException(assertThrows(GrpcStatusException.class, executable));
     }
 
     private static void assertGrpcStatusException(GrpcStatusException grpcStatusException) {

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/TrailersOnlyErrorTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/TrailersOnlyErrorTest.java
@@ -42,7 +42,7 @@ import io.servicetalk.transport.api.ServerContext;
 import io.grpc.examples.helloworld.Greeter;
 import io.grpc.examples.helloworld.Greeter.GreeterClient;
 import io.grpc.examples.helloworld.HelloRequest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.BlockingQueue;
@@ -63,18 +63,18 @@ import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAnd
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TrailersOnlyErrorTest {
+class TrailersOnlyErrorTest {
 
     private static final CharSequence GRPC_STATUS_HEADER = newAsciiString("grpc-status");
 
     @Test
-    public void testRouteThrows() throws Exception {
+    void testRouteThrows() throws Exception {
         final BlockingQueue<Throwable> asyncErrors = new LinkedBlockingDeque<>();
         try (ServerContext serverContext = GrpcServers.forAddress(localAddress(0))
                 .listenAndAwait(new Tester.ServiceFactory(mockTesterService()))) {
@@ -93,7 +93,7 @@ public class TrailersOnlyErrorTest {
     }
 
     @Test
-    public void testServiceThrows() throws Exception {
+    void testServiceThrows() throws Exception {
         final BlockingQueue<Throwable> asyncErrors = new LinkedBlockingDeque<>();
         final TesterService service = mockTesterService();
         setupServiceThrows(service);
@@ -126,7 +126,7 @@ public class TrailersOnlyErrorTest {
     }
 
     @Test
-    public void testServiceSingleThrows() throws Exception {
+    void testServiceSingleThrows() throws Exception {
         final BlockingQueue<Throwable> asyncErrors = new LinkedBlockingDeque<>();
         final TesterService service = mockTesterService();
         setupServiceSingleThrows(service);
@@ -146,7 +146,7 @@ public class TrailersOnlyErrorTest {
     }
 
     @Test
-    public void testServiceFilterThrows() throws Exception {
+    void testServiceFilterThrows() throws Exception {
         final BlockingQueue<Throwable> asyncErrors = new LinkedBlockingDeque<>();
         final TesterService service = mockTesterService();
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/protoc/GeneratorTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/protoc/GeneratorTest.java
@@ -17,7 +17,7 @@ package io.servicetalk.grpc.protoc;
 
 import io.servicetalk.grpc.netty.TesterProto.Tester;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -28,10 +28,10 @@ import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class GeneratorTest {
+class GeneratorTest {
 
     @Test
-    public void testGeneratedFunctionalInterfaces() {
+    void testGeneratedFunctionalInterfaces() {
 
         final List<Class<?>> generatedRpcInterfaces = stream(Tester.class.getDeclaredClasses())
                 .filter(declaredClass -> declaredClass.getAnnotation(FunctionalInterface.class) != null

--- a/servicetalk-grpc-protobuf/build.gradle
+++ b/servicetalk-grpc-protobuf/build.gradle
@@ -36,9 +36,11 @@ dependencies {
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
 
   testImplementation project(":servicetalk-test-resources")
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }
 
 protobuf {

--- a/servicetalk-grpc-protobuf/src/test/java/io/servicetalk/grpc/protobuf/ProtoDeserializerTest.java
+++ b/servicetalk-grpc-protobuf/src/test/java/io/servicetalk/grpc/protobuf/ProtoDeserializerTest.java
@@ -20,7 +20,7 @@ import io.servicetalk.buffer.api.CompositeBuffer;
 import io.servicetalk.serialization.api.StreamingDeserializer;
 
 import com.google.protobuf.Parser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -37,62 +37,62 @@ import static java.util.stream.StreamSupport.stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 
-public class ProtoDeserializerTest {
+class ProtoDeserializerTest {
 
     private final Parser<DummyMessage> parser = DummyMessage.parser();
     private final ProtoBufSerializationProvider<DummyMessage> serializationProvider =
             new ProtoBufSerializationProvider<>(DummyMessage.class, identity(), parser);
 
     @Test
-    public void zeroLengthMessageAligned() throws IOException {
+    void zeroLengthMessageAligned() throws IOException {
         List<String> deserialized = deserialize(grpcBufferFor(new String[]{null}));
         assertThat("Unexpected messages deserialized.", deserialized, contains(""));
     }
 
     @Test
-    public void zeroLengthFirstMessageAligned() throws IOException {
+    void zeroLengthFirstMessageAligned() throws IOException {
         List<String> deserialized = deserialize(grpcBufferFor(null, "Hello"));
         assertThat("Unexpected messages deserialized.", deserialized, contains("", "Hello"));
     }
 
     @Test
-    public void zeroLengthLastMessageAligned() throws IOException {
+    void zeroLengthLastMessageAligned() throws IOException {
         List<String> deserialized = deserialize(grpcBufferFor("Hello", null));
         assertThat("Unexpected messages deserialized.", deserialized, contains("Hello", ""));
     }
 
     @Test
-    public void zeroLengthMiddleMessageAligned() throws IOException {
+    void zeroLengthMiddleMessageAligned() throws IOException {
         List<String> deserialized = deserialize(grpcBufferFor("Hello1", null, "Hello2"));
         assertThat("Unexpected messages deserialized.", deserialized, contains("Hello1", "", "Hello2"));
     }
 
     @Test
-    public void singleMessageAligned() throws IOException {
+    void singleMessageAligned() throws IOException {
         List<String> deserialized = deserialize(grpcBufferFor("Hello"));
         assertThat("Unexpected messages deserialized.", deserialized, contains("Hello"));
     }
 
     @Test
-    public void singleMessageAlignedAsIterable() throws IOException {
+    void singleMessageAlignedAsIterable() throws IOException {
         List<String> deserialized = deserialize(new Buffer[]{grpcBufferFor("Hello")});
         assertThat("Unexpected messages deserialized.", deserialized, contains("Hello"));
     }
 
     @Test
-    public void multipleMessagesAligned() throws IOException {
+    void multipleMessagesAligned() throws IOException {
         List<String> deserialized = deserialize(grpcBufferFor("Hello1"), grpcBufferFor("Hello2"));
         assertThat("Unexpected messages deserialized.", deserialized, contains("Hello1", "Hello2"));
     }
 
     @Test
-    public void multipleMessagesInSingleBuffer() throws IOException {
+    void multipleMessagesInSingleBuffer() throws IOException {
         List<String> deserialized = deserialize(grpcBufferFor("Hello1", "Hello2"));
         assertThat("Unexpected messages deserialized.", deserialized, contains("Hello1", "Hello2"));
     }
 
     @Test
-    public void splitMessageInBuffers() throws IOException {
+    void splitMessageInBuffers() throws IOException {
         Buffer msg = grpcBufferFor("Hello");
         List<Buffer> buffers = new ArrayList<>();
         while (msg.readableBytes() > 0) {
@@ -103,7 +103,7 @@ public class ProtoDeserializerTest {
     }
 
     @Test
-    public void multipleMessagesInCompositeBuffer() throws IOException {
+    void multipleMessagesInCompositeBuffer() throws IOException {
         final CompositeBuffer composite = DEFAULT_ALLOCATOR.newCompositeBuffer();
         Buffer msg = grpcBufferFor("Hello");
         while (msg.readableBytes() > 0) {

--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -33,7 +33,10 @@ dependencies {
 
   testImplementation project(":servicetalk-grpc-api")
   testImplementation project(":servicetalk-grpc-protobuf")
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
+  testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }
 
 jar {

--- a/servicetalk-grpc-protoc/src/test/java/io/servicetalk/grpc/protoc/StringUtilsTest.java
+++ b/servicetalk-grpc-protoc/src/test/java/io/servicetalk/grpc/protoc/StringUtilsTest.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.grpc.protoc;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -23,29 +23,29 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class StringUtilsTest {
+class StringUtilsTest {
     @Test
-    public void emptyOptions() {
+    void emptyOptions() {
         Map<String, String> options = StringUtils.parseOptions("");
         assertThat(options.isEmpty(), is(true));
     }
 
     @Test
-    public void singleEntryNoValue() {
+    void singleEntryNoValue() {
         Map<String, String> options = StringUtils.parseOptions("foo");
         assertThat(options.size(), is(1));
         assertContainsNullValue(options, "foo");
     }
 
     @Test
-    public void singleEntryValue() {
+    void singleEntryValue() {
         Map<String, String> options = StringUtils.parseOptions("foo=bar");
         assertThat(options.size(), is(1));
         assertThat(options.get("foo"), is("bar"));
     }
 
     @Test
-    public void twoEntriesNoValues() {
+    void twoEntriesNoValues() {
         Map<String, String> options = StringUtils.parseOptions("foo1,foo2");
         assertThat(options.size(), is(2));
         assertContainsNullValue(options, "foo1");
@@ -53,7 +53,7 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void twoEntriesFirstValue() {
+    void twoEntriesFirstValue() {
         Map<String, String> options = StringUtils.parseOptions("foo1=bar1,foo2");
         assertThat(options.size(), is(2));
         assertThat(options.get("foo1"), is("bar1"));
@@ -61,7 +61,7 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void twoEntriesSecondValue() {
+    void twoEntriesSecondValue() {
         Map<String, String> options = StringUtils.parseOptions("foo1,foo2=bar2");
         assertThat(options.size(), is(2));
         assertContainsNullValue(options, "foo1");
@@ -69,7 +69,7 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void twoEntriesBothValues() {
+    void twoEntriesBothValues() {
         Map<String, String> options = StringUtils.parseOptions("foo1=bar1,foo2=bar2");
         assertThat(options.size(), is(2));
         assertThat(options.get("foo1"), is("bar1"));
@@ -77,7 +77,7 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void threeEntriesNoValues() {
+    void threeEntriesNoValues() {
         Map<String, String> options = StringUtils.parseOptions("foo1,foo2,foo3");
         assertThat(options.size(), is(3));
         assertContainsNullValue(options, "foo1");
@@ -86,7 +86,7 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void threeEntriesFirstValue() {
+    void threeEntriesFirstValue() {
         Map<String, String> options = StringUtils.parseOptions("foo1=bar1,foo2,foo3");
         assertThat(options.size(), is(3));
         assertThat(options.get("foo1"), is("bar1"));
@@ -95,7 +95,7 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void threeEntriesSecondValue() {
+    void threeEntriesSecondValue() {
         Map<String, String> options = StringUtils.parseOptions("foo1,foo2=bar2,foo3");
         assertThat(options.size(), is(3));
         assertContainsNullValue(options, "foo1");
@@ -104,7 +104,7 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void threeEntriesThirdValue() {
+    void threeEntriesThirdValue() {
         Map<String, String> options = StringUtils.parseOptions("foo1,foo2,foo3=bar3");
         assertThat(options.size(), is(3));
         assertContainsNullValue(options, "foo1");
@@ -113,7 +113,7 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void threeEntriesFirstSecondValue() {
+    void threeEntriesFirstSecondValue() {
         Map<String, String> options = StringUtils.parseOptions("foo1=bar1,foo2=bar2,foo3");
         assertThat(options.size(), is(3));
         assertThat(options.get("foo1"), is("bar1"));
@@ -122,7 +122,7 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void threeEntriesFirstThirdValue() {
+    void threeEntriesFirstThirdValue() {
         Map<String, String> options = StringUtils.parseOptions("foo1=bar1,foo2,foo3=bar3");
         assertThat(options.size(), is(3));
         assertThat(options.get("foo1"), is("bar1"));
@@ -131,7 +131,7 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void threeEntriesSecondThirdValue() {
+    void threeEntriesSecondThirdValue() {
         Map<String, String> options = StringUtils.parseOptions("foo1,foo2=bar2,foo3=bar3");
         assertThat(options.size(), is(3));
         assertContainsNullValue(options, "foo1");
@@ -140,7 +140,7 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void threeEntriesValues() {
+    void threeEntriesValues() {
         Map<String, String> options = StringUtils.parseOptions("foo1=bar1,foo2=bar2,foo3=bar3");
         assertThat(options.size(), is(3));
         assertThat(options.get("foo1"), is("bar1"));

--- a/servicetalk-grpc-protoc/src/test/java/io/servicetalk/grpc/protoc/TestConflictMultiService.java
+++ b/servicetalk-grpc-protoc/src/test/java/io/servicetalk/grpc/protoc/TestConflictMultiService.java
@@ -19,13 +19,13 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.grpc.protoc.test.conflict.multi.service.TestConflictMultiService0.TestConflictMultiServiceService;
 import io.servicetalk.grpc.protoc.test.conflict.multi.service.TestReply;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
 
-public class TestConflictMultiService {
+class TestConflictMultiService {
     @Test
-    public void conflictMultiServiceGenerated() throws ExecutionException, InterruptedException {
+    void conflictMultiServiceGenerated() throws ExecutionException, InterruptedException {
         TestConflictMultiServiceService service = (ctx, request) -> Single.succeeded(TestReply.newBuilder().build());
         service.closeAsync().toFuture().get();
     }

--- a/servicetalk-grpc-protoc/src/test/java/io/servicetalk/grpc/protoc/TestConflictRpc.java
+++ b/servicetalk-grpc-protoc/src/test/java/io/servicetalk/grpc/protoc/TestConflictRpc.java
@@ -19,15 +19,15 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.grpc.protoc.test.conflict.rpc.TestConflictRpc.Test.TestService;
 import io.servicetalk.grpc.protoc.test.conflict.rpc.TestConflictRpc.TestRpc.TestRpcService;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
 
 import static io.servicetalk.grpc.protoc.test.conflict.rpc.TestConflictRpc.TestReply;
 
-public class TestConflictRpc {
+class TestConflictRpc {
     @Test
-    public void conflictRpcServiceGenerated() throws ExecutionException, InterruptedException {
+    void conflictRpcServiceGenerated() throws ExecutionException, InterruptedException {
         TestService service = (ctx, request) -> Single.succeeded(TestReply.newBuilder().build());
         TestRpcService rpcService = (ctx, request) -> Single.succeeded(TestReply.newBuilder().build());
 

--- a/servicetalk-grpc-protoc/src/test/java/io/servicetalk/grpc/protoc/TestConflictService.java
+++ b/servicetalk-grpc-protoc/src/test/java/io/servicetalk/grpc/protoc/TestConflictService.java
@@ -18,15 +18,15 @@ package io.servicetalk.grpc.protoc;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.grpc.protoc.test.conflict.service.TestConflictService.TestConflict.TestConflictService0;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
 
 import static io.servicetalk.grpc.protoc.test.conflict.service.TestConflictService.TestReply;
 
-public class TestConflictService {
+class TestConflictService {
     @Test
-    public void conflictRpcServiceGenerated() throws ExecutionException, InterruptedException {
+    void conflictRpcServiceGenerated() throws ExecutionException, InterruptedException {
         TestConflictService0 service = (ctx, request) -> Single.succeeded(TestReply.newBuilder().build());
 
         service.closeAsync().toFuture().get();

--- a/servicetalk-grpc-protoc/src/test/java/io/servicetalk/grpc/protoc/TestMulti.java
+++ b/servicetalk-grpc-protoc/src/test/java/io/servicetalk/grpc/protoc/TestMulti.java
@@ -23,16 +23,16 @@ import io.servicetalk.grpc.protoc.test.multi.TestRequest;
 import io.servicetalk.grpc.protoc.test.multi.Tester.TesterService;
 import io.servicetalk.grpc.protoc.test.multi.Tester2.Tester2Service;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import test.shared.TestShared.Generic;
 import test.shared.TestShared.SharedReply;
 import test.shared.TestShared.Untils;
 
 import java.util.concurrent.ExecutionException;
 
-public class TestMulti {
+class TestMulti {
     @Test
-    public void multiGenerated() throws ExecutionException, InterruptedException {
+    void multiGenerated() throws ExecutionException, InterruptedException {
         TesterService service = new TesterService() {
             @Override
             public Publisher<TestReply> testBiDiStream(final GrpcServiceContext ctx,

--- a/servicetalk-grpc-protoc/src/test/java/io/servicetalk/grpc/protoc/TestSingle.java
+++ b/servicetalk-grpc-protoc/src/test/java/io/servicetalk/grpc/protoc/TestSingle.java
@@ -23,16 +23,16 @@ import io.servicetalk.grpc.protoc.test.single.HelloWorldProto.Greeter.GreeterSer
 import io.servicetalk.grpc.protoc.test.single.HelloWorldProto.HelloReply;
 import io.servicetalk.grpc.protoc.test.single.HelloWorldProto.UserRequest;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import test.shared.TestShared.Generic;
 import test.shared.TestShared.SharedReply;
 import test.shared.TestShared.Untils;
 
 import java.util.concurrent.ExecutionException;
 
-public class TestSingle {
+class TestSingle {
     @Test
-    public void singleGenerated() throws ExecutionException, InterruptedException {
+    void singleGenerated() throws ExecutionException, InterruptedException {
         GreeterService service = new GreeterService() {
             @Override
             public Single<HelloReply> sayHelloFromMany(final GrpcServiceContext ctx,


### PR DESCRIPTION
JUnit 5 leverages features from Java 8 or later, such as lambda functions, making tests more powerful and easier to maintain.
JUnit 5 has added some very useful new features for describing, organizing, and executing tests. For instance, tests get better display names and can be organized hierarchically.
JUnit 5 is organized into multiple libraries, so only the features you need are imported into your project. With build systems such as Maven and Gradle, including the right libraries is easy.
JUnit 5 can use more than one extension at a time, which JUnit 4 could not (only one runner could be used at a time). This means you can easily combine the Spring extension with other extensions (such as your own custom extension).
Modifications:

Unit tests have been migrated from JUnit 4 to JUnit 5

Result:

Modules servicetalk-grpc-* now run tests and test suits using JUnit 5

#1568