### PR TITLE
Deprecate RunnableCompletable

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RunnableCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RunnableCompletable.java
@@ -24,6 +24,11 @@ import static io.servicetalk.concurrent.internal.SubscriberUtils.handleException
 import static java.lang.Thread.currentThread;
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Runnable used internally for {@link Completable#fromRunnable(Runnable)}.
+ * @deprecated Use {@link Completable#fromRunnable(Runnable)}.
+ */
+@Deprecated
 public class RunnableCompletable extends AbstractSynchronousCompletable {
     private static final Logger LOGGER = LoggerFactory.getLogger(RunnableCompletable.class);
     private final Runnable runnable;


### PR DESCRIPTION
Motivation:
RunnableCompletable is an implementation detail of
Completable#fromRunnable(Runnable), but the class is public. This API
shouldn't be exposed to users.

Modifications:
- Deprecate RunnableCompletable

Result:
Internal API marked as deprecated to clarify users shouldn't rely upon
it directly.