### PR TITLE
Remove gRPC not performance tested statement from docs

### DIFF
--- a/servicetalk-grpc-api/docs/modules/ROOT/pages/index.adoc
+++ b/servicetalk-grpc-api/docs/modules/ROOT/pages/index.adoc
@@ -8,9 +8,6 @@ endif::[]
 
 = gRPC
 
-IMPORTANT: ServiceTalk gRPC support is an active work-in-progress and is not yet
-xref:{page-version}@servicetalk::performance.adoc[peformance tested].
-
 == Motivation
 
 A design philosophy for ServiceTalk is


### PR DESCRIPTION
Motivation:
The docs say that gRPC is an active work in progress and not yet
performance tested. Nightly benchmarks are run on HTTP transport now,
and this statement is no longer accurate.

Modifications:
- Remove caveat about not being performance tested from docs

Result:
Docs on gRPC more accurately reflect the current state.