### PR TITLE
Convert "ASCII-art" arrows to unicode arrows

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -244,7 +244,7 @@ public final class DefaultDnsServiceDiscovererBuilder {
      * making a request to a service discoverer wrapped by this filter chain the order of invocation of these filters
      * will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; service discoverer
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ service discoverer
      * </pre>
      *
      * @param factory {@link DnsClientFilterFactory} to decorate a {@link DnsClient} for the purpose of

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/BaseGrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/BaseGrpcClientBuilder.java
@@ -113,7 +113,7 @@ interface BaseGrpcClientBuilder<U, R> {
      * </pre>
      * making a request to a connection wrapped by this filter chain the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; connection
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ connection
      * </pre>
      *
      * @param factory {@link StreamingHttpConnectionFilterFactory} to decorate a {@link StreamingHttpConnection} for the
@@ -136,7 +136,7 @@ interface BaseGrpcClientBuilder<U, R> {
      * </pre>
      * making a request to a connection wrapped by this filter chain the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; connection
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ connection
      * </pre>
      *
      * @param predicate the {@link Predicate} to test if the filter must be applied.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -118,7 +118,7 @@ public abstract class GrpcClientBuilder<U, R>
      * </pre>
      * making a request to a client wrapped by this filter chain the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; client
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ client
      * </pre>
      *
      * @param factory {@link StreamingHttpClientFilterFactory} to decorate a client for the purpose of filtering.
@@ -140,7 +140,7 @@ public abstract class GrpcClientBuilder<U, R>
      * </pre>
      * making a request to a client wrapped by this filter chain the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; client
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ client
      * </pre>
      *
      * @param predicate the {@link Predicate} to test if the filter must be applied.
@@ -237,7 +237,7 @@ public abstract class GrpcClientBuilder<U, R>
      * </pre>
      * making a request to a client wrapped by this filter chain the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; client
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ client
      * </pre>
      *
      * @param factory {@link StreamingHttpClientFilterFactory} to decorate a client for the purpose of filtering.
@@ -254,7 +254,7 @@ public abstract class GrpcClientBuilder<U, R>
      * </pre>
      * making a request to a client wrapped by this filter chain the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; client
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ client
      * </pre>
      *
      * @param predicate the {@link Predicate} to test if the filter must be applied.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientFactory.java
@@ -93,7 +93,7 @@ public abstract class GrpcClientFactory<Client extends GrpcClient<BlockingClient
      * </pre>
      * making a request to a client wrapped by this filter chain the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; client
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ client
      * </pre>
      *
      * @param before the factory to apply before this factory is applied

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -162,7 +162,7 @@ public abstract class GrpcServerBuilder {
      * accepting a connection by a filter wrapped by this filter chain, the order of invocation of these filters will
      * be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3
+     *     filter1 ⇒ filter2 ⇒ filter3
      * </pre>
      * @param factory {@link ConnectionAcceptorFactory} to append. Lifetime of this
      * {@link ConnectionAcceptorFactory} is managed by this builder and the server started thereof.
@@ -179,7 +179,7 @@ public abstract class GrpcServerBuilder {
      * </pre>
      * accepting a request by a service wrapped by this filter chain, the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; service
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ service
      * </pre>
      * @param factory {@link StreamingHttpServiceFilterFactory} to append.
      * @return {@code this}.
@@ -200,7 +200,7 @@ public abstract class GrpcServerBuilder {
      * </pre>
      * accepting a request by a service wrapped by this filter chain, the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; service
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ service
      * </pre>
      * @param predicate the {@link Predicate} to test if the filter must be applied.
      * @param factory {@link StreamingHttpServiceFilterFactory} to append.
@@ -317,7 +317,7 @@ public abstract class GrpcServerBuilder {
      * </pre>
      * accepting a request by a service wrapped by this filter chain, the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; service
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ service
      * </pre>
      * @param factory {@link StreamingHttpServiceFilterFactory} to append.
      */
@@ -333,7 +333,7 @@ public abstract class GrpcServerBuilder {
      * </pre>
      * accepting a request by a service wrapped by this filter chain, the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; service
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ service
      * </pre>
      * @param predicate the {@link Predicate} to test if the filter must be applied.
      * @param factory {@link StreamingHttpServiceFilterFactory} to append.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceFactory.java
@@ -93,7 +93,7 @@ public abstract class GrpcServiceFactory<Filter extends Service, Service extends
      * </pre>
      * making a request to a client wrapped by this filter chain the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; client
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ client
      * </pre>
      *
      * @param before the factory to apply before this factory is applied

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/SingleAddressGrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/SingleAddressGrpcClientBuilder.java
@@ -80,7 +80,7 @@ interface SingleAddressGrpcClientBuilder<U, R,
      * </pre>
      * Calling {@link ConnectionFactory} wrapped by this filter chain, the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; original connection factory
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ original connection factory
      * </pre>
      * @param factory {@link ConnectionFactoryFilter} to use.
      * @return {@code this}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseHttpBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseHttpBuilder.java
@@ -131,7 +131,7 @@ abstract class BaseHttpBuilder<ResolvedAddress> {
      * </pre>
      * making a request to a connection wrapped by this filter chain the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; connection
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ connection
      * </pre>
      * @param factory {@link StreamingHttpConnectionFilterFactory} to decorate a {@link StreamingHttpConnection} for the
      * purpose of filtering.
@@ -154,7 +154,7 @@ abstract class BaseHttpBuilder<ResolvedAddress> {
      * </pre>
      * making a request to a connection wrapped by this filter chain the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; connection
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ connection
      * </pre>
      * @param predicate the {@link Predicate} to test if the filter must be applied.
      * @param factory {@link StreamingHttpConnectionFilterFactory} to decorate a {@link StreamingHttpConnection} for the

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
@@ -89,7 +89,7 @@ abstract class HttpClientBuilder<U, R, SDE extends ServiceDiscovererEvent<R>> ex
      * </pre>
      * Calling {@link ConnectionFactory} wrapped by this filter chain, the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; original connection factory
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ original connection factory
      * </pre>
      * @param factory {@link ConnectionFactoryFilter} to use.
      * @return {@code this}
@@ -110,7 +110,7 @@ abstract class HttpClientBuilder<U, R, SDE extends ServiceDiscovererEvent<R>> ex
      * </pre>
      * making a request to a client wrapped by this filter chain the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; client
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ client
      * </pre>
      *
      * @param factory {@link StreamingHttpClientFilterFactory} to decorate a {@link HttpClient} for the purpose of
@@ -132,7 +132,7 @@ abstract class HttpClientBuilder<U, R, SDE extends ServiceDiscovererEvent<R>> ex
      * </pre>
      * making a request to a client wrapped by this filter chain the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; client
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ client
      * </pre>
      *
      * @param predicate the {@link Predicate} to test if the filter must be applied.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
@@ -102,7 +102,7 @@ public final class HttpExecutionStrategies {
      * {@link HttpExecutionStrategy}. This method is useful to reduce duplicating work across these entities if the
      * caller has already offloaded all the paths required to be offloaded by the callee.
      * <pre>
-     *     Entities:         Entity 1      =&gt;    Entity 2      =&gt;      Entity 3
+     *     Entities:         Entity 1      ⇒      Entity 2      ⇒      Entity 3
      *                                  (calls)              (calls)
      *     Strategies:     No offloads          Offload Send        Offload Send + Meta
      * </pre>

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -170,7 +170,7 @@ public abstract class HttpServerBuilder {
      * accepting a connection by a filter wrapped by this filter chain, the order of invocation of these filters will
      * be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3
+     *     filter1 ⇒ filter2 ⇒ filter3
      * </pre>
      *
      * @param factory {@link ConnectionAcceptorFactory} to append. Lifetime of this
@@ -199,7 +199,7 @@ public abstract class HttpServerBuilder {
      * </pre>
      * accepting a request by a service wrapped by this filter chain, the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; service
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ service
      * </pre>
      *
      * @param factory {@link StreamingHttpServiceFilterFactory} to append.
@@ -227,7 +227,7 @@ public abstract class HttpServerBuilder {
      * </pre>
      * accepting a request by a service wrapped by this filter chain, the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; service
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ service
      * </pre>
      *
      * @param predicate the {@link Predicate} to test if the filter must be applied.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -291,7 +291,7 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
      * </pre>
      * Making a request to a client wrapped by this filter chain the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; client
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ client
      * </pre>
      *
      * @param factory {@link MultiAddressHttpClientFilterFactory} to decorate a {@link StreamingHttpClient} for the
@@ -314,7 +314,7 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
      * </pre>
      * Making a request to a client wrapped by this filter chain the order of invocation of these filters will be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3 =&gt; client
+     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ client
      * </pre>
      *
      * @param predicate the {@link Predicate} to test if the filter must be applied.

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionAcceptor.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionAcceptor.java
@@ -52,7 +52,7 @@ public interface ConnectionAcceptor extends AsyncCloseable {
      * accepting a connection by a filter wrapped by this filter chain, the order of invocation of these filters will
      * be:
      * <pre>
-     *     this =&gt; filter1 =&gt; filter2 =&gt; filter3
+     *     this ⇒ filter1 ⇒ filter2 ⇒ filter3
      * </pre>
      * @param after the {@link ConnectionAcceptor} to apply after {@code this} {@link ConnectionAcceptor} is
      * applied

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionAcceptorFactory.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionAcceptorFactory.java
@@ -42,7 +42,7 @@ public interface ConnectionAcceptorFactory {
      * accepting a connection by a filter wrapped by this filter chain, the order of invocation of these filters will
      * be:
      * <pre>
-     *     filter1 =&gt; filter2 =&gt; filter3
+     *     filter1 ⇒ filter2 ⇒ filter3
      * </pre>
      * @param before the function to apply before this function is applied
      * @return a composed function that first applies the {@code before}


### PR DESCRIPTION
Motivation:
The javadoc for quite a few methods includes use of `=&gt;` to
approximate an arrow for diagrams in small figures. Converting these to
unicode characters is cleaner, makes the source the same as the
rendered output and is more accessible.
Modifications:
Use of `=&gt;` is replaced with `⇒`
Result:
Cleaner source.