### PR TITLE
Verify that TFO works with all protocols combinations

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProtocol.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProtocol.java
@@ -18,6 +18,9 @@ package io.servicetalk.http.netty;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpProtocolVersion;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
+
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
@@ -34,5 +37,9 @@ enum HttpProtocol {
     HttpProtocol(HttpProtocolConfig config, HttpProtocolVersion version) {
         this.config = config;
         this.version = version;
+    }
+
+    static HttpProtocolConfig[] toConfigs(Collection<HttpProtocol> protocols) {
+        return protocols.stream().map(p -> p.config).collect(Collectors.toList()).toArray(new HttpProtocolConfig[] {});
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TcpFastOpenTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TcpFastOpenTest.java
@@ -19,8 +19,11 @@ import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.test.resources.DefaultTestCerts;
+import io.servicetalk.transport.api.ClientSslConfigBuilder;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.ServerSslConfigBuilder;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -28,28 +31,42 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.InetSocketAddress;
 import java.net.SocketOption;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Stream;
 
+import static io.servicetalk.http.netty.HttpProtocol.HTTP_1;
+import static io.servicetalk.http.netty.HttpProtocol.HTTP_2;
+import static io.servicetalk.http.netty.HttpProtocol.toConfigs;
+import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;
 import static io.servicetalk.transport.api.ServiceTalkSocketOptions.TCP_FASTOPEN_BACKLOG;
 import static io.servicetalk.transport.api.ServiceTalkSocketOptions.TCP_FASTOPEN_CONNECT;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TcpFastOpenTest {
 
     @SuppressWarnings("unused")
-    private static Stream<Arguments> sslProviders() {
-        return Stream.of(
-                Arguments.of(emptyMap(), emptyMap()),
-                Arguments.of(emptyMap(), clientTcpFastOpenOptions()),
-                Arguments.of(serverTcpFastOpenOptions(), emptyMap()),
-                Arguments.of(serverTcpFastOpenOptions(), clientTcpFastOpenOptions())
-        );
+    private static List<Arguments> sslProviders() {
+        List<Arguments> args = new ArrayList<>();
+        for (Map<?, Object> serverListenOptions : asList(emptyMap(), serverTcpFastOpenOptions())) {
+            for (Map<?, Object> clientOptions : asList(emptyMap(), clientTcpFastOpenOptions())) {
+                args.add(Arguments.of(singletonList(HTTP_1), false, serverListenOptions, clientOptions));
+                args.add(Arguments.of(singletonList(HTTP_1), true, serverListenOptions, clientOptions));
+                args.add(Arguments.of(singletonList(HTTP_2), false, serverListenOptions, clientOptions));
+                args.add(Arguments.of(singletonList(HTTP_2), true, serverListenOptions, clientOptions));
+                args.add(Arguments.of(asList(HTTP_2, HTTP_1), true, serverListenOptions, clientOptions));
+                args.add(Arguments.of(asList(HTTP_1, HTTP_2), true, serverListenOptions, clientOptions));
+            }
+        }
+        return args;
     }
 
     @SuppressWarnings("rawtypes")
@@ -62,13 +79,20 @@ class TcpFastOpenTest {
         return singletonMap(TCP_FASTOPEN_BACKLOG, 1);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name =
+            "{displayName} [{index}] protocols={0}, secure={1}, serverListenOptions={2}, clientOptions={3}")
     @MethodSource("sslProviders")
-    void requestSucceedsEvenIfTcpFastOpenNotEnabledOrSupported(
+    void requestSucceedsEvenIfTcpFastOpenNotEnabledOrSupported(final Collection<HttpProtocol> protocols,
+            final boolean secure,
             @SuppressWarnings("rawtypes") final Map<SocketOption, Object> serverListenOptions,
             @SuppressWarnings("rawtypes") final Map<SocketOption, Object> clientOptions)
         throws Exception {
-        HttpServerBuilder serverBuilder = HttpServers.forAddress(localAddress(0));
+        HttpServerBuilder serverBuilder = HttpServers.forAddress(localAddress(0))
+                .protocols(toConfigs(protocols));
+        if (secure) {
+            serverBuilder.sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem,
+                    DefaultTestCerts::loadServerKey).build());
+        }
         for (@SuppressWarnings("rawtypes") Entry<SocketOption, Object> entry : serverListenOptions.entrySet()) {
             @SuppressWarnings("unchecked")
             SocketOption<Object> option = entry.getKey();
@@ -76,21 +100,26 @@ class TcpFastOpenTest {
         }
         try (ServerContext serverContext = serverBuilder.listenBlockingAndAwait(
                 (ctx, request, responseFactory) -> responseFactory.ok());
-             BlockingHttpClient client = newClientBuilder(serverContext, clientOptions).buildBlocking()) {
+             BlockingHttpClient client = newClient(serverContext, protocols, secure, clientOptions)) {
             assertEquals(HttpResponseStatus.OK, client.request(client.get("/")).status());
         }
     }
 
-    private SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> newClientBuilder(
-            ServerContext serverContext,
+    private static BlockingHttpClient newClient(final ServerContext serverContext,
+            final Collection<HttpProtocol> protocols, final boolean secure,
             @SuppressWarnings("rawtypes") final Map<SocketOption, Object> clientOptions) {
         SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
-                HttpClients.forSingleAddress(serverHostAndPort(serverContext));
+                HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                        .protocols(toConfigs(protocols));
+        if (secure) {
+            builder.sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
+                    .sniHostname(serverPemHostname()).build());
+        }
         for (@SuppressWarnings("rawtypes") Entry<SocketOption, Object> entry : clientOptions.entrySet()) {
             @SuppressWarnings("unchecked")
             SocketOption<Object> option = entry.getKey();
             builder.socketOption(option, entry.getValue());
         }
-        return builder;
+        return builder.buildBlocking();
     }
 }


### PR DESCRIPTION
Motivation:

Netty had a bug when TFO was enabled with ALPN [1]. Let's make sure ST
works with any HTTP protocols combination when TFO is enabled.

1. https://github.com/netty/netty/pull/11472

Modifications:

- Add more arguments for `TcpFastOpenTest`;

Result:

`TcpFastOpenTest` runs for various protocols combinations.