### PR TITLE
Specify PITest version in `Versions.groovy`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-
 org.gradle.parallel=true
 
 group=io.servicetalk
@@ -62,9 +61,7 @@ testngVersion=6.14.3
 hamcrestVersion=1.3
 mockitoCoreVersion=2.28.2
 spotbugsPluginVersion=4.7.1
-pitestVersion=1.6.7
 pitestPluginVersion=1.6.0
-pitestPluginJunit5Version=0.12
 
 apacheDirectoryServerVersion=1.5.7
 commonsLangVersion=2.6

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -27,6 +27,8 @@ import static io.servicetalk.gradle.plugin.internal.ProjectUtils.addQualityTask
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.createJavadocJarTask
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.createSourcesJarTask
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.locateBuildLevelConfigFile
+import static io.servicetalk.gradle.plugin.internal.Versions.PITEST_JUNIT5_PLUGIN_VERSION
+import static io.servicetalk.gradle.plugin.internal.Versions.PITEST_VERSION
 import static io.servicetalk.gradle.plugin.internal.Versions.PMD_VERSION
 import static io.servicetalk.gradle.plugin.internal.Versions.SPOTBUGS_VERSION
 import static io.servicetalk.gradle.plugin.internal.Versions.TARGET_VERSION
@@ -215,8 +217,8 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
       pluginManager.apply("info.solidsoft.pitest")
 
       pitest {
-        pitestVersion = project.properties["pitestVersion"]
-        junit5PluginVersion = project.properties["pitestPluginJunit5Version"]
+        pitestVersion = PITEST_VERSION
+        junit5PluginVersion = PITEST_JUNIT5_PLUGIN_VERSION
       }
 
       tasks.withType(PitestTask) {
@@ -230,7 +232,7 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
         failWhenNoMutations = false
         verbose = false
       }
-      
+
       tasks.withType(PitestTask).all {
         group = "verification"
       }

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/Versions.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/Versions.groovy
@@ -23,5 +23,7 @@ final class Versions {
   static final String CHECKSTYLE_VERSION = "8.43"
   static final String PMD_VERSION = "6.35.0"
   static final String SPOTBUGS_VERSION = "4.2.3"
+  static final String PITEST_VERSION = "1.6.7"
+  static final String PITEST_JUNIT5_PLUGIN_VERSION = "0.12"
   static final JavaVersion TARGET_VERSION = VERSION_1_8
 }


### PR DESCRIPTION
Motivation:
For Gradle modules which are not part of ServiceTalk butuse the ServiceTalk Gradle plugin it is necessary to include the versions referenced in the `Versions.groovy` file because they cannot reference the `gradle.properties` of the main ServiceTalk project.
Modifications:
`PITEST_VERSION` and `PITEST_PLUGIN_JUNIT5_VERSION` added to `Versions.groovy`
Result:
Modules using servicetalk-gradle-plugin build