### PR TITLE
Permit copy for `TestExecutor` `AsyncContextMap`

### DIFF
--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestExecutor.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestExecutor.java
@@ -418,7 +418,7 @@ public class TestExecutor implements Executor {
 
         @Override
         public AsyncContextMap copy() {
-            throw invalidAccess();
+            return this;
         }
     }
 }


### PR DESCRIPTION
As observed by @chemicL

Motivation:
The `TestExecutor` was recently enhanced to install an invalid
`AsyncContextMap` when executing `Runnable` tasks to check for tasks
which did not properly save/restore the appropriate async context. The
invalid map should allow itself to be copied, producing an empty map,
for usages which want to initiate a new subscribe operation.
Modifications:
`copy()` returns a new empty map rather than generating an exception.
Result:
Now possible to subscribe() within a `Runnable` without providing an
`AsyncContextMap`.