### PR TITLE
SequentialSubscription reentry bug fix

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SequentialSubscription.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SequentialSubscription.java
@@ -144,7 +144,6 @@ final class SequentialSubscription implements Subscription, Cancellable {
         long effectiveSourceRequested = sourceEmitted;
         for (;;) {
             final long currSourceRequested = sourceRequested;
-            assert currSourceRequested != SWITCHING; // no concurrency on this method allowed
             if (currSourceRequested == CANCELLED) {
                 final long currRequested = requested;
                 if (currRequested >= 0) {
@@ -152,6 +151,11 @@ final class SequentialSubscription implements Subscription, Cancellable {
                 } else { // invalid requestN is pending, deliver to each subscription.
                     next.request(currRequested);
                 }
+                break;
+            } else if (currSourceRequested == SWITCHING) {
+                // concurrency is not allowed on this method, but reentry is allowed. save next into subscription so
+                // we can use it when the stack unwinds to deliver demand to it.
+                subscription = next;
                 break;
             } else if (sourceRequestedUpdater.compareAndSet(this, currSourceRequested, SWITCHING)) {
                 assert currSourceRequested >= 0 || currSourceRequested == REQUESTED;
@@ -168,6 +172,7 @@ final class SequentialSubscription implements Subscription, Cancellable {
                 // effectiveSourceRequested ...[delta]... requested
                 final long delta = currRequested - effectiveSourceRequested;
                 assert delta >= 0;
+                final Subscription beforeSubscription = subscription;
                 if (delta != 0) {
                     // There maybe concurrency with the Subscription thread, or synchronous delivery of data from
                     // request(n). In these cases we want to avoid "double request" from requested, so we track how much
@@ -176,20 +181,32 @@ final class SequentialSubscription implements Subscription, Cancellable {
                     next.request(delta);
                 }
 
-                // Make the subscription visible before restoring the state of sourceRequested. If the Subscription
-                // thread observes the sourceRequested change it will also observe the subscription change. The
-                // Subscription thread also uses sourceRequested to make sure there is no concurrent invocation of
-                // the switched Subscription.
-                subscription = next;
+                final boolean reentry = beforeSubscription != subscription;
+                if (reentry) {
+                    // subscription was overwritten higher in the stack to track the more recent value, so use it on the
+                    // next iteration on the loop to deliver demand to.
+                    next = subscription;
+
+                    // There is a new subscription so we need to reset state for how much has been emitted, so we
+                    // deliver demand to the more recent subscriber on the next loop iteration.
+                    effectiveSourceRequested = sourceEmitted;
+                } else {
+                    // Make the subscription visible before restoring the state of sourceRequested. If the Subscription
+                    // thread observes the sourceRequested change it will also observe the subscription change. The
+                    // Subscription thread also uses sourceRequested to make sure there is no concurrent invocation of
+                    // the switched Subscription.
+                    subscription = next;
+                }
+
                 // We want to set sourceRequested to currRequested because we have already requested the delta between
                 // the two above, and we want to ensure sourceRequested is always monotonically increasing
                 // (besides control values) to prevent the Subscription thread from requesting from an old subscription.
-                if (sourceRequestedUpdater.compareAndSet(this, SWITCHING, currRequested)) {
+                if (sourceRequestedUpdater.compareAndSet(this, SWITCHING, currRequested) && !reentry) {
                     break;
                 }
                 // else the Subscription thread was active in the mean time, we need to process the pending event(s).
                 // if the state is cancelled the Subscription thread defers to this thread to do the cancel on the
-                // next loop invocation.
+                // next loop invocation. or this method was invoked in a re-entry fashion and we need to loop again.
             }
         }
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SequentialSubscription.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SequentialSubscription.java
@@ -183,12 +183,12 @@ final class SequentialSubscription implements Subscription, Cancellable {
 
                 final boolean reentry = beforeSubscription != subscription;
                 if (reentry) {
-                    // subscription was overwritten higher in the stack to track the more recent value, so use it on the
-                    // next iteration on the loop to deliver demand to.
+                    // subscription was overwritten higher in the stack to track the more recent value. overwrite next
+                    // in our current stack frame to use the more recent value on the next loop iteration.
                     next = subscription;
 
                     // There is a new subscription so we need to reset state for how much has been emitted, so we
-                    // deliver demand to the more recent subscriber on the next loop iteration.
+                    // deliver demand to the more recent subscription on the next loop iteration.
                     effectiveSourceRequested = sourceEmitted;
                 } else {
                     // Make the subscription visible before restoring the state of sourceRequested. If the Subscription

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherRepeatTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherRepeatTckTest.java
@@ -19,11 +19,17 @@ import io.servicetalk.concurrent.api.Publisher;
 
 import org.testng.annotations.Test;
 
+import static io.servicetalk.concurrent.api.Publisher.from;
+
 @Test
-public class PublisherRepeatTckTest extends AbstractPublisherOperatorTckTest<Integer> {
+public class PublisherRepeatTckTest extends AbstractPublisherTckTest<Integer> {
+    @Override
+    public Publisher<Integer> createServiceTalkPublisher(long elements) {
+        return from(1).repeat(i -> i < elements);
+    }
 
     @Override
-    protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
-        return publisher.repeat(integer -> false);
+    public long maxElementsFromPublisher() {
+        return TckUtils.maxElementsFromPublisher();
     }
 }


### PR DESCRIPTION
Motivation:
SequentialSubscription didn't expect reentry, which triggered an
assertion. This may happen when synchronous sources are used, terminal
events are delivered, and operators which use SequentialSubscription
attempt to deliver demand to the next Subscriber. For example:
`Publisher.from(1).repeat(i -> i < 10)`.

Modifications:
- Enhance SequentialSubscription to accommodate reentry switchTo calls

Result:
Operators which use SequentialSubscription (concat, onErrorResume,
repeat*, retry*) now support reentry switching between async sources.