### PR TITLE
Publisher#flatMapConcatIterable propagate error even if no onSubscribe

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherConcatMapIterable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherConcatMapIterable.java
@@ -172,7 +172,6 @@ final class PublisherConcatMapIterable<T, U> extends AbstractSynchronousPublishe
         }
 
         private void tryDrainIterator(ErrorHandlingStrategyInDrain errorHandlingStrategyInDrain) {
-            assert sourceSubscription != null;
             boolean hasNext = false;
             boolean thrown = false;
             boolean terminated = false;
@@ -241,7 +240,9 @@ final class PublisherConcatMapIterable<T, U> extends AbstractSynchronousPublishe
                                 // here before we unlock emitting so visibility to other threads should be taken care of
                                 // by the write to emitting below (and later read).
                                 currentIterator = EmptyIterator.instance();
-                                sourceSubscription.request(1);
+                                if (sourceSubscription != null) {
+                                    sourceSubscription.request(1);
+                                }
                             }
                         } finally {
                             // The lock must be released after we interact with the subscription for thread safety


### PR DESCRIPTION
Motivation:
The ReactiveStreams specification says that onSubscribe(Subscription)
must be called prior to any other signals being delivered [1]. However
in practice user code may throw in onSubscribe which may stop the
propagation. In this case Publisher#flatMapConcatIterable has an
assertion which may prevent the error from propagating downstream and
result in a control flow deadlock.

[1] https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#1.9

Modifications:
- Move assertion in Publisher#flatMapConcatIterable to allow for null
  subscription, add a runtime check before it is used.

Result:
More robust error propagation for Publisher#flatMapConcatIterable in the
precense of Reactive Streams specification violations.