### PR TITLE
Fix H2 Server with SNI bug

### DIFF
--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/VerificationTestUtils.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/VerificationTestUtils.java
@@ -84,6 +84,10 @@ public final class VerificationTestUtils {
         return o == null ? "null" : className(o);
     }
 
+    private static String className(Class<?> o) {
+        return o.getCanonicalName();
+    }
+
     private static String className(Object o) {
         return o.getClass().getCanonicalName();
     }

--- a/servicetalk-examples/http/http2/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/http2/src/main/resources/log4j2.xml
@@ -22,7 +22,7 @@
   </Appenders>
   <Loggers>
     <!-- Prints server start and shutdown -->
-    <Logger name="io.servicetalk.http.netty.AlpnServerContext" level="DEBUG"/>
+    <Logger name="io.servicetalk.http.netty.DeferredServerChannelBinder" level="DEBUG"/>
     <Logger name="io.servicetalk.http.netty.H2ServerParentConnectionContext" level="DEBUG"/>
 
     <!-- Prints default subscriber errors-->

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ChannelInitSingle.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ChannelInitSingle.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.api.internal.SubscribableSingle;
+import io.servicetalk.transport.netty.internal.ChannelInitializer;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
+import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.close;
+
+abstract class ChannelInitSingle<T> extends SubscribableSingle<T> {
+    private final Channel channel;
+    private final ChannelInitializer channelInitializer;
+
+    ChannelInitSingle(final Channel channel, final ChannelInitializer channelInitializer) {
+        this.channel = channel;
+        this.channelInitializer = channelInitializer;
+    }
+
+    @Override
+    protected final void handleSubscribe(final Subscriber<? super T> subscriber) {
+        try {
+            channelInitializer.init(channel);
+        } catch (Throwable cause) {
+            close(channel, cause);
+            deliverErrorFromSource(subscriber, cause);
+            return;
+        }
+        subscriber.onSubscribe(channel::close);
+        // We have to add to the pipeline AFTER we call onSubscribe, because adding to the pipeline may invoke
+        // callbacks that interact with the subscriber.
+        channel.pipeline().addLast(newChannelHandler(subscriber));
+    }
+
+    protected abstract ChannelHandler newChannelHandler(Subscriber<? super T> subscriber);
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DeferredServerChannelBinder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DeferredServerChannelBinder.java
@@ -111,7 +111,7 @@ final class DeferredServerChannelBinder {
                                                                  final boolean drainRequestPayloadBody,
                                                                  final ConnectionObserver observer) {
         return new SniCompleteChannelSingle(channel,
-                new TcpServerChannelInitializer(config.tcpConfig(), observer), true).flatMap(sniEvt -> {
+                new TcpServerChannelInitializer(config.tcpConfig(), observer)).flatMap(sniEvt -> {
             Throwable failureCause = sniEvt.cause();
             if (failureCause != null) {
                 return failed(failureCause);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DeferredServerChannelBinder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DeferredServerChannelBinder.java
@@ -33,17 +33,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.SocketAddress;
+import java.util.function.BiFunction;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.http.netty.AlpnIds.HTTP_1_1;
 import static io.servicetalk.http.netty.AlpnIds.HTTP_2;
 
-final class AlpnServerContext {
+final class DeferredServerChannelBinder {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AlpnServerContext.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeferredServerChannelBinder.class);
 
-    private AlpnServerContext() {
+    private DeferredServerChannelBinder() {
         // No instances
     }
 
@@ -52,16 +53,20 @@ final class AlpnServerContext {
                                       final SocketAddress listenAddress,
                                       @Nullable final ConnectionAcceptor connectionAcceptor,
                                       final StreamingHttpService service,
-                                      final boolean drainRequestPayloadBody) {
-        assert config.h1Config() != null && config.h2Config() != null;
+                                      final boolean drainRequestPayloadBody,
+                                      final boolean sniOnly) {
         final ReadOnlyTcpServerConfig tcpConfig = config.tcpConfig();
         assert tcpConfig.sslContext() != null;
 
+        final BiFunction<Channel, ConnectionObserver, Single<NettyConnectionContext>> channelInit = sniOnly ?
+                (channel, connectionObserver) -> sniInitChannel(listenAddress, channel, config, executionContext,
+                        service, drainRequestPayloadBody, connectionObserver) :
+                (channel, connectionObserver) -> alpnInitChannel(listenAddress, channel, config, executionContext,
+                        service, drainRequestPayloadBody, connectionObserver);
+
         // We disable auto read by default so we can handle stuff in the ConnectionFilter before we accept any content.
         // In case ALPN negotiates h2, h2 connection MUST enable auto read for its Channel.
-        return TcpServerBinder.bind(listenAddress, tcpConfig, false, executionContext, connectionAcceptor,
-                (channel, connectionObserver) -> initChannel(listenAddress, channel, config, executionContext, service,
-                        drainRequestPayloadBody, connectionObserver),
+        return TcpServerBinder.bind(listenAddress, tcpConfig, false, executionContext, connectionAcceptor, channelInit,
                 serverConnection -> {
                     // Start processing requests on http/1.1 connection:
                     if (serverConnection instanceof NettyHttpServerConnection) {
@@ -76,13 +81,13 @@ final class AlpnServerContext {
                 });
     }
 
-    private static Single<NettyConnectionContext> initChannel(final SocketAddress listenAddress,
-                                                              final Channel channel,
-                                                              final ReadOnlyHttpServerConfig config,
-                                                              final HttpExecutionContext httpExecutionContext,
-                                                              final StreamingHttpService service,
-                                                              final boolean drainRequestPayloadBody,
-                                                              final ConnectionObserver observer) {
+    private static Single<NettyConnectionContext> alpnInitChannel(final SocketAddress listenAddress,
+                                                                  final Channel channel,
+                                                                  final ReadOnlyHttpServerConfig config,
+                                                                  final HttpExecutionContext httpExecutionContext,
+                                                                  final StreamingHttpService service,
+                                                                  final boolean drainRequestPayloadBody,
+                                                                  final ConnectionObserver observer) {
         return new AlpnChannelSingle(channel,
                 new TcpServerChannelInitializer(config.tcpConfig(), observer), true).flatMap(protocol -> {
             switch (protocol) {
@@ -95,6 +100,32 @@ final class AlpnServerContext {
                 default:
                     return failed(new IllegalStateException("Unknown ALPN protocol negotiated: " + protocol));
             }
+        });
+    }
+
+    private static Single<NettyConnectionContext> sniInitChannel(final SocketAddress listenAddress,
+                                                                 final Channel channel,
+                                                                 final ReadOnlyHttpServerConfig config,
+                                                                 final HttpExecutionContext httpExecutionContext,
+                                                                 final StreamingHttpService service,
+                                                                 final boolean drainRequestPayloadBody,
+                                                                 final ConnectionObserver observer) {
+        return new SniCompleteChannelSingle(channel,
+                new TcpServerChannelInitializer(config.tcpConfig(), observer), true).flatMap(sniEvt -> {
+            Throwable failureCause = sniEvt.cause();
+            if (failureCause != null) {
+                return failed(failureCause);
+            }
+
+            if (config.h2Config() != null) {
+                return H2ServerParentConnectionContext.initChannel(listenAddress, channel, httpExecutionContext, config,
+                        NoopChannelInitializer.INSTANCE, service, drainRequestPayloadBody, observer);
+            } else if (config.h1Config() != null) {
+                return NettyHttpServer.initChannel(channel, httpExecutionContext, config,
+                        NoopChannelInitializer.INSTANCE, service, drainRequestPayloadBody, observer);
+            }
+            return failed(new IllegalStateException(
+                    "SSL handshake completed, but no protocols to initialize. Consider using ALPN."));
         });
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DeferredServerChannelBinder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DeferredServerChannelBinder.java
@@ -120,12 +120,14 @@ final class DeferredServerChannelBinder {
             if (config.h2Config() != null) {
                 return H2ServerParentConnectionContext.initChannel(listenAddress, channel, httpExecutionContext, config,
                         NoopChannelInitializer.INSTANCE, service, drainRequestPayloadBody, observer);
-            } else if (config.h1Config() != null) {
+            }
+            if (config.h1Config() != null) {
                 return NettyHttpServer.initChannel(channel, httpExecutionContext, config,
                         NoopChannelInitializer.INSTANCE, service, drainRequestPayloadBody, observer);
             }
             return failed(new IllegalStateException(
-                    "SSL handshake completed, but no protocols to initialize. Consider using ALPN."));
+                    "SSL handshake completed, but no protocols to initialize. Consider using ALPN to explicitly " +
+                            "negotiate the protocol and/or configure protocols on the client/server builder."));
         });
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -52,6 +52,7 @@ import org.slf4j.LoggerFactory;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.HeaderUtils.LAST_CHUNK_PREDICATE;
@@ -84,9 +85,6 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                                       @Nullable final ConnectionAcceptor connectionAcceptor,
                                       final StreamingHttpService service,
                                       final boolean drainRequestPayloadBody) {
-
-        assert config.isH2PriorKnowledge();
-        assert config.h2Config() != null;
         final ReadOnlyTcpServerConfig tcpServerConfig = config.tcpConfig();
         // Auto read is required for h2
         return TcpServerBinder.bind(listenAddress, tcpServerConfig, true, executionContext, connectionAcceptor,
@@ -106,9 +104,11 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                 final ReadOnlyHttpServerConfig config, final ChannelInitializer initializer,
                 final StreamingHttpService service, final boolean drainRequestPayloadBody,
                 final ConnectionObserver observer) {
-
         final H2ProtocolConfig h2ServerConfig = config.h2Config();
-        assert h2ServerConfig != null;
+        if (h2ServerConfig == null) {
+            return failed(new IllegalStateException(
+                    "HTTP/2 channel initialization failure due to missing HTTP/2 configuration"));
+        }
         return showPipeline(new SubscribableSingle<H2ServerParentConnectionContext>() {
             @Override
             protected void handleSubscribe(final Subscriber<? super H2ServerParentConnectionContext> subscriber) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -86,6 +86,7 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.toListenableAsyncClo
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Completable.defer;
 import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
@@ -117,7 +118,6 @@ final class NettyHttpServer {
                                       @Nullable final ConnectionAcceptor connectionAcceptor,
                                       final StreamingHttpService service,
                                       final boolean drainRequestPayloadBody) {
-        assert config.h1Config() != null;
         // This state is read only, so safe to keep a copy across Subscribers
         final ReadOnlyTcpServerConfig tcpServerConfig = config.tcpConfig();
         // We disable auto read so we can handle stuff in the ConnectionFilter before we accept any content.
@@ -153,7 +153,10 @@ final class NettyHttpServer {
                                                          final ConnectionObserver observer,
                                                          final CloseHandler closeHandler) {
         final H1ProtocolConfig h1Config = config.h1Config();
-        assert h1Config != null;
+        if (h1Config == null) {
+            return failed(new IllegalStateException(
+                    "HTTP/1.x channel initialization failure due to missing HTTP/1.x configuration"));
+        }
         return showPipeline(DefaultNettyConnection.initChannel(channel,
                 httpExecutionContext.bufferAllocator(), httpExecutionContext.executor(), LAST_CHUNK_PREDICATE,
                 closeHandler, config.tcpConfig().flushStrategy(), config.tcpConfig().idleTimeoutMs(),

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -118,6 +118,9 @@ final class NettyHttpServer {
                                       @Nullable final ConnectionAcceptor connectionAcceptor,
                                       final StreamingHttpService service,
                                       final boolean drainRequestPayloadBody) {
+        if (config.h1Config() == null) {
+            return failed(newH1ConfigException());
+        }
         // This state is read only, so safe to keep a copy across Subscribers
         final ReadOnlyTcpServerConfig tcpServerConfig = config.tcpConfig();
         // We disable auto read so we can handle stuff in the ConnectionFilter before we accept any content.
@@ -133,6 +136,11 @@ final class NettyHttpServer {
                 });
     }
 
+    private static Throwable newH1ConfigException() {
+        return new IllegalStateException(
+                "HTTP/1.x channel initialization failure due to missing HTTP/1.x configuration");
+    }
+
     static Single<NettyHttpServerConnection> initChannel(final Channel channel,
                                                          final HttpExecutionContext httpExecutionContext,
                                                          final ReadOnlyHttpServerConfig config,
@@ -144,18 +152,17 @@ final class NettyHttpServer {
                 observer, forPipelinedRequestResponse(false, channel.config()));
     }
 
-    static Single<NettyHttpServerConnection> initChannel(final Channel channel,
-                                                         final HttpExecutionContext httpExecutionContext,
-                                                         final ReadOnlyHttpServerConfig config,
-                                                         final ChannelInitializer initializer,
-                                                         final StreamingHttpService service,
-                                                         final boolean drainRequestPayloadBody,
-                                                         final ConnectionObserver observer,
-                                                         final CloseHandler closeHandler) {
+    private static Single<NettyHttpServerConnection> initChannel(final Channel channel,
+                                                                 final HttpExecutionContext httpExecutionContext,
+                                                                 final ReadOnlyHttpServerConfig config,
+                                                                 final ChannelInitializer initializer,
+                                                                 final StreamingHttpService service,
+                                                                 final boolean drainRequestPayloadBody,
+                                                                 final ConnectionObserver observer,
+                                                                 final CloseHandler closeHandler) {
         final H1ProtocolConfig h1Config = config.h1Config();
         if (h1Config == null) {
-            return failed(new IllegalStateException(
-                    "HTTP/1.x channel initialization failure due to missing HTTP/1.x configuration"));
+            return failed(newH1ConfigException());
         }
         return showPipeline(DefaultNettyConnection.initChannel(channel,
                 httpExecutionContext.bufferAllocator(), httpExecutionContext.executor(), LAST_CHUNK_PREDICATE,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReadOnlyHttpServerConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReadOnlyHttpServerConfig.java
@@ -55,6 +55,6 @@ final class ReadOnlyHttpServerConfig {
     }
 
     boolean isH2PriorKnowledge() {
-        return h2Config != null && h1Config == null;
+        return h2Config != null && h1Config == null && !tcpConfig.isAlpnConfigured();
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/SniCompleteChannelSingle.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/SniCompleteChannelSingle.java
@@ -30,39 +30,30 @@ import javax.annotation.Nullable;
 import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.assignConnectionError;
 
 final class SniCompleteChannelSingle extends ChannelInitSingle<SniCompletionEvent> {
-    private final boolean forceRead;
-
-    SniCompleteChannelSingle(final Channel channel, final ChannelInitializer channelInitializer,
-                             final boolean forceRead) {
+    SniCompleteChannelSingle(final Channel channel, final ChannelInitializer channelInitializer) {
         super(channel, channelInitializer);
-        this.forceRead = forceRead;
     }
 
     @Override
     protected ChannelHandler newChannelHandler(final Subscriber<? super SniCompletionEvent> subscriber) {
-        return new SniCompleteChannelHandler(subscriber, forceRead);
+        return new SniCompleteChannelHandler(subscriber);
     }
 
     private static final class SniCompleteChannelHandler extends ChannelInboundHandlerAdapter {
         @Nullable
         private Subscriber<? super SniCompletionEvent> subscriber;
-        private final boolean forceRead;
 
-        SniCompleteChannelHandler(Subscriber<? super SniCompletionEvent> subscriber,
-                                  final boolean forceRead) {
+        SniCompleteChannelHandler(Subscriber<? super SniCompletionEvent> subscriber) {
             this.subscriber = subscriber;
-            this.forceRead = forceRead;
         }
 
         @Override
         public void handlerAdded(final ChannelHandlerContext ctx) throws Exception {
             super.handlerAdded(ctx);
-            if (forceRead) {
-                // Force a read to get the SSL handshake started. We initialize pipeline before
-                // SslHandshakeCompletionEvent will complete, therefore, no data will be propagated before we finish
-                // initialization.
-                ctx.read();
-            }
+            // Force a read to get the SSL handshake started. We initialize pipeline before
+            // SslHandshakeCompletionEvent will complete, therefore, no data will be propagated before we finish
+            // initialization.
+            ctx.read();
         }
 
         @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/SniCompleteChannelSingle.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/SniCompleteChannelSingle.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.transport.netty.internal.ChannelInitializer;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.ssl.SniCompletionEvent;
+
+import java.nio.channels.ClosedChannelException;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.assignConnectionError;
+
+final class SniCompleteChannelSingle extends ChannelInitSingle<SniCompletionEvent> {
+    private final boolean forceRead;
+
+    SniCompleteChannelSingle(final Channel channel, final ChannelInitializer channelInitializer,
+                             final boolean forceRead) {
+        super(channel, channelInitializer);
+        this.forceRead = forceRead;
+    }
+
+    @Override
+    protected ChannelHandler newChannelHandler(final Subscriber<? super SniCompletionEvent> subscriber) {
+        return new SniCompleteChannelHandler(subscriber, forceRead);
+    }
+
+    private static final class SniCompleteChannelHandler extends ChannelInboundHandlerAdapter {
+        @Nullable
+        private Subscriber<? super SniCompletionEvent> subscriber;
+        private final boolean forceRead;
+
+        SniCompleteChannelHandler(Subscriber<? super SniCompletionEvent> subscriber,
+                                  final boolean forceRead) {
+            this.subscriber = subscriber;
+            this.forceRead = forceRead;
+        }
+
+        @Override
+        public void handlerAdded(final ChannelHandlerContext ctx) throws Exception {
+            super.handlerAdded(ctx);
+            if (forceRead) {
+                // Force a read to get the SSL handshake started. We initialize pipeline before
+                // SslHandshakeCompletionEvent will complete, therefore, no data will be propagated before we finish
+                // initialization.
+                ctx.read();
+            }
+        }
+
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            if (evt instanceof SniCompletionEvent && subscriber != null) {
+                ctx.pipeline().remove(this);
+                Subscriber<? super SniCompletionEvent> subscriberCopy = subscriber;
+                subscriber = null;
+                subscriberCopy.onSuccess((SniCompletionEvent) evt);
+            }
+            ctx.fireUserEventTriggered(evt);
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            if (subscriber != null) {
+                Exception e = new ClosedChannelException();
+                assignConnectionError(ctx.channel(), e);
+                final SingleSource.Subscriber<? super SniCompletionEvent> subscriberCopy = subscriber;
+                subscriber = null;
+                subscriberCopy.onError(e);
+            } else {
+                // Propagate exception in the pipeline if subscriber is already complete
+                ctx.fireExceptionCaught(cause);
+                ctx.close();
+            }
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) {
+            if (subscriber != null) {
+                Exception e = new ClosedChannelException();
+                assignConnectionError(ctx.channel(), e);
+                final SingleSource.Subscriber<? super SniCompletionEvent> subscriberCopy = subscriber;
+                subscriber = null;
+                subscriberCopy.onError(e);
+            } else {
+                ctx.fireChannelInactive();
+            }
+        }
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
@@ -27,7 +27,6 @@ import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServerSslConfigBuilder;
 
-import io.netty.handler.codec.DecoderException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -112,7 +111,7 @@ class AlpnClientAndServerTest {
                 Arguments.of(singletonList(HTTP_2), singletonList(HTTP_2),
                         HttpProtocolVersion.HTTP_2_0, null, null),
                 Arguments.of(singletonList(HTTP_2), singletonList(HTTP_1_1),
-                        null, DecoderException.class, ClosedChannelException.class),
+                        null, ClosedChannelException.class, null),
 
                 Arguments.of(singletonList(HTTP_1_1), asList(HTTP_2, HTTP_1_1),
                         HttpProtocolVersion.HTTP_1_1, null, null),

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SniTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SniTest.java
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SniTest {
     private static final String SNI_HOSTNAME = "servicetalk.io";
-    
+
     @ParameterizedTest(name = "protocols={0}, alpn={1}")
     @MethodSource("protocolsAndAlpn")
     void sniSuccess(List<HttpProtocol> protocols, boolean useALPN) throws Exception {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SniTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SniTest.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.BlockingHttpService;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpRequest;
 import io.servicetalk.http.api.HttpResponseStatus;
@@ -30,16 +31,18 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.net.InetAddress;
+import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLHandshakeException;
 
-import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
-import static io.servicetalk.http.netty.HttpProtocolConfigs.h2Default;
+import static io.servicetalk.http.netty.HttpProtocol.HTTP_1;
+import static io.servicetalk.http.netty.HttpProtocol.HTTP_2;
 import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.net.InetAddress.getLoopbackAddress;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -47,86 +50,85 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SniTest {
     private static final String SNI_HOSTNAME = "servicetalk.io";
-
-    @ParameterizedTest(name = "h2={0}, alpn={1}")
-    @MethodSource("useH2UseAlpn")
-    void sniSuccess(boolean useH2, boolean useALPN) throws Exception {
+    
+    @ParameterizedTest(name = "protocols={0}, alpn={1}")
+    @MethodSource("protocolsAndAlpn")
+    void sniSuccess(List<HttpProtocol> protocols, boolean useALPN) throws Exception {
         try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
-                .protocols(protocolConfigs(useH2))
-                .sslConfig(untrustedServerConfig(alpnIds(useH2, useALPN)),
-                        singletonMap(SNI_HOSTNAME, trustedServerConfig()))
-                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
-             BlockingHttpClient client = newClient(serverContext, useH2, useALPN)) {
+                .protocols(protocolConfigs(protocols))
+                .sslConfig(untrustedServerConfig(alpnIds(protocols, useALPN)),
+                        singletonMap(SNI_HOSTNAME, trustedServerConfig(alpnIds(protocols, useALPN))))
+                .listenBlockingAndAwait(newSslVerifyService());
+             BlockingHttpClient client = newClient(serverContext, protocols, useALPN)) {
             assertEquals(HttpResponseStatus.OK, client.request(client.get("/")).status());
         }
     }
 
-    @ParameterizedTest(name = "h2={0}, alpn={1}")
-    @MethodSource("useH2UseAlpn")
-    void sniDefaultFallbackSuccess(boolean useH2, boolean useALPN) throws Exception {
+    @ParameterizedTest(name = "protocols={0}, alpn={1}")
+    @MethodSource("protocolsAndAlpn")
+    void sniDefaultFallbackSuccess(List<HttpProtocol> protocols, boolean useALPN) throws Exception {
         try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
-                .protocols(protocolConfigs(useH2))
-                .sslConfig(trustedServerConfig(alpnIds(useH2, useALPN)),
+                .protocols(protocolConfigs(protocols))
+                .sslConfig(trustedServerConfig(alpnIds(protocols, useALPN)),
                         singletonMap("no_match" + SNI_HOSTNAME, untrustedServerConfig()))
-                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
-             BlockingHttpClient client = newClient(serverContext, useH2, useALPN)) {
+                .listenBlockingAndAwait(newSslVerifyService());
+             BlockingHttpClient client = newClient(serverContext, protocols, useALPN)) {
             assertEquals(HttpResponseStatus.OK, client.request(client.get("/")).status());
         }
     }
 
-    @ParameterizedTest(name = "h2={0}, alpn={1}")
-    @MethodSource("useH2UseAlpn")
-    void sniFailExpected(boolean useH2, boolean useALPN) throws Exception {
+    @ParameterizedTest(name = "protocols={0}, alpn={1}")
+    @MethodSource("protocolsAndAlpn")
+    void sniFailExpected(List<HttpProtocol> protocols, boolean useALPN) throws Exception {
         try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
-                .protocols(protocolConfigs(useH2))
-                .sslConfig(trustedServerConfig(alpnIds(useH2, useALPN)),
-                        singletonMap(SNI_HOSTNAME, untrustedServerConfig()))
-                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
-             BlockingHttpClient client = newClient(serverContext, useH2, useALPN)) {
+                .protocols(protocolConfigs(protocols))
+                .sslConfig(trustedServerConfig(alpnIds(protocols, useALPN)),
+                        singletonMap(SNI_HOSTNAME, untrustedServerConfig(alpnIds(protocols, useALPN))))
+                .listenBlockingAndAwait(newSslVerifyService());
+             BlockingHttpClient client = newClient(serverContext, protocols, useALPN)) {
             assertThrows(SSLHandshakeException.class, () -> client.request(client.get("/")));
         }
     }
 
-    @ParameterizedTest(name = "h2={0}, alpn={1}")
-    @MethodSource("useH2UseAlpn")
-    void sniDefaultFallbackFailExpected(boolean useH2, boolean useALPN) throws Exception {
+    @ParameterizedTest(name = "protocols={0}, alpn={1}")
+    @MethodSource("protocolsAndAlpn")
+    void sniDefaultFallbackFailExpected(List<HttpProtocol> protocols, boolean useALPN) throws Exception {
         try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
-                .protocols(protocolConfigs(useH2))
-                .sslConfig(untrustedServerConfig(alpnIds(useH2, useALPN)),
-                        singletonMap("no_match" + SNI_HOSTNAME, trustedServerConfig()))
-                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
-             BlockingHttpClient client = newClient(serverContext, useH2, useALPN)) {
+                .protocols(protocolConfigs(protocols))
+                .sslConfig(untrustedServerConfig(alpnIds(protocols, useALPN)),
+                        singletonMap("no_match" + SNI_HOSTNAME, trustedServerConfig(alpnIds(protocols, useALPN))))
+                .listenBlockingAndAwait(newSslVerifyService());
+             BlockingHttpClient client = newClient(serverContext, protocols, useALPN)) {
             assertThrows(SSLHandshakeException.class, () -> client.request(client.get("/")));
         }
     }
 
-    @ParameterizedTest(name = "h2={0}, alpn={1}")
-    @MethodSource("useH2UseAlpn")
-    void sniClientDefaultServerSuccess(boolean useH2, boolean useALPN) throws Exception {
+    @ParameterizedTest(name = "protocols={0}, alpn={1}")
+    @MethodSource("protocolsAndAlpn")
+    void sniClientDefaultServerSuccess(List<HttpProtocol> protocols, boolean useALPN) throws Exception {
         try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
-                .protocols(protocolConfigs(useH2))
-                .sslConfig(trustedServerConfig(alpnIds(useH2, useALPN)))
-                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
-             BlockingHttpClient client = newClient(serverContext, useH2, useALPN)) {
+                .protocols(protocolConfigs(protocols))
+                .sslConfig(trustedServerConfig(alpnIds(protocols, useALPN)))
+                .listenBlockingAndAwait(newSslVerifyService());
+             BlockingHttpClient client = newClient(serverContext, protocols, useALPN)) {
             assertEquals(HttpResponseStatus.OK, client.request(client.get("/")).status());
         }
     }
 
-    @ParameterizedTest(name = "h2={0}, alpn={1}")
-    @MethodSource("useH2UseAlpn")
-    void noSniClientDefaultServerFallbackSuccess(boolean useH2, boolean useALPN) throws Exception {
+    @ParameterizedTest(name = "protocols={0}, alpn={1}")
+    @MethodSource("protocolsAndAlpn")
+    void noSniClientDefaultServerFallbackSuccess(List<HttpProtocol> protocols, boolean useALPN) throws Exception {
         try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
-                .protocols(protocolConfigs(useH2))
-                .sslConfig(trustedServerConfig(alpnIds(useH2, useALPN)),
+                .protocols(protocolConfigs(protocols))
+                .sslConfig(trustedServerConfig(alpnIds(protocols, useALPN)),
                         singletonMap("localhost", untrustedServerConfig()))
-                .listenBlockingAndAwait((ctx, request, responseFactory) ->
-                        ctx.sslSession() != null ? responseFactory.ok() : responseFactory.internalServerError());
+                .listenBlockingAndAwait(newSslVerifyService());
              BlockingHttpClient client = HttpClients.forSingleAddress(
-                     InetAddress.getLoopbackAddress().getHostName(),
+                     getLoopbackAddress().getHostName(),
                      serverHostAndPort(serverContext).port())
-                     .protocols(protocolConfigs(useH2))
+                     .protocols(protocolConfigs(protocols))
                      .sslConfig(configureAlpn(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
-                             .peerHost(serverPemHostname()), useH2, useALPN).build())
+                             .peerHost(serverPemHostname()), protocols, useALPN).build())
                      .inferSniHostname(false)
                      .buildBlocking()) {
             HttpRequest request = client.get("/");
@@ -137,23 +139,20 @@ class SniTest {
         }
     }
 
-    @ParameterizedTest(name = "h2={0}, alpn={1}")
-    @MethodSource("useH2UseAlpn")
-    void noSniClientDefaultServerFallbackFailExpected(boolean useH2, boolean useALPN) throws Exception {
+    @ParameterizedTest(name = "protocols={0}, alpn={1}")
+    @MethodSource("protocolsAndAlpn")
+    void noSniClientDefaultServerFallbackFailExpected(List<HttpProtocol> protocols, boolean useALPN) throws Exception {
         try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
-                .protocols(protocolConfigs(useH2))
-                .sslConfig(
-                        untrustedServerConfig(alpnIds(useH2, useALPN)),
-                        singletonMap(InetAddress.getLoopbackAddress().getHostName(), trustedServerConfig())
-                )
-                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
-             BlockingHttpClient client = HttpClients.forSingleAddress(
-                     InetAddress.getLoopbackAddress().getHostName(),
-                     serverHostAndPort(serverContext).port()
-             )
-                     .protocols(protocolConfigs(useH2))
+                .protocols(protocolConfigs(protocols))
+                .sslConfig(untrustedServerConfig(alpnIds(protocols, useALPN)),
+                        singletonMap(getLoopbackAddress().getHostName(),
+                                trustedServerConfig(alpnIds(protocols, useALPN))))
+                .listenBlockingAndAwait(newSslVerifyService());
+             BlockingHttpClient client = HttpClients.forSingleAddress(getLoopbackAddress().getHostName(),
+                        serverHostAndPort(serverContext).port())
+                     .protocols(protocolConfigs(protocols))
                      .sslConfig(configureAlpn(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem),
-                             useH2, useALPN).build())
+                             protocols, useALPN).build())
                      .inferSniHostname(false)
                      .buildBlocking()) {
             assertThrows(SSLHandshakeException.class, () -> client.request(client.get("/")));
@@ -161,27 +160,27 @@ class SniTest {
     }
 
     @SuppressWarnings("unused")
-    private static Stream<Arguments> useH2UseAlpn() {
-        return Stream.of(Arguments.of(false, false),
-                Arguments.of(false, true),
-                Arguments.of(true, false),
-                Arguments.of(true, true)
+    private static Stream<Arguments> protocolsAndAlpn() {
+        return Stream.of(Arguments.of(singletonList(HTTP_2), false),
+                Arguments.of(singletonList(HTTP_2), true),
+                Arguments.of(singletonList(HTTP_1), false),
+                Arguments.of(singletonList(HTTP_1), true)
         );
     }
 
     private static BlockingHttpClient newClient(ServerContext serverContext,
-                                                boolean useH2, boolean useALPN) {
+                                                List<HttpProtocol> protocols, boolean useALPN) {
         return HttpClients.forSingleAddress(serverHostAndPort(serverContext))
-                .protocols(protocolConfigs(useH2))
+                .protocols(protocolConfigs(protocols))
                 .sslConfig(configureAlpn(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
-                        .sniHostname(SNI_HOSTNAME).peerHost(serverPemHostname()), useH2, useALPN).build())
+                        .sniHostname(SNI_HOSTNAME).peerHost(serverPemHostname()), protocols, useALPN).build())
                 .buildBlocking();
     }
 
-    private static ClientSslConfigBuilder configureAlpn(ClientSslConfigBuilder builder, boolean useH2,
+    private static ClientSslConfigBuilder configureAlpn(ClientSslConfigBuilder builder, List<HttpProtocol> protocols,
                                                         boolean useALPN) {
         if (useALPN) {
-            builder.alpnProtocols(alpnIds(useH2, true));
+            builder.alpnProtocols(alpnIds(protocols));
         }
         return builder;
     }
@@ -200,13 +199,17 @@ class SniTest {
         return builder.build();
     }
 
-    private static ServerSslConfig trustedServerConfig() {
-        return trustedServerConfig((String[]) null);
+    @Nullable
+    private static String[] alpnIds(List<HttpProtocol> protocols, boolean useALPN) {
+        return useALPN ? alpnIds(protocols) : null;
     }
 
-    @Nullable
-    private static String[] alpnIds(boolean useH2, boolean useALPN) {
-        return useALPN ? (useH2 ? new String[] {AlpnIds.HTTP_2} : new String[] {AlpnIds.HTTP_1_1}) : null;
+    private static String[] alpnIds(List<HttpProtocol> protocols) {
+        String[] ids = new String[protocols.size()];
+        for (int i = 0; i < ids.length; ++i) {
+            ids[i] = protocols.get(i).config.alpnId();
+        }
+        return ids;
     }
 
     private static ServerSslConfig trustedServerConfig(@Nullable String... alpn) {
@@ -218,7 +221,16 @@ class SniTest {
         return builder.build();
     }
 
-    private static HttpProtocolConfig[] protocolConfigs(boolean useH2) {
-        return useH2 ? new HttpProtocolConfig[] {h2Default()} : new HttpProtocolConfig[] {h1Default()};
+    private static HttpProtocolConfig[] protocolConfigs(List<HttpProtocol> protocols) {
+        HttpProtocolConfig[] configs = new HttpProtocolConfig[protocols.size()];
+        for (int i = 0; i < configs.length; ++i) {
+            configs[i] = protocols.get(i).config;
+        }
+        return configs;
+    }
+
+    private static BlockingHttpService newSslVerifyService() {
+        return (ctx, request, responseFactory) ->
+                ctx.sslSession() != null ? responseFactory.ok() : responseFactory.internalServerError();
     }
 }


### PR DESCRIPTION
Motivation:
H2 server with SNI enabled current does not work. Netty's SniHandler
does not queue writes in the same way that the SslHandler does. The h2
handler is added and writes a settings frame immediately on the server,
which is written to the socket before the handshake is completed. This
results in a handshake failure.

Modifications:
- Defer adding h2 protocol handlers to the pipeline until after the SNI
  selection is made.

Result:
H2 Server with SNI now works as expected.