### PR TITLE
Consolidate Completable#fromRunnable and Single#fromCallable implementations

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RunnableCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RunnableCompletable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +17,11 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.internal.ThreadInterruptingCancellable;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnComplete;
 import static java.lang.Thread.currentThread;
 import static java.util.Objects.requireNonNull;
 
-public class RunnableCompletable extends AbstractSynchronousCompletable {
-    private static final Logger LOGGER = LoggerFactory.getLogger(RunnableCompletable.class);
+final class RunnableCompletable extends AbstractSynchronousCompletable {
     private final Runnable runnable;
 
     RunnableCompletable(final Runnable runnable) {
@@ -37,23 +33,16 @@ public class RunnableCompletable extends AbstractSynchronousCompletable {
         final ThreadInterruptingCancellable cancellable = new ThreadInterruptingCancellable(currentThread());
         try {
             subscriber.onSubscribe(cancellable);
-        } catch (Throwable t) {
-            handleExceptionFromOnSubscribe(subscriber, t);
+            runnable.run();
+        } catch (Throwable cause) {
+            cancellable.setDone(cause);
+            subscriber.onError(cause);
             return;
         }
-
-        try {
-            runnable.run();
-
-            try {
-                cancellable.setDone();
-                subscriber.onComplete();
-            } catch (Throwable t) {
-                LOGGER.info("Ignoring exception from onComplete of Subscriber {}.", subscriber, t);
-            }
-        } catch (Throwable t) {
-            cancellable.setDone(t);
-            subscriber.onError(t);
-        }
+        // It is safe to set this outside the scope of the try/catch above because we don't do any blocking
+        // operations which may be interrupted between the completion of the blockingHttpService call and
+        // here.
+        cancellable.setDone();
+        safeOnComplete(subscriber);
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/RunnableCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/RunnableCompletableTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import java.util.concurrent.CountDownLatch;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -34,8 +35,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 class RunnableCompletableTest {
-    private static final RuntimeException DELIBERATE_EXCEPTION = new IllegalArgumentException();
-
     private Runnable factory;
 
     @BeforeEach

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CallableSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CallableSingleTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CountDownLatch;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -36,8 +37,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class CallableSingleTest {
-    private static final RuntimeException DELIBERATE_EXCEPTION = new IllegalArgumentException();
-
     private Callable<Integer> factory;
 
     @SuppressWarnings("unchecked")

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingToStreamingService.java
@@ -18,8 +18,8 @@ package io.servicetalk.http.api;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 
+import static io.servicetalk.concurrent.api.Single.fromCallable;
 import static io.servicetalk.http.api.BlockingUtils.blockingToCompletable;
-import static io.servicetalk.http.api.BlockingUtils.blockingToSingle;
 import static io.servicetalk.http.api.HttpExecutionStrategies.OFFLOAD_RECEIVE_DATA_STRATEGY;
 import static java.util.Objects.requireNonNull;
 
@@ -36,7 +36,7 @@ final class BlockingToStreamingService extends AbstractServiceAdapterHolder {
     public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
                                                 final StreamingHttpRequest request,
                                                 final StreamingHttpResponseFactory responseFactory) {
-        return request.toRequest().flatMap(req -> blockingToSingle(() -> original.handle(
+        return request.toRequest().flatMap(req -> fromCallable(() -> original.handle(
                 ctx, req, ctx.responseFactory())).map(HttpResponse::toStreamingResponse));
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingUtils.java
@@ -15,19 +15,14 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.concurrent.CompletableSource;
-import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.concurrent.api.internal.SubscribableCompletable;
-import io.servicetalk.concurrent.api.internal.SubscribableSingle;
-import io.servicetalk.concurrent.internal.ThreadInterruptingCancellable;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import static io.servicetalk.concurrent.api.Completable.fromRunnable;
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
-import static java.lang.Thread.currentThread;
 
 final class BlockingUtils {
 
@@ -39,54 +34,14 @@ final class BlockingUtils {
         void run() throws Exception;
     }
 
-    interface SupplierCheckedException<T> {
-        T get() throws Exception;
-    }
-
     static Completable blockingToCompletable(RunnableCheckedException r) {
-        return new SubscribableCompletable() {
-            @Override
-            protected void handleSubscribe(final CompletableSource.Subscriber subscriber) {
-                ThreadInterruptingCancellable cancellable = new ThreadInterruptingCancellable(currentThread());
-                subscriber.onSubscribe(cancellable);
-                try {
-                    r.run();
-                } catch (Throwable cause) {
-                    cancellable.setDone(cause);
-                    subscriber.onError(cause);
-                    return;
-                }
-                // It is safe to set this outside the scope of the try/catch above because we don't do any blocking
-                // operations which may be interrupted between the completion of the blockingHttpService call and
-                // here.
-                cancellable.setDone();
-                subscriber.onComplete();
+        return fromRunnable(() -> {
+            try {
+                r.run();
+            } catch (Exception e) {
+                throwException(e);
             }
-        };
-    }
-
-    static <T> Single<T> blockingToSingle(SupplierCheckedException<T> supplier) {
-        return new SubscribableSingle<T>() {
-            @Override
-            protected void handleSubscribe(final SingleSource.Subscriber<? super T> subscriber) {
-                ThreadInterruptingCancellable cancellable = new ThreadInterruptingCancellable(currentThread());
-                subscriber.onSubscribe(cancellable);
-                final T response;
-                try {
-                    response = supplier.get();
-                } catch (Throwable cause) {
-                    cancellable.setDone(cause);
-                    subscriber.onError(cause);
-                    return;
-                }
-                // It is safe to set this outside the scope of the try/catch above because we don't do any blocking
-                // operations which may be interrupted between the completion of the blockingHttpService call and here.
-                cancellable.setDone();
-
-                // The from(..) operator will take care of propagating cancel.
-                subscriber.onSuccess(response);
-            }
-        };
+        });
     }
 
     static <T> T futureGetCancelOnInterrupt(Future<T> future) throws Exception {
@@ -101,47 +56,12 @@ final class BlockingUtils {
         }
     }
 
-    static BlockingStreamingHttpResponse request(final StreamingHttpRequester requester,
-                                                 final HttpExecutionStrategy strategy,
-                                                 final BlockingStreamingHttpRequest request) throws Exception {
-        // It is assumed that users will always apply timeouts at the StreamingHttpService layer (e.g. via filter). So
-        // we don't apply any explicit timeout here and just wait forever.
-        return blockingInvocation(requester.request(strategy, request.toStreamingRequest()))
-                .toBlockingStreamingResponse();
-    }
-
-    static Single<StreamingHttpResponse> request(final BlockingHttpRequester requester,
-                                                 final HttpExecutionStrategy strategy,
-                                                 final StreamingHttpRequest request) {
-        return request.toRequest().flatMap(req -> blockingToSingle(() -> requester.request(strategy, req)))
-                .map(HttpResponse::toStreamingResponse);
-    }
-
-    static HttpResponse request(final HttpRequester requester, final HttpExecutionStrategy strategy,
-                                final HttpRequest request) throws Exception {
-        // It is assumed that users will always apply timeouts at the StreamingHttpService layer (e.g. via filter). So
-        // we don't apply any explicit timeout here and just wait forever.
-        return blockingInvocation(requester.request(strategy, request));
-    }
-
     static HttpResponse request(final StreamingHttpRequester requester, final HttpExecutionStrategy strategy,
                                 final HttpRequest request) throws Exception {
         // It is assumed that users will always apply timeouts at the StreamingHttpService layer (e.g. via filter). So
         // we don't apply any explicit timeout here and just wait forever.
         return blockingInvocation(requester.request(strategy, request.toStreamingRequest())
                 .flatMap(StreamingHttpResponse::toResponse));
-    }
-
-    static Single<StreamingHttpResponse> request(final BlockingStreamingHttpRequester requester,
-                                                 final HttpExecutionStrategy strategy,
-                                                 final StreamingHttpRequest request) {
-        return blockingToSingle(() -> requester.request(strategy, request.toBlockingStreamingRequest())
-                .toStreamingResponse());
-    }
-
-    static Single<HttpResponse> request(final BlockingHttpRequester requester, final HttpExecutionStrategy strategy,
-                                        final HttpRequest request) {
-        return blockingToSingle(() -> requester.request(strategy, request));
     }
 
     static <T> T blockingInvocation(Single<T> source) throws Exception {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingUtils.java
@@ -32,16 +32,18 @@ final class BlockingUtils {
 
     interface RunnableCheckedException {
         void run() throws Exception;
-    }
 
-    static Completable blockingToCompletable(RunnableCheckedException r) {
-        return fromRunnable(() -> {
+        default void runUnchecked() {
             try {
-                r.run();
+                run();
             } catch (Exception e) {
                 throwException(e);
             }
-        });
+        }
+    }
+
+    static Completable blockingToCompletable(RunnableCheckedException r) {
+        return fromRunnable(r::runUnchecked);
     }
 
     static <T> T futureGetCancelOnInterrupt(Future<T> future) throws Exception {


### PR DESCRIPTION
Motivation:
There are duplicate implementations of Completable#fromRunnable and
Single#fromCallable inside the code base. We should consolidate them and
make them consistent.

Modifications:
- Make RunnableCompletable package private
- Make RunnableCompletable and CallableSingle use pre-existing
  implementations from BlockingUtils

Result:
Less duplicate code and more consistent handling of exception path.