### PR TITLE
Minor javadoc updates and generics usage fix

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -1425,7 +1425,8 @@ public abstract class Completable {
     /**
      * Creates a new {@link Completable} that terminates with the result (either success or error) of either this
      * {@link Completable} or the passed {@code other} {@link Completable}, whichever terminates first. Therefore the
-     * result is said to be <strong>ambiguous</strong> relative to which source it originated from.
+     * result is said to be <strong>ambiguous</strong> relative to which source it originated from. After the first
+     * source terminates the non-terminated source will be cancelled.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -1889,7 +1890,8 @@ public abstract class Completable {
     /**
      * Creates a new {@link Completable} that terminates with the result (either success or error) of whichever amongst
      * the passed {@code completables} that terminates first. Therefore the result is said to be
-     * <strong>ambiguous</strong> relative to which source it originated from.
+     * <strong>ambiguous</strong> relative to which source it originated from. After the first source terminates the
+     * non-terminated sources will be cancelled.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -1912,7 +1914,8 @@ public abstract class Completable {
 
     /**
      * Creates a new {@link Completable} that terminates with the result (either success or error) of whichever amongst
-     * the passed {@code completables} that terminates first.
+     * the passed {@code completables} that terminates first. After the first source terminates the non-terminated
+     * sources will be cancelled.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -1424,7 +1424,8 @@ public abstract class Completable {
 
     /**
      * Creates a new {@link Completable} that terminates with the result (either success or error) of either this
-     * {@link Completable} or the passed {@code other} {@link Completable}, whichever terminates first.
+     * {@link Completable} or the passed {@code other} {@link Completable}, whichever terminates first. Therefore the
+     * result is said to be <strong>ambiguous</strong> relative to which source it originated from.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -1434,9 +1435,11 @@ public abstract class Completable {
      *      }
      * }</pre>
      *
-     * @param other {@link Completable} with which the result of this {@link Completable} is to be ambiguated.
+     * @param other {@link Completable} to subscribe to and race with this {@link Completable} to propagate to the
+     * return value.
      * @return A new {@link Completable} that terminates with the result (either success or error) of either this
-     * {@link Completable} or the passed {@code other} {@link Completable}, whichever terminates first.
+     * {@link Completable} or the passed {@code other} {@link Completable}, whichever terminates first. Therefore the
+     * result is said to be <strong>ambiguous</strong> relative to which source it originated from.
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
      */
     public final Completable ambWith(final Completable other) {
@@ -1885,7 +1888,8 @@ public abstract class Completable {
 
     /**
      * Creates a new {@link Completable} that terminates with the result (either success or error) of whichever amongst
-     * the passed {@code completables} that terminates first.
+     * the passed {@code completables} that terminates first. Therefore the result is said to be
+     * <strong>ambiguous</strong> relative to which source it originated from.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -1895,9 +1899,10 @@ public abstract class Completable {
      *      }
      * }</pre>
      *
-     * @param completables {@link Completable}s the result of which are to be ambiguated.
+     * @param completables {@link Completable}s to subscribe to and race to propagate to the return value.
      * @return A new {@link Completable} that terminates with the result (either success or error) of whichever amongst
-     * the passed {@code completables} that terminates first.
+     * the passed {@code completables} that terminates first. Therefore the result is said to be
+     * <strong>ambiguous</strong> relative to which source it originated from.
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
      */
     public static Completable amb(final Completable... completables) {
@@ -1917,10 +1922,10 @@ public abstract class Completable {
      *      }
      * }</pre>
      *
-     * @param completables {@link Completable}s the result of which are to be ambiguated.
+     * @param completables {@link Completable}s to subscribe to and race to propagate to the return value.
      * @return A new {@link Completable} that terminates with the result (either success or error) of whichever amongst
-     * the passed {@code completables} that terminates first.
-     * that result.
+     * the passed {@code completables} that terminates first. Therefore the result is said to be
+     * <strong>ambiguous</strong> relative to which source it originated from.
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
      */
     public static Completable amb(final Iterable<Completable> completables) {
@@ -1940,7 +1945,7 @@ public abstract class Completable {
      *      }
      * }</pre>
      *
-     * @param completables {@link Completable}s the result of which are to be ambiguated.
+     * @param completables {@link Completable}s which to subscribe to and race to propagate to the return value.
      * @return A new {@link Completable} that terminates with the result (either success or error) of whichever amongst
      * the passed {@code completables} that terminates first.
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
@@ -1961,7 +1966,7 @@ public abstract class Completable {
      *      }
      * }</pre>
      *
-     * @param completables {@link Completable}s the result of which are to be ambiguated.
+     * @param completables {@link Completable}s which to subscribe to and race to propagate to the return value.
      * @return A new {@link Completable} that terminates with the result (either success or error) of whichever amongst
      * the passed {@code completables} that terminates first.
      * that result.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -3178,7 +3178,7 @@ public abstract class Publisher<T> {
      *     <li>{@link Subscription} received by {@link Subscriber#onSubscribe(PublisherSource.Subscription)} is used to
      *     request more data when required. If the returned {@link InputStream} is closed, {@link Subscription} is
      *     cancelled and any unread data is disposed.</li>
-     *     <li>Any items received by {@link Subscriber#onNext(Object)} are convertedto a {@code byte[]} using the
+     *     <li>Any items received by {@link Subscriber#onNext(Object)} are converted to a {@code byte[]} using the
      *     passed {@code serializer}. These {@code byte}s are available to be read from the {@link InputStream}</li>
      *     <li>Any {@link Throwable} received by {@link Subscriber#onError(Throwable)} is thrown (wrapped in an
      *     {@link IOException}) when data is read from the returned {@link InputStream}. This error will be thrown

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithPublisher.java
@@ -50,7 +50,7 @@ final class ScanWithPublisher<T, R> extends AbstractNoHandleSubscribePublisher<R
     @Override
     void handleSubscribe(final Subscriber<? super R> subscriber,
                          final AsyncContextMap contextMap, final AsyncContextProvider contextProvider) {
-        original.delegateSubscribe(new ScanWithSubscriber(subscriber, mapperSupplier.get(),
+        original.delegateSubscribe(new ScanWithSubscriber<>(subscriber, mapperSupplier.get(),
                 contextProvider, contextMap), contextMap, contextProvider);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1462,7 +1462,8 @@ public abstract class Single<T> {
     /**
      * Creates a new {@link Single} that terminates with the result (either success or error) of either this
      * {@link Single} or the passed {@code other} {@link Single}, whichever terminates first. Therefore the result is
-     * said to be <strong>ambiguous</strong> relative to which source it originated from.
+     * said to be <strong>ambiguous</strong> relative to which source it originated from. After the first source
+     * terminates the non-terminated source will be cancelled.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -1989,7 +1990,8 @@ public abstract class Single<T> {
     /**
      * Creates a new {@link Single} that terminates with the result (either success or error) of whichever amongst the
      * passed {@code singles} that terminates first. Therefore the result is said to be <strong>ambiguous</strong>
-     * relative to which source it originated from.
+     * relative to which source it originated from. After the first source terminates the non-terminated sources will be
+     * cancelled.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -2014,7 +2016,8 @@ public abstract class Single<T> {
     /**
      * Creates a new {@link Single} that terminates with the result (either success or error) of whichever amongst the
      * passed {@code singles} that terminates first. Therefore the result is said to be <strong>ambiguous</strong>
-     * relative to which source it originated from.
+     * relative to which source it originated from. After the first source terminates the non-terminated sources will be
+     * cancelled.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1461,7 +1461,8 @@ public abstract class Single<T> {
 
     /**
      * Creates a new {@link Single} that terminates with the result (either success or error) of either this
-     * {@link Single} or the passed {@code other} {@link Single}, whichever terminates first.
+     * {@link Single} or the passed {@code other} {@link Single}, whichever terminates first. Therefore the result is
+     * said to be <strong>ambiguous</strong> relative to which source it originated from.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -1471,9 +1472,10 @@ public abstract class Single<T> {
      *      }
      * }</pre>
      *
-     * @param other {@link Single} with which the result of this {@link Single} is to be ambiguated.
+     * @param other {@link Single} to subscribe to and race with this {@link Single} to propagate to the return value.
      * @return A new {@link Single} that terminates with the result (either success or error) of either this
-     * {@link Single} or the passed {@code other} {@link Single}, whichever terminates first.
+     * {@link Single} or the passed {@code other} {@link Single}, whichever terminates first. Therefore the result is
+     * said to be <strong>ambiguous</strong> relative to which source it originated from.
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
      */
     public final Single<T> ambWith(final Single<T> other) {
@@ -1986,7 +1988,8 @@ public abstract class Single<T> {
 
     /**
      * Creates a new {@link Single} that terminates with the result (either success or error) of whichever amongst the
-     * passed {@code singles} that terminates first.
+     * passed {@code singles} that terminates first. Therefore the result is said to be <strong>ambiguous</strong>
+     * relative to which source it originated from.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -1996,10 +1999,11 @@ public abstract class Single<T> {
      *      }
      * }</pre>
      *
-     * @param singles {@link Single}s the result of which are to be ambiguated.
+     * @param singles {@link Single}s to subscribe to and race to propagate to the return value.
      * @param <T> Type of the result of the individual {@link Single}s
      * @return A new {@link Single} that terminates with the result (either success or error) of whichever amongst the
-     * passed {@code singles} that terminates first.
+     * passed {@code singles} that terminates first. Therefore the result is said to be <strong>ambiguous</strong>
+     * relative to which source it originated from.
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
      */
     @SafeVarargs
@@ -2009,7 +2013,8 @@ public abstract class Single<T> {
 
     /**
      * Creates a new {@link Single} that terminates with the result (either success or error) of whichever amongst the
-     * passed {@code singles} that terminates first.
+     * passed {@code singles} that terminates first. Therefore the result is said to be <strong>ambiguous</strong>
+     * relative to which source it originated from.
      * <p>
      * From a sequential programming point of view this method is roughly equivalent to the following:
      * <pre>{@code
@@ -2019,10 +2024,11 @@ public abstract class Single<T> {
      *      }
      * }</pre>
      *
-     * @param singles {@link Single}s the result of which are to be ambiguated.
+     * @param singles {@link Single}s to subscribe to and race to propagate to the return value.
      * @param <T> Type of the result of the individual {@link Single}s
      * @return A new {@link Single} that terminates with the result (either success or error) of whichever amongst the
-     * passed {@code singles} that terminates first.
+     * passed {@code singles} that terminates first. Therefore the result is said to be <strong>ambiguous</strong>
+     * relative to which source it originated from.
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX amb operator.</a>
      */
     public static <T> Single<T> amb(final Iterable<Single<? extends T>> singles) {
@@ -2041,7 +2047,7 @@ public abstract class Single<T> {
      *      }
      * }</pre>
      *
-     * @param singles {@link Single}s the result of which are to be ambiguated.
+     * @param singles {@link Single}s to subscribe to and race to propagate to the return value.
      * @param <T> Type of the result of the individual {@link Single}s
      * @return A new {@link Single} that terminates with the result (either success or error) of whichever amongst the
      * passed {@code singles} that terminates first.
@@ -2064,7 +2070,7 @@ public abstract class Single<T> {
      *      }
      * }</pre>
      *
-     * @param singles {@link Single}s the result of which are to be ambiguated.
+     * @param singles {@link Single}s to subscribe to and race to propagate to the return value.
      * @param <T> Type of the result of the individual {@link Single}s
      * @return A new {@link Single} that terminates with the result (either success or error) of whichever amongst the
      * passed {@code singles} that terminates first.


### PR DESCRIPTION
Motivation:
Some javadocs in Publisher, Completable, Single could be clarified. One
usage of a generic type is missing the dimond operator.

Modifications:
- Enhance javadocs for "amb" related operators.
- Add diamond operator for generic type usage in ScanWithPublisher

Result:
Minor code/javadoc cleanup.