### PR TITLE
Fix flaky `HttpRequestDecoderTest.unexpectedContentAfterNoContentHeaders()`

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -99,7 +99,7 @@ abstract class HttpObjectDecoderTest {
         writeMsg(msg, channel());
     }
 
-    final void writeMsg(String msg, EmbeddedChannel channel) {
+    static void writeMsg(String msg, EmbeddedChannel channel) {
         assertThat("writeInbound(msg) did not produce something for readInbound()",
                 channel.writeInbound(fromAscii(msg)), is(true));
     }
@@ -108,12 +108,12 @@ abstract class HttpObjectDecoderTest {
         writeContent(length, channel());
     }
 
-    final void writeContent(int length, EmbeddedChannel channel) {
+    static void writeContent(int length, EmbeddedChannel channel) {
         assertThat("writeInbound(content) did not produce something for readInbound()",
                 channel.writeInbound(content(length)), is(true));
     }
 
-    final void writeChunkSize(int length, EmbeddedChannel channel) {
+    static void writeChunkSize(int length, EmbeddedChannel channel) {
         writeMsg(toHexString(length) + "\r\n", channel);
     }
 
@@ -121,7 +121,7 @@ abstract class HttpObjectDecoderTest {
         writeChunk(length, channel());
     }
 
-    final void writeChunk(int length, EmbeddedChannel channel) {
+    static void writeChunk(int length, EmbeddedChannel channel) {
         if (length == 0) {
             writeMsg("0\r\n", channel);
             return;
@@ -131,7 +131,7 @@ abstract class HttpObjectDecoderTest {
         writeMsg("\r\n", channel);
     }
 
-    final void writeLastChunk(EmbeddedChannel channel) {
+    static void writeLastChunk(EmbeddedChannel channel) {
         writeMsg("0\r\n\r\n", channel);
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
@@ -272,9 +272,13 @@ class HttpRequestDecoderTest extends HttpObjectDecoderTest {
         writeMsg("POST /some/path HTTP/1.1" + "\r\n" +
                 "Host: servicetalk.io" + "\r\n" +
                 "Connection: keep-alive" + "\r\n" + "\r\n");
+
+        HttpMetaData metaData = assertStartLineForContent();
+        assertStandardHeaders(metaData.headers());
+        assertEmptyTrailers(channel);
         // Content is not expected for requests if no "content-length" nor "transfer-encoding: chunked" is present
-        assertThrows(DecoderException.class, () -> writeContent(128));
-        assertThat(channel.inboundMessages(), is(not(empty())));
+        assertThrows(DecoderException.class, () -> writeMsg("some_content"));
+        assertThat(channel.inboundMessages(), is(empty()));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

`HttpRequestDecoderTest.unexpectedContentAfterNoContentHeaders()` uses
random bytes for unexpected content. If the first two random bytes are an
upper-case letter followed by a whitespace, `HttpObjectDecoder` may
consider it as a legit HTTP method name (if there is no CRLF) and won't
throw a `DecoderException`.

Modifications:
- Use non-random content that can not be considered as a valid input
for the next request;
- Make some internal methods `static`, where possible;

Result:

Fixes #1694.