### PR TITLE
Remove unused imports from examples

### DIFF
--- a/servicetalk-examples/grpc/routeguide/src/main/java/io/servicetalk/examples/grpc/routeguide/FeaturesFinder.java
+++ b/servicetalk-examples/grpc/routeguide/src/main/java/io/servicetalk/examples/grpc/routeguide/FeaturesFinder.java
@@ -20,7 +20,6 @@ import io.grpc.examples.routeguide.Point;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.Collection;
 import javax.annotation.Nullable;
 
 public interface FeaturesFinder extends Iterable<Feature> {

--- a/servicetalk-examples/http/jaxrs/src/main/java/io/servicetalk/examples/http/jaxrs/HelloWorldJaxRsApplication.java
+++ b/servicetalk-examples/http/jaxrs/src/main/java/io/servicetalk/examples/http/jaxrs/HelloWorldJaxRsApplication.java
@@ -17,13 +17,11 @@ package io.servicetalk.examples.http.jaxrs;
 
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import javax.ws.rs.core.Application;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.singleton;
 
 /**
  * JAX-RS Hello World {@link Application}.


### PR DESCRIPTION
Motivation:
Some of the examples contains imports that are never use by the code.
Thus the imports are not needed.

Modifications:
Remove unused imports.

Results:
No unused imports are left in the examples anymore. There's no change
to any of the running code.