### PR TITLE
`ClientEffectiveStrategyTest` and `ServerEffectiveStrategyTest` cleanups

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StrategyInfluencerChainBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StrategyInfluencerChainBuilder.java
@@ -50,7 +50,6 @@ public final class StrategyInfluencerChainBuilder {
      * Adds the passed {@link HttpExecutionStrategyInfluencer} to the head of this chain.
      *
      * @param influencer {@link HttpExecutionStrategyInfluencer} to add.
-     * @throws IndexOutOfBoundsException If the passed index is invalid.
      */
     public void prepend(HttpExecutionStrategyInfluencer influencer) {
         influencers.addFirst(requireNonNull(influencer));
@@ -62,7 +61,6 @@ public final class StrategyInfluencerChainBuilder {
      *
      * @param mayBeInfluencer An object which may be an {@link HttpExecutionStrategyInfluencer}.
      * @return {@code true} if the passed {@code mayBeInfluencer} was added to the chain.
-     * @throws IndexOutOfBoundsException If the passed index is invalid.
      */
     public boolean prependIfInfluencer(Object mayBeInfluencer) {
         if (mayBeInfluencer instanceof HttpExecutionStrategyInfluencer) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -23,6 +23,7 @@ import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.BlockingIterator;
 import io.servicetalk.concurrent.api.DefaultThreadFactory;
 import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.Executors;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.BlockingHttpClient;
@@ -43,14 +44,11 @@ import io.servicetalk.loadbalancer.RoundRobinLoadBalancer;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
+import java.util.EnumSet;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
@@ -65,7 +63,7 @@ import static io.servicetalk.http.netty.ClientEffectiveStrategyTest.ClientOffloa
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.noStrategy;
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.userStrategy;
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.userStrategyNoVerify;
-import static java.util.Arrays.asList;
+import static org.junit.Assert.fail;
 
 class ClientEffectiveStrategyTest {
 
@@ -76,277 +74,258 @@ class ClientEffectiveStrategyTest {
         params.dispose();
     }
 
-    static Collection<ParamsSupplier> params() {
-        List<ParamsSupplier> params = new ArrayList<>();
-        params.add(wrap("noUserStrategyNoFilter", ClientEffectiveStrategyTest::noUserStrategyNoFilter));
-        params.add(wrap("noUserStrategyWithFilter", ClientEffectiveStrategyTest::noUserStrategyWithFilter));
-        params.add(wrap("noUserStrategyWithLB", ClientEffectiveStrategyTest::noUserStrategyWithLB));
-        params.add(wrap("noUserStrategyWithCF", ClientEffectiveStrategyTest::noUserStrategyWithCF));
-        params.add(wrap("userStrategyNoFilter", ClientEffectiveStrategyTest::userStrategyNoFilter));
-        params.add(wrap("userStrategyWithFilter", ClientEffectiveStrategyTest::userStrategyWithFilter));
-        params.add(wrap("userStrategyWithLB", ClientEffectiveStrategyTest::userStrategyWithLB));
-        params.add(wrap("userStrategyWithCF", ClientEffectiveStrategyTest::userStrategyWithCF));
-        params.add(wrap("userStrategyNoExecutorNoFilter",
-                ClientEffectiveStrategyTest::userStrategyNoExecutorNoFilter));
-        params.add(wrap("userStrategyNoExecutorWithFilter",
-                ClientEffectiveStrategyTest::userStrategyNoExecutorWithFilter));
-        params.add(wrap("userStrategyNoExecutorWithLB",
-                ClientEffectiveStrategyTest::userStrategyNoExecutorWithLB));
-        params.add(wrap("userStrategyNoExecutorWithCF",
-                ClientEffectiveStrategyTest::userStrategyNoExecutorWithCF));
-        params.add(wrap("userStrategyNoOffloadsNoFilter",
-                ClientEffectiveStrategyTest::userStrategyNoOffloadsNoFilter));
-        params.add(wrap("userStrategyNoOffloadsWithFilter",
-                ClientEffectiveStrategyTest::userStrategyNoOffloadsWithFilter));
-        params.add(wrap("userStrategyNoOffloadsWithLB",
-                ClientEffectiveStrategyTest::userStrategyNoOffloadsWithLB));
-        params.add(wrap("userStrategyNoOffloadsWithCF",
-                ClientEffectiveStrategyTest::userStrategyNoOffloadsWithCF));
-        params.add(wrap("userStrategyNoOffloadsNoExecutorNoFilter",
-                ClientEffectiveStrategyTest::userStrategyNoOffloadsNoExecutorNoFilter));
-        params.add(wrap("userStrategyNoOffloadsNoExecutorWithFilter",
-                ClientEffectiveStrategyTest::userStrategyNoOffloadsNoExecutorWithFilter));
-        params.add(wrap("userStrategyNoOffloadsNoExecutorWithLB",
-                ClientEffectiveStrategyTest::userStrategyNoOffloadsNoExecutorWithLB));
-        params.add(wrap("userStrategyNoOffloadsNoExecutorWithCF",
-                ClientEffectiveStrategyTest::userStrategyNoOffloadsNoExecutorWithCF));
-        params.add(wrap("customUserStrategyNoFilter",
-                ClientEffectiveStrategyTest::customUserStrategyNoFilter));
-        params.add(wrap("customUserStrategyWithFilter",
-                ClientEffectiveStrategyTest::customUserStrategyWithFilter));
-        params.add(wrap("customUserStrategyWithLB",
-                ClientEffectiveStrategyTest::customUserStrategyWithLB));
-        params.add(wrap("customUserStrategyWithCF",
-                ClientEffectiveStrategyTest::customUserStrategyWithCF));
-        params.add(wrap("customUserStrategyNoExecutorNoFilter",
-                ClientEffectiveStrategyTest::customUserStrategyNoExecutorNoFilter));
-        params.add(wrap("customUserStrategyNoExecutorWithFilter",
-                ClientEffectiveStrategyTest::customUserStrategyNoExecutorWithFilter));
-        params.add(wrap("customUserStrategyNoExecutorWithLB",
-                ClientEffectiveStrategyTest::customUserStrategyNoExecutorWithLB));
-        params.add(wrap("customUserStrategyNoExecutorWithCF",
-                ClientEffectiveStrategyTest::customUserStrategyNoExecutorWithCF));
-        return params;
-    }
+    enum ClientStrategyCase implements Supplier<Params> {
+        noUserStrategyNoFilter(ClientEffectiveStrategyTest::noUserStrategyNoFilter),
+        noUserStrategyWithFilter(ClientEffectiveStrategyTest::noUserStrategyWithFilter),
+        noUserStrategyWithLB(ClientEffectiveStrategyTest::noUserStrategyWithLB),
+        noUserStrategyWithCF(ClientEffectiveStrategyTest::noUserStrategyWithCF),
+        userStrategyNoFilter(ClientEffectiveStrategyTest::userStrategyNoFilter),
+        userStrategyWithFilter(ClientEffectiveStrategyTest::userStrategyWithFilter),
+        userStrategyWithLB(ClientEffectiveStrategyTest::userStrategyWithLB),
+        userStrategyWithCF(ClientEffectiveStrategyTest::userStrategyWithCF),
+        userStrategyNoExecutorNoFilter(ClientEffectiveStrategyTest::userStrategyNoExecutorNoFilter),
+        userStrategyNoExecutorWithFilter(ClientEffectiveStrategyTest::userStrategyNoExecutorWithFilter),
+        userStrategyNoExecutorWithLB(ClientEffectiveStrategyTest::userStrategyNoExecutorWithLB),
+        userStrategyNoExecutorWithCF(ClientEffectiveStrategyTest::userStrategyNoExecutorWithCF),
+        userStrategyNoOffloadsNoFilter(ClientEffectiveStrategyTest::userStrategyNoOffloadsNoFilter),
+        userStrategyNoOffloadsWithFilter(ClientEffectiveStrategyTest::userStrategyNoOffloadsWithFilter),
+        userStrategyNoOffloadsWithLB(ClientEffectiveStrategyTest::userStrategyNoOffloadsWithLB),
+        userStrategyNoOffloadsWithCF(ClientEffectiveStrategyTest::userStrategyNoOffloadsWithCF),
+        userStrategyNoOffloadsNoExecutorNoFilter(
+                ClientEffectiveStrategyTest::userStrategyNoOffloadsNoExecutorNoFilter),
+        userStrategyNoOffloadsNoExecutorWithFilter(
+                ClientEffectiveStrategyTest::userStrategyNoOffloadsNoExecutorWithFilter),
+        userStrategyNoOffloadsNoExecutorWithLB(ClientEffectiveStrategyTest::userStrategyNoOffloadsNoExecutorWithLB),
+        userStrategyNoOffloadsNoExecutorWithCF(ClientEffectiveStrategyTest::userStrategyNoOffloadsNoExecutorWithCF),
+        customUserStrategyNoFilter(ClientEffectiveStrategyTest::customUserStrategyNoFilter),
+        customUserStrategyWithFilter(ClientEffectiveStrategyTest::customUserStrategyWithFilter),
+        customUserStrategyWithLB(ClientEffectiveStrategyTest::customUserStrategyWithLB),
+        customUserStrategyWithCF(ClientEffectiveStrategyTest::customUserStrategyWithCF),
+        customUserStrategyNoExecutorNoFilter(ClientEffectiveStrategyTest::customUserStrategyNoExecutorNoFilter),
+        customUserStrategyNoExecutorWithFilter(ClientEffectiveStrategyTest::customUserStrategyNoExecutorWithFilter),
+        customUserStrategyNoExecutorWithLB(ClientEffectiveStrategyTest::customUserStrategyNoExecutorWithLB),
+        customUserStrategyNoExecutorWithCF(ClientEffectiveStrategyTest::customUserStrategyNoExecutorWithCF);
 
-    static ParamsSupplier wrap(String name, Supplier<Params> supplier) {
-        return new ParamsSupplier(name) {
-            @Override
-            Params newParams() {
-                return supplier.get();
-            }
-        };
+        final Supplier<Params> paramsSupplier;
+
+        ClientStrategyCase(Supplier<Params> paramsSupplier) {
+            this.paramsSupplier = paramsSupplier;
+        }
+
+        public Params get() {
+            return paramsSupplier.get();
+        }
     }
 
     private static Params noUserStrategyNoFilter() {
-        Params params = new Params();
+        Params params = new Params(false, false);
         params.initStateHolderDefaultStrategy(false, false, false);
         params.defaultOffloadPoints();
         return params;
     }
 
     private static Params noUserStrategyWithFilter() {
-        Params params = new Params();
+        Params params = new Params(false, false);
         params.initStateHolderDefaultStrategy(true, false, false);
         params.allPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params noUserStrategyWithLB() {
-        Params params = new Params();
+        Params params = new Params(false, false);
         params.initStateHolderDefaultStrategy(false, true, false);
         params.allPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params noUserStrategyWithCF() {
-        Params params = new Params();
+        Params params = new Params(false, false);
         params.initStateHolderDefaultStrategy(false, false, true);
         params.allPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params userStrategyNoFilter() {
-        Params params = new Params();
+        Params params = new Params(true, false);
         params.initStateHolderUserStrategy(false, false, false);
         params.defaultOffloadPoints();
         return params;
     }
 
     private static Params userStrategyWithFilter() {
-        Params params = new Params();
+        Params params = new Params(true, false);
         params.initStateHolderUserStrategy(true, false, false);
         params.allPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params userStrategyWithLB() {
-        Params params = new Params();
+        Params params = new Params(true, false);
         params.initStateHolderUserStrategy(false, true, false);
         params.allPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params userStrategyWithCF() {
-        Params params = new Params();
+        Params params = new Params(true, false);
         params.initStateHolderUserStrategy(false, false, true);
         params.allPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params userStrategyNoExecutorNoFilter() {
-        Params params = new Params();
+        Params params = new Params(false, false);
         params.initStateHolderUserStrategyNoExecutor(false, false, false);
         params.defaultOffloadPoints();
         return params;
     }
 
     private static Params userStrategyNoExecutorWithFilter() {
-        Params params = new Params();
+        Params params = new Params(false, false);
         params.initStateHolderUserStrategyNoExecutor(true, false, false);
         params.allPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params userStrategyNoExecutorWithLB() {
-        Params params = new Params();
+        Params params = new Params(false, false);
         params.initStateHolderUserStrategyNoExecutor(false, true, false);
         params.allPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params userStrategyNoExecutorWithCF() {
-        Params params = new Params();
+        Params params = new Params(false, false);
         params.initStateHolderUserStrategyNoExecutor(false, false, true);
         params.allPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params userStrategyNoOffloadsNoFilter() {
-        Params params = new Params();
+        Params params = new Params(false, false);
         params.initStateHolderUserStrategyNoOffloads(false, false, false);
         params.noPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params userStrategyNoOffloadsWithFilter() {
-        Params params = new Params();
+        Params params = new Params(false, false);
         params.initStateHolderUserStrategyNoOffloads(true, false, false);
         params.noPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params userStrategyNoOffloadsWithLB() {
-        Params params = new Params();
+        Params params = new Params(false, false);
         params.initStateHolderUserStrategyNoOffloads(false, true, false);
         params.noPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params userStrategyNoOffloadsWithCF() {
-        Params params = new Params();
+        Params params = new Params(false, false);
         params.initStateHolderUserStrategyNoOffloads(false, false, true);
         params.noPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params userStrategyNoOffloadsNoExecutorNoFilter() {
-        Params params = new Params();
+        Params params = new Params(false, false);
         params.initStateHolderUserStrategyNoOffloadsNoExecutor(false, false, false);
         params.noPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params userStrategyNoOffloadsNoExecutorWithFilter() {
-        Params params = new Params();
+        Params params = new Params(false, false);
         params.initStateHolderUserStrategyNoOffloadsNoExecutor(true, false, false);
         params.noPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params userStrategyNoOffloadsNoExecutorWithLB() {
-        Params params = new Params();
+        Params params = new Params(false, false);
         params.initStateHolderUserStrategyNoOffloadsNoExecutor(false, true, false);
         params.noPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params userStrategyNoOffloadsNoExecutorWithCF() {
-        Params params = new Params();
+        Params params = new Params(false, false);
         params.initStateHolderUserStrategyNoOffloadsNoExecutor(false, false, true);
         params.noPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params customUserStrategyNoExecutorNoFilter() {
-        Params params = new Params();
+        Params params = new Params(false, true);
         params.initStateHolderCustomUserStrategyNoExecutor(false, false, false);
         params.allPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params customUserStrategyNoExecutorWithFilter() {
-        Params params = new Params();
+        Params params = new Params(false, true);
         params.initStateHolderCustomUserStrategyNoExecutor(true, false, false);
         params.allPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params customUserStrategyNoExecutorWithLB() {
-        Params params = new Params();
+        Params params = new Params(false, true);
         params.initStateHolderCustomUserStrategyNoExecutor(false, true, false);
         params.allPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params customUserStrategyNoExecutorWithCF() {
-        Params params = new Params();
+        Params params = new Params(false, true);
         params.initStateHolderCustomUserStrategyNoExecutor(false, false, true);
         params.allPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params customUserStrategyNoFilter() {
-        Params params = new Params();
+        Params params = new Params(true, true);
         params.initStateHolderCustomUserStrategy(false, false, false);
         params.allPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params customUserStrategyWithFilter() {
-        Params params = new Params();
+        Params params = new Params(true, true);
         params.initStateHolderCustomUserStrategy(true, false, false);
         params.allPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params customUserStrategyWithLB() {
-        Params params = new Params();
+        Params params = new Params(true, true);
         params.initStateHolderCustomUserStrategy(false, true, false);
         params.allPointsOffloadedForAllClients();
         return params;
     }
 
     private static Params customUserStrategyWithCF() {
-        Params params = new Params();
+        Params params = new Params(true, true);
         params.initStateHolderCustomUserStrategy(false, false, true);
         params.allPointsOffloadedForAllClients();
         return params;
     }
 
     @ParameterizedTest
-    @MethodSource("params")
-    void blocking(ParamsSupplier paramSupplier) throws Exception {
-        params = paramSupplier.newParams();
+    @EnumSource(ClientStrategyCase.class)
+    void blocking(ClientStrategyCase strategyCase) throws Exception {
+        params = strategyCase.get();
         BlockingHttpClient blockingClient = params.client().asBlockingClient();
         blockingClient.request(blockingClient.get("/"));
         params.verifyOffloads(ClientType.Blocking);
     }
 
     @ParameterizedTest
-    @MethodSource("params")
-    void blockingStreaming(ParamsSupplier paramSupplier) throws Exception {
-        params = paramSupplier.newParams();
+    @EnumSource(ClientStrategyCase.class)
+    void blockingStreaming(ClientStrategyCase strategyCase) throws Exception {
+        params = strategyCase.get();
         BlockingStreamingHttpClient blockingClient = params.client().asBlockingStreamingClient();
         BlockingIterator<Buffer> iter = blockingClient.request(blockingClient.get("/")).payloadBody().iterator();
         iter.forEachRemaining(__ -> { });
@@ -355,81 +334,75 @@ class ClientEffectiveStrategyTest {
     }
 
     @ParameterizedTest
-    @MethodSource("params")
-    void streaming(ParamsSupplier paramSupplier) throws Exception {
-        params = paramSupplier.newParams();
+    @EnumSource(ClientStrategyCase.class)
+    void streaming(ClientStrategyCase strategyCase) throws Exception {
+        params = strategyCase.get();
         params.client().request(params.client().get("/"))
                 .flatMapPublisher(StreamingHttpResponse::payloadBody).toFuture().get();
         params.verifyOffloads(ClientType.AsyncStreaming);
     }
 
     @ParameterizedTest
-    @MethodSource("params")
-    void async(ParamsSupplier paramSupplier) throws Exception {
-        params = paramSupplier.newParams();
+    @EnumSource(ClientStrategyCase.class)
+    void async(ClientStrategyCase strategyCase) throws Exception {
+        params = strategyCase.get();
         HttpClient httpClient = params.client().asClient();
         httpClient.request(httpClient.get("/")).toFuture().get();
         params.verifyOffloads(ClientType.Async);
     }
 
-    private abstract static class ParamsSupplier {
-        private final String name;
-
-        ParamsSupplier(final String name) {
-            this.name = name;
-        }
-
-        abstract Params newParams();
-
-        @Override
-        public String toString() {
-            return name;
-        }
-    }
-
     private static final class Params {
         private static final String USER_STRATEGY_EXECUTOR_NAME_PREFIX = "user-strategy-executor";
 
-
-        private final Map<ClientType, List<ClientOffloadPoint>> offloadPoints;
-        private final Map<ClientType, List<ClientOffloadPoint>> nonOffloadPoints;
+        private final EnumMap<ClientType, EnumSet<ClientOffloadPoint>> offloadPoints =
+                new EnumMap<>(ClientType.class);
+        private final EnumMap<ClientType, EnumSet<ClientOffloadPoint>> nonOffloadPoints =
+                new EnumMap<>(ClientType.class);
         private final Executor executor;
         @Nullable
         private InvokingThreadsRecorder<ClientOffloadPoint> invokingThreadsRecorder;
-        private boolean executorUsedForStrategy = true;
-        private boolean verifyStrategyUsed;
+        private final boolean executorUsedForStrategy;
+        private final boolean verifyStrategyUsed;
 
-        Params() {
-            this.executor = newCachedThreadExecutor(new DefaultThreadFactory(USER_STRATEGY_EXECUTOR_NAME_PREFIX));
-            offloadPoints = new EnumMap<>(ClientType.class);
+        Params(boolean executorUsedForStrategy, boolean verifyStrategyUsed) {
             for (ClientType clientType : ClientType.values()) {
-                offloadPoints.put(clientType, new ArrayList<>());
+                offloadPoints.put(clientType, EnumSet.noneOf(ClientOffloadPoint.class));
             }
-            nonOffloadPoints = new EnumMap<>(ClientType.class);
             for (ClientType clientType : ClientType.values()) {
-                nonOffloadPoints.put(clientType, new ArrayList<>());
+                nonOffloadPoints.put(clientType, EnumSet.noneOf(ClientOffloadPoint.class));
             }
+            this.executorUsedForStrategy = executorUsedForStrategy;
+            this.executor = executorUsedForStrategy ?
+                    newCachedThreadExecutor(new DefaultThreadFactory(USER_STRATEGY_EXECUTOR_NAME_PREFIX)) :
+                    Executors.from(r -> fail("This executor was not to be used"));
+            this.verifyStrategyUsed = verifyStrategyUsed;
         }
 
         void addOffloadedPointFor(ClientType clientType, ClientOffloadPoint... points) {
-            offloadPoints.get(clientType).addAll(asList(points));
+            EnumSet<ClientOffloadPoint> offloads = offloadPoints.get(clientType);
+            for (ClientOffloadPoint point : points) {
+                offloads.add(point);
+            }
         }
 
         void addNonOffloadedPointFor(ClientType clientType, ClientOffloadPoint... points) {
-            nonOffloadPoints.get(clientType).addAll(asList(points));
+            EnumSet<ClientOffloadPoint> nonOffloads = nonOffloadPoints.get(clientType);
+            for (ClientOffloadPoint point : points) {
+                nonOffloads.add(point);
+            }
         }
 
         void allPointsOffloadedForAllClients() {
+            EnumSet<ClientOffloadPoint> all = EnumSet.allOf(ClientOffloadPoint.class);
             for (ClientType clientType : ClientType.values()) {
-                offloadPoints.get(clientType).addAll(asList(ResponseData,
-                        ResponseMeta, RequestPayloadSubscription));
+                offloadPoints.get(clientType).addAll(all);
             }
         }
 
         void noPointsOffloadedForAllClients() {
+            EnumSet<ClientOffloadPoint> all = EnumSet.allOf(ClientOffloadPoint.class);
             for (ClientType clientType : ClientType.values()) {
-                nonOffloadPoints.get(clientType).addAll(asList(ResponseData,
-                        ResponseMeta, RequestPayloadSubscription));
+                nonOffloadPoints.get(clientType).addAll(all);
             }
         }
 
@@ -447,7 +420,6 @@ class ClientEffectiveStrategyTest {
 
         void initStateHolderDefaultStrategy(boolean addFilter, boolean addLoadBalancer,
                                             boolean addConnectionFilter) {
-            executorUsedForStrategy = false;
             invokingThreadsRecorder = noStrategy();
             initState(addFilter, addLoadBalancer, addConnectionFilter);
         }
@@ -460,36 +432,30 @@ class ClientEffectiveStrategyTest {
 
         void initStateHolderUserStrategyNoExecutor(boolean addFilter, boolean addLoadBalancer,
                                                    boolean addConnectionFilter) {
-            executorUsedForStrategy = false;
             invokingThreadsRecorder = userStrategyNoVerify(defaultStrategy());
             initState(addFilter, addLoadBalancer, addConnectionFilter);
         }
 
         void initStateHolderUserStrategyNoOffloads(boolean addFilter, boolean addLoadBalancer,
                                                    boolean addConnectionFilter) {
-            executorUsedForStrategy = false;
             invokingThreadsRecorder = userStrategy(customStrategyBuilder().offloadNone().executor(immediate()).build());
             initState(addFilter, addLoadBalancer, addConnectionFilter);
         }
 
         void initStateHolderUserStrategyNoOffloadsNoExecutor(boolean addFilter, boolean addLoadBalancer,
                                                              boolean addConnectionFilter) {
-            executorUsedForStrategy = false;
             invokingThreadsRecorder = userStrategy(noOffloadsStrategy());
             initState(addFilter, addLoadBalancer, addConnectionFilter);
         }
 
         void initStateHolderCustomUserStrategy(boolean addFilter, boolean addLoadBalancer,
                                                boolean addConnectionFilter) {
-            verifyStrategyUsed = true;
             invokingThreadsRecorder = userStrategy(customStrategyBuilder().offloadAll().executor(executor).build());
             initState(addFilter, addLoadBalancer, addConnectionFilter);
         }
 
         void initStateHolderCustomUserStrategyNoExecutor(boolean addFilter, boolean addLoadBalancer,
                                                          boolean addConnectionFilter) {
-            executorUsedForStrategy = false;
-            verifyStrategyUsed = true;
             invokingThreadsRecorder = userStrategy(customStrategyBuilder().offloadAll().build());
             initState(addFilter, addLoadBalancer, addConnectionFilter);
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import java.net.InetSocketAddress;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.function.Supplier;
@@ -390,16 +391,12 @@ class ClientEffectiveStrategyTest {
 
         void addOffloadedPointFor(ClientType clientType, ClientOffloadPoint... points) {
             EnumSet<ClientOffloadPoint> offloads = offloadPoints.get(clientType);
-            for (ClientOffloadPoint point : points) {
-                offloads.add(point);
-            }
+            Collections.addAll(offloads, points);
         }
 
         void addNonOffloadedPointFor(ClientType clientType, ClientOffloadPoint... points) {
             EnumSet<ClientOffloadPoint> nonOffloads = nonOffloadPoints.get(clientType);
-            for (ClientOffloadPoint point : points) {
-                nonOffloads.add(point);
-            }
+            Collections.addAll(nonOffloads, points);
         }
 
         void allPointsOffloadedForAllClients() {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
@@ -18,6 +18,7 @@ package io.servicetalk.http.netty;
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.api.DefaultThreadFactory;
 import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.Executors;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.HttpExecutionStrategy;
@@ -36,19 +37,16 @@ import io.servicetalk.transport.api.ServerContext;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.EnumMap;
-import java.util.List;
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
 import static io.servicetalk.concurrent.api.Single.succeeded;
@@ -61,11 +59,12 @@ import static io.servicetalk.http.netty.InvokingThreadsRecorder.userStrategy;
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.userStrategyNoVerify;
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.lang.Character.isDigit;
-import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.either;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class ServerEffectiveStrategyTest {
@@ -80,147 +79,141 @@ class ServerEffectiveStrategyTest {
         }
     }
 
-    static Collection<ParamsSupplier> params() {
-        List<ParamsSupplier> params = new ArrayList<>();
-        params.add(wrap("noUserStrategyNoFilter", ServerEffectiveStrategyTest::noUserStrategyNoFilter));
-        params.add(wrap("noUserStrategyWithFilter", ServerEffectiveStrategyTest::noUserStrategyWithFilter));
-        params.add(wrap("userStrategyNoFilter", ServerEffectiveStrategyTest::userStrategyNoFilter));
-        params.add(wrap("userStrategyWithFilter", ServerEffectiveStrategyTest::userStrategyWithFilter));
-        params.add(wrap("userStrategyNoExecutorNoFilter",
-                ServerEffectiveStrategyTest::userStrategyNoExecutorNoFilter));
-        params.add(wrap("userStrategyNoExecutorWithFilter",
-                ServerEffectiveStrategyTest::userStrategyNoExecutorWithFilter));
-        params.add(wrap("userStrategyNoOffloadsNoExecutorNoFilter",
-                ServerEffectiveStrategyTest::userStrategyNoOffloadsNoExecutorNoFilter));
-        params.add(wrap("userStrategyNoOffloadsNoExecutorWithFilter",
-                ServerEffectiveStrategyTest::userStrategyNoOffloadsNoExecutorWithFilter));
-        params.add(wrap("userStrategyNoOffloadsWithExecutorNoFilter",
-                ServerEffectiveStrategyTest::userStrategyNoOffloadsWithExecutorNoFilter));
-        params.add(wrap("userStrategyNoOffloadsWithExecutorWithFilter",
-                ServerEffectiveStrategyTest::userStrategyNoOffloadsWithExecutorWithFilter));
-        params.add(wrap("customUserStrategyNoFilter",
-                ServerEffectiveStrategyTest::customUserStrategyNoFilter));
-        params.add(wrap("customUserStrategyWithFilter",
-                ServerEffectiveStrategyTest::customUserStrategyWithFilter));
-        params.add(wrap("customUserStrategyNoExecutorNoFilter",
-                ServerEffectiveStrategyTest::customUserStrategyNoExecutorNoFilter));
-        params.add(wrap("customUserStrategyNoExecutorWithFilter",
-                ServerEffectiveStrategyTest::customUserStrategyNoExecutorWithFilter));
-        return params;
-    }
+    enum ServerStrategyCase implements Supplier<Params> {
+       noUserStrategyNoFilter(ServerEffectiveStrategyTest::noUserStrategyNoFilter),
+       noUserStrategyWithFilter(ServerEffectiveStrategyTest::noUserStrategyWithFilter),
+       userStrategyNoFilter(ServerEffectiveStrategyTest::userStrategyNoFilter),
+       userStrategyWithFilter(ServerEffectiveStrategyTest::userStrategyWithFilter),
+       userStrategyNoExecutorNoFilter(ServerEffectiveStrategyTest::userStrategyNoExecutorNoFilter),
+       userStrategyNoExecutorWithFilter(ServerEffectiveStrategyTest::userStrategyNoExecutorWithFilter),
+       userStrategyNoOffloadsNoExecutorNoFilter(
+               ServerEffectiveStrategyTest::userStrategyNoOffloadsNoExecutorNoFilter),
+       userStrategyNoOffloadsNoExecutorWithFilter(
+               ServerEffectiveStrategyTest::userStrategyNoOffloadsNoExecutorWithFilter),
+       userStrategyNoOffloadsWithExecutorNoFilter(
+               ServerEffectiveStrategyTest::userStrategyNoOffloadsWithExecutorNoFilter),
+       userStrategyNoOffloadsWithExecutorWithFilter(
+               ServerEffectiveStrategyTest::userStrategyNoOffloadsWithExecutorWithFilter),
+       customUserStrategyNoFilter(ServerEffectiveStrategyTest::customUserStrategyNoFilter),
+       customUserStrategyWithFilter(ServerEffectiveStrategyTest::customUserStrategyWithFilter),
+       customUserStrategyNoExecutorNoFilter(ServerEffectiveStrategyTest::customUserStrategyNoExecutorNoFilter),
+       customUserStrategyNoExecutorWithFilter(ServerEffectiveStrategyTest::customUserStrategyNoExecutorWithFilter);
 
-    static ParamsSupplier wrap(String name, Supplier<Params> supplier) {
-        return new ParamsSupplier(name) {
-            @Override
-            Params newParams() {
-                return supplier.get();
-            }
-        };
+        private final Supplier<Params> paramsSupplier;
+
+        ServerStrategyCase(Supplier<Params> paramsSupplier) {
+            this.paramsSupplier = paramsSupplier;
+        }
+
+        @Override
+        public Params get() {
+            return paramsSupplier.get();
+        }
     }
 
     private static Params noUserStrategyNoFilter() {
-        Params params = new Params(false);
+        Params params = new Params(false, false, false);
         params.initStateHolderDefaultStrategy();
         params.defaultOffloadPoints();
         return params;
     }
 
     private static Params noUserStrategyWithFilter() {
-        Params params = new Params(true);
+        Params params = new Params(false, false, true);
         params.initStateHolderDefaultStrategy();
         params.allPointsOffloadedForAllServices();
         return params;
     }
 
     private static Params userStrategyNoFilter() {
-        Params params = new Params(false);
+        Params params = new Params(true, false, false);
         params.initStateHolderUserStrategy();
         params.defaultOffloadPoints();
         return params;
     }
 
     private static Params userStrategyWithFilter() {
-        Params params = new Params(true);
+        Params params = new Params(true, false, true);
         params.initStateHolderUserStrategy();
         params.allPointsOffloadedForAllServices();
         return params;
     }
 
     private static Params userStrategyNoOffloadsNoExecutorNoFilter() {
-        Params params = new Params(false);
+        Params params = new Params(true, true, false);
         params.initStateHolderUserStrategyNoOffloadsNoExecutor();
         params.noPointsOffloadedForAllServices();
         return params;
     }
 
     private static Params userStrategyNoOffloadsNoExecutorWithFilter() {
-        Params params = new Params(true);
+        Params params = new Params(true, true, true);
         params.initStateHolderUserStrategyNoOffloadsNoExecutor();
         params.noPointsOffloadedForAllServices();
         return params;
     }
 
     private static Params userStrategyNoOffloadsWithExecutorNoFilter() {
-        Params params = new Params(false);
+        Params params = new Params(true, true, false);
         params.initStateHolderUserStrategyNoOffloads();
         params.noPointsOffloadedForAllServices();
         return params;
     }
 
     private static Params userStrategyNoOffloadsWithExecutorWithFilter() {
-        Params params = new Params(true);
+        Params params = new Params(true, true, true);
         params.initStateHolderUserStrategyNoOffloads();
         params.noPointsOffloadedForAllServices();
         return params;
     }
 
     private static Params userStrategyNoExecutorNoFilter() {
-        Params params = new Params(false);
+        Params params = new Params(false, false, false);
         params.initStateHolderUserStrategyNoExecutor();
         params.defaultOffloadPoints();
         return params;
     }
 
     private static Params userStrategyNoExecutorWithFilter() {
-        Params params = new Params(true);
+        Params params = new Params(false, false, true);
         params.initStateHolderUserStrategyNoExecutor();
         params.allPointsOffloadedForAllServices();
         return params;
     }
 
     private static Params customUserStrategyNoFilter() {
-        Params params = new Params(false);
+        Params params = new Params(true, false, false);
         params.initStateHolderCustomUserStrategy();
         params.allPointsOffloadedForAllServices();
         return params;
     }
 
     private static Params customUserStrategyWithFilter() {
-        Params params = new Params(true);
+        Params params = new Params(true, false, true);
         params.initStateHolderCustomUserStrategy();
         params.allPointsOffloadedForAllServices();
         return params;
     }
 
     private static Params customUserStrategyNoExecutorNoFilter() {
-        Params params = new Params(false);
+        Params params = new Params(false, false, false);
         params.initStateHolderCustomUserStrategyNoExecutor();
         params.allPointsOffloadedForAllServices();
         return params;
     }
 
     private static Params customUserStrategyNoExecutorWithFilter() {
-        Params params = new Params(true);
+        Params params = new Params(false, false, true);
         params.initStateHolderCustomUserStrategyNoExecutor();
         params.allPointsOffloadedForAllServices();
         return params;
     }
 
     @ParameterizedTest
-    @MethodSource("params")
-    void blocking(final ParamsSupplier paramSupplier) throws Exception {
-        params = paramSupplier.newParams();
-        assert params != null;
+    @EnumSource(ServerStrategyCase.class)
+    void blocking(final ServerStrategyCase strategyCase) throws Exception {
+        params = strategyCase.get();
+        assertThat("Null params supplied", params, notNullValue());
         BlockingHttpClient client = params.startBlocking();
         client.request(client.get("/")
                 .payloadBody(client.executionContext().bufferAllocator().fromAscii("Hello")));
@@ -228,9 +221,10 @@ class ServerEffectiveStrategyTest {
     }
 
     @ParameterizedTest
-    @MethodSource("params")
-    void blockingStreaming(final ParamsSupplier paramSupplier) throws Exception {
-        params = paramSupplier.newParams();
+    @EnumSource(ServerStrategyCase.class)
+    void blockingStreaming(final ServerStrategyCase strategyCase) throws Exception {
+        params = strategyCase.get();
+        assertThat("Null params supplied", params, notNullValue());
         assumeFalse(params.isNoOffloadsStrategy(), "Ignoring no-offloads strategy for blocking-streaming.");
         BlockingHttpClient client = params.startBlockingStreaming();
         client.request(client.get("/")
@@ -239,10 +233,10 @@ class ServerEffectiveStrategyTest {
     }
 
     @ParameterizedTest
-    @MethodSource("params")
-    void asyncStreaming(final ParamsSupplier paramSupplier) throws Exception {
-        params = paramSupplier.newParams();
-        assert params != null;
+    @EnumSource(ServerStrategyCase.class)
+    void asyncStreaming(final ServerStrategyCase strategyCase) throws Exception {
+        params = strategyCase.get();
+        assertThat("Null params supplied", params, notNullValue());
         BlockingHttpClient client = params.startAsyncStreaming();
         client.request(client.get("/")
                 .payloadBody(client.executionContext().bufferAllocator().fromAscii("Hello")));
@@ -250,80 +244,71 @@ class ServerEffectiveStrategyTest {
     }
 
     @ParameterizedTest
-    @MethodSource("params")
-    void async(final ParamsSupplier paramSupplier) throws Exception {
-        params = paramSupplier.newParams();
-        assert params != null;
+    @EnumSource(ServerStrategyCase.class)
+    void async(final ServerStrategyCase strategyCase) throws Exception {
+        params = strategyCase.get();
+        assertThat("Null params supplied", params, notNullValue());
         BlockingHttpClient client = params.startAsync();
         client.request(client.get("/")
                 .payloadBody(client.executionContext().bufferAllocator().fromAscii("Hello")));
         params.verifyOffloads(ServiceType.Async);
     }
 
-    private abstract static class ParamsSupplier {
-        private final String name;
-
-        ParamsSupplier(final String name) {
-            this.name = name;
-        }
-
-        abstract Params newParams();
-
-        @Override
-        public String toString() {
-            return name;
-        }
-    }
-
     private static final class Params {
         private static final String USER_STRATEGY_EXECUTOR_NAME_PREFIX = "user-strategy-executor";
-        private static final String SERVICE_EXECUTOR_NAME_PREFIX = "service-executor";
 
-
-        private final Map<ServiceType, List<ServerOffloadPoint>> offloadPoints;
-        private final Map<ServiceType, List<ServerOffloadPoint>> nonOffloadPoints;
+        private final Map<ServiceType, EnumSet<ServerOffloadPoint>> offloadPoints =
+                new EnumMap<>(ServiceType.class);
+        private final Map<ServiceType, EnumSet<ServerOffloadPoint>> nonOffloadPoints =
+                new EnumMap<>(ServiceType.class);
         private final Executor executor;
-        private final Executor serviceExecutor;
         private final boolean addFilter;
         @Nullable
         private InvokingThreadsRecorder<ServerOffloadPoint> invokingThreadsRecorder;
-        private boolean executorUsedForStrategy = true;
+        private final boolean executorUsedForStrategy;
         private boolean verifyStrategyUsed;
-        private boolean noOffloadsStrategy;
+        private final boolean noOffloadsStrategy;
 
-        Params(boolean addFilter) {
+        Params(boolean executorUsedForStrategy, final boolean noOffloadsStrategy, boolean addFilter) {
+            this.executorUsedForStrategy = executorUsedForStrategy;
+            this.noOffloadsStrategy = noOffloadsStrategy;
             this.addFilter = addFilter;
-            this.executor = newCachedThreadExecutor(new DefaultThreadFactory(USER_STRATEGY_EXECUTOR_NAME_PREFIX));
-            serviceExecutor = newCachedThreadExecutor(new DefaultThreadFactory(SERVICE_EXECUTOR_NAME_PREFIX));
-            offloadPoints = new EnumMap<>(ServiceType.class);
+            this.executor = executorUsedForStrategy ?
+                    newCachedThreadExecutor(new DefaultThreadFactory(USER_STRATEGY_EXECUTOR_NAME_PREFIX)) :
+                    Executors.from(r -> fail("This executor was not to be used"));
             for (ServiceType serviceType : ServiceType.values()) {
-                offloadPoints.put(serviceType, new ArrayList<>());
+                offloadPoints.put(serviceType, EnumSet.noneOf(ServerOffloadPoint.class));
             }
-            nonOffloadPoints = new EnumMap<>(ServiceType.class);
             for (ServiceType serviceType : ServiceType.values()) {
-                nonOffloadPoints.put(serviceType, new ArrayList<>());
+                nonOffloadPoints.put(serviceType, EnumSet.noneOf(ServerOffloadPoint.class));
             }
         }
 
         void addOffloadedPointFor(ServiceType serviceType, ServerOffloadPoint... points) {
-            offloadPoints.get(serviceType).addAll(asList(points));
+            EnumSet<ServerOffloadPoint> offloads = offloadPoints.get(serviceType);
+            for (ServerOffloadPoint point : points) {
+                offloads.add(point);
+            }
         }
 
         void addNonOffloadedPointFor(ServiceType serviceType, ServerOffloadPoint... points) {
-            nonOffloadPoints.get(serviceType).addAll(asList(points));
+            EnumSet<ServerOffloadPoint> nonOffloads = nonOffloadPoints.get(serviceType);
+            for (ServerOffloadPoint point : points) {
+                nonOffloads.add(point);
+            }
         }
 
         void allPointsOffloadedForAllServices() {
+            EnumSet<ServerOffloadPoint> all = EnumSet.allOf(ServerOffloadPoint.class);
             for (ServiceType serviceType : ServiceType.values()) {
-                offloadPoints.get(serviceType).addAll(asList(ServerOffloadPoint.ServiceHandle,
-                        ServerOffloadPoint.RequestPayload, ServerOffloadPoint.Response));
+                offloadPoints.get(serviceType).addAll(all);
             }
         }
 
         void noPointsOffloadedForAllServices() {
+            EnumSet<ServerOffloadPoint> all = EnumSet.allOf(ServerOffloadPoint.class);
             for (ServiceType serviceType : ServiceType.values()) {
-                nonOffloadPoints.get(serviceType).addAll(asList(ServerOffloadPoint.ServiceHandle,
-                        ServerOffloadPoint.RequestPayload, ServerOffloadPoint.Response));
+                nonOffloadPoints.get(serviceType).addAll(all);
             }
         }
 
@@ -344,7 +329,6 @@ class ServerEffectiveStrategyTest {
         }
 
         void initStateHolderDefaultStrategy() {
-            executorUsedForStrategy = false;
             invokingThreadsRecorder = noStrategy();
         }
 
@@ -355,7 +339,6 @@ class ServerEffectiveStrategyTest {
 
         void initStateHolderUserStrategyNoExecutor() {
             verifyStrategyUsed = false;
-            executorUsedForStrategy = false;
             newRecorder(defaultStrategy());
         }
 
@@ -365,21 +348,17 @@ class ServerEffectiveStrategyTest {
         }
 
         void initStateHolderUserStrategyNoOffloads() {
-            noOffloadsStrategy = true;
             verifyStrategyUsed = !addFilter;
             newRecorder(customStrategyBuilder().offloadNone().executor(immediate()).build());
         }
 
         void initStateHolderUserStrategyNoOffloadsNoExecutor() {
-            noOffloadsStrategy = true;
             verifyStrategyUsed = !addFilter;
-            executorUsedForStrategy = false;
             newRecorder(noOffloadsStrategy());
         }
 
         void initStateHolderCustomUserStrategyNoExecutor() {
             verifyStrategyUsed = !addFilter;
-            executorUsedForStrategy = false;
             newRecorder(customStrategyBuilder().offloadAll().build());
         }
 
@@ -500,7 +479,7 @@ class ServerEffectiveStrategyTest {
             try {
                 invokingThreadsRecorder.dispose();
             } finally {
-                newCompositeCloseable().appendAll(executor, serviceExecutor).close();
+                executor.closeAsync().toFuture().get();
             }
         }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.Map;
@@ -286,16 +287,12 @@ class ServerEffectiveStrategyTest {
 
         void addOffloadedPointFor(ServiceType serviceType, ServerOffloadPoint... points) {
             EnumSet<ServerOffloadPoint> offloads = offloadPoints.get(serviceType);
-            for (ServerOffloadPoint point : points) {
-                offloads.add(point);
-            }
+            Collections.addAll(offloads, points);
         }
 
         void addNonOffloadedPointFor(ServiceType serviceType, ServerOffloadPoint... points) {
             EnumSet<ServerOffloadPoint> nonOffloads = nonOffloadPoints.get(serviceType);
-            for (ServerOffloadPoint point : points) {
-                nonOffloads.add(point);
-            }
+            Collections.addAll(nonOffloads, points);
         }
 
         void allPointsOffloadedForAllServices() {


### PR DESCRIPTION
Motivation:
The parameterization pattern used for both `ClientEffectiveStrategyTest` and `ServerEffectiveStrategyTest` makes it difficult to understand the configuration under test because the configuration is built imperatively rather than as a set of declarative options.
Modifications:
Restructured test parameterization. One specific case is improved; for the cases where no offloading to provided executor is to be performed the test now explicitly ensures that the test fails if the executor is used.
Result:
Easier to understand test with easier to understand test cases.