### PR TITLE
StreamingHttpPayloadHolder remove unused constructor argument

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpRequest.java
@@ -40,8 +40,7 @@ final class DefaultStreamingHttpRequest extends DefaultHttpRequestMetaData
         if (encoding != null) {
             encoding(encoding);
         }
-        payloadHolder = new StreamingHttpPayloadHolder(headers, allocator, payloadBody, payloadInfo, headersFactory,
-                version);
+        payloadHolder = new StreamingHttpPayloadHolder(headers, allocator, payloadBody, payloadInfo, headersFactory);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpResponse.java
@@ -35,8 +35,7 @@ final class DefaultStreamingHttpResponse extends DefaultHttpResponseMetaData
                                  @Nullable final Publisher<?> payloadBody, final DefaultPayloadInfo payloadInfo,
                                  final HttpHeadersFactory headersFactory) {
         super(status, version, headers);
-        payloadHolder = new StreamingHttpPayloadHolder(headers, allocator, payloadBody, payloadInfo, headersFactory,
-                version);
+        payloadHolder = new StreamingHttpPayloadHolder(headers, allocator, payloadBody, payloadInfo, headersFactory);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpPayloadHolder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpPayloadHolder.java
@@ -58,7 +58,7 @@ final class StreamingHttpPayloadHolder implements PayloadInfo {
 
     StreamingHttpPayloadHolder(final HttpHeaders headers, final BufferAllocator allocator,
                                @Nullable final Publisher<?> messageBody, final DefaultPayloadInfo messageBodyInfo,
-                               final HttpHeadersFactory headersFactory, final HttpProtocolVersion version) {
+                               final HttpHeadersFactory headersFactory) {
         assert messageBody != null || !messageBodyInfo.mayHaveTrailers();
         this.headers = requireNonNull(headers);
         this.allocator = requireNonNull(allocator);

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/StreamingHttpPayloadHolderDrainTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/StreamingHttpPayloadHolderDrainTest.java
@@ -30,7 +30,6 @@ import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.http.api.DefaultPayloadInfo.forUserCreated;
-import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -56,7 +55,7 @@ class StreamingHttpPayloadHolderDrainTest {
     void resubscribeDrainOriginalSource(Publisher<?> payload) throws Exception {
         AtomicInteger completeCount = new AtomicInteger();
         StreamingHttpPayloadHolder holder = new StreamingHttpPayloadHolder(H_FACTORY.newHeaders(), ALLOCATOR,
-                payload.afterFinally(completeCount::incrementAndGet), forUserCreated(), H_FACTORY, HTTP_1_1);
+                payload.afterFinally(completeCount::incrementAndGet), forUserCreated(), H_FACTORY);
         holder.payloadBody(from(ALLOCATOR.fromAscii("second")));
         // Subscribe twice and verify the results are the same both times (from supports multiple subscribes), and that
         // the original payload has been subscribed to and consumed.

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/StreamingHttpPayloadHolderTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/StreamingHttpPayloadHolderTest.java
@@ -112,7 +112,7 @@ class StreamingHttpPayloadHolderTest {
             payloadInfo.setMayHaveTrailers(false);
         }
         payloadHolder = new StreamingHttpPayloadHolder(headers, DEFAULT_ALLOCATOR, payloadSource, payloadInfo,
-                headersFactory, HTTP_1_1);
+                headersFactory);
 
         if (sourceType == SourceType.Trailers) {
             assertThat("Unexpected payload info trailer indication.", payloadHolder.mayHaveTrailers(), is(true));


### PR DESCRIPTION
Motivation:
StreamingHttpPayloadHolder is a package private class with an unused
argument on the constructor.

Modifications:
- Remove the http protocol version argument from the constructor.

Result:
All arguments for the StreamingHttpPayloadHolder constructor are used.