### PR TITLE
Code/test/javadoc updates for JDK 16 (#1687)

### DIFF
--- a/servicetalk-annotations/src/main/java/io/servicetalk/annotations/package-info.java
+++ b/servicetalk-annotations/src/main/java/io/servicetalk/annotations/package-info.java
@@ -13,5 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Common annotations used by ServiceTalk.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.annotations;

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/package-info.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * ServiceTalk Buffer APIs.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.buffer.api;
 

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/package-info.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Internal utilities which leverage the Client API package.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.client.api.internal;
 

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/partition/PowerSetPartitionMapFactory.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/partition/PowerSetPartitionMapFactory.java
@@ -26,6 +26,9 @@ import java.util.function.Function;
  * A {@link PartitionMapFactory} that generates {@link PowerSetPartitionMap} type objects.
  */
 public final class PowerSetPartitionMapFactory implements PartitionMapFactory {
+    /**
+     * Singleton instance.
+     */
     public static final PartitionMapFactory INSTANCE = new PowerSetPartitionMapFactory();
 
     private PowerSetPartitionMapFactory() {

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/partition/package-info.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/partition/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Internal client utilities that support partitioning use cases.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.client.api.internal.partition;
 

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/package-info.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * API definitions for Client use cases.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.client.api;
 

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/partition/package-info.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/partition/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Client APIs targeted at partitioned use cases.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.client.api.partition;
 

--- a/servicetalk-concurrent-api-internal/src/main/java/io/servicetalk/concurrent/api/internal/package-info.java
+++ b/servicetalk-concurrent-api-internal/src/main/java/io/servicetalk/concurrent/api/internal/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Internal utilities which leverage the concurrent API package.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.concurrent.api.internal;
 

--- a/servicetalk-concurrent-api-test/src/main/java/io/servicetalk/concurrent/api/test/package-info.java
+++ b/servicetalk-concurrent-api-test/src/main/java/io/servicetalk/concurrent/api/test/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Utilities that help build tests when interacting with ServiceTalk concurrent APIs.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.concurrent.api.test;
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultThreadFactory.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultThreadFactory.java
@@ -28,6 +28,9 @@ import static java.util.Objects.requireNonNull;
 public final class DefaultThreadFactory implements ThreadFactory {
 
     private static final AtomicInteger factoryCount = new AtomicInteger();
+    /**
+     * The default prefix used for new thread names.
+     */
     public static final String DEFAULT_NAME_PREFIX = "servicetalk-executor";
 
     private final String namePrefix;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Executors.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Executors.java
@@ -94,7 +94,7 @@ public final class Executors {
      * {@link java.util.concurrent.Executor} is an instance of {@link ScheduledExecutorService}.<p>
      * Task execution will not honor cancellations unless passed {@link java.util.concurrent.Executor}
      * is an instance of {@link ExecutorService}.
-     * <h2>Long running tasks</h2>
+     * <p><strong>Long running tasks</strong></p>
      * {@link java.util.concurrent.Executor} implementations are expected to run long running (blocking) tasks which may
      * depend on other tasks submitted to the same {@link java.util.concurrent.Executor} instance.
      * In order to avoid deadlocks, it is generally a good idea to not allow task queuing in the
@@ -115,7 +115,7 @@ public final class Executors {
      * is an instance of {@link ScheduledExecutorService}.<p>
      * When a running task is cancelled, the thread running it will be interrupted.
      * For overriding this behavior use {@link #from(ExecutorService, boolean)}.
-     * <h2>Long running tasks</h2>
+     * <p><strong>Long running tasks</strong></p>
      * {@link java.util.concurrent.Executor} implementations are expected to run long running (blocking) tasks which may
      * depend on other tasks submitted to the same {@link java.util.concurrent.Executor} instance.
      * In order to avoid deadlocks, it is generally a good idea to not allow task queuing in the
@@ -134,7 +134,7 @@ public final class Executors {
      * Creates a new {@link Executor} from the provided {@link ExecutorService}.
      * Delayed task execution will be delegated to a global scheduler, unless passed {@link ExecutorService}
      * is an instance of {@link ScheduledExecutorService}.
-     * <h2>Long running tasks</h2>
+     * <p><strong>Long running tasks</strong></p>
      * {@link java.util.concurrent.Executor} implementations are expected to run long running (blocking) tasks which may
      * depend on other tasks submitted to the same {@link java.util.concurrent.Executor} instance.
      * In order to avoid deadlocks, it is generally a good idea to not allow task queuing in the
@@ -155,7 +155,7 @@ public final class Executors {
      * Creates a new {@link Executor} from the provided {@link ScheduledExecutorService}.
      * When a running task is cancelled, the thread running it will be interrupted.
      * For overriding this behavior use {@link #from(ScheduledExecutorService, boolean)}.
-     * <h2>Long running tasks</h2>
+     * <p><strong>Long running tasks</strong></p>
      * {@link java.util.concurrent.Executor} implementations are expected to run long running (blocking) tasks which may
      * depend on other tasks submitted to the same {@link java.util.concurrent.Executor} instance.
      * In order to avoid deadlocks, it is generally a good idea to not allow task queuing in the
@@ -172,7 +172,7 @@ public final class Executors {
 
     /**
      * Creates a new {@link Executor} from the provided {@link ScheduledExecutorService}.
-     * <h2>Long running tasks</h2>
+     * <p><strong>Long running tasks</strong></p>
      * {@link java.util.concurrent.Executor} implementations are expected to run long running (blocking) tasks which may
      * depend on other tasks submitted to the same {@link java.util.concurrent.Executor} instance.
      * In order to avoid deadlocks, it is generally a good idea to not allow task queuing in the
@@ -197,7 +197,7 @@ public final class Executors {
      * For overriding this behavior use {@link #from(java.util.concurrent.Executor, ScheduledExecutorService, boolean)}.
      * Task execution will not honor cancellations unless passed {@link java.util.concurrent.Executor}
      * is an instance of {@link ExecutorService}.
-     * <h2>Long running tasks</h2>
+     * <p><strong>Long running tasks</strong></p>
      * {@link java.util.concurrent.Executor} implementations are expected to run long running (blocking) tasks which may
      * depend on other tasks submitted to the same {@link java.util.concurrent.Executor} instance.
      * In order to avoid deadlocks, it is generally a good idea to not allow task queuing in the
@@ -221,7 +221,7 @@ public final class Executors {
      * schedule delayed tasks.
      * Task execution will not honor cancellations unless passed {@link java.util.concurrent.Executor}
      * is an instance of {@link ExecutorService}.
-     * <h2>Long running tasks</h2>
+     * <p><strong>Long running tasks</strong></p>
      * {@link java.util.concurrent.Executor} implementations are expected to run long running (blocking) tasks which may
      * depend on other tasks submitted to the same {@link java.util.concurrent.Executor} instance.
      * In order to avoid deadlocks, it is generally a good idea to not allow task queuing in the

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -3228,7 +3228,7 @@ public abstract class Publisher<T> {
      *     {@code -1} to indicate end of stream after emitting all received data.</li>
      * </ul>
      *
-     * <h2>Flow control</h2>
+     * <p><strong>Flow control</strong></p>
      * This operator may pre-fetch may pre-fetch items from {@code this} {@link Publisher} if available to reduce
      * blocking for read operations from the returned {@link InputStream}. In order to increase responsiveness of the
      * {@link InputStream} some amount of buffering may be done. Use {@link #toInputStream(Function, int)} to manage
@@ -3259,7 +3259,7 @@ public abstract class Publisher<T> {
      *     {@code -1} to indicate end of stream after emitting all received data.</li>
      * </ul>
      *
-     * <h2>Flow control</h2>
+     * <p><strong>Flow control</strong></p>
      * This operator may pre-fetch items from {@code this} {@link Publisher} if available to reduce blocking for read
      * operations from the returned {@link InputStream}. In order to increase responsiveness of the {@link InputStream}
      * some amount of buffering may be done. {@code queueCapacity} can be used to bound this buffer.
@@ -3293,13 +3293,13 @@ public abstract class Publisher<T> {
      *     {@link NoSuchElementException}. This error will be thrown only after draining all queued data, if any.</li>
      * </ul>
      *
-     * <h2>Flow control</h2>
+     * <p><strong>Flow control</strong></p>
      * This operator may pre-fetch items from {@code this} {@link Publisher} if available to reduce blocking of
      * {@link Iterator#hasNext()} from the returned {@link BlockingIterable}. In order to increase responsiveness of
      * the {@link Iterator} some amount of buffering may be done. Use {@link #toIterable(int)} to manage capacity of
      * this buffer.
      *
-     * <h2>Blocking</h2>
+     * <p><strong>Blocking</strong></p>
      * The returned {@link BlockingIterator} from the returned {@link BlockingIterable} will block on
      * {@link BlockingIterator#hasNext()} and {@link BlockingIterator#next()} if no data is available. This operator may
      * try to reduce this blocking by requesting data ahead of time.
@@ -3330,13 +3330,13 @@ public abstract class Publisher<T> {
      *     {@link NoSuchElementException}. This error will be thrown only after draining all queued data, if any.</li>
      * </ul>
      *
-     * <h2>Flow control</h2>
+     * <p><strong>Flow control</strong></p>
      * This operator may pre-fetch items from {@code this} {@link Publisher} if available to reduce blocking of
      * {@link BlockingIterator#hasNext()} from the returned {@link BlockingIterable}. In order to increase
      * responsiveness of the {@link BlockingIterator} some amount of buffering may be done. {@code queueCapacityHint}
      * can be used to bound this buffer.
      *
-     * <h2>Blocking</h2>
+     * <p><strong>Blocking</strong></p>
      * The returned {@link BlockingIterator} from the returned {@link BlockingIterable} will block on
      * {@link BlockingIterator#hasNext()} and {@link BlockingIterator#next()} if no data is available. This operator may
      * try to reduce this blocking by requesting data ahead of time.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/package-info.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * ServiceTalk concurrent APIs which follow Reactive Streams semantics.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.concurrent.api;
 

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/CancelImmediatelySubscriber.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/CancelImmediatelySubscriber.java
@@ -27,6 +27,9 @@ import org.slf4j.LoggerFactory;
  */
 public final class CancelImmediatelySubscriber implements PublisherSource.Subscriber<Object> {
     private static final Logger LOGGER = LoggerFactory.getLogger(CancelImmediatelySubscriber.class);
+    /**
+     * Singleton instance.
+     */
     public static final CancelImmediatelySubscriber INSTANCE = new CancelImmediatelySubscriber();
 
     private CancelImmediatelySubscriber() {

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/package-info.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Internal utilities used by concurrent packages.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.concurrent.internal;
 

--- a/servicetalk-concurrent-jdkflow/src/main/java/io/servicetalk/concurrent/jdkflow/package-info.java
+++ b/servicetalk-concurrent-jdkflow/src/main/java/io/servicetalk/concurrent/jdkflow/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Adapters between ServiceTalk's concurrency APIs and the JDK's {@link java.util.concurrent.Flow} API.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.concurrent.jdkflow;
 

--- a/servicetalk-concurrent-reactivestreams/src/main/java/io/servicetalk/concurrent/reactivestreams/package-info.java
+++ b/servicetalk-concurrent-reactivestreams/src/main/java/io/servicetalk/concurrent/reactivestreams/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Adapters between Reactive Streams {@link org.reactivestreams.Publisher} and ServiceTalk concurrent APIs.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.concurrent.reactivestreams;
 

--- a/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/package-info.java
+++ b/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Internal concurrent test utilities used by ServiceTalk.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.concurrent.test.internal;
 

--- a/servicetalk-concurrent/src/main/java/io/servicetalk/concurrent/package-info.java
+++ b/servicetalk-concurrent/src/main/java/io/servicetalk/concurrent/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * ServiceTalk concurrent common types.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.concurrent;
 

--- a/servicetalk-data-jackson-jersey/src/main/java/io/servicetalk/data/jackson/jersey/config/package-info.java
+++ b/servicetalk-data-jackson-jersey/src/main/java/io/servicetalk/data/jackson/jersey/config/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Configuration for bindings of ServiceTalk's jackson serialization while using the Jersey router.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.data.jackson.jersey.config;
 

--- a/servicetalk-data-jackson-jersey/src/main/java/io/servicetalk/data/jackson/jersey/package-info.java
+++ b/servicetalk-data-jackson-jersey/src/main/java/io/servicetalk/data/jackson/jersey/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Bindings of ServiceTalk's jackson serialization while using the Jersey router.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.data.jackson.jersey;
 

--- a/servicetalk-data-jackson/src/main/java/io/servicetalk/data/jackson/package-info.java
+++ b/servicetalk-data-jackson/src/main/java/io/servicetalk/data/jackson/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Data serialization which depends upon the Jackson library.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.data.jackson;
 

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/package-info.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * ServiceTalk DNS client exposed as a {@link io.servicetalk.client.api.ServiceDiscoverer}.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.dns.discovery.netty;
 

--- a/servicetalk-encoding-api-internal/src/main/java/io/servicetalk/encoding/api/internal/HeaderUtils.java
+++ b/servicetalk-encoding-api-internal/src/main/java/io/servicetalk/encoding/api/internal/HeaderUtils.java
@@ -29,6 +29,9 @@ import static io.servicetalk.encoding.api.Identity.identity;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Header utilities to support encoding.
+ */
 public final class HeaderUtils {
 
     private static final List<ContentCodec> NONE_CONTENT_ENCODING_SINGLETON = singletonList(identity());

--- a/servicetalk-encoding-api-internal/src/main/java/io/servicetalk/encoding/api/internal/package-info.java
+++ b/servicetalk-encoding-api-internal/src/main/java/io/servicetalk/encoding/api/internal/package-info.java
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+/**
+ * Internal utilities that use the encoding API package.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.encoding.api.internal;
 

--- a/servicetalk-encoding-api/src/main/java/io/servicetalk/encoding/api/package-info.java
+++ b/servicetalk-encoding-api/src/main/java/io/servicetalk/encoding/api/package-info.java
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+/**
+ * Content encoding and compression related APIs.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.encoding.api;
 

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -20,6 +20,8 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.quality.Pmd
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
+import org.gradle.external.javadoc.JavadocOptionFileOption
+import org.gradle.external.javadoc.internal.JavadocOptionFileWriterContext
 
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.addManifestAttributes
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.addQualityTask
@@ -50,8 +52,6 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
   }
 
   private static void applyJavaLibraryPlugin(Project project) {
-
-
     project.configure(project) {
       pluginManager.apply("java-library")
 
@@ -64,8 +64,9 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
 
       javadoc {
         options.noQualifiers "all"
-        // -quiet is a workaround for addStringOption(s) being broken: it's ignored as already added in the command by Gradle
-        options.addStringOption("Xwerror", "-quiet")
+        options.addBooleanOption("Xwerror", true)
+        options.addBooleanOption("Xdoclint:all,-missing", true)
+        options.addBooleanOption("protected", true)
       }
 
       def sourcesJar = createSourcesJarTask(project, sourceSets.main)

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/package-info.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * ServiceTalk protoc compiler for the gRPC protocol.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.grpc.protoc;
 

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/SimpleHttpRequesterFilterTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/SimpleHttpRequesterFilterTest.java
@@ -114,8 +114,8 @@ class SimpleHttpRequesterFilterTest extends AbstractHttpRequesterFilterTest {
 
         assertThat(request.headers().get("X-Unit"), hasToString("Test"));
         if (type != Client) {
-            assertThat(request.headers().get("X-Local"), hasToString("127.0.1.2:28080"));
-            assertThat(request.headers().get("X-Remote"), hasToString("127.0.1.1:80"));
+            assertThat(request.headers().get("X-Local"), hasToString(localAddress().toString()));
+            assertThat(request.headers().get("X-Remote"), hasToString(remoteAddress().toString()));
             if (security == Secure) {
                 assertThat(request.headers().get("X-Secure"), hasToString("True"));
             }

--- a/servicetalk-logging-api/src/main/java/io/servicetalk/logging/api/package-info.java
+++ b/servicetalk-logging-api/src/main/java/io/servicetalk/logging/api/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * ServiceTalk logging APIs.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.logging.api;
 

--- a/servicetalk-logging-slf4j-internal/src/main/java/io/servicetalk/logging/slf4j/internal/package-info.java
+++ b/servicetalk-logging-slf4j-internal/src/main/java/io/servicetalk/logging/slf4j/internal/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * ServiceTalk internal logging utilities for slf4j.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.logging.slf4j.internal;
 

--- a/servicetalk-opentracing-inmemory-api/src/main/java/io/servicetalk/opentracing/inmemory/api/package-info.java
+++ b/servicetalk-opentracing-inmemory-api/src/main/java/io/servicetalk/opentracing/inmemory/api/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * APIs which build off of OpenTracing APIs to provide in memory span storage.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.opentracing.inmemory.api;
 

--- a/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/SingleLineFormatter.java
+++ b/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/SingleLineFormatter.java
@@ -32,6 +32,9 @@ import static io.servicetalk.opentracing.internal.TracingConstants.NO_PARENT_ID;
  * </ul>
  */
 public final class SingleLineFormatter implements InMemoryTraceStateFormat<SingleLineValue> {
+    /**
+     * Singleton instance.
+     */
     public static final SingleLineFormatter INSTANCE = new SingleLineFormatter();
 
     private SingleLineFormatter() {

--- a/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/package-info.java
+++ b/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Opentracing implementations leveraging the ServiceTalk In Memory APIs.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.opentracing.inmemory;
 

--- a/servicetalk-opentracing-internal/src/main/java/io/servicetalk/opentracing/internal/TracingConstants.java
+++ b/servicetalk-opentracing-internal/src/main/java/io/servicetalk/opentracing/internal/TracingConstants.java
@@ -19,6 +19,9 @@ package io.servicetalk.opentracing.internal;
  * Various constants for tracing.
  */
 public final class TracingConstants {
+    /**
+     * Text value that can be used if there is no parent span.
+     */
     public static final String NO_PARENT_ID = "null";
 
     private TracingConstants() { } // no instantiation

--- a/servicetalk-opentracing-internal/src/main/java/io/servicetalk/opentracing/internal/ZipkinHeaderNames.java
+++ b/servicetalk-opentracing-internal/src/main/java/io/servicetalk/opentracing/internal/ZipkinHeaderNames.java
@@ -22,9 +22,21 @@ public final class ZipkinHeaderNames {
     // Use lowercase so the same header names can be used for HTTP/2 which requires lower case header names.
     // Header names in HTTP/1 should be compared in a case insensitive manner so this shouldn't impact existing
     // deployments.
+    /**
+     * Header name for the trace id.
+     */
     public static final String TRACE_ID = "x-b3-traceid";
+    /**
+     * Header name for the span id.
+     */
     public static final String SPAN_ID = "x-b3-spanid";
+    /**
+     * Header name for the parent span id.
+     */
     public static final String PARENT_SPAN_ID = "x-b3-parentspanid";
+    /**
+     * Header name which determines if sampling is requested.
+     */
     public static final String SAMPLED = "x-b3-sampled";
 
     private ZipkinHeaderNames() { } // no instantiation

--- a/servicetalk-opentracing-internal/src/main/java/io/servicetalk/opentracing/internal/package-info.java
+++ b/servicetalk-opentracing-internal/src/main/java/io/servicetalk/opentracing/internal/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * OpenTracing internal utilities.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.opentracing.internal;
 

--- a/servicetalk-router-api/src/main/java/io/servicetalk/router/api/package-info.java
+++ b/servicetalk-router-api/src/main/java/io/servicetalk/router/api/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * APIs that can be used while implementing routers (typically route requests on the server side).
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.router.api;
 

--- a/servicetalk-serialization-api/src/main/java/io/servicetalk/serialization/api/Serializer.java
+++ b/servicetalk-serialization-api/src/main/java/io/servicetalk/serialization/api/Serializer.java
@@ -366,7 +366,7 @@ public interface Serializer {
     /**
      * Deserializes the passed encoded {@link Buffer} to one or more instances of {@link T}.
      *
-     * <h2>Incomplete data</h2>
+     * <p><strong>Incomplete data</strong></p>
      *
      * This method assumes that the passed {@link Buffer} contains exact amount of data required to deserialize into
      * at least one complete instance of {@link T}. If there is any left over data in the {@link Buffer} after the
@@ -391,7 +391,7 @@ public interface Serializer {
     /**
      * Deserializes the passed encoded {@link Buffer} to zero or more instances of {@link T}.
      *
-     * <h2>Incomplete data</h2>
+     * <p><strong>Incomplete data</strong></p>
      *
      * This method assumes that the passed {@link Buffer} contains exact amount of data required to deserialize into
      * at least one complete instance of {@link T}. If there is any left over data in the {@link Buffer} after

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ByteToMessageDecoder.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ByteToMessageDecoder.java
@@ -62,7 +62,7 @@ import static java.lang.Integer.MAX_VALUE;
  *     }
  * </pre>
  *
- * <h3>Frame detection</h3>
+ * <p><strong>Frame detection</strong></p>
  * <p>
  * Generally frame detection should be handled earlier in the pipeline by adding a
  * {@link DelimiterBasedFrameDecoder}, {@link FixedLengthFrameDecoder}, {@link LengthFieldBasedFrameDecoder},
@@ -77,7 +77,7 @@ import static java.lang.Integer.MAX_VALUE;
  * One <strong>MUST</strong> use the reader index when using methods like {@link ByteBuf#getInt(int)}.
  * For example calling <code>in.getInt(0)</code> is assuming the frame starts at the beginning of the buffer, which
  * is not always the case. Use <code>in.getInt(in.readerIndex())</code> instead.
- * <h3>Pitfalls</h3>
+ * <p><strong>Pitfalls</strong></p>
  * <p>
  * Be aware that sub-classes of {@link ByteToMessageDecoder} <strong>MUST NOT</strong>
  * annotated with {@link Sharable}.

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutor.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutor.java
@@ -20,15 +20,14 @@ import io.servicetalk.transport.api.IoExecutor;
 
 /**
  * {@link IoExecutor} for netty.
- *
- * <h2>Caution</h2>
+ * <p><strong>Caution</strong></p>
  * Implementations of this interface assumes that they would not be used to run blocking code.
  * If this assumption is violated, it will impact eventloop responsiveness and hence should be avoided.
  */
 public interface NettyIoExecutor extends IoExecutor {
     /**
      * Get an {@link Executor} which will use an {@link IoExecutor} thread for execution.
-     * <h2>Caution</h2>
+     * <p><strong>Caution</strong></p>
      * Implementation of this method assumes there would be no blocking code inside the submitted {@link Runnable}s.
      * If this assumption is violated, it will impact EventLoop responsiveness and hence should be avoided.
      * @return an {@link Executor} which will use an {@link IoExecutor} thread for execution.

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/package-info.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/package-info.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Internal general utilities used by ServiceTalk.
+ */
 @ElementsAreNonnullByDefault
 package io.servicetalk.utils.internal;
 


### PR DESCRIPTION
Motivation:
In preparation for the next major LTS JDK release 17, we should start
running CI builds for the current latest major release 16.

Modifications:
- Update javadocs which fail the more strict validation
- Update tests that fail due to JDK access restrictions

Result:
Builds pass on JDK 16, CI is ready to run automated builds.