### PR TITLE
`AllWritesPromise` should not be writable after channel is closed

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -337,7 +337,8 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
 
         boolean isWritable() {
             assert channel.eventLoop().inEventLoop();
-            return !hasAnyFlags(CHANNEL_CLOSED, SUBSCRIBER_TERMINATED, SOURCE_TERMINATED);
+            return !hasAnyFlags(CHANNEL_CLOSED, SUBSCRIBER_TERMINATED, SOURCE_TERMINATED,
+                    CLOSE_OUTBOUND_ON_SUBSCRIBER_TERMINATION);
         }
 
         void writeNext(Object msg) {
@@ -538,8 +539,8 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
             return (state & (flag1 | flag2)) > 0;
         }
 
-        private boolean hasAnyFlags(final byte flag1, final byte flag2, final byte flag3) {
-            return (state & (flag1 | flag2 | flag3)) > 0;
+        private boolean hasAnyFlags(final byte flag1, final byte flag2, final byte flag3, final byte flag4) {
+            return (state & (flag1 | flag2 | flag3 | flag4)) > 0;
         }
 
         private void setFlag(final byte flag) {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -337,8 +337,7 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
 
         boolean isWritable() {
             assert channel.eventLoop().inEventLoop();
-            return !hasAnyFlags(CHANNEL_CLOSED, SUBSCRIBER_TERMINATED, SOURCE_TERMINATED,
-                    CLOSE_OUTBOUND_ON_SUBSCRIBER_TERMINATION);
+            return state != 0;  // of any of the flags set, it's non-writable
         }
 
         void writeNext(Object msg) {
@@ -537,10 +536,6 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
 
         private boolean hasAnyFlags(final byte flag1, final byte flag2) {
             return (state & (flag1 | flag2)) > 0;
-        }
-
-        private boolean hasAnyFlags(final byte flag1, final byte flag2, final byte flag3, final byte flag4) {
-            return (state & (flag1 | flag2 | flag3 | flag4)) > 0;
         }
 
         private void setFlag(final byte flag) {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -337,7 +337,7 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
 
         boolean isWritable() {
             assert channel.eventLoop().inEventLoop();
-            return state != 0;  // of any of the flags set, it's non-writable
+            return state == 0;  // if any of the flags set, it's non-writable
         }
 
         void writeNext(Object msg) {


### PR DESCRIPTION
Motivation:

`AllWritesPromise` is closed when a channels becomes inactive or the
output side of the channel is shutdown. We should not try to write
more messages after that, even if a subscriber is not terminated yet.

Modifications:

- Consider `AllWritesPromise` as non-writable if any of the `state` flag
is set, including `CLOSE_OUTBOUND_ON_SUBSCRIBER_TERMINATION`;
- Add a test to verify further writes are discarded after
`WSS#channelClosed` is invoked;

Result:

No failed writes on netty pipeline after the channel is closed.