### PR TITLE
Migrate tests to junit5 - Step 4

### DIFF
--- a/servicetalk-data-jackson/build.gradle
+++ b/servicetalk-data-jackson/build.gradle
@@ -31,7 +31,9 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-buffer-netty")
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-data-jackson/src/test/java/io/servicetalk/data/jackson/JacksonSerializationProviderTest.java
+++ b/servicetalk-data-jackson/src/test/java/io/servicetalk/data/jackson/JacksonSerializationProviderTest.java
@@ -17,16 +17,13 @@ package io.servicetalk.data.jackson;
 
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.buffer.api.EmptyBuffer;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.serialization.api.SerializationException;
 import io.servicetalk.serialization.api.StreamingDeserializer;
 import io.servicetalk.serialization.api.TypeHolder;
 
 import com.fasterxml.jackson.core.JsonParseException;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 import java.util.List;
@@ -37,20 +34,17 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class JacksonSerializationProviderTest {
-
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
+class JacksonSerializationProviderTest {
 
     private final JacksonSerializationProvider serializationProvider = new JacksonSerializationProvider();
 
     @Test
-    public void testFromClass() {
+    void testFromClass() {
         TestPojo expected = new TestPojo(true, (byte) -2, (short) -3, 'a', 2, 5, 3.2f, -8.5, null, new String[] {"bar"},
                 null);
 
@@ -64,7 +58,7 @@ public class JacksonSerializationProviderTest {
     }
 
     @Test
-    public void testFromTypeHolder() {
+    void testFromTypeHolder() {
         TypeHolder<List<TestPojo>> listTypeHolder = new TypeHolder<List<TestPojo>>() { };
 
         TestPojo expected = new TestPojo(true, (byte) -2, (short) -3, 'a', 2, 5, 3.2f, -8.5, null, new String[] {"bar"},
@@ -82,7 +76,7 @@ public class JacksonSerializationProviderTest {
     }
 
     @Test
-    public void deserializeInvalidData() {
+    void deserializeInvalidData() {
         TestPojo expected = new TestPojo(true, (byte) -2, (short) -3, 'a', 2, 5, 3.2f, -8.5, null, new String[] {"bar"},
                 null);
         final Buffer serialized = serializePojo(expected);
@@ -99,7 +93,7 @@ public class JacksonSerializationProviderTest {
     }
 
     @Test
-    public void deserializeEmpty() {
+    void deserializeEmpty() {
         final StreamingDeserializer<TestPojo> deserializer = serializationProvider.getDeserializer(TestPojo.class);
         Iterable<TestPojo> pojos = deserializer.deserialize(EmptyBuffer.EMPTY_BUFFER);
         Iterator<TestPojo> pojoItr = pojos.iterator();
@@ -108,7 +102,7 @@ public class JacksonSerializationProviderTest {
     }
 
     @Test
-    public void deserializeSingleItem() {
+    void deserializeSingleItem() {
         TestPojo expected = new TestPojo(true, Byte.MAX_VALUE, Short.MAX_VALUE, Character.MAX_VALUE, Integer.MIN_VALUE,
                 Long.MAX_VALUE, Float.MAX_VALUE, Double.MAX_VALUE, "foo", new String[] {"bar", "baz"}, null);
         final StreamingDeserializer<TestPojo> deserializer = serializationProvider.getDeserializer(TestPojo.class);
@@ -120,7 +114,7 @@ public class JacksonSerializationProviderTest {
     }
 
     @Test
-    public void deserializeTwoItemsFromTwoBuffers() {
+    void deserializeTwoItemsFromTwoBuffers() {
         TestPojo expected1 = new TestPojo(true, (byte) -2, (short) -3, 'a', 2, 5, 3.2f, -8.5, null,
                 new String[] {"bar", "baz"}, null);
         TestPojo expected2 = new TestPojo(false, (byte) 500, (short) 353, 'r', 100, 534, 33.25f, 888.5, null,
@@ -140,7 +134,7 @@ public class JacksonSerializationProviderTest {
     }
 
     @Test
-    public void deserializeTwoItemsFromSingleBuffer() {
+    void deserializeTwoItemsFromSingleBuffer() {
         TestPojo expected1 = new TestPojo(true, (byte) -2, (short) -3, 'a', 2, 5, 3.2f, -8.5, null,
                 new String[] {"bar", "baz"}, null);
         TestPojo expected2 = new TestPojo(false, (byte) 500, (short) 353, 'r', 100, 534, 33.25f, 888.5, null,
@@ -158,14 +152,15 @@ public class JacksonSerializationProviderTest {
         assertTrue(iter.hasNext());
         assertEquals(expected1, iter.next());
         assertTrue(iter.hasNext());
-        assertEquals(expected2, iter.next());
+        final TestPojo next = iter.next();
+        assertEquals(expected2, next);
         assertFalse(iter.hasNext());
 
         assertThat("Unexpected data remaining in deserializer", deserializer.hasData(), is(false));
     }
 
     @Test
-    public void deserializeSplitAcrossMultipleBuffers() {
+    void deserializeSplitAcrossMultipleBuffers() {
         TestPojo expected1 = new TestPojo(true, (byte) -2, (short) -3, 'a', 2, 5, 3.2f, -8.5, null,
                 new String[] {"bar", "baz"}, null);
         TestPojo expected2 = new TestPojo(false, (byte) 500, (short) 353, 'r', 100, 534, 33.25f, 888.5, null,
@@ -184,7 +179,7 @@ public class JacksonSerializationProviderTest {
     }
 
     @Test
-    public void deserializeIncompleteBufferAsAggregated() {
+    void deserializeIncompleteBufferAsAggregated() {
         TestPojo expected = new TestPojo(true, (byte) -2, (short) -3, 'a', 2, 5, 3.2f, -8.5, null, new String[] {"bar"},
                 null);
         final Buffer buffer = serializePojo(expected);
@@ -199,7 +194,7 @@ public class JacksonSerializationProviderTest {
     }
 
     @Test
-    public void testParseOnlyValueString() {
+    void testParseOnlyValueString() {
         String json = "\"x\"";
         final Buffer buffer = DEFAULT_ALLOCATOR.fromAscii(json);
         final StreamingDeserializer<String> deSerializer = serializationProvider.getDeserializer(String.class);
@@ -210,7 +205,7 @@ public class JacksonSerializationProviderTest {
     }
 
     @Test
-    public void testParseOnlyValueNull() {
+    void testParseOnlyValueNull() {
         String json = "null";
         final Buffer buffer = DEFAULT_ALLOCATOR.fromAscii(json);
         final StreamingDeserializer<String> deSerializer = serializationProvider.getDeserializer(String.class);
@@ -219,9 +214,9 @@ public class JacksonSerializationProviderTest {
         deSerializer.close();
     }
 
-    @Ignore("Jackson currently does not support parsing only boolean value.")
+    @Disabled("Jackson currently does not support parsing only boolean value.")
     @Test
-    public void testParseOnlyValueBoolean() {
+    void testParseOnlyValueBoolean() {
         String json = "true";
         final Buffer buffer = DEFAULT_ALLOCATOR.fromAscii(json);
         final StreamingDeserializer<Boolean> deSerializer = serializationProvider.getDeserializer(Boolean.class);
@@ -231,9 +226,9 @@ public class JacksonSerializationProviderTest {
         deSerializer.close();
     }
 
-    @Ignore("Jackson currently does not support parsing only number value.")
+    @Disabled("Jackson currently does not support parsing only number value.")
     @Test
-    public void testParseOnlyValueInt() {
+    void testParseOnlyValueInt() {
         String json = "1";
         final Buffer buffer = DEFAULT_ALLOCATOR.fromAscii(json);
         final StreamingDeserializer<Integer> deSerializer = serializationProvider.getDeserializer(Integer.class);

--- a/servicetalk-data-jackson/src/test/java/io/servicetalk/data/jackson/TestPojo.java
+++ b/servicetalk-data-jackson/src/test/java/io/servicetalk/data/jackson/TestPojo.java
@@ -23,9 +23,9 @@ import javax.annotation.Nullable;
 
 import static java.lang.Math.abs;
 import static java.util.Objects.hash;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * An {@link Object} for testing JSON serialization.
@@ -98,7 +98,8 @@ public final class TestPojo {
 
     @Override
     public int hashCode() {
-        return hash(myBoolean, myByte, myShort, myChar, myInt, myLong, myFloat, myDouble, myString, myStringArray,
+        return hash(myBoolean, myByte, myShort, myChar, myInt, myLong, myFloat, myDouble, myString,
+                Arrays.hashCode(myStringArray),
                 myPojo);
     }
 

--- a/servicetalk-data-protobuf/build.gradle
+++ b/servicetalk-data-protobuf/build.gradle
@@ -40,9 +40,11 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-buffer-netty")
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }
 
 protobuf {

--- a/servicetalk-encoding-netty/build.gradle
+++ b/servicetalk-encoding-netty/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
     testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
-    testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
     testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
+
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-log4j2-mdc-utils/build.gradle
+++ b/servicetalk-log4j2-mdc-utils/build.gradle
@@ -25,9 +25,11 @@ dependencies {
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
 
   testImplementation project(":servicetalk-test-resources")
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.slf4j:slf4j-api:$slf4jVersion"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/servicetalk-log4j2-mdc-utils/src/test/java/io/servicetalk/log4j2/mdc/utils/ServiceTalkThreadContextMapTest.java
+++ b/servicetalk-log4j2-mdc-utils/src/test/java/io/servicetalk/log4j2/mdc/utils/ServiceTalkThreadContextMapTest.java
@@ -19,8 +19,8 @@ import io.servicetalk.concurrent.SingleSource.Subscriber;
 import io.servicetalk.concurrent.api.Single;
 
 import org.apache.logging.log4j.ThreadContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -32,33 +32,31 @@ import java.util.concurrent.Executors;
 
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.log4j2.mdc.utils.ServiceTalkThreadContextMap.getStorage;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class ServiceTalkThreadContextMapTest {
+class ServiceTalkThreadContextMapTest {
     private static final Logger logger = LoggerFactory.getLogger(ServiceTalkThreadContextMapTest.class);
 
-    @Before
-    public void verifyMDCSetup() {
-        assumeThat(ThreadContext.getThreadContextMap(), is(instanceOf(ServiceTalkThreadContextMap.class)));
+    @BeforeEach
+    void verifyMDCSetup() {
+        assumeTrue(ThreadContext.getThreadContextMap() instanceof ServiceTalkThreadContextMap);
     }
 
     @Test
-    public void testSimpleExecution() {
+    void testSimpleExecution() {
         MDC.clear();
         assertEquals(0, MDC.getCopyOfContextMap().size());
-        assertEquals("unexpected map: " + getStorage(), 0, getStorage().size());
+        assertEquals(0, getStorage().size(), "unexpected map: " + getStorage());
 
         MDC.put("aa", "1");
         assertEquals("1", MDC.get("aa"));
         assertEquals(1, MDC.getCopyOfContextMap().size());
-        assertEquals("unexpected map: " + getStorage(), 1, getStorage().size());
+        assertEquals(1, getStorage().size(), "unexpected map: " + getStorage());
 
         MDC.put("bb", "2");
         assertEquals("2", MDC.get("bb"));
@@ -82,7 +80,7 @@ public class ServiceTalkThreadContextMapTest {
     }
 
     @Test
-    public void testAsyncExecution() throws Exception {
+    void testAsyncExecution() throws Exception {
         ExecutorService executor = Executors.newSingleThreadExecutor();
         try {
             MDC.clear();
@@ -102,7 +100,7 @@ public class ServiceTalkThreadContextMapTest {
                     });
                 }
             }.map(v -> {
-                assertNotEquals(original, Thread.currentThread());
+                assertNotEquals(Thread.currentThread(), original);
                 assertEquals("1", MDC.get("a"));
                 assertEquals("2", MDC.get("b"));
                 MDC.put("b", "22");
@@ -120,7 +118,7 @@ public class ServiceTalkThreadContextMapTest {
     }
 
     @Test
-    public void testGetImmutableMapOrNull() {
+    void testGetImmutableMapOrNull() {
         ServiceTalkThreadContextMap map = new ServiceTalkThreadContextMap();
         // The map is backed by thread local storage. So we make sure to clear it so other tests don't interfere.
         map.clear();
@@ -128,7 +126,7 @@ public class ServiceTalkThreadContextMapTest {
         map.put("x", "10");
         Map<String, String> immutableMap = map.getImmutableMapOrNull();
         assertNotNull(immutableMap);
-        assertEquals(immutableMap.size(), 1);
+        assertEquals(1, immutableMap.size());
         try {
             immutableMap.put("y", "20");
             fail();

--- a/servicetalk-log4j2-mdc/build.gradle
+++ b/servicetalk-log4j2-mdc/build.gradle
@@ -21,6 +21,8 @@ dependencies {
   implementation project(":servicetalk-log4j2-mdc-utils")
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
 
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-log4j2-mdc/src/test/java/io/servicetalk/log4j2/mdc/ServiceTalkThreadContextMapLog4jProviderTest.java
+++ b/servicetalk-log4j2-mdc/src/test/java/io/servicetalk/log4j2/mdc/ServiceTalkThreadContextMapLog4jProviderTest.java
@@ -18,15 +18,15 @@ package io.servicetalk.log4j2.mdc;
 import io.servicetalk.log4j2.mdc.utils.ServiceTalkThreadContextMap;
 
 import org.apache.logging.log4j.ThreadContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
-public class ServiceTalkThreadContextMapLog4jProviderTest {
+class ServiceTalkThreadContextMapLog4jProviderTest {
     @Test
-    public void testProviderLoadsClass() {
+    void testProviderLoadsClass() {
         assertThat(ThreadContext.getThreadContextMap(), is(instanceOf(ServiceTalkThreadContextMap.class)));
     }
 }

--- a/servicetalk-serialization-api/build.gradle
+++ b/servicetalk-serialization-api/build.gradle
@@ -28,7 +28,9 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-concurrent-test-internal")
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-serialization-api/src/test/java/io/servicetalk/serialization/api/BlockingIterableFlatMapTest.java
+++ b/servicetalk-serialization-api/src/test/java/io/servicetalk/serialization/api/BlockingIterableFlatMapTest.java
@@ -17,8 +17,8 @@ package io.servicetalk.serialization.api;
 
 import io.servicetalk.concurrent.BlockingIterator;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -45,15 +45,15 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class BlockingIterableFlatMapTest {
+class BlockingIterableFlatMapTest {
 
     private BlockingIterator<Integer> source;
     private Function<Integer, Iterable<String>> mapper;
     private BlockingIterableFlatMap<Integer, String> flatMap;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() throws TimeoutException {
+    @BeforeEach
+    void setUp() throws TimeoutException {
         source = mock(BlockingIterator.class);
         when(source.hasNext(leq(0), any(TimeUnit.class))).thenThrow(new TimeoutException());
         mapper = mock(Function.class);
@@ -61,7 +61,7 @@ public class BlockingIterableFlatMapTest {
     }
 
     @Test
-    public void emptyIteratorTimeout() throws TimeoutException {
+    void emptyIteratorTimeout() throws TimeoutException {
         when(source.hasNext(anyLong(), any(TimeUnit.class))).thenReturn(false);
 
         assertThat("Iterator not empty.", flatMap.iterator().hasNext(1, MILLISECONDS), is(false));
@@ -71,7 +71,7 @@ public class BlockingIterableFlatMapTest {
     }
 
     @Test
-    public void emptyIterator() {
+    void emptyIterator() {
         when(source.hasNext()).thenReturn(false);
 
         assertThat("Iterator not empty.", flatMap.iterator().hasNext(), is(false));
@@ -81,7 +81,7 @@ public class BlockingIterableFlatMapTest {
     }
 
     @Test
-    public void sourceReturnsNullTimeout() throws TimeoutException {
+    void sourceReturnsNullTimeout() throws TimeoutException {
         when(source.hasNext(anyLong(), any(TimeUnit.class))).thenReturn(true);
         when(source.next(anyLong(), any(TimeUnit.class))).thenReturn(null);
         when(mapper.apply(null)).thenReturn(singletonList(null));
@@ -96,7 +96,7 @@ public class BlockingIterableFlatMapTest {
     }
 
     @Test
-    public void sourceReturnsNull() {
+    void sourceReturnsNull() {
         when(source.hasNext()).thenReturn(true);
         when(source.next()).thenReturn(null);
         when(mapper.apply(null)).thenReturn(singletonList(null));
@@ -111,7 +111,7 @@ public class BlockingIterableFlatMapTest {
     }
 
     @Test
-    public void mapperReturnsEmptyIteratorTimeout() throws TimeoutException {
+    void mapperReturnsEmptyIteratorTimeout() throws TimeoutException {
         when(source.hasNext(anyLong(), any(TimeUnit.class))).thenAnswer(new DynamicHasNext(1));
         when(source.next(anyLong(), any(TimeUnit.class))).thenReturn(null);
         when(mapper.apply(null)).thenReturn(emptyList());
@@ -125,7 +125,7 @@ public class BlockingIterableFlatMapTest {
     }
 
     @Test
-    public void mapperReturnsEmptyIterator() {
+    void mapperReturnsEmptyIterator() {
         when(source.hasNext()).thenAnswer(new DynamicHasNext(1));
         when(source.next()).thenReturn(null);
         when(mapper.apply(null)).thenReturn(emptyList());
@@ -139,7 +139,7 @@ public class BlockingIterableFlatMapTest {
     }
 
     @Test
-    public void mapperReturnsEmptyIteratorAndThenDataTimeout() throws TimeoutException {
+    void mapperReturnsEmptyIteratorAndThenDataTimeout() throws TimeoutException {
         when(source.hasNext(anyLong(), any(TimeUnit.class))).thenAnswer(new DynamicHasNext(2));
         when(source.next(anyLong(), any(TimeUnit.class))).thenAnswer(new CountingAnswer());
         when(mapper.apply(1)).thenReturn(emptyList());
@@ -155,7 +155,7 @@ public class BlockingIterableFlatMapTest {
     }
 
     @Test
-    public void mapperReturnsEmptyIteratorAndThenData() {
+    void mapperReturnsEmptyIteratorAndThenData() {
         when(source.hasNext()).thenAnswer(new DynamicHasNext(2));
         when(source.next()).thenAnswer(new CountingAnswer());
         when(mapper.apply(1)).thenReturn(emptyList());
@@ -172,7 +172,7 @@ public class BlockingIterableFlatMapTest {
     }
 
     @Test
-    public void oneIntegerToOneStringTimeout() throws TimeoutException {
+    void oneIntegerToOneStringTimeout() throws TimeoutException {
         when(source.hasNext(anyLong(), any(TimeUnit.class))).thenReturn(true);
         when(source.next(anyLong(), any(TimeUnit.class))).thenReturn(1);
         when(mapper.apply(1)).thenReturn(singletonList("1"));
@@ -182,7 +182,7 @@ public class BlockingIterableFlatMapTest {
     }
 
     @Test
-    public void oneIntegerToOneString() {
+    void oneIntegerToOneString() {
         when(source.hasNext()).thenReturn(true);
         when(source.next()).thenReturn(1);
         when(mapper.apply(1)).thenReturn(singletonList("1"));
@@ -192,7 +192,7 @@ public class BlockingIterableFlatMapTest {
     }
 
     @Test
-    public void oneIntegerToMultipleStringsTimeout() throws TimeoutException {
+    void oneIntegerToMultipleStringsTimeout() throws TimeoutException {
         when(source.hasNext(anyLong(), any(TimeUnit.class))).thenReturn(true);
         when(source.next(anyLong(), any(TimeUnit.class))).thenReturn(1);
         when(mapper.apply(1)).thenReturn(asList("1", "2"));
@@ -203,7 +203,7 @@ public class BlockingIterableFlatMapTest {
     }
 
     @Test
-    public void oneIntegerToMultipleStrings() {
+    void oneIntegerToMultipleStrings() {
         when(source.hasNext()).thenReturn(true);
         when(source.next()).thenReturn(1);
         when(mapper.apply(1)).thenReturn(asList("1", "2"));
@@ -215,7 +215,7 @@ public class BlockingIterableFlatMapTest {
     }
 
     @Test
-    public void closeClosesSource() throws Exception {
+    void closeClosesSource() throws Exception {
         final BlockingIterator<String> iterator = flatMap.iterator();
         iterator.close();
         verify(source).close();

--- a/servicetalk-serialization-api/src/test/java/io/servicetalk/serialization/api/DefaultSerializerDeserializationTest.java
+++ b/servicetalk-serialization-api/src/test/java/io/servicetalk/serialization/api/DefaultSerializerDeserializationTest.java
@@ -21,13 +21,11 @@ import io.servicetalk.concurrent.BlockingIterator;
 import io.servicetalk.concurrent.CloseableIterable;
 import io.servicetalk.concurrent.CloseableIterator;
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -46,19 +44,16 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class DefaultSerializerDeserializationTest {
+class DefaultSerializerDeserializationTest {
 
-    private static final TypeHolder<List<String>> TYPE_FOR_LIST = new TypeHolder<List<String>>() { };
-
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
+    private static final TypeHolder<List<String>> TYPE_FOR_LIST = new TypeHolder<List<String>>() {
+    };
 
     private StreamingDeserializer<String> deSerializer;
     private StreamingDeserializer<List<String>> listDeSerializer;
@@ -66,8 +61,8 @@ public class DefaultSerializerDeserializationTest {
     private DefaultSerializer factory;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         deSerializer = mock(StreamingDeserializer.class);
         listDeSerializer = mock(StreamingDeserializer.class);
         provider = mock(SerializationProvider.class);
@@ -77,7 +72,7 @@ public class DefaultSerializerDeserializationTest {
     }
 
     @Test
-    public void applyDeserializerForPublisherWithType() throws Exception {
+    void applyDeserializerForPublisherWithType() throws Exception {
         Buffer first = mock(Buffer.class);
         Buffer second = mock(Buffer.class);
         when(deSerializer.deserialize(first)).thenReturn(singletonList("Hello1"));
@@ -92,7 +87,7 @@ public class DefaultSerializerDeserializationTest {
     }
 
     @Test
-    public void applyDeserializerForPublisherWithTypeHolder() throws Exception {
+    void applyDeserializerForPublisherWithTypeHolder() throws Exception {
         final List<String> firstList = singletonList("Hello1");
         final List<String> secondList = singletonList("Hello2");
         List<List<String>> expected = asList(firstList, secondList);
@@ -111,7 +106,7 @@ public class DefaultSerializerDeserializationTest {
     }
 
     @Test
-    public void applyDeserializerForIterableWithType() {
+    void applyDeserializerForIterableWithType() {
         Buffer first = mock(Buffer.class);
         Buffer second = mock(Buffer.class);
         final List<Buffer> source = asList(first, second);
@@ -127,7 +122,7 @@ public class DefaultSerializerDeserializationTest {
     }
 
     @Test
-    public void applyDeserializerForIterableWithTypeHolder() {
+    void applyDeserializerForIterableWithTypeHolder() {
         final List<String> firstList = singletonList("Hello1");
         final List<String> secondList = singletonList("Hello2");
         List<List<String>> expected = asList(firstList, secondList);
@@ -146,7 +141,7 @@ public class DefaultSerializerDeserializationTest {
     }
 
     @Test
-    public void applyDeserializerForBlockingIterableWithType() throws Exception {
+    void applyDeserializerForBlockingIterableWithType() throws Exception {
         final Buffer first = mock(Buffer.class);
         final Buffer second = mock(Buffer.class);
         // Since deserialize(BlockingIterable) calls deserialize(Buffer), we set up the mock for these granular calls.
@@ -166,7 +161,7 @@ public class DefaultSerializerDeserializationTest {
     }
 
     @Test
-    public void applyDeserializerForBlockingIterableWithTypeHolder() throws Exception {
+    void applyDeserializerForBlockingIterableWithTypeHolder() throws Exception {
         final Buffer first = mock(Buffer.class);
         final Buffer second = mock(Buffer.class);
         // Since deserialize(BlockingIterable) calls deserialize(Buffer), we set up the mock for these granular calls.
@@ -204,7 +199,7 @@ public class DefaultSerializerDeserializationTest {
     }
 
     @Test
-    public void publisherCompletesWithLeftOverData() {
+    void publisherCompletesWithLeftOverData() {
         Buffer first = mock(Buffer.class);
         Buffer second = mock(Buffer.class);
         when(deSerializer.deserialize(first)).thenReturn(singletonList("Hello1"));
@@ -228,7 +223,7 @@ public class DefaultSerializerDeserializationTest {
     }
 
     @Test
-    public void iterableCompletesWithLeftOverData() {
+    void iterableCompletesWithLeftOverData() {
         Buffer first = mock(Buffer.class);
         Buffer second = mock(Buffer.class);
         final List<Buffer> source = asList(first, second);
@@ -250,7 +245,7 @@ public class DefaultSerializerDeserializationTest {
 
         try {
             iterator.hasNext();
-            fail();
+            Assertions.fail();
         } catch (RuntimeException re) {
             assertThat("Unexpected exception.", re.getCause(), sameInstance(e));
         }
@@ -258,7 +253,7 @@ public class DefaultSerializerDeserializationTest {
     }
 
     @Test
-    public void deserializeAggregatedWithType() {
+    void deserializeAggregatedWithType() {
         Buffer buffer = mock(Buffer.class);
         when(deSerializer.deserialize(buffer)).thenReturn(singletonList("Hello1"));
 
@@ -272,7 +267,7 @@ public class DefaultSerializerDeserializationTest {
     }
 
     @Test
-    public void deserializeAggregatedWithTypeHolder() {
+    void deserializeAggregatedWithTypeHolder() {
         final List<List<String>> expected = singletonList(singletonList("Hello1"));
         Buffer buffer = mock(Buffer.class);
         when(listDeSerializer.deserialize(buffer)).thenReturn(expected);
@@ -287,7 +282,7 @@ public class DefaultSerializerDeserializationTest {
     }
 
     @Test
-    public void deserializeIncompleteAggregatedWithType() {
+    void deserializeIncompleteAggregatedWithType() {
         Buffer buffer = mock(Buffer.class);
         when(deSerializer.deserialize(buffer)).thenReturn(emptyList());
 
@@ -302,7 +297,7 @@ public class DefaultSerializerDeserializationTest {
 
         try {
             deserialized.iterator().hasNext();
-            fail();
+            Assertions.fail();
         } catch (RuntimeException re) {
             assertThat("Unexpected exception.", re.getCause(), sameInstance(e));
         }
@@ -310,7 +305,7 @@ public class DefaultSerializerDeserializationTest {
     }
 
     @Test
-    public void deserializeIncompleteAggregatedWithTypeHolder() {
+    void deserializeIncompleteAggregatedWithTypeHolder() {
         Buffer buffer = mock(Buffer.class);
         when(listDeSerializer.deserialize(buffer)).thenReturn(emptyList());
 
@@ -325,7 +320,7 @@ public class DefaultSerializerDeserializationTest {
 
         try {
             deserialized.iterator().hasNext();
-            fail();
+            Assertions.fail();
         } catch (RuntimeException re) {
             assertThat("Unexpected exception.", re.getCause(), sameInstance(e));
         }

--- a/servicetalk-serialization-api/src/test/java/io/servicetalk/serialization/api/DefaultSerializerSerializationTest.java
+++ b/servicetalk-serialization-api/src/test/java/io/servicetalk/serialization/api/DefaultSerializerSerializationTest.java
@@ -21,13 +21,10 @@ import io.servicetalk.concurrent.BlockingIterable;
 import io.servicetalk.concurrent.BlockingIterator;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TestPublisher;
-import io.servicetalk.concurrent.internal.ServiceTalkTestTimeout;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,13 +46,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class DefaultSerializerSerializationTest {
+class DefaultSerializerSerializationTest {
 
     private static final TypeHolder<List<String>> TYPE_FOR_LIST = new TypeHolder<List<String>>() { };
-
-    @Rule
-    public final Timeout timeout = new ServiceTalkTestTimeout();
-
     private IntUnaryOperator sizeEstimator;
     private List<Buffer> createdBuffers;
     private StreamingSerializer serializer;
@@ -63,9 +56,8 @@ public class DefaultSerializerSerializationTest {
     private SerializationProvider provider;
     private DefaultSerializer factory;
 
-    @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         createdBuffers = new ArrayList<>();
         allocator = mock(BufferAllocator.class);
         when(allocator.newBuffer(anyInt())).then(invocation -> {
@@ -83,7 +75,7 @@ public class DefaultSerializerSerializationTest {
     }
 
     @Test
-    public void applySerializationForPublisherWithType() throws Exception {
+    void applySerializationForPublisherWithType() throws Exception {
         final Publisher<Buffer> serialized = factory.serialize(from("Hello1", "Hello2"), allocator, String.class);
         final List<Buffer> buffers = awaitIndefinitelyNonNull(serialized);
         verify(provider).getSerializer(String.class);
@@ -94,7 +86,7 @@ public class DefaultSerializerSerializationTest {
     }
 
     @Test
-    public void applySerializationForPublisherWithTypeHolder() throws Exception {
+    void applySerializationForPublisherWithTypeHolder() throws Exception {
         final List<String> first = singletonList("Hello1");
         final List<String> second = singletonList("Hello2");
         final Publisher<Buffer> serialized = factory.serialize(from(first, second), allocator, TYPE_FOR_LIST);
@@ -107,7 +99,7 @@ public class DefaultSerializerSerializationTest {
     }
 
     @Test
-    public void applySerializationForPublisherWithTypeAndEstimator() {
+    void applySerializationForPublisherWithTypeAndEstimator() {
         TestPublisher<String> source = new TestPublisher<>();
 
         final Publisher<Buffer> serialized = factory.serialize(source, allocator, String.class, sizeEstimator);
@@ -127,7 +119,7 @@ public class DefaultSerializerSerializationTest {
     }
 
     @Test
-    public void applySerializationForPublisherWithTypeHolderAndEstimator() {
+    void applySerializationForPublisherWithTypeHolderAndEstimator() {
         TestPublisher<List<String>> source = new TestPublisher<>();
 
         final Publisher<Buffer> serialized = factory.serialize(source, allocator, TYPE_FOR_LIST, sizeEstimator);
@@ -147,7 +139,7 @@ public class DefaultSerializerSerializationTest {
     }
 
     @Test
-    public void applySerializationForIterableWithType() {
+    void applySerializationForIterableWithType() {
         final Iterable<Buffer> buffers = factory.serialize(asList("Hello1", "Hello2"), allocator, String.class);
         verify(provider).getSerializer(String.class);
         assertThat("Unexpected created buffers.", createdBuffers, hasSize(2));
@@ -157,7 +149,7 @@ public class DefaultSerializerSerializationTest {
     }
 
     @Test
-    public void applySerializationForIterableWithTypeHolder() {
+    void applySerializationForIterableWithTypeHolder() {
         final List<String> first = singletonList("Hello1");
         final List<String> second = singletonList("Hello2");
         final Iterable<Buffer> buffers = factory.serialize(asList(first, second), allocator, TYPE_FOR_LIST);
@@ -169,7 +161,7 @@ public class DefaultSerializerSerializationTest {
     }
 
     @Test
-    public void applySerializationForIterableWithTypeAndEstimator() {
+    void applySerializationForIterableWithTypeAndEstimator() {
         final Iterable<Buffer> buffers = factory.serialize(asList("Hello1", "Hello2"), allocator, String.class,
                 sizeEstimator);
         verify(provider).getSerializer(String.class);
@@ -180,7 +172,7 @@ public class DefaultSerializerSerializationTest {
     }
 
     @Test
-    public void applySerializationForIterableWithTypeHolderAndEstimator() {
+    void applySerializationForIterableWithTypeHolderAndEstimator() {
         final List<String> first = singletonList("Hello1");
         final List<String> second = singletonList("Hello2");
         final Iterable<Buffer> buffers = factory.serialize(asList(first, second), allocator, TYPE_FOR_LIST,
@@ -193,7 +185,7 @@ public class DefaultSerializerSerializationTest {
     }
 
     @Test
-    public void applySerializationForBlockingIterableWithType() throws Exception {
+    void applySerializationForBlockingIterableWithType() throws Exception {
         final List<String> data = asList("Hello1", "Hello2");
         BlockingIterableMock<String> source = new BlockingIterableMock<>(data);
         final BlockingIterable<Buffer> buffers = factory.serialize(source.iterable(), allocator, String.class);
@@ -203,7 +195,7 @@ public class DefaultSerializerSerializationTest {
     }
 
     @Test
-    public void applySerializationForBlockingIterableWithTypeHolder() throws Exception {
+    void applySerializationForBlockingIterableWithTypeHolder() throws Exception {
         final List<List<String>> data = asList(singletonList("Hello1"), singletonList("Hello2"));
         BlockingIterableMock<List<String>> source = new BlockingIterableMock<>(data);
         final BlockingIterable<Buffer> buffers = factory.serialize(source.iterable(), allocator, TYPE_FOR_LIST);
@@ -213,7 +205,7 @@ public class DefaultSerializerSerializationTest {
     }
 
     @Test
-    public void applySerializationForBlockingIterableWithTypeAndEstimator() throws Exception {
+    void applySerializationForBlockingIterableWithTypeAndEstimator() throws Exception {
         final List<String> data = asList("Hello1", "Hello2");
         BlockingIterableMock<String> source = new BlockingIterableMock<>(data);
         final BlockingIterable<Buffer> buffers = factory.serialize(source.iterable(), allocator, String.class,
@@ -224,7 +216,7 @@ public class DefaultSerializerSerializationTest {
     }
 
     @Test
-    public void applySerializationForBlockingIterableWithTypeHolderAndEstimator() throws Exception {
+    void applySerializationForBlockingIterableWithTypeHolderAndEstimator() throws Exception {
         final List<List<String>> data = asList(singletonList("Hello1"), singletonList("Hello2"));
         BlockingIterableMock<List<String>> source = new BlockingIterableMock<>(data);
         final BlockingIterable<Buffer> buffers = factory.serialize(source.iterable(), allocator, TYPE_FOR_LIST,
@@ -235,7 +227,7 @@ public class DefaultSerializerSerializationTest {
     }
 
     @Test
-    public void serializeSingle() {
+    void serializeSingle() {
         final Buffer buffer = factory.serialize("Hello", allocator);
         assertThat("Unexpected created buffers.", createdBuffers, hasSize(1));
         verify(provider).serialize("Hello", createdBuffers.get(0));
@@ -243,7 +235,7 @@ public class DefaultSerializerSerializationTest {
     }
 
     @Test
-    public void serializeSingleWithSize() {
+    void serializeSingleWithSize() {
         final Buffer buffer = factory.serialize("Hello", allocator, 1);
         verify(allocator).newBuffer(1);
         assertThat("Unexpected created buffers.", createdBuffers, hasSize(1));
@@ -252,7 +244,7 @@ public class DefaultSerializerSerializationTest {
     }
 
     @Test
-    public void serializeSingleWithBuffer() {
+    void serializeSingleWithBuffer() {
         final Buffer buffer = mock(Buffer.class);
         factory.serialize("Hello", buffer);
         verify(provider).serialize("Hello", buffer);

--- a/servicetalk-tcp-netty-internal/build.gradle
+++ b/servicetalk-tcp-netty-internal/build.gradle
@@ -35,9 +35,12 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testImplementation project(":servicetalk-test-resources")
   testImplementation "io.netty:netty-tcnative-boringssl-static:$tcnativeVersion"
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
+  testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testFixturesImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
@@ -47,7 +50,7 @@ dependencies {
   testFixturesRuntimeOnly "io.netty:netty-transport-native-epoll:$nettyVersion:linux-aarch_64"
   testFixturesImplementation "io.netty:netty-transport-native-kqueue:$nettyVersion"
   testFixturesRuntimeOnly "io.netty:netty-transport-native-kqueue:$nettyVersion:osx-x86_64"
-  testFixturesImplementation "junit:junit:$junitVersion"
+  testFixturesImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testFixturesImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testFixturesImplementation "org.slf4j:slf4j-api:$slf4jVersion"

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverTest.java
@@ -19,8 +19,9 @@ import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.transport.api.ConnectionInfo;
 import io.servicetalk.transport.netty.internal.NettyConnection;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.CountDownLatch;
@@ -34,11 +35,16 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class TcpTransportObserverTest extends AbstractTransportObserverTest {
+class TcpTransportObserverTest extends AbstractTransportObserverTest {
 
-    @Ignore("https://github.com/apple/servicetalk/issues/1262")
+    @BeforeEach
+    void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Disabled("https://github.com/apple/servicetalk/issues/1262")
     @Test
-    public void testConnectionObserverEvents() throws Exception {
+    void testConnectionObserverEvents() throws Exception {
         NettyConnection<Buffer, Buffer> connection = client.connectBlocking(CLIENT_CTX, serverAddress);
         verify(clientTransportObserver).onNewConnection();
         verify(serverTransportObserver, await()).onNewConnection();

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
@@ -47,12 +47,12 @@ import static io.servicetalk.transport.netty.internal.DefaultNettyConnection.ini
 import static java.util.Objects.requireNonNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * A utility to create a TCP clients for tests.
  */
-public final class TcpClient {
+final class TcpClient {
 
     private final ReadOnlyTcpClientConfig config;
     private final TransportObserver observer;
@@ -63,7 +63,7 @@ public final class TcpClient {
      * @param config for the client.
      * @param observer {@link TransportObserver} for the newly created connection.
      */
-    public TcpClient(TcpClientConfig config, TransportObserver observer) {
+    TcpClient(TcpClientConfig config, TransportObserver observer) {
         this.config = config.asReadOnly();
         this.observer = requireNonNull(observer);
     }

--- a/servicetalk-test-resources/build.gradle
+++ b/servicetalk-test-resources/build.gradle
@@ -23,5 +23,7 @@ dependencies {
   api "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
   api "org.hamcrest:hamcrest-library:$hamcrestVersion"
 
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-test-resources/src/test/java/io/servicetalk/test/resources/DefaultTestCertsTest.java
+++ b/servicetalk-test-resources/src/test/java/io/servicetalk/test/resources/DefaultTestCertsTest.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.test.resources;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -24,44 +24,44 @@ import java.io.InputStreamReader;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.stream.Collectors.joining;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 // Not a particularly robust test, but ensures the file is found and loaded.
 // If we change algorithms/settings this size may need to change.
-public class DefaultTestCertsTest {
+class DefaultTestCertsTest {
 
     @Test
-    public void loadServerKey() throws Exception {
+    void loadServerKey() throws Exception {
         String contents = readFully(DefaultTestCerts.loadServerKey());
         assertEquals(1707, contents.length());
     }
 
     @Test
-    public void loadServerPem() throws Exception {
+    void loadServerPem() throws Exception {
         String contents = readFully(DefaultTestCerts.loadServerPem());
         assertEquals(992, contents.length());
     }
 
     @Test
-    public void loadServerCAPem() throws Exception {
+    void loadServerCAPem() throws Exception {
         String contents = readFully(DefaultTestCerts.loadServerCAPem());
         assertEquals(1020, contents.length());
     }
 
     @Test
-    public void loadClientKey() throws Exception {
+    void loadClientKey() throws Exception {
         String contents = readFully(DefaultTestCerts.loadClientKey());
         assertEquals(1707, contents.length());
     }
 
     @Test
-    public void loadClientPem() throws Exception {
+    void loadClientPem() throws Exception {
         String contents = readFully(DefaultTestCerts.loadClientPem());
         assertEquals(992, contents.length());
     }
 
     @Test
-    public void loadClientCAPem() throws Exception {
+    void loadClientCAPem() throws Exception {
         String contents = readFully(DefaultTestCerts.loadClientCAPem());
         assertEquals(1020, contents.length());
     }

--- a/servicetalk-utils-internal/build.gradle
+++ b/servicetalk-utils-internal/build.gradle
@@ -23,5 +23,8 @@ dependencies {
     implementation "org.jctools:jctools-core:$jcToolsVersion"
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
-    testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
+    testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
+
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/DurationUtilsTest.java
+++ b/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/DurationUtilsTest.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.utils.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
@@ -26,28 +26,28 @@ import static java.time.Duration.ofNanos;
 import static java.time.Duration.ofSeconds;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class DurationUtilsTest {
+class DurationUtilsTest {
 
     private static final Duration MAX_DURATION = ofSeconds(2);
 
     @Test
-    public void testIsPositiveSeconds() {
+    void testIsPositiveSeconds() {
         assertThat(isPositive(ofSeconds(1L)), is(true));
         assertThat(isPositive(ofSeconds(0L)), is(false));
         assertThat(isPositive(ofSeconds(1L).negated()), is(false));
     }
 
     @Test
-    public void testIsPositiveNanos() {
+    void testIsPositiveNanos() {
         assertThat(isPositive(ofNanos(1L)), is(true));
         assertThat(isPositive(ofNanos(0L)), is(false));
         assertThat(isPositive(ofNanos(1L).negated()), is(false));
     }
 
     @Test
-    public void testEnsurePositive() {
+    void testEnsurePositive() {
         assertThrows(NullPointerException.class, () -> ensurePositive(null, "duration"));
         assertThrows(IllegalArgumentException.class, () -> ensurePositive(Duration.ZERO, "duration"));
         assertThrows(IllegalArgumentException.class, () -> ensurePositive(ofNanos(1L).negated(), "duration"));
@@ -55,7 +55,7 @@ public class DurationUtilsTest {
     }
 
     @Test
-    public void testIsInfinite() {
+    void testIsInfinite() {
         assertThat(isInfinite(null, MAX_DURATION), is(true));
         assertThat(isInfinite(ofSeconds(3), MAX_DURATION), is(true));
         assertThat(isInfinite(ofSeconds(1), MAX_DURATION), is(false));

--- a/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/IllegalCharacterExceptionTest.java
+++ b/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/IllegalCharacterExceptionTest.java
@@ -15,13 +15,13 @@
  */
 package io.servicetalk.utils.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class IllegalCharacterExceptionTest {
+class IllegalCharacterExceptionTest {
 
     @Test
     @SuppressWarnings("ThrowableNotThrown")
-    public void messageCanBeGeneratedForAnyByteValue() {
+    void messageCanBeGeneratedForAnyByteValue() {
         for (int value = Byte.MIN_VALUE; value <= Byte.MAX_VALUE; ++value) {
             new IllegalCharacterException((byte) value);
             new IllegalCharacterException((byte) value, "something");


### PR DESCRIPTION
Motivation:

JUnit 5 leverages features from Java 8 or later, such as lambda functions, making tests more powerful and easier to maintain.
JUnit 5 has added some very useful new features for describing, organizing, and executing tests. For instance, tests get better display names and can be organized hierarchically.
JUnit 5 is organized into multiple libraries, so only the features you need are imported into your project. With build systems such as Maven and Gradle, including the right libraries is easy.
JUnit 5 can use more than one extension at a time, which JUnit 4 could not (only one runner could be used at a time). This means you can easily combine the Spring extension with other extensions (such as your own custom extension).
Modifications:

Unit tests have been migrated from JUnit 4 to JUnit 5

Result:

Converted modules now run tests using JUnit 5

#1568